### PR TITLE
GUI3 fix: router UI parity with gui3

### DIFF
--- a/src/app/src/App.tsx
+++ b/src/app/src/App.tsx
@@ -1184,8 +1184,8 @@ const App: React.FC = () => {
                 className="titlebar__window-btn titlebar__window-btn--close"
                 data-tauri-drag-region="false"
                 onClick={() => window.api?.closeWindow?.()}
-                aria-label="Close"
-                title="Close"
+                aria-label="Cancel"
+                title="Cancel"
               >
                 <Icon name="x" size={14} />
               </button>

--- a/src/app/src/components/EffectiveSettingsModal.tsx
+++ b/src/app/src/components/EffectiveSettingsModal.tsx
@@ -395,8 +395,8 @@ const EffectiveSettingsModal: React.FC<EffectiveSettingsModalProps> = ({
             iconOnly
             className="close-modal-btn"
             onClick={onClose}
-            aria-label="Close"
-            title="Close"
+            aria-label="Cancel"
+            title="Cancel"
           />
         </div>
 

--- a/src/app/src/components/ModelListPanel.tsx
+++ b/src/app/src/components/ModelListPanel.tsx
@@ -727,6 +727,7 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
               title="Update all downloaded models"
             />
           )}
+
         </WorkspaceActionGroup>
       )}
     >

--- a/src/app/src/components/ModelManager.tsx
+++ b/src/app/src/components/ModelManager.tsx
@@ -2895,15 +2895,11 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
             ariaLabel={customFormTitle}
             leading={<Icon name="compose" size={20} aria-hidden="true" />}
             title={<h2 className="workspace-detail-panel__title custom-model-editor__title">{customFormTitle}</h2>}
-            metadata={(
-              <>
-                <WorkspaceMetadataChip emphasis="high" tone="accent">
-                  {isCustomOmniCollectionDraft ? 'Omni collection' : 'Custom model'}
-                </WorkspaceMetadataChip>
-                {editingCustomModelName && <WorkspaceMetadataChip emphasis="medium">Editing saved definition</WorkspaceMetadataChip>}
-              </>
-            )}
+            metadata={editingCustomModelName ? (
+              <WorkspaceMetadataChip emphasis="medium">Editing saved definition</WorkspaceMetadataChip>
+            ) : undefined}
             description={<p>Register a model or collection that is not included in the Lemonade catalog.</p>}
+            descriptionPlacement="identity"
             actions={(
               <WorkspaceActionGroup className="custom-model-editor__actions" label={`${customFormTitle} actions`}>
                 <WorkspaceActionButton
@@ -2915,13 +2911,12 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
                 >
                   Save
                 </WorkspaceActionButton>
-                <WorkspaceActionButton appearance="secondary" icon="x" onClick={closeCustomForm}>Cancel</WorkspaceActionButton>
+                <WorkspaceActionButton appearance="secondary" icon="x" onClick={closeCustomForm}>Close</WorkspaceActionButton>
+                <span className="workspace-action-group__spacer" />
                 <WorkspaceActionButton appearance="quiet" icon="file" onClick={handleExportCustomModels}>Export</WorkspaceActionButton>
                 <WorkspaceActionButton appearance="quiet" icon="file-up" onClick={() => customJsonInputRef.current?.click()}>Import</WorkspaceActionButton>
               </WorkspaceActionGroup>
             )}
-            onClose={closeCustomForm}
-            closeLabel="Close custom model editor"
           >
             <div className="custom-model-form__body">
             <div className="custom-model-form__toolbar">
@@ -2935,7 +2930,7 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
                     aria-pressed={!isCustomOmniCollectionDraft}
                     onClick={() => openCustomForm('model')}
                   >
-                    Custom model
+                    Custom Model
                   </button>
                   <button
                     type="button"
@@ -2943,7 +2938,7 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
                     aria-pressed={isCustomOmniCollectionDraft}
                     onClick={() => openCustomForm('omni-collection')}
                   >
-                    Omni collection
+                    Omni Collection
                   </button>
                 </div>
               )}

--- a/src/app/src/components/ModelManager.tsx
+++ b/src/app/src/components/ModelManager.tsx
@@ -22,6 +22,7 @@ import { useWorkspacePanelResize } from '../hooks/useWorkspacePanelResize';
 import { DEFAULT_OMNI_SYSTEM_PROMPT_TEMPLATE } from '../tools/omniTools';
 import { remoteResultAsModelInfo } from '../remoteModelCapabilities';
 import {WorkspaceActionButton, WorkspaceActionGroup, WorkspaceDetailPanel, WorkspaceList, WorkspaceListRow, WorkspaceMetadataChip, WorkspacePanelResizer } from './WorkspacePanels';
+import Modal from './inspect/Modal';
 
 import { ROUTER_RECIPE, type RouterPullRequest } from '../features/router/routerTypes';
 import { deleteRouterRecord, loadRouterRecords, routerRecordToModelInfo } from '../features/router/routerStore';
@@ -1112,6 +1113,9 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
   const [routerModels, setRouterModels] = useState<ModelInfo[]>(() => loadRouterRecords().map(routerRecordToModelInfo));
   const [showRouterEditor, setShowRouterEditor] = useState(false);
   const [routerEditorModel, setRouterEditorModel] = useState<ModelInfo | null>(null);
+  const [routerDeleteCandidate, setRouterDeleteCandidate] = useState<ModelInfo | null>(null);
+  const [routerDeleteError, setRouterDeleteError] = useState<string | null>(null);
+  const [deletingRouterDefinition, setDeletingRouterDefinition] = useState(false);
   const [showCustomForm, setShowCustomForm] = useState(false);
   const [editingCustomModelName, setEditingCustomModelName] = useState<string | null>(null);
   const [customError, setCustomError] = useState<string | null>(null);
@@ -1679,22 +1683,50 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
     await refresh();
   };
 
-  const handleDeleteRouterDefinition = async (name: string): Promise<void> => {
-    if (api.isConnected) await api.deleteModel(name);
-    deleteRouterRecord(name);
-    reloadRouterModels();
+  const handleDeleteRouterDefinition = async (name: string): Promise<string | void> => {
+    const warnings: string[] = [];
+    if (api.isConnected) {
+      await api.deleteModel(name);
+    } else {
+      warnings.push(`Removed the local entry for ${name}, but Lemonade is disconnected so the server definition was not deleted.`);
+    }
+    try {
+      deleteRouterRecord(name);
+      reloadRouterModels();
+    } catch (cacheError) {
+      // A completed server mutation (or an explicitly offline local removal)
+      // must not be turned into a false generic delete failure because only the
+      // recent-router cache cleanup failed.
+      console.warn('Router local cache cleanup failed:', cacheError);
+      setRouterModels(current => current.filter(model => modelName(model) !== name));
+      warnings.push(`The local recent-router cache for ${name} could not be updated.`);
+    }
     if (selectedDetailModelId === name) setSelectedDetailModelId(null);
+    return warnings.length ? warnings.join(' ') : undefined;
+  };
+
+  const confirmRouterDefinitionDelete = async () => {
+    const candidate = routerDeleteCandidate;
+    if (!candidate || deletingRouterDefinition) return;
+    const name = modelName(candidate);
+    setDeletingRouterDefinition(true);
+    setRouterDeleteError(null);
+    try {
+      const warning = await handleDeleteRouterDefinition(name);
+      if (warning) console.warn(warning);
+      setRouterDeleteCandidate(null);
+    } catch (err) {
+      setRouterDeleteError(err instanceof Error ? err.message : 'Could not delete router definition.');
+    } finally {
+      setDeletingRouterDefinition(false);
+    }
   };
 
   const handleDelete = async (model: ModelInfo) => {
     const name = modelName(model);
     if (modelIsCustom(model) && String((model as any).recipe || '').toLowerCase() === ROUTER_RECIPE) {
-      if (!confirm(`Delete router definition "${model.display_name || name}"?`)) return;
-      try {
-        await handleDeleteRouterDefinition(name);
-      } catch (err) {
-        console.error('Router delete failed:', err);
-      }
+      setRouterDeleteError(null);
+      setRouterDeleteCandidate(model);
       return;
     }
     if (modelIsCustom(model)) {
@@ -2752,6 +2784,28 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
         onClick={mobileRail.toggle}
         triggerRef={mobileRail.triggerRef}
       />
+
+      <Modal
+        isOpen={routerDeleteCandidate != null}
+        onClose={() => {
+          if (deletingRouterDefinition) return;
+          setRouterDeleteCandidate(null);
+          setRouterDeleteError(null);
+        }}
+        title="Delete router definition?"
+        maxWidth="480px"
+      >
+        <div className="inspect-modal-body">
+          <p>Delete <strong>{routerDeleteCandidate?.display_name || modelName(routerDeleteCandidate)}</strong>? This removes the saved router definition.</p>
+          {routerDeleteError && <div className="manager__inline-notice" role="alert">{routerDeleteError}</div>}
+        </div>
+        <div className="inspect-modal-footer">
+          <WorkspaceActionButton appearance="secondary" disabled={deletingRouterDefinition} onClick={() => { setRouterDeleteCandidate(null); setRouterDeleteError(null); }}>Cancel</WorkspaceActionButton>
+          <WorkspaceActionButton appearance="danger" disabled={deletingRouterDefinition} onClick={() => { void confirmRouterDefinitionDelete(); }}>
+            {deletingRouterDefinition ? 'Deleting…' : 'Delete router'}
+          </WorkspaceActionButton>
+        </div>
+      </Modal>
 
       {/* Left rail: navigation / filter dimensions */}
       <ModelNavRail

--- a/src/app/src/components/RouterEditorPanel.tsx
+++ b/src/app/src/components/RouterEditorPanel.tsx
@@ -2,7 +2,9 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import api, { type CloudProviderRow, type ModelInfo } from '../api';
 import { capabilityFromModelInfo, isRouterRecipe } from '../modelCapabilities';
 import { Icon } from './Icon';
-import RouterNodeEditor from './RouterNodeEditor';
+import Modal from './inspect/Modal';
+import RouterModelPicker from './RouterModelPicker';
+import RouterRuleGraph from './RouterRuleGraph';
 import {
   WorkspaceActionButton,
   WorkspaceActionGroup,
@@ -106,6 +108,24 @@ interface RouterEditorPanelProps {
   onClose: () => void;
 }
 
+type RouterConfirmationKind = 'switch-rules' | 'switch-llm' | 'reset' | 'delete';
+
+interface RouterConfirmation {
+  kind: RouterConfirmationKind;
+  title: string;
+  message: string;
+  confirmLabel: string;
+  tone: 'primary' | 'danger';
+}
+
+function moveItemTo<T>(items: T[], from: number, to: number): T[] {
+  if (from === to || from < 0 || to < 0 || from >= items.length || to >= items.length) return items;
+  const next = [...items];
+  const [item] = next.splice(from, 1);
+  next.splice(to, 0, item);
+  return next;
+}
+
 export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
   models,
   initialModel,
@@ -121,6 +141,9 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
+  const [confirmation, setConfirmation] = useState<RouterConfirmation | null>(null);
+  const [dragRuleIndex, setDragRuleIndex] = useState<number | null>(null);
+  const [selectedRuleIndex, setSelectedRuleIndex] = useState(0);
   const [cloudProviders, setCloudProviders] = useState<CloudProviderRow[]>([]);
   const [connectionsError, setConnectionsError] = useState<string | null>(null);
   const [editingProvider, setEditingProvider] = useState<string | null>(null);
@@ -146,11 +169,26 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
   }, [refreshCloudProviders]);
 
   useEffect(() => {
+    if (!notice) return;
+    const timeout = window.setTimeout(() => setNotice(current => current === notice ? null : current), 4200);
+    return () => window.clearTimeout(timeout);
+  }, [notice]);
+
+  useEffect(() => {
+    if (draft.rules.length === 0) {
+      if (selectedRuleIndex !== 0) setSelectedRuleIndex(0);
+      return;
+    }
+    if (selectedRuleIndex >= draft.rules.length) setSelectedRuleIndex(draft.rules.length - 1);
+  }, [draft.rules.length, selectedRuleIndex]);
+
+  useEffect(() => {
     if (!initialModel || !isRouterRecipe((initialModel as any).recipe)) return;
 
     const applyModel = (sourceModel: ModelInfo) => {
       try {
         setDraft(routerDraftFromModelInfo(sourceModel));
+        setSelectedRuleIndex(0);
         setError(null);
         setNotice(null);
       } catch (initialError) {
@@ -245,40 +283,72 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
     setNotice(null);
   };
 
-  const setRoutingMode = (mode: RouterDraft['mode']) => {
-    if (mode === draft.mode) return;
-
-    if (draft.mode === 'rules') {
-      if (routerDraftHasRulesProgress(draft) && !window.confirm(
-        'Switch to Natural-language router?\n\nSwitching modes will clear your existing rules and classifiers. This cannot be undone.',
-      )) return;
-      setDraft(current => switchRouterDraftMode(current, 'llm'));
-    } else {
-      if (routerDraftHasLlmProgress(draft) && !window.confirm(
-        'Switch to ordered rules?\n\nSwitching modes will clear your Natural-language routing model and instruction. This cannot be undone.',
-      )) return;
-      setDraft(current => switchRouterDraftMode(current, 'rules'));
-    }
+  const applyRoutingMode = (mode: RouterDraft['mode']) => {
+    setDraft(current => switchRouterDraftMode(current, mode));
+    setSelectedRuleIndex(0);
     setError(null);
     setNotice(null);
+  };
+
+  const setRoutingMode = (mode: RouterDraft['mode']) => {
+    if (mode === draft.mode) return;
+    if (draft.mode === 'rules' && routerDraftHasRulesProgress(draft)) {
+      setConfirmation({
+        kind: 'switch-llm',
+        title: 'Switch routing strategy?',
+        message: 'Switching to the Natural-language router will clear the current ordered rules and classifiers. This cannot be undone.',
+        confirmLabel: 'Switch and clear rules',
+        tone: 'danger',
+      });
+      return;
+    }
+    if (draft.mode === 'llm' && routerDraftHasLlmProgress(draft)) {
+      setConfirmation({
+        kind: 'switch-rules',
+        title: 'Switch routing strategy?',
+        message: 'Switching to Ordered rules will clear the current routing model and instruction. This cannot be undone.',
+        confirmLabel: 'Switch and clear NL router',
+        tone: 'danger',
+      });
+      return;
+    }
+    applyRoutingMode(mode);
   };
 
   const resetDraft = () => {
     setDraft(createEmptyRouterDraft());
+    setSelectedRuleIndex(0);
     setError(null);
     setNotice(null);
     setTab('builder');
+    setCandidateSearch('');
+    setDragRuleIndex(null);
+  };
+
+  const requestResetDraft = () => {
+    if (routerDraftHasRulesProgress(draft) || routerDraftHasLlmProgress(draft)) {
+      setConfirmation({
+        kind: 'reset',
+        title: 'Start a new router?',
+        message: 'This will discard the routing work currently in the editor. Saved routers are not affected.',
+        confirmLabel: 'Discard draft',
+        tone: 'danger',
+      });
+      return;
+    }
+    resetDraft();
   };
 
   const loadSaved = (modelNameValue: string) => {
     if (!modelNameValue) {
-      resetDraft();
+      requestResetDraft();
       return;
     }
     const record = savedRecords.find(item => item.model_name === modelNameValue);
     if (!record) return;
     try {
       setDraft(routerRecordToDraft(record));
+      setSelectedRuleIndex(0);
       setError(null);
       setNotice(`Loaded ${record.display_name}.`);
     } catch (loadError) {
@@ -360,6 +430,27 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
     const rule = createRouterRule(draft.rules.length, draft.defaultModel);
     rule.id = nextSafeId('rule', draft.rules.map(item => item.id));
     setPatch({ rules: [...draft.rules, rule] });
+    setSelectedRuleIndex(draft.rules.length);
+  };
+
+  const moveRuleTo = (from: number, to: number) => {
+    if (from === to || from < 0 || to < 0 || from >= draft.rules.length || to >= draft.rules.length) return;
+    setPatch({ rules: moveItemTo(draft.rules, from, to) });
+    setSelectedRuleIndex(current => {
+      if (current === from) return to;
+      if (from < current && to >= current) return current - 1;
+      if (from > current && to <= current) return current + 1;
+      return current;
+    });
+  };
+
+  const removeRuleAt = (index: number) => {
+    setPatch({ rules: draft.rules.filter((_, itemIndex) => itemIndex !== index) });
+    setSelectedRuleIndex(current => {
+      if (current > index) return current - 1;
+      if (current === index) return Math.max(0, Math.min(index, draft.rules.length - 2));
+      return current;
+    });
   };
 
   const importFile = async (file: File | undefined) => {
@@ -367,6 +458,7 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
     try {
       const parsed = JSON.parse(await file.text());
       setDraft(parseRouterPayload(parsed));
+      setSelectedRuleIndex(0);
       setError(null);
       setNotice(`Imported ${file.name}. Save & register to persist it.`);
       setTab('builder');
@@ -437,7 +529,6 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
   const deleteCurrent = async () => {
     const modelNameValue = draft.modelName;
     if (!modelNameValue) return;
-    if (!window.confirm(`Delete ${modelNameValue}?`)) return;
     try {
       await onDeleted?.(modelNameValue);
       refreshSaved();
@@ -447,6 +538,38 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
       setError(deleteError instanceof Error ? deleteError.message : 'Could not delete router.');
     }
   };
+
+  const requestDeleteCurrent = () => {
+    if (!draft.modelName) return;
+    setConfirmation({
+      kind: 'delete',
+      title: 'Delete router?',
+      message: `Delete ${draft.modelName}? This removes the saved router definition from Lemonade.`,
+      confirmLabel: 'Delete router',
+      tone: 'danger',
+    });
+  };
+
+  const confirmPendingAction = () => {
+    const pending = confirmation;
+    if (!pending) return;
+    setConfirmation(null);
+    if (pending.kind === 'switch-llm') {
+      applyRoutingMode('llm');
+      return;
+    }
+    if (pending.kind === 'switch-rules') {
+      applyRoutingMode('rules');
+      return;
+    }
+    if (pending.kind === 'reset') {
+      resetDraft();
+      return;
+    }
+    void deleteCurrent();
+  };
+
+  const selectedRule = draft.rules[selectedRuleIndex] || null;
 
   return (
     <WorkspaceDetailPanel
@@ -462,7 +585,7 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
             {saving ? 'Registering…' : 'Save & register'}
           </WorkspaceActionButton>
           {draft.modelName && (
-            <WorkspaceActionButton appearance="danger" icon="trash" onClick={() => { void deleteCurrent(); }}>Delete</WorkspaceActionButton>
+            <WorkspaceActionButton appearance="danger" icon="trash" onClick={requestDeleteCurrent}>Delete</WorkspaceActionButton>
           )}
           <span className="workspace-action-group__spacer" />
           <WorkspaceActionButton appearance="secondary" icon="x" onClick={onClose}>Close</WorkspaceActionButton>
@@ -473,7 +596,7 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
     >
 
       <div className="router-editor__toolbar">
-        <WorkspaceActionButton size="small" icon="compose" onClick={resetDraft}>New</WorkspaceActionButton>
+        <WorkspaceActionButton size="small" icon="compose" onClick={requestResetDraft}>New</WorkspaceActionButton>
         <label className="router-editor__saved-select">
           <span className="sr-only">Saved routers</span>
           <select className="select" value={draft.modelName || ''} onChange={event => loadSaved(event.target.value)}>
@@ -654,17 +777,17 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
                   <WorkspaceMetadataChip emphasis="high" tone="accent">routing.router</WorkspaceMetadataChip>
                 </div>
                 <div className="router-editor__form-grid">
-                  <label className="router-editor__wide">
+                  <div className="router-editor__wide router-editor__field">
                     <span>Routing model <small>Usually a small, fast chat model.</small></span>
-                    <select
-                      className="select"
+                    <RouterModelPicker
+                      models={candidateModels}
                       value={draft.llmRouter.model}
-                      onChange={event => setPatch({ llmRouter: { ...draft.llmRouter, model: event.target.value } })}
-                    >
-                      <option value="">Select routing model</option>
-                      {candidateModels.map(model => <option key={modelName(model)} value={modelName(model)}>{modelLabel(model)} · {modelName(model)}</option>)}
-                    </select>
-                  </label>
+                      onChange={model => setPatch({ llmRouter: { ...draft.llmRouter, model } })}
+                      placeholder="Select routing model"
+                      searchPlaceholder="Search routing models"
+                      ariaLabel="Natural-language routing model"
+                    />
+                  </div>
                   <label className="router-editor__wide">
                     <span>Routing instruction <small>Describe clearly when each candidate should be selected.</small></span>
                     <textarea
@@ -701,7 +824,17 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
                         <div className="router-editor__form-grid router-editor__form-grid--classifier">
                           <label><span>ID</span><input className="input" value={classifier.id} onChange={event => updateClassifier(index, { id: event.target.value })} /></label>
                           <label><span>Type</span><select className="select" value={classifier.type} onChange={event => updateClassifier(index, { ...createRouterClassifier(index, event.target.value as RouterClassifier['type']), id: classifier.id })}><option value="classifier">classifier</option><option value="semantic_similarity">semantic_similarity</option><option value="llm">llm</option></select></label>
-                          <label className="router-editor__wide"><span>Model</span><select className="select" value={classifier.model} onChange={event => updateClassifier(index, { model: event.target.value })}><option value="">Select model</option>{(classifier.type === 'semantic_similarity' ? embeddingModels : classifier.type === 'llm' ? candidateModels : classifierModels).map(model => <option key={modelName(model)} value={modelName(model)}>{modelLabel(model)} · {modelName(model)}</option>)}</select></label>
+                          <div className="router-editor__wide router-editor__field">
+                            <span>Model</span>
+                            <RouterModelPicker
+                              models={classifier.type === 'semantic_similarity' ? embeddingModels : classifier.type === 'llm' ? candidateModels : classifierModels}
+                              value={classifier.model}
+                              onChange={model => updateClassifier(index, { model })}
+                              placeholder="Select model"
+                              searchPlaceholder={classifier.type === 'semantic_similarity' ? 'Search embedding models' : classifier.type === 'llm' ? 'Search chat models' : 'Search classification models'}
+                              ariaLabel={`${classifier.id || `Classifier ${index + 1}`} model`}
+                            />
+                          </div>
                           {classifier.type === 'semantic_similarity' ? (
                             <div className="router-editor__wide router-editor__concepts">
                               <div className="router-editor__mini-head"><span>Concepts and reference phrases</span><WorkspaceActionButton size="small" icon="plus" onClick={() => updateClassifier(index, { referencePhrases: { ...classifier.referencePhrases, [nextConceptName(classifier.referencePhrases)]: ['example phrase'] } })}>Concept</WorkspaceActionButton></div>
@@ -739,30 +872,98 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
                 <div><h3>Ordered rules</h3><p>First matching rule wins. The default model handles the remainder.</p></div>
                 <WorkspaceActionButton size="small" icon="plus" onClick={addRule}>Rule</WorkspaceActionButton>
               </div>
-              <div className="router-editor__rule-list">
-                {draft.rules.map((rule, index) => (
-                  <article className="router-editor__rule" key={`${rule.id}-${index}`}>
-                    <div className="router-editor__card-head">
-                      <span className="router-editor__rule-order">{index + 1}</span>
-                      <strong>{rule.id || `Rule ${index + 1}`}</strong>
+              <div className="router-editor__rules-workspace">
+                <div className="router-editor__rule-list" aria-label="Ordered routing rules">
+                  {draft.rules.map((rule, index) => (
+                    <div
+                      className={`router-editor__rule-summary ${selectedRuleIndex === index ? 'is-selected' : ''} ${dragRuleIndex === index ? 'is-dragging' : ''}`}
+                      key={`${rule.id}-${index}`}
+                      onDragOver={event => {
+                        if (dragRuleIndex == null || dragRuleIndex === index) return;
+                        event.preventDefault();
+                        event.dataTransfer.dropEffect = 'move';
+                      }}
+                      onDrop={event => {
+                        if (dragRuleIndex == null || dragRuleIndex === index) return;
+                        event.preventDefault();
+                        moveRuleTo(dragRuleIndex, index);
+                        setDragRuleIndex(null);
+                      }}
+                    >
+                      <span
+                        className="router-editor__drag-handle"
+                        draggable
+                        aria-hidden="true"
+                        title="Drag to reorder rule"
+                        onDragStart={event => {
+                          setDragRuleIndex(index);
+                          event.dataTransfer.effectAllowed = 'move';
+                          event.dataTransfer.setData('text/plain', rule.id || String(index));
+                        }}
+                        onDragEnd={() => setDragRuleIndex(null)}
+                      >
+                        ⠿
+                      </span>
+                      <button
+                        type="button"
+                        className="router-editor__rule-summary-main"
+                        onClick={() => setSelectedRuleIndex(index)}
+                        aria-current={selectedRuleIndex === index ? 'true' : undefined}
+                      >
+                        <span className="router-editor__rule-order">{index + 1}</span>
+                        <span className="router-editor__rule-summary-copy">
+                          <strong>{rule.id || `Rule ${index + 1}`}</strong>
+                          <small>{rule.routeTo ? `→ ${rule.routeTo}` : 'No route selected'}</small>
+                        </span>
+                      </button>
                       <div className="router-editor__rule-actions">
-                        <button type="button" disabled={index === 0} onClick={() => setPatch({ rules: moveItem(draft.rules, index, -1) })} title="Move rule up"><Icon name="chevron-up" size={14} /></button>
-                        <button type="button" disabled={index === draft.rules.length - 1} onClick={() => setPatch({ rules: moveItem(draft.rules, index, 1) })} title="Move rule down"><Icon name="chevron-down" size={14} /></button>
-                        <button type="button" onClick={() => setPatch({ rules: draft.rules.filter((_, itemIndex) => itemIndex !== index) })} title="Remove rule"><Icon name="trash" size={14} /></button>
+                        <button type="button" disabled={index === 0} onClick={() => moveRuleTo(index, index - 1)} title="Move rule up"><Icon name="chevron-up" size={14} /></button>
+                        <button type="button" disabled={index === draft.rules.length - 1} onClick={() => moveRuleTo(index, index + 1)} title="Move rule down"><Icon name="chevron-down" size={14} /></button>
+                        <button type="button" onClick={() => removeRuleAt(index)} title="Remove rule"><Icon name="trash" size={14} /></button>
                       </div>
                     </div>
-                    <div className="router-editor__rule-meta">
-                      <label><span>Rule ID</span><input className="input" value={rule.id} onChange={event => setPatch({ rules: draft.rules.map((item, itemIndex) => itemIndex === index ? { ...item, id: event.target.value } : item) })} /></label>
-                      <label><span>Route to</span><select className="select" value={rule.routeTo} onChange={event => setPatch({ rules: draft.rules.map((item, itemIndex) => itemIndex === index ? { ...item, routeTo: event.target.value } : item) })}><option value="">Select candidate</option>{draft.candidates.map(candidate => <option key={candidate} value={candidate}>{candidate}</option>)}</select></label>
+                  ))}
+                  {draft.rules.length === 0 && <div className="router-editor__empty">At least one rule is required.</div>}
+                  {draft.defaultModel && (
+                    <div className="router-editor__default-rule">
+                      <span className="router-editor__rule-order">↩</span>
+                      <span><strong>Default</strong><small>→ {draft.defaultModel}</small></span>
                     </div>
-                    <RouterNodeEditor node={rule.condition} classifiers={draft.classifiers} onChange={condition => setPatch({ rules: draft.rules.map((item, itemIndex) => itemIndex === index ? { ...item, condition } : item) })} />
-                    <details className="router-editor__outputs">
-                      <summary>Optional decision outputs</summary>
-                      <textarea className="textarea" value={rule.outputsText || ''} placeholder={'{\n  "tier": "fast"\n}'} spellCheck={false} onChange={event => setPatch({ rules: draft.rules.map((item, itemIndex) => itemIndex === index ? { ...item, outputsText: event.target.value } : item) })} />
-                    </details>
-                  </article>
-                ))}
-                {draft.rules.length === 0 && <div className="router-editor__empty">At least one rule is required.</div>}
+                  )}
+                </div>
+
+                <div className="router-editor__rule-builder">
+                  {selectedRule ? (
+                    <>
+                      <div className="router-editor__rule-builder-head">
+                        <div>
+                          <strong>Rule {selectedRuleIndex + 1}: {selectedRule.id || 'Untitled rule'}</strong>
+                          <span>Build the match expression by dragging gates and conditions onto the graph.</span>
+                        </div>
+                      </div>
+                      <div className="router-editor__rule-meta">
+                        <label><span>Rule ID</span><input className="input" value={selectedRule.id} onChange={event => setPatch({ rules: draft.rules.map((item, itemIndex) => itemIndex === selectedRuleIndex ? { ...item, id: event.target.value } : item) })} /></label>
+                        <label><span>Route to</span><select className="select" value={selectedRule.routeTo} onChange={event => setPatch({ rules: draft.rules.map((item, itemIndex) => itemIndex === selectedRuleIndex ? { ...item, routeTo: event.target.value } : item) })}><option value="">Select candidate</option>{draft.candidates.map(candidate => <option key={candidate} value={candidate}>{candidate}</option>)}</select></label>
+                      </div>
+                      <RouterRuleGraph
+                        key={`${selectedRuleIndex}-${selectedRule.id}`}
+                        node={selectedRule.condition}
+                        classifiers={draft.classifiers}
+                        onChange={condition => setPatch({ rules: draft.rules.map((item, itemIndex) => itemIndex === selectedRuleIndex ? { ...item, condition } : item) })}
+                      />
+                      <details className="router-editor__outputs">
+                        <summary>Optional decision outputs</summary>
+                        <textarea className="textarea" value={selectedRule.outputsText || ''} placeholder={'{\n  "tier": "fast"\n}'} spellCheck={false} onChange={event => setPatch({ rules: draft.rules.map((item, itemIndex) => itemIndex === selectedRuleIndex ? { ...item, outputsText: event.target.value } : item) })} />
+                      </details>
+                    </>
+                  ) : (
+                    <div className="router-editor__rule-builder-empty">
+                      <Icon name="router" size={18} />
+                      <strong>Select or add a rule</strong>
+                      <span>The graph editor will appear here.</span>
+                    </div>
+                  )}
+                </div>
               </div>
             </section>
               </>
@@ -777,8 +978,32 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
           </section>
         )}
         {error && <div className="router-editor__message router-editor__message--error"><Icon name="alert" size={14} /> {error}</div>}
-        {notice && <div className="router-editor__message router-editor__message--success"><Icon name="check" size={14} /> {notice}</div>}
       </div>
+
+      {notice && (
+        <div className="router-editor__toast" role="status" aria-live="polite">
+          <Icon name="check" size={15} />
+          <span>{notice}</span>
+          <button type="button" onClick={() => setNotice(null)} aria-label="Dismiss notification"><Icon name="x" size={12} /></button>
+        </div>
+      )}
+
+      <Modal
+        isOpen={confirmation != null}
+        onClose={() => setConfirmation(null)}
+        title={confirmation?.title || 'Confirm action'}
+        maxWidth="480px"
+        ariaLabelledBy="router-confirm-dialog-title"
+      >
+        <div className="inspect-modal-body router-confirm-dialog__body">
+          <div className="router-confirm-dialog__icon"><Icon name="alert" size={18} /></div>
+          <p>{confirmation?.message}</p>
+        </div>
+        <div className="inspect-modal-footer">
+          <WorkspaceActionButton appearance="secondary" onClick={() => setConfirmation(null)}>Cancel</WorkspaceActionButton>
+          <WorkspaceActionButton appearance={confirmation?.tone || 'primary'} onClick={confirmPendingAction}>{confirmation?.confirmLabel || 'Continue'}</WorkspaceActionButton>
+        </div>
+      </Modal>
 
     </WorkspaceDetailPanel>
   );

--- a/src/app/src/components/RouterEditorPanel.tsx
+++ b/src/app/src/components/RouterEditorPanel.tsx
@@ -5,6 +5,7 @@ import { Icon } from './Icon';
 import Modal from './inspect/Modal';
 import RouterModelPicker from './RouterModelPicker';
 import RouterRuleGraph from './RouterRuleGraph';
+import { RouterSelect } from './RouterNodeEditor';
 import {
   WorkspaceActionButton,
   WorkspaceActionGroup,
@@ -217,6 +218,10 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
   const [dragRuleIndex, setDragRuleIndex] = useState<number | null>(null);
   const [selectedRuleIndex, setSelectedRuleIndex] = useState(0);
   const [expandedRuleIndex, setExpandedRuleIndex] = useState<number | null>(null);
+  // Tracks rule indices whose graph has been committed at least once. Needed to
+  // pass initialCommitted=true to the expanded RouterRuleGraph so a blank
+  // keywords_any node (textValue='') isn't mistaken for the initial empty state.
+  const committedRuleIndicesRef = useRef<Set<number>>(new Set());
   const [cloudProviders, setCloudProviders] = useState<CloudProviderRow[]>([]);
   const [connectionsError, setConnectionsError] = useState<string | null>(null);
   const [editingProvider, setEditingProvider] = useState<string | null>(null);
@@ -908,13 +913,15 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
       actions={(
         <WorkspaceActionGroup label="Router editor actions">
           <WorkspaceActionButton appearance="primary" icon="check" disabled={saving || deleting || savingProvider || validationErrors.length > 0} onClick={() => { void save(); }}>
-            {saving ? 'Registering…' : 'Save & register'}
+            {saving ? 'Saving…' : 'Save'}
           </WorkspaceActionButton>
           {draft.modelName && (
             <WorkspaceActionButton appearance="danger" icon="trash" disabled={saving || deleting || savingProvider} onClick={requestDeleteCurrent}>Delete</WorkspaceActionButton>
           )}
-          <span className="workspace-action-group__spacer" />
           <WorkspaceActionButton appearance="secondary" icon="x" disabled={saving || deleting || savingProvider} onClick={requestClose}>Close</WorkspaceActionButton>
+          <span className="workspace-action-group__spacer" />
+          <WorkspaceActionButton appearance="quiet" icon="file" disabled={!request} onClick={() => request && downloadJson(routerDisplayName(request.model_name), request)}>Export</WorkspaceActionButton>
+          <WorkspaceActionButton appearance="quiet" icon="file-up" disabled={saving} onClick={() => importRef.current?.click()}>Import</WorkspaceActionButton>
         </WorkspaceActionGroup>
       )}
       titleExtras={(
@@ -923,15 +930,14 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
             <WorkspaceActionButton size="small" icon="compose" disabled={saving || deleting || savingProvider} onClick={requestResetDraft}>New</WorkspaceActionButton>
             <label className="router-editor__saved-select">
               <span className="sr-only">Saved routers</span>
-              <select className="select" value={draft.modelName || ''} disabled={saving || deleting || savingProvider} onChange={event => loadSaved(event.target.value)}>
-                <option value="">Unsaved router</option>
-                {savedRecords.map(record => <option key={record.model_name} value={record.model_name}>{record.display_name}</option>)}
-              </select>
+              <RouterSelect
+                value={draft.modelName || ''}
+                options={[{ value: '', label: 'Unsaved router' }, ...savedRecords.map(r => ({ value: r.model_name, label: r.display_name }))]}
+                onChange={(val: string) => loadSaved(val)}
+                ariaLabel="Saved routers"
+                disabled={saving || deleting || savingProvider}
+              />
             </label>
-          </div>
-          <div className="router-editor__toolbar-row router-editor__toolbar-row--files">
-            <WorkspaceActionButton size="small" icon="file-up" disabled={saving} onClick={() => importRef.current?.click()}>Import</WorkspaceActionButton>
-            <WorkspaceActionButton size="small" icon="file" disabled={!request} onClick={() => request && downloadJson(routerDisplayName(request.model_name), request)}>Export</WorkspaceActionButton>
           </div>
           <input ref={importRef} className="hidden-file-input" type="file" accept="application/json,.json" onChange={event => { void importFile(event.target.files?.[0]); }} />
         </div>
@@ -964,7 +970,7 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
           <>
             <section className="router-editor__section">
               <div className="router-editor__section-head">
-                <div><h3>Identity</h3><p>Saved as a virtual model.</p></div>
+                <div><h3>Identity</h3><p>Appears in your model list like any other model.</p></div>
               </div>
               <div className="router-editor__form-grid">
                 <label><span>Router Name</span><input className="input" value={draft.name} placeholder="Fast-or-smart" onChange={event => setPatch({ name: event.target.value })} /></label>
@@ -974,7 +980,7 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
 
             <section className="router-editor__section">
               <div className="router-editor__section-head">
-                <div><h3>Candidate Models</h3><p>The router may select only from these registered models.</p></div>
+                <div><h3>Candidate Models</h3><p>Traffic is distributed only among these models.</p></div>
                 <span className="router-editor__count">{draft.candidates.length} selected</span>
               </div>
               <div className="router-editor__candidate-search"><Icon name="search" size={14} /><input value={candidateSearch} placeholder="Search registered models" onChange={event => setCandidateSearch(event.target.value)} /></div>
@@ -1001,10 +1007,12 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
               </div>
               <label className="router-editor__default-model">
                 <span>Default Model <small>Used when no rule matches or evaluation fails.</small></span>
-                <select className="select" value={draft.defaultModel} onChange={event => setPatch({ defaultModel: event.target.value })}>
-                  <option value="">Select default</option>
-                  {draft.candidates.map(candidate => <option key={candidate} value={candidate}>{candidate}</option>)}
-                </select>
+                <RouterSelect
+                  value={draft.defaultModel}
+                  options={[{ value: '', label: 'Select default' }, ...draft.candidates.map(c => ({ value: c, label: c }))]}
+                  onChange={(val: string) => setPatch({ defaultModel: val })}
+                  ariaLabel="Default model"
+                />
               </label>
 
               <div className="router-editor__connections" aria-label="Connected model topology">
@@ -1021,6 +1029,12 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
                           <div>
                             <strong>{connection.displayName}</strong>
                             {connection.modelName === draft.defaultModel && <span className="router-editor__default-badge">Default</span>}
+                          </div>
+                          <div className="router-editor__connection-source">
+                            <span className={`router-editor__source-badge router-editor__source-badge--${connection.kind}`}>
+                              {connection.kind === 'external' ? 'External' : connection.kind === 'internal' ? 'Internal' : 'Unresolved'}
+                            </span>
+                            <small>{connection.kind === 'external' ? (connection.provider || 'Unknown provider') : (connection.backend || connection.recipe || 'Unknown source')}</small>
                           </div>
                         </div>
                         {connection.kind === 'external' && (
@@ -1059,12 +1073,6 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
                           </div>
                         )}
                         <div className="router-editor__connection-trailing">
-                          <div className="router-editor__connection-source">
-                            <span className={`router-editor__source-badge router-editor__source-badge--${connection.kind}`}>
-                              {connection.kind === 'external' ? 'External' : connection.kind === 'internal' ? 'Internal' : 'Unresolved'}
-                            </span>
-                            <small>{connection.kind === 'external' ? (connection.provider || 'Unknown provider') : (connection.backend || connection.recipe || 'Unknown source')}</small>
-                          </div>
                           {draft.candidates.includes(connection.modelName) && (
                             <WorkspaceActionButton
                               appearance="danger"
@@ -1087,7 +1095,7 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
 
             <section className="router-editor__section">
               <div className="router-editor__section-head">
-                <div><h3>Routing Strategy</h3><p>Choose how the router selects a candidate. Switching modes clears incompatible configuration after confirmation.</p></div>
+                <div><h3>Routing Strategy</h3><p>Pick the mechanism that decides which model handles each request.</p></div>
               </div>
               <div className="router-editor__strategy" role="radiogroup" aria-label="Routing strategy">
                 <button
@@ -1098,7 +1106,7 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
                   onClick={() => setRoutingMode('rules')}
                 >
                   <Icon name="layers" size={18} />
-                  <span><strong>Ordered Rules</strong><small>Deterministic conditions and optional model-backed signals. First match wins.</small></span>
+                  <span><strong>Ordered Rules</strong><small>Pattern-based rules with optional classifier signals - first match wins.</small></span>
                 </button>
                 <button
                   type="button"
@@ -1108,7 +1116,7 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
                   onClick={() => setRoutingMode('llm')}
                 >
                   <Icon name="brain-circuit" size={18} />
-                  <span><strong>Natural-Language Router</strong><small>A routing model reads your instruction and chooses one candidate directly.</small></span>
+                  <span><strong>Natural-Language Router</strong><small>An LLM model reads your instruction and picks the right candidate for each request.</small></span>
                 </button>
               </div>
             </section>
@@ -1143,7 +1151,7 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
               <>
             <section className="router-editor__section">
               <div className="router-editor__section-head">
-                <div><h3>Classifiers</h3><p>Optional model-backed signals evaluated once per request.</p></div>
+                <div><h3>Classifiers</h3><p>Model-scored signals you can reference inside your rules.</p></div>
                 <div className="router-editor__section-actions">
                   <WorkspaceActionButton size="small" icon="plus" onClick={() => addClassifier('classifier')}>Classifier</WorkspaceActionButton>
                   <WorkspaceActionButton size="small" icon="plus" onClick={() => addClassifier('semantic_similarity')}>Semantic</WorkspaceActionButton>
@@ -1162,7 +1170,7 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
                         </div>
                         <div className="router-editor__form-grid router-editor__form-grid--classifier">
                           <label><span>ID</span><CommittedTextInput value={classifier.id} ariaLabel={`Classifier ${index + 1} ID`} normalize={input => input} onCommit={nextId => commitClassifierId(index, nextId)} /></label>
-                          <label><span>Type</span><select className="select" value={classifier.type} onChange={event => updateClassifier(index, { ...createRouterClassifier(index, event.target.value as RouterClassifier['type']), id: classifier.id })}><option value="classifier">classifier</option><option value="semantic_similarity">semantic_similarity</option><option value="llm">llm</option></select></label>
+                          <label><span>Type</span><RouterSelect value={classifier.type} options={[{ value: 'classifier', label: 'classifier' }, { value: 'semantic_similarity', label: 'semantic_similarity' }, { value: 'llm', label: 'llm' }]} onChange={(val: string) => updateClassifier(index, { ...createRouterClassifier(index, val as RouterClassifier['type']), id: classifier.id })} ariaLabel="Classifier type" /></label>
                           <div className="router-editor__wide router-editor__field">
                             <span>Model</span>
                             <RouterModelPicker
@@ -1219,8 +1227,8 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
                               /></label>
                             </>
                           )}
-                          <label><span>Default Label</span><select className="select" value={classifier.defaultLabel || ''} onChange={event => updateClassifier(index, { defaultLabel: event.target.value || undefined })}><option value="">None</option>{labels.map(label => <option key={label} value={label}>{label}</option>)}</select></label>
-                          <label><span>On Error</span><select className="select" value={classifier.onError} onChange={event => updateClassifier(index, { onError: event.target.value as RouterClassifier['onError'] })}><option value="match_false">Do not match</option><option value="match_true">Match rule</option></select></label>
+                          <label><span>Default Label</span><RouterSelect value={classifier.defaultLabel || ''} options={[{ value: '', label: 'None' }, ...labels.map(label => ({ value: label, label }))]} onChange={(val: string) => updateClassifier(index, { defaultLabel: val || undefined })} ariaLabel="Default label" /></label>
+                          <label><span>On Error</span><RouterSelect value={classifier.onError} options={[{ value: 'match_false', label: 'Do not match' }, { value: 'match_true', label: 'Match rule' }]} onChange={(val: string) => updateClassifier(index, { onError: val as RouterClassifier['onError'] })} ariaLabel="On error" /></label>
                         </div>
                       </article>
                     );
@@ -1231,7 +1239,7 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
 
             <section className="router-editor__section">
               <div className="router-editor__section-head">
-                <div><h3>Ordered Rules</h3><p>First matching rule wins. The default model handles the remainder.</p></div>
+                <div><h3>Ordered Rules</h3><p>Evaluated top to bottom - the first match wins, everything else falls back to the default.</p></div>
                 <WorkspaceActionButton size="small" icon="plus" onClick={addRule}>Rule</WorkspaceActionButton>
               </div>
               <div className="router-editor__rules-workspace">
@@ -1300,20 +1308,29 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
                   {selectedRule ? (
                     <>
                       <div className="router-editor__rule-builder-head">
-                        <div>
-                          <strong>Rule {selectedRuleIndex + 1}: {selectedRule.id || 'Untitled rule'}</strong>
-                          <span>Build the match expression by dragging gates and conditions onto the graph.</span>
-                        </div>
-                      </div>
-                      <div className="router-editor__rule-meta">
-                        <label><span>Rule ID</span><input className="input" value={selectedRule.id} onChange={event => setPatch({ rules: draft.rules.map((item, itemIndex) => itemIndex === selectedRuleIndex ? { ...item, id: event.target.value } : item) })} /></label>
-                        <label><span>Route To</span><select className="select" value={selectedRule.routeTo} onChange={event => setPatch({ rules: draft.rules.map((item, itemIndex) => itemIndex === selectedRuleIndex ? { ...item, routeTo: event.target.value } : item) })}><option value="">Select candidate</option>{draft.candidates.map(candidate => <option key={candidate} value={candidate}>{candidate}</option>)}</select></label>
+                        <span className="router-editor__rule-builder-label">Rule {selectedRuleIndex + 1}:</span>
+                        <input
+                          className="input router-editor__rule-id-input"
+                          value={selectedRule.id}
+                          aria-label="Rule ID"
+                          onChange={event => setPatch({ rules: draft.rules.map((item, itemIndex) => itemIndex === selectedRuleIndex ? { ...item, id: event.target.value } : item) })}
+                        />
+                        <RouterSelect
+                          className="router-editor__rule-route-select"
+                          value={selectedRule.routeTo}
+                          options={[{ value: '', label: 'Route to…' }, ...draft.candidates.map(c => ({ value: c, label: c }))]}
+                          onChange={(val: string) => setPatch({ rules: draft.rules.map((item, itemIndex) => itemIndex === selectedRuleIndex ? { ...item, routeTo: val } : item) })}
+                          ariaLabel="Route To"
+                        />
                       </div>
                       <RouterRuleGraph
                         key={`rule-${selectedRuleIndex}`}
                         node={selectedRule.condition}
                         classifiers={draft.classifiers}
-                        onChange={condition => setPatch({ rules: draft.rules.map((item, itemIndex) => itemIndex === selectedRuleIndex ? { ...item, condition } : item) })}
+                        onChange={condition => {
+                          committedRuleIndicesRef.current.add(selectedRuleIndex);
+                          setPatch({ rules: draft.rules.map((item, itemIndex) => itemIndex === selectedRuleIndex ? { ...item, condition } : item) });
+                        }}
                         onExpand={() => setExpandedRuleIndex(selectedRuleIndex)}
                       />
                       <details className="router-editor__outputs">
@@ -1358,6 +1375,7 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
         onClose={() => setExpandedRuleIndex(null)}
         title={expandedRule && expandedRuleIndex != null ? `Rule ${expandedRuleIndex + 1}: ${expandedRule.id || 'Untitled Rule'}` : 'Graph Builder'}
         maxWidth="calc(100vw - 48px)"
+        className="inspect-modal-content--full-height"
         ariaLabelledBy="router-graph-expanded-title"
       >
         {expandedRule && expandedRuleIndex != null && (
@@ -1366,6 +1384,8 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
               key={`expanded-${expandedRuleIndex}`}
               node={expandedRule.condition}
               classifiers={draft.classifiers}
+              expanded
+              initialCommitted={committedRuleIndicesRef.current.has(expandedRuleIndex)}
               onChange={condition => setPatch({
                 rules: draft.rules.map((item, itemIndex) => itemIndex === expandedRuleIndex ? { ...item, condition } : item),
               })}
@@ -1386,7 +1406,7 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
           <p>{confirmation?.message}</p>
         </div>
         <div className="inspect-modal-footer">
-          <WorkspaceActionButton appearance="secondary" disabled={deleting} onClick={dismissConfirmation}>Cancel</WorkspaceActionButton>
+          <WorkspaceActionButton appearance="secondary" disabled={deleting} onClick={dismissConfirmation}>Close</WorkspaceActionButton>
           <WorkspaceActionButton appearance={confirmation?.tone || 'primary'} disabled={deleting} onClick={confirmPendingAction}>
             {deleting && confirmation?.kind === 'delete' ? 'Deleting…' : (confirmation?.confirmLabel || 'Continue')}
           </WorkspaceActionButton>

--- a/src/app/src/components/RouterEditorPanel.tsx
+++ b/src/app/src/components/RouterEditorPanel.tsx
@@ -17,15 +17,18 @@ import {
   createEmptyRouterDraft,
   createRouterClassifier,
   createRouterRule,
+  normalizeRouterModelName,
   parseRouterPayload,
   renameClassifierReference,
   renameClassifierLabelReference,
   routerNodeReferencesClassifier,
   routerDraftFromModelInfo,
+  routerDraftFingerprint,
   routerDraftHasLlmProgress,
   routerDraftHasRulesProgress,
   routerDisplayName,
   switchRouterDraftMode,
+  toggleRouterDraftCandidate,
   validateRouterDraft,
   type RouterClassifier,
   type RouterDraft,
@@ -52,6 +55,23 @@ function modelLabel(model: ModelInfo): string {
   return String(model.display_name || modelName(model));
 }
 
+function routerRequestToModelInfo(request: RouterPullRequest, draft: RouterDraft): ModelInfo {
+  return {
+    id: request.model_name,
+    name: request.model_name,
+    model_name: request.model_name,
+    display_name: draft.name.trim() || routerDisplayName(request.model_name),
+    recipe: request.recipe,
+    type: 'chat',
+    labels: ['custom', 'router', 'chat'],
+    downloaded: true,
+    custom: true,
+    version: request.version,
+    components: request.components,
+    routing: request.routing,
+  } as ModelInfo;
+}
+
 function downloadJson(name: string, payload: unknown): void {
   const safeName = name.replace(/[^A-Za-z0-9._-]+/g, '-').replace(/^-+|-+$/g, '') || 'router';
   const url = URL.createObjectURL(new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' }));
@@ -74,9 +94,13 @@ async function copyText(text: string): Promise<void> {
   textarea.style.position = 'fixed';
   textarea.style.opacity = '0';
   document.body.appendChild(textarea);
-  textarea.select();
-  document.execCommand('copy');
-  textarea.remove();
+  try {
+    textarea.select();
+    const copied = document.execCommand('copy');
+    if (!copied) throw new Error('Clipboard copy was not accepted.');
+  } finally {
+    textarea.remove();
+  }
 }
 
 function moveItem<T>(items: T[], index: number, delta: number): T[] {
@@ -98,17 +122,63 @@ function nextConceptName(existing: Record<string, string[]>): string {
   return nextSafeId('concept', Object.keys(existing));
 }
 
+const CommittedTextInput: React.FC<{
+  value: string;
+  ariaLabel?: string;
+  className?: string;
+  onCommit: (next: string) => boolean;
+  normalize?: (value: string) => string;
+}> = ({ value, ariaLabel, className = 'input', onCommit, normalize = input => input.trim() }) => {
+  const [editingValue, setEditingValue] = useState(value);
+  const cancelCommitRef = useRef(false);
+  useEffect(() => setEditingValue(value), [value]);
+
+  const commit = () => {
+    if (cancelCommitRef.current) {
+      cancelCommitRef.current = false;
+      setEditingValue(value);
+      return;
+    }
+    const next = normalize(editingValue);
+    if (next === value) {
+      if (editingValue !== value) setEditingValue(value);
+      return;
+    }
+    if (!onCommit(next)) setEditingValue(value);
+  };
+
+  return (
+    <input
+      className={className}
+      value={editingValue}
+      aria-label={ariaLabel}
+      onChange={event => setEditingValue(event.target.value)}
+      onBlur={commit}
+      onKeyDown={event => {
+        if (event.key === 'Enter') {
+          event.preventDefault();
+          event.currentTarget.blur();
+        } else if (event.key === 'Escape') {
+          event.preventDefault();
+          cancelCommitRef.current = true;
+          setEditingValue(value);
+          event.currentTarget.blur();
+        }
+      }}
+    />
+  );
+};
 
 interface RouterEditorPanelProps {
   models: ModelInfo[];
   initialModel?: ModelInfo | null;
   onRegister: (request: RouterPullRequest) => Promise<void>;
   onSaved?: (model: ModelInfo) => void;
-  onDeleted?: (modelName: string) => Promise<void> | void;
+  onDeleted?: (modelName: string) => Promise<string | void> | string | void;
   onClose: () => void;
 }
 
-type RouterConfirmationKind = 'switch-rules' | 'switch-llm' | 'reset' | 'delete';
+type RouterConfirmationKind = 'switch-rules' | 'switch-llm' | 'reset' | 'delete' | 'discard';
 
 interface RouterConfirmation {
   kind: RouterConfirmationKind;
@@ -139,11 +209,14 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
   const [candidateSearch, setCandidateSearch] = useState('');
   const [tab, setTab] = useState<'builder' | 'json'>('builder');
   const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
+  const [jsonCopied, setJsonCopied] = useState(false);
   const [confirmation, setConfirmation] = useState<RouterConfirmation | null>(null);
   const [dragRuleIndex, setDragRuleIndex] = useState<number | null>(null);
   const [selectedRuleIndex, setSelectedRuleIndex] = useState(0);
+  const [expandedRuleIndex, setExpandedRuleIndex] = useState<number | null>(null);
   const [cloudProviders, setCloudProviders] = useState<CloudProviderRow[]>([]);
   const [connectionsError, setConnectionsError] = useState<string | null>(null);
   const [editingProvider, setEditingProvider] = useState<string | null>(null);
@@ -152,6 +225,23 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
   const [providerAllowInsecureDraft, setProviderAllowInsecureDraft] = useState(false);
   const [savingProvider, setSavingProvider] = useState(false);
   const importRef = useRef<HTMLInputElement>(null);
+  const jsonCopyTimeoutRef = useRef<number | null>(null);
+  const baselineFingerprintRef = useRef(routerDraftFingerprint(createEmptyRouterDraft()));
+  const draftFingerprint = useMemo(() => routerDraftFingerprint(draft), [draft]);
+  const draftFingerprintRef = useRef(draftFingerprint);
+  const pendingDiscardActionRef = useRef<(() => void) | null>(null);
+  const initialModelKeyRef = useRef<string | null>(null);
+  draftFingerprintRef.current = draftFingerprint;
+  const isDirty = draftFingerprint !== baselineFingerprintRef.current;
+
+  const markBaseline = (nextDraft: RouterDraft) => {
+    baselineFingerprintRef.current = routerDraftFingerprint(nextDraft);
+  };
+
+  const requestDiscard = (title: string, message: string, confirmLabel: string, action: () => void) => {
+    pendingDiscardActionRef.current = action;
+    setConfirmation({ kind: 'discard', title, message, confirmLabel, tone: 'danger' });
+  };
 
   const refreshSaved = () => setSavedRecords(loadRouterRecords());
   const refreshCloudProviders = useCallback(async () => {
@@ -174,6 +264,10 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
     return () => window.clearTimeout(timeout);
   }, [notice]);
 
+  useEffect(() => () => {
+    if (jsonCopyTimeoutRef.current != null) window.clearTimeout(jsonCopyTimeoutRef.current);
+  }, []);
+
   useEffect(() => {
     if (draft.rules.length === 0) {
       if (selectedRuleIndex !== 0) setSelectedRuleIndex(0);
@@ -183,41 +277,89 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
   }, [draft.rules.length, selectedRuleIndex]);
 
   useEffect(() => {
+    if (expandedRuleIndex == null) return;
+    if (draft.mode !== 'rules' || expandedRuleIndex < 0 || expandedRuleIndex >= draft.rules.length) {
+      setExpandedRuleIndex(null);
+    }
+  }, [draft.mode, draft.rules.length, expandedRuleIndex]);
+
+  useEffect(() => {
     if (!initialModel || !isRouterRecipe((initialModel as any).recipe)) return;
 
-    const applyModel = (sourceModel: ModelInfo) => {
-      try {
-        setDraft(routerDraftFromModelInfo(sourceModel));
-        setSelectedRuleIndex(0);
-        setError(null);
-        setNotice(null);
-      } catch (initialError) {
-        setError(initialError instanceof Error ? initialError.message : 'Could not open this router.');
-      }
+    const modelNameValue = modelName(initialModel);
+    const modelKey = modelNameValue || '__inline-router__';
+    if (initialModelKeyRef.current === modelKey) return;
+    initialModelKeyRef.current = modelKey;
+
+    const applyLoadedDraft = (nextDraft: RouterDraft) => {
+      markBaseline(nextDraft);
+      setDraft(nextDraft);
+      setSelectedRuleIndex(0);
+      setExpandedRuleIndex(null);
+      setError(null);
+      setNotice(null);
     };
 
-    const modelNameValue = modelName(initialModel);
     if (!modelNameValue) {
-      applyModel(initialModel);
+      try { applyLoadedDraft(routerDraftFromModelInfo(initialModel)); }
+      catch (initialError) {
+        initialModelKeyRef.current = null;
+        setError(initialError instanceof Error ? initialError.message : 'Could not open this router.');
+      }
       return;
     }
 
-    // The /models list can contain only summary fields. Always prefer the
-    // authoritative detail record when editing an existing server router, just
-    // like the current main RouterCollectionPanel. A locally persisted request
-    // is used only as a fallback if the detail request itself fails.
+    // The list endpoint may expose summary-only router fields. Fetch the
+    // authoritative detail before using any cached/list routing payload. A late
+    // response is guarded by the dirty baseline so it can never clobber edits.
+    const baselineAtDetailStart = baselineFingerprintRef.current;
     let cancelled = false;
     void api.modelDetail(modelNameValue)
       .then(detailedModel => {
         if (cancelled) return;
-        applyModel(detailedModel);
+        let detailedDraft: RouterDraft;
+        try {
+          detailedDraft = routerDraftFromModelInfo(detailedModel);
+        } catch (detailParseError) {
+          initialModelKeyRef.current = null;
+          setError(detailParseError instanceof Error ? detailParseError.message : 'Could not open this router.');
+          return;
+        }
+        if (draftFingerprintRef.current === baselineAtDetailStart) {
+          applyLoadedDraft(detailedDraft);
+          return;
+        }
+        requestDiscard(
+          'Load router policy?',
+          'The full router policy finished loading after you started editing. Loading it now will discard the changes currently in the editor.',
+          'Load and discard changes',
+          () => applyLoadedDraft(detailedDraft),
+        );
       })
       .catch(detailError => {
         if (cancelled) return;
         if ((initialModel as any).routing) {
-          applyModel(initialModel);
+          let fallbackDraft: RouterDraft;
+          try {
+            fallbackDraft = routerDraftFromModelInfo(initialModel);
+          } catch (fallbackError) {
+            initialModelKeyRef.current = null;
+            setError(fallbackError instanceof Error ? fallbackError.message : 'Could not load this router policy.');
+            return;
+          }
+          if (draftFingerprintRef.current === baselineAtDetailStart) {
+            applyLoadedDraft(fallbackDraft);
+          } else {
+            requestDiscard(
+              'Load cached router policy?',
+              'The server detail request failed, but cached router data is available. Loading it will discard the changes currently in the editor.',
+              'Load cached data',
+              () => applyLoadedDraft(fallbackDraft),
+            );
+          }
           return;
         }
+        initialModelKeyRef.current = null;
         setError(detailError instanceof Error ? detailError.message : 'Could not load this router policy.');
       });
     return () => { cancelled = true; };
@@ -252,24 +394,26 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
     .filter(model => (model.labels || []).some(label => label.toLowerCase() === 'classification'))
     .sort((a, b) => modelLabel(a).localeCompare(modelLabel(b))), [models]);
 
-  const connectedModelRoles = useMemo(() => {
-    const roles = new Map<string, string[]>();
-    const add = (name: string, role: string) => {
-      const normalized = name.trim();
-      if (!normalized) return;
-      const current = roles.get(normalized) || [];
-      if (!current.includes(role)) current.push(role);
-      roles.set(normalized, current);
+  const connectedModelNames = useMemo(() => {
+    const names = new Set<string>();
+    const add = (name: string) => {
+      // Model/component identifiers are exact server identities. Do not trim
+      // them here or the connection row can stop matching the draft/payload.
+      if (!name.length) return;
+      names.add(name);
     };
-    draft.candidates.forEach(candidate => add(candidate, 'Routing target'));
-    if (draft.mode === 'llm') add(draft.llmRouter.model, 'Natural-language router');
-    if (draft.mode === 'rules') draft.classifiers.forEach(classifier => add(classifier.model, `Classifier · ${classifier.id || classifier.type}`));
-    return roles;
+    draft.candidates.forEach(add);
+    if (draft.mode === 'llm') add(draft.llmRouter.model);
+    if (draft.mode === 'rules') draft.classifiers.forEach(classifier => add(classifier.model));
+    return names;
   }, [draft.candidates, draft.mode, draft.llmRouter.model, draft.classifiers]);
 
-  const selectedConnections = useMemo(() => [...connectedModelRoles.keys()].map(candidate =>
-    describeRouterModelConnection(candidate, models, cloudProviders)
-  ), [connectedModelRoles, models, cloudProviders]);
+  const selectedConnections = useMemo(() => [...connectedModelNames].map(candidate => ({
+    ...describeRouterModelConnection(candidate, models, cloudProviders),
+    // The connection helper normalizes for catalog lookup/display. Keep the
+    // draft's exact component identity for default badges and candidate removal.
+    modelName: candidate,
+  })), [connectedModelNames, models, cloudProviders]);
 
   const validationErrors = useMemo(() => validateRouterDraft(draft), [draft]);
   const request = useMemo(() => {
@@ -277,15 +421,38 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
   }, [draft]);
   const jsonPreview = useMemo(() => request ? JSON.stringify(request, null, 2) : '', [request]);
 
+  useEffect(() => {
+    // A successful copy only describes the exact payload that was copied. As
+    // soon as the draft changes, return the button to its normal state rather
+    // than showing a stale "Copied" confirmation for a different payload.
+    setJsonCopied(false);
+  }, [jsonPreview]);
+
   const setPatch = (patch: Partial<RouterDraft>) => {
     setDraft(current => ({ ...current, ...patch }));
     setError(null);
     setNotice(null);
   };
 
+  const copyJsonPreview = async () => {
+    if (!jsonPreview) return;
+    try {
+      await copyText(jsonPreview);
+      setJsonCopied(true);
+      if (jsonCopyTimeoutRef.current != null) window.clearTimeout(jsonCopyTimeoutRef.current);
+      jsonCopyTimeoutRef.current = window.setTimeout(() => {
+        setJsonCopied(false);
+        jsonCopyTimeoutRef.current = null;
+      }, 2200);
+    } catch (copyError) {
+      setError(copyError instanceof Error ? copyError.message : 'Could not copy router JSON.');
+    }
+  };
+
   const applyRoutingMode = (mode: RouterDraft['mode']) => {
     setDraft(current => switchRouterDraftMode(current, mode));
     setSelectedRuleIndex(0);
+    setExpandedRuleIndex(null);
     setError(null);
     setNotice(null);
   };
@@ -316,21 +483,29 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
   };
 
   const resetDraft = () => {
-    setDraft(createEmptyRouterDraft());
+    const nextDraft = createEmptyRouterDraft();
+    markBaseline(nextDraft);
+    // Keep the last processed initial-model key. `initialModel` is an opener
+    // prop, not the current draft identity; clearing it here would let a later
+    // same-router list refresh silently rehydrate the router we just replaced
+    // with a blank draft.
+    setDraft(nextDraft);
     setSelectedRuleIndex(0);
     setError(null);
     setNotice(null);
     setTab('builder');
     setCandidateSearch('');
     setDragRuleIndex(null);
+    setExpandedRuleIndex(null);
+    setJsonCopied(false);
   };
 
   const requestResetDraft = () => {
-    if (routerDraftHasRulesProgress(draft) || routerDraftHasLlmProgress(draft)) {
+    if (isDirty) {
       setConfirmation({
         kind: 'reset',
         title: 'Start a new router?',
-        message: 'This will discard the routing work currently in the editor. Saved routers are not affected.',
+        message: 'This will discard the unsaved routing work currently in the editor. Saved routers are not affected.',
         confirmLabel: 'Discard draft',
         tone: 'danger',
       });
@@ -339,16 +514,16 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
     resetDraft();
   };
 
-  const loadSaved = (modelNameValue: string) => {
-    if (!modelNameValue) {
-      requestResetDraft();
-      return;
-    }
-    const record = savedRecords.find(item => item.model_name === modelNameValue);
-    if (!record) return;
+  const applySavedRecord = (record: (typeof savedRecords)[number]) => {
     try {
-      setDraft(routerRecordToDraft(record));
+      const nextDraft = routerRecordToDraft(record);
+      markBaseline(nextDraft);
+      // Loading a saved record is a user action and does not mean the parent
+      // `initialModel` prop changed. Preserve the processed prop key so an
+      // unrelated refresh of the opener cannot re-apply itself.
+      setDraft(nextDraft);
       setSelectedRuleIndex(0);
+      setExpandedRuleIndex(null);
       setError(null);
       setNotice(`Loaded ${record.display_name}.`);
     } catch (loadError) {
@@ -356,19 +531,42 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
     }
   };
 
+  const loadSaved = (modelNameValue: string) => {
+    if (!modelNameValue) {
+      requestResetDraft();
+      return;
+    }
+    if (modelNameValue === draft.modelName) return;
+    const record = savedRecords.find(item => item.model_name === modelNameValue);
+    if (!record) return;
+    if (isDirty) {
+      requestDiscard(
+        'Load another router?',
+        'Loading a saved router will discard the unsaved changes currently in the editor.',
+        'Load and discard changes',
+        () => applySavedRecord(record),
+      );
+      return;
+    }
+    applySavedRecord(record);
+  };
+
   const toggleCandidate = (name: string) => {
-    setDraft(current => {
-      const exists = current.candidates.includes(name);
-      const candidates = exists ? current.candidates.filter(item => item !== name) : [...current.candidates, name];
-      const defaultModel = candidates.includes(current.defaultModel) ? current.defaultModel : (candidates[0] || '');
-      const rules = current.rules.map(rule => ({
-        ...rule,
-        routeTo: candidates.includes(rule.routeTo) ? rule.routeTo : defaultModel,
-      }));
-      return { ...current, candidates, defaultModel, rules };
-    });
+    const removing = draft.candidates.includes(name);
+    const wasDefault = removing && draft.defaultModel === name;
+    const affectedRules = removing ? draft.rules.filter(rule => rule.routeTo === name).length : 0;
+    const remainingCandidates = removing ? draft.candidates.filter(candidate => candidate !== name) : draft.candidates;
+    const replacement = remainingCandidates[0] || '';
+    setDraft(current => toggleRouterDraftCandidate(current, name));
     setError(null);
-    setNotice(null);
+    if (removing && (wasDefault || affectedRules > 0)) {
+      const updates: string[] = [];
+      if (wasDefault) updates.push(replacement ? `default changed to ${replacement}` : 'default cleared');
+      if (affectedRules > 0) updates.push(`${affectedRules} rule target${affectedRules === 1 ? '' : 's'} ${replacement ? `changed to ${replacement}` : 'cleared'}`);
+      setNotice(`Removed ${name}; ${updates.join('; ')}.`);
+    } else {
+      setNotice(null);
+    }
   };
 
   const addClassifier = (type: RouterClassifier['type']) => {
@@ -378,17 +576,36 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
   };
 
   const updateClassifier = (index: number, patch: Partial<RouterClassifier>) => {
-    setDraft(current => {
-      const previous = current.classifiers[index];
-      const nextClassifier = { ...previous, ...patch };
-      const classifiers = current.classifiers.map((item, itemIndex) => itemIndex === index ? nextClassifier : item);
-      const rules = previous.id !== nextClassifier.id
-        ? current.rules.map(rule => ({ ...rule, condition: renameClassifierReference(rule.condition, previous.id, nextClassifier.id) }))
-        : current.rules;
-      return { ...current, classifiers, rules };
-    });
+    setDraft(current => ({
+      ...current,
+      classifiers: current.classifiers.map((item, itemIndex) => itemIndex === index ? { ...item, ...patch } : item),
+    }));
     setError(null);
     setNotice(null);
+  };
+
+  const commitClassifierId = (index: number, nextId: string): boolean => {
+    const previous = draft.classifiers[index];
+    if (!previous) return false;
+    if (!nextId) {
+      setError('Classifier ID cannot be empty.');
+      return false;
+    }
+    if (draft.classifiers.some((item, itemIndex) => itemIndex !== index && item.id === nextId)) {
+      setError(`Classifier ID "${nextId}" is already in use.`);
+      return false;
+    }
+    setDraft(current => ({
+      ...current,
+      classifiers: current.classifiers.map((item, itemIndex) => itemIndex === index ? { ...item, id: nextId } : item),
+      rules: current.rules.map(rule => ({
+        ...rule,
+        condition: renameClassifierReference(rule.condition, previous.id, nextId),
+      })),
+    }));
+    setError(null);
+    setNotice(null);
+    return true;
   };
 
   const removeClassifier = (index: number) => {
@@ -400,30 +617,40 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
     setPatch({ classifiers: draft.classifiers.filter((_, itemIndex) => itemIndex !== index) });
   };
 
-  const renameSemanticConcept = (classifierIndex: number, previousName: string, nextName: string): void => {
+  const commitSemanticConceptName = (classifierIndex: number, previousName: string, nextName: string): boolean => {
+    const classifier = draft.classifiers[classifierIndex];
+    if (!classifier || classifier.type !== 'semantic_similarity') return false;
+    if (!nextName) {
+      setError('Semantic concept name cannot be empty.');
+      return false;
+    }
+    if (nextName !== previousName && Object.keys(classifier.referencePhrases).some(name => name === nextName)) {
+      setError(`Semantic concept "${nextName}" already exists.`);
+      return false;
+    }
     setDraft(current => {
-      const classifier = current.classifiers[classifierIndex];
-      if (!classifier || classifier.type !== 'semantic_similarity') return current;
-      if (nextName !== previousName && Object.prototype.hasOwnProperty.call(classifier.referencePhrases, nextName)) return current;
-      const entries = Object.entries(classifier.referencePhrases).map(([name, phrases]) =>
+      const currentClassifier = current.classifiers[classifierIndex];
+      if (!currentClassifier || currentClassifier.type !== 'semantic_similarity') return current;
+      const entries = Object.entries(currentClassifier.referencePhrases).map(([name, phrases]) =>
         name === previousName ? [nextName, phrases] as const : [name, phrases] as const,
       );
       const nextClassifier = {
-        ...classifier,
+        ...currentClassifier,
         referencePhrases: Object.fromEntries(entries),
-        defaultLabel: classifier.defaultLabel === previousName ? nextName : classifier.defaultLabel,
+        defaultLabel: currentClassifier.defaultLabel === previousName ? nextName : currentClassifier.defaultLabel,
       };
       return {
         ...current,
         classifiers: current.classifiers.map((item, index) => index === classifierIndex ? nextClassifier : item),
         rules: current.rules.map(rule => ({
           ...rule,
-          condition: renameClassifierLabelReference(rule.condition, classifier.id, previousName, nextName),
+          condition: renameClassifierLabelReference(rule.condition, currentClassifier.id, previousName, nextName),
         })),
       };
     });
     setError(null);
     setNotice(null);
+    return true;
   };
 
   const addRule = () => {
@@ -456,12 +683,31 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
   const importFile = async (file: File | undefined) => {
     if (!file) return;
     try {
-      const parsed = JSON.parse(await file.text());
-      setDraft(parseRouterPayload(parsed));
-      setSelectedRuleIndex(0);
-      setError(null);
-      setNotice(`Imported ${file.name}. Save & register to persist it.`);
-      setTab('builder');
+      const parsedPayload = JSON.parse(await file.text());
+      const importedDraft = parseRouterPayload(parsedPayload);
+      const applyImport = () => {
+        // Imported JSON is editable but not yet registered in this session, so
+        // closing it should still count as discarding unsaved work.
+        baselineFingerprintRef.current = '__imported-router__';
+        // Preserve the processed initial-model key for the same reason as New:
+        // a background refresh of the opener must not replace this import.
+        setDraft(importedDraft);
+        setSelectedRuleIndex(0);
+        setExpandedRuleIndex(null);
+        setError(null);
+        setNotice(`Imported ${file.name}. Save & register to persist it.`);
+        setTab('builder');
+      };
+      if (isDirty) {
+        requestDiscard(
+          'Import router JSON?',
+          'Importing this file will replace the unsaved changes currently in the editor.',
+          'Import and discard changes',
+          applyImport,
+        );
+      } else {
+        applyImport();
+      }
     } catch (importError) {
       setError(importError instanceof Error ? importError.message : 'Could not import router JSON.');
     } finally {
@@ -502,11 +748,14 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
   };
 
   const save = async () => {
+    if (saving || deleting || savingProvider) return;
     setError(null);
     setNotice(null);
+    const submittedDraft = draft;
+    const submittedFingerprint = routerDraftFingerprint(submittedDraft);
     let nextRequest: RouterPullRequest;
     try {
-      nextRequest = buildRouterPullRequest(draft);
+      nextRequest = buildRouterPullRequest(submittedDraft);
     } catch (buildError) {
       setError(buildError instanceof Error ? buildError.message : 'Router validation failed.');
       return;
@@ -514,11 +763,34 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
     setSaving(true);
     try {
       await onRegister(nextRequest);
-      const record = upsertRouterRecord({ ...draft, modelName: nextRequest.model_name });
-      refreshSaved();
-      setDraft(routerRecordToDraft(record));
-      setNotice(`Registered ${record.model_name}.`);
-      onSaved?.(routerRecordToModelInfo(record));
+
+      const savedDraft: RouterDraft = { ...submittedDraft, modelName: nextRequest.model_name };
+      markBaseline(savedDraft);
+      initialModelKeyRef.current = nextRequest.model_name;
+
+      let savedModel = routerRequestToModelInfo(nextRequest, savedDraft);
+      let cacheWarning = '';
+      try {
+        const record = upsertRouterRecord(savedDraft);
+        refreshSaved();
+        savedModel = routerRecordToModelInfo(record);
+      } catch (cacheError) {
+        // The server registration already succeeded. A local cache failure must
+        // not be reported as a failed registration or cause a duplicate retry.
+        cacheWarning = cacheError instanceof Error ? cacheError.message : String(cacheError);
+      }
+
+      setDraft(current => {
+        // If the user edited while /pull was in flight, preserve those newer
+        // edits. Only attach the now-authoritative model ID. If nothing changed,
+        // commit the exact submitted snapshot as the clean baseline.
+        if (routerDraftFingerprint(current) === submittedFingerprint) return savedDraft;
+        return { ...current, modelName: current.modelName || nextRequest.model_name };
+      });
+      setNotice(cacheWarning
+        ? `Registered ${nextRequest.model_name}. Local recent-router cache could not be updated.`
+        : `Registered ${nextRequest.model_name}.`);
+      onSaved?.(savedModel);
     } catch (saveError) {
       setError(saveError instanceof Error ? saveError.message : 'Could not register router.');
     } finally {
@@ -528,31 +800,78 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
 
   const deleteCurrent = async () => {
     const modelNameValue = draft.modelName;
-    if (!modelNameValue) return;
+    if (!modelNameValue || deleting) return;
+    if (!onDeleted) {
+      setConfirmation(null);
+      setError('Router deletion is unavailable in this context.');
+      return;
+    }
+    setDeleting(true);
+    setError(null);
     try {
-      await onDeleted?.(modelNameValue);
-      refreshSaved();
+      const deletionWarning = await onDeleted?.(modelNameValue);
+      if (typeof deletionWarning === 'string' && deletionWarning) {
+        // The server delete succeeded but persistent cache cleanup did not. Do
+        // not immediately re-read that stale cache and resurrect the deleted
+        // router in this editor session.
+        setSavedRecords(current => current.filter(record => record.model_name !== modelNameValue));
+      } else {
+        refreshSaved();
+      }
+      setConfirmation(null);
       resetDraft();
-      setNotice(`Deleted ${modelNameValue}.`);
+      setNotice(typeof deletionWarning === 'string' && deletionWarning
+        ? deletionWarning
+        : `Deleted ${modelNameValue}.`);
     } catch (deleteError) {
+      // Close the modal so the persistent editor error is immediately visible;
+      // the router remains loaded and the user can retry intentionally.
+      setConfirmation(null);
       setError(deleteError instanceof Error ? deleteError.message : 'Could not delete router.');
+    } finally {
+      setDeleting(false);
     }
   };
 
   const requestDeleteCurrent = () => {
-    if (!draft.modelName) return;
+    if (!draft.modelName || saving || deleting) return;
     setConfirmation({
       kind: 'delete',
       title: 'Delete router?',
-      message: `Delete ${draft.modelName}? This removes the saved router definition from Lemonade.`,
+      message: `Delete ${draft.modelName}? This removes the saved router definition from Lemonade.${isDirty ? ' Unsaved edits in this editor will also be discarded.' : ''}`,
       confirmLabel: 'Delete router',
       tone: 'danger',
     });
   };
 
+  const requestClose = () => {
+    if (!isDirty) {
+      onClose();
+      return;
+    }
+    requestDiscard(
+      'Close router editor?',
+      'Closing now will discard the unsaved changes currently in the editor.',
+      'Close and discard changes',
+      onClose,
+    );
+  };
+
+  const dismissConfirmation = () => {
+    if (deleting) return;
+    if (confirmation?.kind === 'discard') pendingDiscardActionRef.current = null;
+    setConfirmation(null);
+  };
+
   const confirmPendingAction = () => {
     const pending = confirmation;
-    if (!pending) return;
+    if (!pending || deleting) return;
+    if (pending.kind === 'delete') {
+      // Keep the modal/focus trap mounted for the entire server mutation so the
+      // underlying draft cannot be edited and deleted concurrently.
+      void deleteCurrent();
+      return;
+    }
     setConfirmation(null);
     if (pending.kind === 'switch-llm') {
       applyRoutingMode('llm');
@@ -566,10 +885,16 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
       resetDraft();
       return;
     }
-    void deleteCurrent();
+    if (pending.kind === 'discard') {
+      const action = pendingDiscardActionRef.current;
+      pendingDiscardActionRef.current = null;
+      action?.();
+      return;
+    }
   };
 
   const selectedRule = draft.rules[selectedRuleIndex] || null;
+  const expandedRule = expandedRuleIndex == null ? null : (draft.rules[expandedRuleIndex] || null);
 
   return (
     <WorkspaceDetailPanel
@@ -579,53 +904,59 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
       title={<h2 className="workspace-detail-panel__title">Router</h2>}
       metadata={<WorkspaceMetadataChip emphasis="high" tone="accent">collection.router</WorkspaceMetadataChip>}
       description={<p>Build and register a virtual model that routes requests across compatible candidates.</p>}
+      descriptionPlacement="identity"
       actions={(
         <WorkspaceActionGroup label="Router editor actions">
-          <WorkspaceActionButton appearance="primary" icon="check" disabled={saving || validationErrors.length > 0} onClick={() => { void save(); }}>
+          <WorkspaceActionButton appearance="primary" icon="check" disabled={saving || deleting || savingProvider || validationErrors.length > 0} onClick={() => { void save(); }}>
             {saving ? 'Registering…' : 'Save & register'}
           </WorkspaceActionButton>
           {draft.modelName && (
-            <WorkspaceActionButton appearance="danger" icon="trash" onClick={requestDeleteCurrent}>Delete</WorkspaceActionButton>
+            <WorkspaceActionButton appearance="danger" icon="trash" disabled={saving || deleting || savingProvider} onClick={requestDeleteCurrent}>Delete</WorkspaceActionButton>
           )}
           <span className="workspace-action-group__spacer" />
-          <WorkspaceActionButton appearance="secondary" icon="x" onClick={onClose}>Close</WorkspaceActionButton>
+          <WorkspaceActionButton appearance="secondary" icon="x" disabled={saving || deleting || savingProvider} onClick={requestClose}>Close</WorkspaceActionButton>
         </WorkspaceActionGroup>
       )}
-      onClose={onClose}
-      closeLabel="Close router editor"
+      titleExtras={(
+        <div className="router-editor__toolbar" aria-label="Router file actions">
+          <div className="router-editor__toolbar-row">
+            <WorkspaceActionButton size="small" icon="compose" disabled={saving || deleting || savingProvider} onClick={requestResetDraft}>New</WorkspaceActionButton>
+            <label className="router-editor__saved-select">
+              <span className="sr-only">Saved routers</span>
+              <select className="select" value={draft.modelName || ''} disabled={saving || deleting || savingProvider} onChange={event => loadSaved(event.target.value)}>
+                <option value="">Unsaved router</option>
+                {savedRecords.map(record => <option key={record.model_name} value={record.model_name}>{record.display_name}</option>)}
+              </select>
+            </label>
+          </div>
+          <div className="router-editor__toolbar-row router-editor__toolbar-row--files">
+            <WorkspaceActionButton size="small" icon="file-up" disabled={saving} onClick={() => importRef.current?.click()}>Import</WorkspaceActionButton>
+            <WorkspaceActionButton size="small" icon="file" disabled={!request} onClick={() => request && downloadJson(routerDisplayName(request.model_name), request)}>Export</WorkspaceActionButton>
+          </div>
+          <input ref={importRef} className="hidden-file-input" type="file" accept="application/json,.json" onChange={event => { void importFile(event.target.files?.[0]); }} />
+        </div>
+      )}
     >
-
-      <div className="router-editor__toolbar">
-        <WorkspaceActionButton size="small" icon="compose" onClick={requestResetDraft}>New</WorkspaceActionButton>
-        <label className="router-editor__saved-select">
-          <span className="sr-only">Saved routers</span>
-          <select className="select" value={draft.modelName || ''} onChange={event => loadSaved(event.target.value)}>
-            <option value="">Unsaved router</option>
-            {savedRecords.map(record => <option key={record.model_name} value={record.model_name}>{record.display_name}</option>)}
-          </select>
-        </label>
-        <span className="router-editor__toolbar-spacer" />
-        <WorkspaceActionButton size="small" icon="file-up" onClick={() => importRef.current?.click()}>Import</WorkspaceActionButton>
-        <WorkspaceActionButton size="small" icon="file" disabled={!request} onClick={() => request && downloadJson(routerDisplayName(request.model_name), request)}>Export</WorkspaceActionButton>
-        <input ref={importRef} className="hidden-file-input" type="file" accept="application/json,.json" onChange={event => { void importFile(event.target.files?.[0]); }} />
-      </div>
-
       <div className="router-editor__tabs" role="tablist" aria-label="Router editor view">
         <button type="button" className={tab === 'builder' ? 'is-active' : ''} role="tab" aria-selected={tab === 'builder'} onClick={() => setTab('builder')}>Builder</button>
-        <button type="button" className={tab === 'json' ? 'is-active' : ''} role="tab" aria-selected={tab === 'json'} onClick={() => setTab('json')}>JSON preview</button>
+        <button type="button" className={tab === 'json' ? 'is-active' : ''} role="tab" aria-selected={tab === 'json'} onClick={() => setTab('json')}>JSON Preview</button>
       </div>
 
       <div className="router-editor__body">
-        <div className="router-editor__backend-note">
-          <Icon name="info" size={15} />
-          <span>Router v1 supports ordered rules, model-backed signals, and natural-language routing. The default model remains the fail-open fallback.</span>
-        </div>
-
         {tab === 'json' ? (
           <section className="router-editor__json-panel">
             <div className="router-editor__section-head">
-              <div><h3>Registration payload</h3><p>Exact body sent to <code>/api/v1/pull</code>.</p></div>
-              <WorkspaceActionButton size="small" icon="copy" disabled={!jsonPreview} onClick={() => { void copyText(jsonPreview).then(() => setNotice('JSON copied.')); }}>Copy</WorkspaceActionButton>
+              <div><h3>Registration Payload</h3><p>Exact body sent to <code>/api/v1/pull</code>.</p></div>
+              <WorkspaceActionButton
+                className={`router-editor__copy-button${jsonCopied ? ' is-copied' : ''}`}
+                size="small"
+                icon={jsonCopied ? 'check' : 'copy'}
+                disabled={!jsonPreview}
+                onClick={() => { void copyJsonPreview(); }}
+                aria-live="polite"
+              >
+                {jsonCopied ? 'Copied' : 'Copy'}
+              </WorkspaceActionButton>
             </div>
             {jsonPreview ? <pre>{jsonPreview}</pre> : <div className="router-editor__empty">Fix validation errors to generate the payload.</div>}
           </section>
@@ -636,14 +967,14 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
                 <div><h3>Identity</h3><p>Saved as a virtual model.</p></div>
               </div>
               <div className="router-editor__form-grid">
-                <label><span>Router name</span><input className="input" value={draft.name} placeholder="Fast-or-smart" onChange={event => setPatch({ name: event.target.value })} /></label>
-                <label><span>Model ID</span><input className="input" value={draft.modelName || (draft.name ? `user.${draft.name.replace(/[^A-Za-z0-9._-]+/g, '-')}` : '')} readOnly /></label>
+                <label><span>Router Name</span><input className="input" value={draft.name} placeholder="Fast-or-smart" onChange={event => setPatch({ name: event.target.value })} /></label>
+                <label><span>Model ID</span><input className="input" value={draft.modelName || (draft.name ? normalizeRouterModelName(draft.name) : '')} readOnly /></label>
               </div>
             </section>
 
             <section className="router-editor__section">
               <div className="router-editor__section-head">
-                <div><h3>Candidate models</h3><p>The router may select only from these registered models.</p></div>
+                <div><h3>Candidate Models</h3><p>The router may select only from these registered models.</p></div>
                 <span className="router-editor__count">{draft.candidates.length} selected</span>
               </div>
               <div className="router-editor__candidate-search"><Icon name="search" size={14} /><input value={candidateSearch} placeholder="Search registered models" onChange={event => setCandidateSearch(event.target.value)} /></div>
@@ -669,7 +1000,7 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
                 {filteredCandidateModels.length === 0 && <div className="router-editor__empty">No compatible models match this search.</div>}
               </div>
               <label className="router-editor__default-model">
-                <span>Default model <small>Used when no rule matches or evaluation fails.</small></span>
+                <span>Default Model <small>Used when no rule matches or evaluation fails.</small></span>
                 <select className="select" value={draft.defaultModel} onChange={event => setPatch({ defaultModel: event.target.value })}>
                   <option value="">Select default</option>
                   {draft.candidates.map(candidate => <option key={candidate} value={candidate}>{candidate}</option>)}
@@ -678,73 +1009,85 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
 
               <div className="router-editor__connections" aria-label="Connected model topology">
                 <div className="router-editor__mini-head">
-                  <span>Connected model topology</span>
-                  <small>External endpoints are provider-wide and affect every model from that provider.</small>
+                  <span>Connected Model Topology</span>
                 </div>
                 {selectedConnections.length === 0 ? (
                   <div className="router-editor__empty">Select candidate models to review their connections.</div>
-                ) : selectedConnections.map(connection => (
-                  <div className="router-editor__connection" key={connection.modelName}>
-                    <div className="router-editor__connection-main">
-                      <div>
-                        <strong>{connection.displayName}</strong>
-                        {connection.modelName === draft.defaultModel && <span className="router-editor__default-badge">Default</span>}
-                      </div>
-                      <small>{connection.modelName}</small>
-                      <small>{(connectedModelRoles.get(connection.modelName) || []).join(' · ')}</small>
-                    </div>
-                    <div className="router-editor__connection-source">
-                      <span className={`router-editor__source-badge router-editor__source-badge--${connection.kind}`}>
-                        {connection.kind === 'external' ? 'External' : connection.kind === 'internal' ? 'Internal' : 'Unresolved'}
-                      </span>
-                      <small>{connection.kind === 'external' ? (connection.provider || 'Unknown provider') : (connection.backend || connection.recipe || 'Local model')}</small>
-                    </div>
-                    {connection.kind === 'external' ? (
-                      <div className="router-editor__connection-endpoint">
-                        {editingProvider === connection.provider && editingConnectionModel === connection.modelName ? (
-                          <div className="router-editor__endpoint-editor">
-                            <input
-                              className="input"
-                              value={providerEndpointDraft}
-                              aria-label={`${connection.provider} endpoint`}
-                              placeholder="https://api.example.com/v1"
-                              onChange={event => setProviderEndpointDraft(event.target.value)}
-                            />
-                            {providerEndpointNeedsInsecureOptIn(providerEndpointDraft) && (
-                              <label className="router-editor__insecure-opt-in">
-                                <input type="checkbox" checked={providerAllowInsecureDraft} onChange={event => setProviderAllowInsecureDraft(event.target.checked)} />
-                                <span>Allow insecure HTTP</span>
-                              </label>
-                            )}
-                            <WorkspaceActionButton size="small" appearance="primary" disabled={savingProvider} onClick={() => { void saveProviderEndpoint(); }}>
-                              {savingProvider ? 'Saving…' : 'Save'}
-                            </WorkspaceActionButton>
-                            <WorkspaceActionButton size="small" onClick={() => { setEditingProvider(null); setEditingConnectionModel(null); setProviderAllowInsecureDraft(false); setConnectionsError(null); }}>Cancel</WorkspaceActionButton>
+                ) : (
+                  <div className="router-editor__connection-list">
+                    {selectedConnections.map(connection => (
+                      <div className={`router-editor__connection router-editor__connection--${connection.kind}`} key={connection.modelName}>
+                        <div className="router-editor__connection-main">
+                          <div>
+                            <strong>{connection.displayName}</strong>
+                            {connection.modelName === draft.defaultModel && <span className="router-editor__default-badge">Default</span>}
                           </div>
-                        ) : (
-                          <>
-                            <span title={connection.endpoint || 'Endpoint unavailable'}>{connection.endpoint || 'Endpoint not configured'}</span>
-                            <small>{connection.authConfigured ? 'Authentication configured' : 'Authentication required'}</small>
-                            {connection.provider && (
-                              <WorkspaceActionButton size="small" icon="edit" onClick={() => startEditingProvider(connection.provider, connection.endpoint, connection.modelName, connection.allowInsecureHttp)}>
-                                Edit endpoint
-                              </WorkspaceActionButton>
+                        </div>
+                        {connection.kind === 'external' && (
+                          <div className="router-editor__connection-endpoint">
+                            {editingProvider === connection.provider && editingConnectionModel === connection.modelName ? (
+                              <div className="router-editor__endpoint-editor">
+                                <input
+                                  className="input"
+                                  value={providerEndpointDraft}
+                                  aria-label={`${connection.provider} endpoint`}
+                                  placeholder="https://api.example.com/v1"
+                                  onChange={event => setProviderEndpointDraft(event.target.value)}
+                                />
+                                {providerEndpointNeedsInsecureOptIn(providerEndpointDraft) && (
+                                  <label className="router-editor__insecure-opt-in">
+                                    <input type="checkbox" checked={providerAllowInsecureDraft} onChange={event => setProviderAllowInsecureDraft(event.target.checked)} />
+                                    <span>Allow insecure HTTP</span>
+                                  </label>
+                                )}
+                                <WorkspaceActionButton size="small" appearance="primary" disabled={savingProvider} onClick={() => { void saveProviderEndpoint(); }}>
+                                  {savingProvider ? 'Saving…' : 'Save'}
+                                </WorkspaceActionButton>
+                                <WorkspaceActionButton size="small" onClick={() => { setEditingProvider(null); setEditingConnectionModel(null); setProviderAllowInsecureDraft(false); setConnectionsError(null); }}>Cancel</WorkspaceActionButton>
+                              </div>
+                            ) : (
+                              <>
+                                <span title={connection.endpoint || 'Endpoint unavailable'}>{connection.endpoint || 'Endpoint not configured'}</span>
+                                <small>{connection.authConfigured ? 'Authentication configured' : 'Authentication required'}</small>
+                                {connection.provider && (
+                                  <WorkspaceActionButton size="small" icon="edit" onClick={() => startEditingProvider(connection.provider, connection.endpoint, connection.modelName, connection.allowInsecureHttp)}>
+                                    Edit Endpoint
+                                  </WorkspaceActionButton>
+                                )}
+                              </>
                             )}
-                          </>
+                          </div>
                         )}
+                        <div className="router-editor__connection-trailing">
+                          <div className="router-editor__connection-source">
+                            <span className={`router-editor__source-badge router-editor__source-badge--${connection.kind}`}>
+                              {connection.kind === 'external' ? 'External' : connection.kind === 'internal' ? 'Internal' : 'Unresolved'}
+                            </span>
+                            <small>{connection.kind === 'external' ? (connection.provider || 'Unknown provider') : (connection.backend || connection.recipe || 'Unknown source')}</small>
+                          </div>
+                          {draft.candidates.includes(connection.modelName) && (
+                            <WorkspaceActionButton
+                              appearance="danger"
+                              size="small"
+                              icon="trash"
+                              iconOnly
+                              onClick={() => toggleCandidate(connection.modelName)}
+                              aria-label={`Remove ${connection.displayName} from candidate models`}
+                              title="Remove candidate"
+                            />
+                          )}
+                        </div>
                       </div>
-                    ) : (
-                      <div className="router-editor__connection-endpoint"><span>Managed by Lemonade</span><small>Local registered model</small></div>
-                    )}
+                    ))}
                   </div>
-                ))}
+                )}
                 {connectionsError && selectedConnections.some(connection => connection.kind === 'external') && <div className="router-editor__message router-editor__message--error"><Icon name="alert" size={14} /> {connectionsError}</div>}
               </div>
             </section>
 
             <section className="router-editor__section">
               <div className="router-editor__section-head">
-                <div><h3>Routing strategy</h3><p>Choose how the router selects a candidate. Switching modes clears incompatible configuration after confirmation.</p></div>
+                <div><h3>Routing Strategy</h3><p>Choose how the router selects a candidate. Switching modes clears incompatible configuration after confirmation.</p></div>
               </div>
               <div className="router-editor__strategy" role="radiogroup" aria-label="Routing strategy">
                 <button
@@ -755,7 +1098,7 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
                   onClick={() => setRoutingMode('rules')}
                 >
                   <Icon name="layers" size={18} />
-                  <span><strong>Ordered rules</strong><small>Deterministic conditions and optional model-backed signals. First match wins.</small></span>
+                  <span><strong>Ordered Rules</strong><small>Deterministic conditions and optional model-backed signals. First match wins.</small></span>
                 </button>
                 <button
                   type="button"
@@ -765,20 +1108,16 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
                   onClick={() => setRoutingMode('llm')}
                 >
                   <Icon name="brain-circuit" size={18} />
-                  <span><strong>Natural-language router</strong><small>A routing model reads your instruction and chooses one candidate directly.</small></span>
+                  <span><strong>Natural-Language Router</strong><small>A routing model reads your instruction and chooses one candidate directly.</small></span>
                 </button>
               </div>
             </section>
 
             {draft.mode === 'llm' ? (
-              <section className="router-editor__section">
-                <div className="router-editor__section-head">
-                  <div><h3>Natural-language router</h3><p>The selected model must return exactly one candidate. Invalid output falls back to the default model.</p></div>
-                  <WorkspaceMetadataChip emphasis="high" tone="accent">routing.router</WorkspaceMetadataChip>
-                </div>
+              <section className="router-editor__section" aria-label="Natural-Language Router settings">
                 <div className="router-editor__form-grid">
                   <div className="router-editor__wide router-editor__field">
-                    <span>Routing model <small>Usually a small, fast chat model.</small></span>
+                    <span>Routing Model <small>Usually a small, fast chat model.</small></span>
                     <RouterModelPicker
                       models={candidateModels}
                       value={draft.llmRouter.model}
@@ -789,7 +1128,7 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
                     />
                   </div>
                   <label className="router-editor__wide">
-                    <span>Routing instruction <small>Describe clearly when each candidate should be selected.</small></span>
+                    <span>Routing Instruction <small>Describe clearly when each candidate should be selected.</small></span>
                     <textarea
                       className="textarea router-editor__prompt"
                       value={draft.llmRouter.prompt}
@@ -816,13 +1155,13 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
                   {draft.classifiers.map((classifier, index) => {
                     const labels = classifierLabels(classifier);
                     return (
-                      <article className="router-editor__classifier" key={`${classifier.id}-${index}`}>
+                      <article className="router-editor__classifier" key={index}>
                         <div className="router-editor__card-head">
-                          <strong>{classifier.type === 'semantic_similarity' ? 'Semantic similarity' : classifier.type === 'llm' ? 'LLM classifier' : 'Text classifier'}</strong>
+                          <strong>{classifier.type === 'semantic_similarity' ? 'Semantic Similarity' : classifier.type === 'llm' ? 'LLM Classifier' : 'Text Classifier'}</strong>
                           <WorkspaceActionButton appearance="danger" size="small" icon="trash" iconOnly onClick={() => removeClassifier(index)} aria-label="Remove classifier" title="Remove classifier" />
                         </div>
                         <div className="router-editor__form-grid router-editor__form-grid--classifier">
-                          <label><span>ID</span><input className="input" value={classifier.id} onChange={event => updateClassifier(index, { id: event.target.value })} /></label>
+                          <label><span>ID</span><CommittedTextInput value={classifier.id} ariaLabel={`Classifier ${index + 1} ID`} normalize={input => input} onCommit={nextId => commitClassifierId(index, nextId)} /></label>
                           <label><span>Type</span><select className="select" value={classifier.type} onChange={event => updateClassifier(index, { ...createRouterClassifier(index, event.target.value as RouterClassifier['type']), id: classifier.id })}><option value="classifier">classifier</option><option value="semantic_similarity">semantic_similarity</option><option value="llm">llm</option></select></label>
                           <div className="router-editor__wide router-editor__field">
                             <span>Model</span>
@@ -837,28 +1176,51 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
                           </div>
                           {classifier.type === 'semantic_similarity' ? (
                             <div className="router-editor__wide router-editor__concepts">
-                              <div className="router-editor__mini-head"><span>Concepts and reference phrases</span><WorkspaceActionButton size="small" icon="plus" onClick={() => updateClassifier(index, { referencePhrases: { ...classifier.referencePhrases, [nextConceptName(classifier.referencePhrases)]: ['example phrase'] } })}>Concept</WorkspaceActionButton></div>
-                              {Object.entries(classifier.referencePhrases).map(([concept, phrases], conceptIndex) => (
-                                <div className="router-editor__concept" key={`${concept}-${conceptIndex}`}>
-                                  <input className="input" value={concept} aria-label="Concept name" onChange={event => renameSemanticConcept(index, concept, event.target.value)} />
-                                  <input className="input" value={phrases.join(', ')} aria-label="Reference phrases" placeholder="Comma-separated phrases" onChange={event => updateClassifier(index, { referencePhrases: { ...classifier.referencePhrases, [concept]: event.target.value.split(',').map(phrase => phrase.trimStart()) } })} />
-                                  <WorkspaceActionButton appearance="danger" size="small" icon="trash" iconOnly title="Remove concept" aria-label="Remove concept" onClick={() => { const next = { ...classifier.referencePhrases }; delete next[concept]; updateClassifier(index, { referencePhrases: next, defaultLabel: undefined }); }} />
-                                </div>
-                              ))}
+                              <div className="router-editor__mini-head"><span>Concepts and Reference Phrases</span><WorkspaceActionButton size="small" icon="plus" onClick={() => updateClassifier(index, { referencePhrases: { ...classifier.referencePhrases, [nextConceptName(classifier.referencePhrases)]: ['example phrase'] } })}>Concept</WorkspaceActionButton></div>
+                              <div className="router-editor__concept-list">
+                                {Object.entries(classifier.referencePhrases).map(([concept, phrases], conceptIndex) => (
+                                  <div className="router-editor__concept" key={conceptIndex}>
+                                    <CommittedTextInput value={concept} ariaLabel="Concept name" onCommit={nextName => commitSemanticConceptName(index, concept, nextName)} />
+                                    <textarea className="textarea" rows={3} value={phrases.join('\n')} aria-label="Reference phrases" placeholder="One reference phrase per line" onChange={event => updateClassifier(index, { referencePhrases: { ...classifier.referencePhrases, [concept]: event.target.value.split(/\r?\n/) } })} />
+                                    <WorkspaceActionButton appearance="danger" size="small" icon="trash" iconOnly title="Remove concept" aria-label="Remove concept" onClick={() => {
+                                      const next = { ...classifier.referencePhrases };
+                                      delete next[concept];
+                                      updateClassifier(index, {
+                                        referencePhrases: next,
+                                        defaultLabel: classifier.defaultLabel === concept ? undefined : classifier.defaultLabel,
+                                      });
+                                    }} />
+                                  </div>
+                                ))}
+                              </div>
                             </div>
                           ) : (
                             <>
                               {classifier.type === 'llm' && (
                                 <label className="router-editor__wide">
-                                  <span>Classification prompt <small>Explain when each label applies.</small></span>
+                                  <span>Classification Prompt <small>Explain when each label applies.</small></span>
                                   <textarea className="textarea router-editor__prompt" value={classifier.prompt} placeholder="Choose SAFE for routine requests and RISKY for requests that could cause external side effects." spellCheck={false} onChange={event => updateClassifier(index, { prompt: event.target.value })} />
                                 </label>
                               )}
-                              <label className="router-editor__wide"><span>Output labels <small>Comma-separated</small></span><input className="input" value={classifier.labels.join(', ')} onChange={event => updateClassifier(index, { labels: event.target.value.split(',').map(label => label.trimStart()), defaultLabel: undefined })} /></label>
+                              <label className="router-editor__wide"><span>Output Labels <small>one per line</small></span><textarea
+                                className="textarea"
+                                rows={3}
+                                value={classifier.labels.join('\n')}
+                                onChange={event => {
+                                  const labels = event.target.value.split(/\r?\n/);
+                                  const normalized = labels.map(label => label.trim()).filter(Boolean);
+                                  updateClassifier(index, {
+                                    labels,
+                                    defaultLabel: classifier.defaultLabel && normalized.includes(classifier.defaultLabel)
+                                      ? classifier.defaultLabel
+                                      : undefined,
+                                  });
+                                }}
+                              /></label>
                             </>
                           )}
-                          <label><span>Default label</span><select className="select" value={classifier.defaultLabel || ''} onChange={event => updateClassifier(index, { defaultLabel: event.target.value || undefined })}><option value="">None</option>{labels.map(label => <option key={label} value={label}>{label}</option>)}</select></label>
-                          <label><span>On error</span><select className="select" value={classifier.onError} onChange={event => updateClassifier(index, { onError: event.target.value as RouterClassifier['onError'] })}><option value="match_false">Do not match</option><option value="match_true">Match rule</option></select></label>
+                          <label><span>Default Label</span><select className="select" value={classifier.defaultLabel || ''} onChange={event => updateClassifier(index, { defaultLabel: event.target.value || undefined })}><option value="">None</option>{labels.map(label => <option key={label} value={label}>{label}</option>)}</select></label>
+                          <label><span>On Error</span><select className="select" value={classifier.onError} onChange={event => updateClassifier(index, { onError: event.target.value as RouterClassifier['onError'] })}><option value="match_false">Do not match</option><option value="match_true">Match rule</option></select></label>
                         </div>
                       </article>
                     );
@@ -869,7 +1231,7 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
 
             <section className="router-editor__section">
               <div className="router-editor__section-head">
-                <div><h3>Ordered rules</h3><p>First matching rule wins. The default model handles the remainder.</p></div>
+                <div><h3>Ordered Rules</h3><p>First matching rule wins. The default model handles the remainder.</p></div>
                 <WorkspaceActionButton size="small" icon="plus" onClick={addRule}>Rule</WorkspaceActionButton>
               </div>
               <div className="router-editor__rules-workspace">
@@ -877,7 +1239,7 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
                   {draft.rules.map((rule, index) => (
                     <div
                       className={`router-editor__rule-summary ${selectedRuleIndex === index ? 'is-selected' : ''} ${dragRuleIndex === index ? 'is-dragging' : ''}`}
-                      key={`${rule.id}-${index}`}
+                      key={index}
                       onDragOver={event => {
                         if (dragRuleIndex == null || dragRuleIndex === index) return;
                         event.preventDefault();
@@ -917,9 +1279,11 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
                         </span>
                       </button>
                       <div className="router-editor__rule-actions">
-                        <button type="button" disabled={index === 0} onClick={() => moveRuleTo(index, index - 1)} title="Move rule up"><Icon name="chevron-up" size={14} /></button>
-                        <button type="button" disabled={index === draft.rules.length - 1} onClick={() => moveRuleTo(index, index + 1)} title="Move rule down"><Icon name="chevron-down" size={14} /></button>
-                        <button type="button" onClick={() => removeRuleAt(index)} title="Remove rule"><Icon name="trash" size={14} /></button>
+                        <div className="router-editor__rule-stepper">
+                          <button className="router-editor__rule-stepper-button router-editor__rule-stepper-button--up" type="button" disabled={index === 0} onClick={() => moveRuleTo(index, index - 1)} title="Move rule up"><Icon name="chevron-up" size={10} /></button>
+                          <button className="router-editor__rule-stepper-button router-editor__rule-stepper-button--down" type="button" disabled={index === draft.rules.length - 1} onClick={() => moveRuleTo(index, index + 1)} title="Move rule down"><Icon name="chevron-down" size={10} /></button>
+                        </div>
+                        <button className="router-editor__rule-remove" type="button" onClick={() => removeRuleAt(index)} title="Remove rule"><Icon name="trash" size={14} /></button>
                       </div>
                     </div>
                   ))}
@@ -943,16 +1307,17 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
                       </div>
                       <div className="router-editor__rule-meta">
                         <label><span>Rule ID</span><input className="input" value={selectedRule.id} onChange={event => setPatch({ rules: draft.rules.map((item, itemIndex) => itemIndex === selectedRuleIndex ? { ...item, id: event.target.value } : item) })} /></label>
-                        <label><span>Route to</span><select className="select" value={selectedRule.routeTo} onChange={event => setPatch({ rules: draft.rules.map((item, itemIndex) => itemIndex === selectedRuleIndex ? { ...item, routeTo: event.target.value } : item) })}><option value="">Select candidate</option>{draft.candidates.map(candidate => <option key={candidate} value={candidate}>{candidate}</option>)}</select></label>
+                        <label><span>Route To</span><select className="select" value={selectedRule.routeTo} onChange={event => setPatch({ rules: draft.rules.map((item, itemIndex) => itemIndex === selectedRuleIndex ? { ...item, routeTo: event.target.value } : item) })}><option value="">Select candidate</option>{draft.candidates.map(candidate => <option key={candidate} value={candidate}>{candidate}</option>)}</select></label>
                       </div>
                       <RouterRuleGraph
-                        key={`${selectedRuleIndex}-${selectedRule.id}`}
+                        key={`rule-${selectedRuleIndex}`}
                         node={selectedRule.condition}
                         classifiers={draft.classifiers}
                         onChange={condition => setPatch({ rules: draft.rules.map((item, itemIndex) => itemIndex === selectedRuleIndex ? { ...item, condition } : item) })}
+                        onExpand={() => setExpandedRuleIndex(selectedRuleIndex)}
                       />
                       <details className="router-editor__outputs">
-                        <summary>Optional decision outputs</summary>
+                        <summary>Optional Decision Outputs</summary>
                         <textarea className="textarea" value={selectedRule.outputsText || ''} placeholder={'{\n  "tier": "fast"\n}'} spellCheck={false} onChange={event => setPatch({ rules: draft.rules.map((item, itemIndex) => itemIndex === selectedRuleIndex ? { ...item, outputsText: event.target.value } : item) })} />
                       </details>
                     </>
@@ -989,8 +1354,29 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
       )}
 
       <Modal
+        isOpen={expandedRule != null && expandedRuleIndex != null}
+        onClose={() => setExpandedRuleIndex(null)}
+        title={expandedRule && expandedRuleIndex != null ? `Rule ${expandedRuleIndex + 1}: ${expandedRule.id || 'Untitled Rule'}` : 'Graph Builder'}
+        maxWidth="calc(100vw - 48px)"
+        ariaLabelledBy="router-graph-expanded-title"
+      >
+        {expandedRule && expandedRuleIndex != null && (
+          <div className="inspect-modal-body router-editor__graph-modal">
+            <RouterRuleGraph
+              key={`expanded-${expandedRuleIndex}`}
+              node={expandedRule.condition}
+              classifiers={draft.classifiers}
+              onChange={condition => setPatch({
+                rules: draft.rules.map((item, itemIndex) => itemIndex === expandedRuleIndex ? { ...item, condition } : item),
+              })}
+            />
+          </div>
+        )}
+      </Modal>
+
+      <Modal
         isOpen={confirmation != null}
-        onClose={() => setConfirmation(null)}
+        onClose={dismissConfirmation}
         title={confirmation?.title || 'Confirm action'}
         maxWidth="480px"
         ariaLabelledBy="router-confirm-dialog-title"
@@ -1000,8 +1386,10 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
           <p>{confirmation?.message}</p>
         </div>
         <div className="inspect-modal-footer">
-          <WorkspaceActionButton appearance="secondary" onClick={() => setConfirmation(null)}>Cancel</WorkspaceActionButton>
-          <WorkspaceActionButton appearance={confirmation?.tone || 'primary'} onClick={confirmPendingAction}>{confirmation?.confirmLabel || 'Continue'}</WorkspaceActionButton>
+          <WorkspaceActionButton appearance="secondary" disabled={deleting} onClick={dismissConfirmation}>Cancel</WorkspaceActionButton>
+          <WorkspaceActionButton appearance={confirmation?.tone || 'primary'} disabled={deleting} onClick={confirmPendingAction}>
+            {deleting && confirmation?.kind === 'delete' ? 'Deleting…' : (confirmation?.confirmLabel || 'Continue')}
+          </WorkspaceActionButton>
         </div>
       </Modal>
 

--- a/src/app/src/components/RouterEditorPanel.tsx
+++ b/src/app/src/components/RouterEditorPanel.tsx
@@ -20,7 +20,10 @@ import {
   renameClassifierLabelReference,
   routerNodeReferencesClassifier,
   routerDraftFromModelInfo,
+  routerDraftHasLlmProgress,
+  routerDraftHasRulesProgress,
   routerDisplayName,
+  switchRouterDraftMode,
   validateRouterDraft,
   type RouterClassifier,
   type RouterDraft,
@@ -143,19 +146,50 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
   }, [refreshCloudProviders]);
 
   useEffect(() => {
-    if (!initialModel || String((initialModel as any).recipe || '').toLowerCase() !== 'collection.router') return;
-    try {
-      setDraft(routerDraftFromModelInfo(initialModel));
-      setError(null);
-      setNotice(null);
-    } catch (initialError) {
-      setError(initialError instanceof Error ? initialError.message : 'Could not open this router.');
+    if (!initialModel || !isRouterRecipe((initialModel as any).recipe)) return;
+
+    const applyModel = (sourceModel: ModelInfo) => {
+      try {
+        setDraft(routerDraftFromModelInfo(sourceModel));
+        setError(null);
+        setNotice(null);
+      } catch (initialError) {
+        setError(initialError instanceof Error ? initialError.message : 'Could not open this router.');
+      }
+    };
+
+    const modelNameValue = modelName(initialModel);
+    if (!modelNameValue) {
+      applyModel(initialModel);
+      return;
     }
+
+    // The /models list can contain only summary fields. Always prefer the
+    // authoritative detail record when editing an existing server router, just
+    // like the current main RouterCollectionPanel. A locally persisted request
+    // is used only as a fallback if the detail request itself fails.
+    let cancelled = false;
+    void api.modelDetail(modelNameValue)
+      .then(detailedModel => {
+        if (cancelled) return;
+        applyModel(detailedModel);
+      })
+      .catch(detailError => {
+        if (cancelled) return;
+        if ((initialModel as any).routing) {
+          applyModel(initialModel);
+          return;
+        }
+        setError(detailError instanceof Error ? detailError.message : 'Could not load this router policy.');
+      });
+    return () => { cancelled = true; };
   }, [initialModel]);
 
   const candidateModels = useMemo(() => models
     .filter(model => !isRouterRecipe((model as any).recipe))
     .filter(model => {
+      const labels = (model.labels || []).map(label => label.toLowerCase());
+      if (labels.includes('classification') || labels.includes('classifier')) return false;
       const capability = capabilityFromModelInfo(model);
       return capability === 'chat';
     })
@@ -167,15 +201,18 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
     return candidateModels.filter(model => `${modelLabel(model)} ${modelName(model)} ${(model.labels || []).join(' ')}`.toLowerCase().includes(query));
   }, [candidateModels, candidateSearch]);
 
-  const embeddingModels = useMemo(() => {
-    const explicit = models.filter(model => {
-      const labels = (model.labels || []).map(label => label.toLowerCase());
-      return capabilityFromModelInfo(model) === 'embedding' || labels.includes('embedding') || labels.includes('embeddings');
-    });
-    return (explicit.length ? explicit : models)
-      .filter(model => !isRouterRecipe((model as any).recipe))
-      .sort((a, b) => modelLabel(a).localeCompare(modelLabel(b)));
-  }, [models]);
+  const embeddingModels = useMemo(() => models
+    .filter(model => !isRouterRecipe((model as any).recipe))
+    .filter(model => (model.labels || []).some(label => {
+      const normalized = label.toLowerCase();
+      return normalized === 'embedding' || normalized === 'embeddings';
+    }))
+    .sort((a, b) => modelLabel(a).localeCompare(modelLabel(b))), [models]);
+
+  const classifierModels = useMemo(() => models
+    .filter(model => !isRouterRecipe((model as any).recipe))
+    .filter(model => (model.labels || []).some(label => label.toLowerCase() === 'classification'))
+    .sort((a, b) => modelLabel(a).localeCompare(modelLabel(b))), [models]);
 
   const connectedModelRoles = useMemo(() => {
     const roles = new Map<string, string[]>();
@@ -209,12 +246,19 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
   };
 
   const setRoutingMode = (mode: RouterDraft['mode']) => {
-    setDraft(current => ({
-      ...current,
-      mode,
-      llmRouter: current.llmRouter || { model: '', prompt: '' },
-      rules: current.rules.length > 0 ? current.rules : [createRouterRule(0, current.defaultModel)],
-    }));
+    if (mode === draft.mode) return;
+
+    if (draft.mode === 'rules') {
+      if (routerDraftHasRulesProgress(draft) && !window.confirm(
+        'Switch to Natural-language router?\n\nSwitching modes will clear your existing rules and classifiers. This cannot be undone.',
+      )) return;
+      setDraft(current => switchRouterDraftMode(current, 'llm'));
+    } else {
+      if (routerDraftHasLlmProgress(draft) && !window.confirm(
+        'Switch to ordered rules?\n\nSwitching modes will clear your Natural-language routing model and instruction. This cannot be undone.',
+      )) return;
+      setDraft(current => switchRouterDraftMode(current, 'rules'));
+    }
     setError(null);
     setNotice(null);
   };
@@ -577,7 +621,7 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
 
             <section className="router-editor__section">
               <div className="router-editor__section-head">
-                <div><h3>Routing strategy</h3><p>Choose how the router selects a candidate. Switching modes keeps the other configuration intact.</p></div>
+                <div><h3>Routing strategy</h3><p>Choose how the router selects a candidate. Switching modes clears incompatible configuration after confirmation.</p></div>
               </div>
               <div className="router-editor__strategy" role="radiogroup" aria-label="Routing strategy">
                 <button
@@ -657,7 +701,7 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
                         <div className="router-editor__form-grid router-editor__form-grid--classifier">
                           <label><span>ID</span><input className="input" value={classifier.id} onChange={event => updateClassifier(index, { id: event.target.value })} /></label>
                           <label><span>Type</span><select className="select" value={classifier.type} onChange={event => updateClassifier(index, { ...createRouterClassifier(index, event.target.value as RouterClassifier['type']), id: classifier.id })}><option value="classifier">classifier</option><option value="semantic_similarity">semantic_similarity</option><option value="llm">llm</option></select></label>
-                          <label className="router-editor__wide"><span>Model</span><select className="select" value={classifier.model} onChange={event => updateClassifier(index, { model: event.target.value })}><option value="">Select model</option>{(classifier.type === 'semantic_similarity' ? embeddingModels : classifier.type === 'llm' ? candidateModels : models).filter(model => !isRouterRecipe((model as any).recipe)).map(model => <option key={modelName(model)} value={modelName(model)}>{modelLabel(model)} · {modelName(model)}</option>)}</select></label>
+                          <label className="router-editor__wide"><span>Model</span><select className="select" value={classifier.model} onChange={event => updateClassifier(index, { model: event.target.value })}><option value="">Select model</option>{(classifier.type === 'semantic_similarity' ? embeddingModels : classifier.type === 'llm' ? candidateModels : classifierModels).map(model => <option key={modelName(model)} value={modelName(model)}>{modelLabel(model)} · {modelName(model)}</option>)}</select></label>
                           {classifier.type === 'semantic_similarity' ? (
                             <div className="router-editor__wide router-editor__concepts">
                               <div className="router-editor__mini-head"><span>Concepts and reference phrases</span><WorkspaceActionButton size="small" icon="plus" onClick={() => updateClassifier(index, { referencePhrases: { ...classifier.referencePhrases, [nextConceptName(classifier.referencePhrases)]: ['example phrase'] } })}>Concept</WorkspaceActionButton></div>

--- a/src/app/src/components/RouterModelPicker.tsx
+++ b/src/app/src/components/RouterModelPicker.tsx
@@ -116,15 +116,20 @@ export const RouterModelPicker: React.FC<RouterModelPickerProps> = ({
     if (activeIndex >= filtered.length) setActiveIndex(filtered.length ? filtered.length - 1 : -1);
   }, [activeIndex, filtered.length]);
 
+  const closeAndRestoreFocus = () => {
+    setOpen(false);
+    window.requestAnimationFrame(() => triggerRef.current?.focus());
+  };
+
   const choose = (name: string) => {
     onChange(name);
-    setOpen(false);
+    closeAndRestoreFocus();
   };
 
   const onSearchKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
     if (event.key === 'Escape') {
       event.preventDefault();
-      setOpen(false);
+      closeAndRestoreFocus();
       return;
     }
     if (event.key === 'ArrowDown') {

--- a/src/app/src/components/RouterModelPicker.tsx
+++ b/src/app/src/components/RouterModelPicker.tsx
@@ -1,0 +1,216 @@
+import React, { useEffect, useId, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { type ModelInfo } from '../api';
+import { Icon } from './Icon';
+
+function pickerModelName(model: ModelInfo): string {
+  return String((model as any).model_name ?? model.name ?? model.id ?? '').trim();
+}
+
+function pickerModelLabel(model: ModelInfo): string {
+  return String(model.display_name || pickerModelName(model));
+}
+
+interface RouterModelPickerProps {
+  models: ModelInfo[];
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  searchPlaceholder?: string;
+  emptyMessage?: string;
+  ariaLabel?: string;
+}
+
+export const RouterModelPicker: React.FC<RouterModelPickerProps> = ({
+  models,
+  value,
+  onChange,
+  placeholder = 'Select model',
+  searchPlaceholder = 'Search models',
+  emptyMessage = 'No compatible models match this search.',
+  ariaLabel = 'Select model',
+}) => {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const [activeIndex, setActiveIndex] = useState(-1);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const popoverRef = useRef<HTMLDivElement>(null);
+  const searchRef = useRef<HTMLInputElement>(null);
+  const [popoverStyle, setPopoverStyle] = useState<React.CSSProperties>({});
+  const baseId = useId();
+  const listboxId = `${baseId}-listbox`;
+
+  const options = useMemo(() => models
+    .map(model => ({ model, name: pickerModelName(model), label: pickerModelLabel(model) }))
+    .filter(option => option.name), [models]);
+
+  const selected = useMemo(() => options.find(option => option.name === value), [options, value]);
+
+  const filtered = useMemo(() => {
+    const normalized = query.trim().toLowerCase();
+    if (!normalized) return options;
+    return options.filter(({ model, name, label }) =>
+      `${label} ${name} ${(model.labels || []).join(' ')}`.toLowerCase().includes(normalized)
+    );
+  }, [options, query]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (event: MouseEvent) => {
+      const target = event.target as Node;
+      if (rootRef.current?.contains(target) || popoverRef.current?.contains(target)) return;
+      setOpen(false);
+    };
+    document.addEventListener('mousedown', onPointerDown);
+    return () => document.removeEventListener('mousedown', onPointerDown);
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const updatePosition = () => {
+      const trigger = triggerRef.current;
+      if (!trigger) return;
+      const rect = trigger.getBoundingClientRect();
+      const viewportPadding = 12;
+      const width = Math.min(Math.max(rect.width, 320), Math.max(240, window.innerWidth - viewportPadding * 2));
+      const left = Math.max(viewportPadding, Math.min(rect.left, window.innerWidth - width - viewportPadding));
+      const below = window.innerHeight - rect.bottom;
+      const above = rect.top;
+      if (below < 280 && above > below) {
+        setPopoverStyle({
+          position: 'fixed',
+          left,
+          bottom: window.innerHeight - rect.top + 6,
+          width,
+        });
+      } else {
+        setPopoverStyle({
+          position: 'fixed',
+          left,
+          top: rect.bottom + 6,
+          width,
+        });
+      }
+    };
+    updatePosition();
+    window.addEventListener('resize', updatePosition);
+    window.addEventListener('scroll', updatePosition, true);
+    return () => {
+      window.removeEventListener('resize', updatePosition);
+      window.removeEventListener('scroll', updatePosition, true);
+    };
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) {
+      setQuery('');
+      setActiveIndex(-1);
+      return;
+    }
+    const frame = window.requestAnimationFrame(() => searchRef.current?.focus());
+    return () => window.cancelAnimationFrame(frame);
+  }, [open]);
+
+  useEffect(() => {
+    if (activeIndex >= filtered.length) setActiveIndex(filtered.length ? filtered.length - 1 : -1);
+  }, [activeIndex, filtered.length]);
+
+  const choose = (name: string) => {
+    onChange(name);
+    setOpen(false);
+  };
+
+  const onSearchKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      setOpen(false);
+      return;
+    }
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      setActiveIndex(index => filtered.length ? (index + 1) % filtered.length : -1);
+      return;
+    }
+    if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      setActiveIndex(index => filtered.length ? (index <= 0 ? filtered.length - 1 : index - 1) : -1);
+      return;
+    }
+    if (event.key === 'Enter' && filtered.length) {
+      event.preventDefault();
+      choose(filtered[Math.max(0, activeIndex)].name);
+    }
+  };
+
+  return (
+    <div className="router-model-picker" ref={rootRef}>
+      <button
+        ref={triggerRef}
+        type="button"
+        className={`router-model-picker__trigger ${open ? 'is-open' : ''}`}
+        aria-label={ariaLabel}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-controls={open ? listboxId : undefined}
+        onClick={() => setOpen(current => !current)}
+      >
+        <span className={value ? '' : 'is-placeholder'} title={value || undefined}>
+          {selected ? `${selected.label} · ${selected.name}` : value || placeholder}
+        </span>
+        <Icon name="chevron-down" size={14} aria-hidden="true" />
+      </button>
+
+      {open && createPortal(
+        <div ref={popoverRef} className="router-model-picker__popover" style={popoverStyle}>
+          <div className="router-model-picker__search">
+            <Icon name="search" size={14} aria-hidden="true" />
+            <input
+              ref={searchRef}
+              type="search"
+              value={query}
+              placeholder={searchPlaceholder}
+              role="combobox"
+              aria-label={searchPlaceholder}
+              aria-autocomplete="list"
+              aria-expanded="true"
+              aria-controls={listboxId}
+              aria-activedescendant={activeIndex >= 0 ? `${baseId}-option-${activeIndex}` : undefined}
+              onChange={event => { setQuery(event.target.value); setActiveIndex(-1); }}
+              onKeyDown={onSearchKeyDown}
+            />
+          </div>
+          <div className="router-model-picker__options" id={listboxId} role="listbox" aria-label={ariaLabel}>
+            {filtered.map((option, index) => (
+              <button
+                type="button"
+                key={option.name}
+                id={`${baseId}-option-${index}`}
+                role="option"
+                aria-selected={option.name === value}
+                className={`router-model-picker__option ${index === activeIndex ? 'is-active' : ''} ${option.name === value ? 'is-selected' : ''}`}
+                onMouseEnter={() => setActiveIndex(index)}
+                onClick={() => choose(option.name)}
+              >
+                <span>
+                  <strong>{option.label}</strong>
+                  <small>{option.name}</small>
+                </span>
+                {option.name === value && <Icon name="check" size={14} aria-hidden="true" />}
+              </button>
+            ))}
+            {filtered.length === 0 && <div className="router-model-picker__empty">{emptyMessage}</div>}
+          </div>
+          {value && !selected && (
+            <div className="router-model-picker__stale" role="note">
+              Current value <code>{value}</code> is not in the compatible model list. Choose another model to replace it.
+            </div>
+          )}
+        </div>,
+        document.body,
+      )}
+    </div>
+  );
+};
+
+export default RouterModelPicker;

--- a/src/app/src/components/RouterNodeEditor.tsx
+++ b/src/app/src/components/RouterNodeEditor.tsx
@@ -7,6 +7,7 @@ import {
   createRouterLeaf,
   createRouterNodeId,
   normalizeRouterNode,
+  routerConditionIdentity,
   type RouterClassifier,
   type RouterGroupNode,
   type RouterLeafNode,
@@ -19,8 +20,8 @@ const LEAF_TYPES: Array<{ value: RouterLeafType; label: string }> = [
   { value: 'keywords_any', label: 'Keywords · any' },
   { value: 'keywords_all', label: 'Keywords · all' },
   { value: 'regex', label: 'Regex' },
-  { value: 'min_chars', label: 'Minimum characters' },
-  { value: 'max_chars', label: 'Maximum characters' },
+  { value: 'min_chars', label: 'Minimum UTF-8 bytes' },
+  { value: 'max_chars', label: 'Maximum UTF-8 bytes' },
   { value: 'has_tools', label: 'Has tools' },
   { value: 'has_images', label: 'Has images' },
   { value: 'classifier', label: 'Classifier score' },
@@ -54,6 +55,19 @@ function moveChild(group: RouterGroupNode, index: number, delta: number): Router
   const children = [...group.children];
   [children[index], children[target]] = [children[target], children[index]];
   return { ...group, children };
+}
+
+function unusedGroupLeafType(group: RouterGroupNode): RouterLeafType | null {
+  const identities = new Set(group.children.map(routerConditionIdentity).filter((identity): identity is string => Boolean(identity)));
+  for (const item of LEAF_TYPES) {
+    const identity = item.value === 'classifier'
+      ? 'classifier:'
+      : item.value === 'metadata'
+        ? 'metadata:'
+        : item.value;
+    if (!identities.has(identity)) return item.value;
+  }
+  return null;
 }
 
 const ScoreInput: React.FC<{
@@ -101,10 +115,11 @@ const RouterLeafEditor: React.FC<{
         </label>
 
         {(node.type === 'keywords_any' || node.type === 'keywords_all') && (
-          <input
-            className="input router-node__grow"
+          <textarea
+            className="textarea router-node__grow"
+            rows={3}
             value={node.textValue ?? ''}
-            placeholder="Comma-separated keywords"
+            placeholder="One keyword per line"
             onChange={event => update({ textValue: event.target.value })}
           />
         )}
@@ -142,11 +157,12 @@ const RouterLeafEditor: React.FC<{
               className="select"
               value={node.classifierId ?? ''}
               onChange={event => {
-                const classifier = classifiers.find(item => item.id === event.target.value);
-                const nextLabels = classifierLabels(classifier);
+                // Keep label omitted when choosing a classifier so the condition
+                // continues to follow that classifier's default_label. Copying the
+                // current default into the rule would silently freeze the old value.
                 update({
                   classifierId: event.target.value,
-                  label: classifier?.defaultLabel || nextLabels[0] || undefined,
+                  label: undefined,
                 });
               }}
             >
@@ -157,7 +173,11 @@ const RouterLeafEditor: React.FC<{
           <label>
             <span>Label</span>
             <select className="select" value={node.label ?? ''} onChange={event => update({ label: event.target.value || undefined })}>
-              <option value="">Use classifier default</option>
+              <option value="" disabled={labels.length > 0 && !selectedClassifier?.defaultLabel}>
+                {selectedClassifier?.defaultLabel
+                  ? `Use classifier default (${selectedClassifier.defaultLabel})`
+                  : labels.length > 0 ? 'Select label' : 'Use classifier output'}
+              </option>
               {labels.map(label => <option key={label} value={label}>{label}</option>)}
             </select>
           </label>
@@ -192,9 +212,14 @@ const RouterLeafEditor: React.FC<{
                 <option value="false">missing</option>
               </select>
             </label>
+          ) : node.metadataComparator === 'any' ? (
+            <label className="router-node__grow-field">
+              <span>Values <small>one per line</small></span>
+              <textarea className="textarea" rows={3} value={node.metadataValues ?? ''} onChange={event => update({ metadataValues: event.target.value })} />
+            </label>
           ) : (
             <label className="router-node__grow-field">
-              <span>{node.metadataComparator === 'any' ? 'Comma-separated values' : 'Value'}</span>
+              <span>Value</span>
               <input className="input" value={node.metadataValues ?? ''} onChange={event => update({ metadataValues: event.target.value })} />
             </label>
           )}
@@ -202,8 +227,8 @@ const RouterLeafEditor: React.FC<{
       )}
       <div className="router-node__wrap-actions" aria-label="Combine condition">
         <span>Combine:</span>
-        <button type="button" onClick={() => onChange({ id: createRouterNodeId('group'), kind: 'group', operator: 'all', children: [node, createRouterLeaf()] })}>AND</button>
-        <button type="button" onClick={() => onChange({ id: createRouterNodeId('group'), kind: 'group', operator: 'any', children: [node, createRouterLeaf()] })}>OR</button>
+        <button type="button" onClick={() => onChange({ id: createRouterNodeId('group'), kind: 'group', operator: 'all', children: [node, createRouterLeaf(node.type === 'keywords_any' ? 'keywords_all' : 'keywords_any')] })}>AND</button>
+        <button type="button" onClick={() => onChange({ id: createRouterNodeId('group'), kind: 'group', operator: 'any', children: [node, createRouterLeaf(node.type === 'keywords_any' ? 'keywords_all' : 'keywords_any')] })}>OR</button>
         <button type="button" onClick={() => onChange({ id: createRouterNodeId('group'), kind: 'group', operator: 'not', children: [node] })}>NOT</button>
       </div>
     </div>
@@ -215,15 +240,21 @@ export const RouterNodeEditor: React.FC<RouterNodeEditorProps> = ({ node, classi
     return <RouterLeafEditor node={node} classifiers={classifiers} onChange={onChange} />;
   }
 
-  const addCondition = () => onChange({ ...node, children: [...node.children, createRouterLeaf()] });
+  const unusedConditionType = unusedGroupLeafType(node);
+  const addCondition = () => {
+    if (unusedConditionType) onChange({ ...node, children: [...node.children, createRouterLeaf(unusedConditionType)] });
+  };
   const addGroup = () => onChange({ ...node, children: [...node.children, createRouterGroup('all')] });
   const changeOperator = (operator: RouterGroupNode['operator']) => {
-    const children = operator === 'not'
-      ? [node.children[0] || createRouterLeaf()]
-      : node.children.length >= 2
-        ? node.children
-        : [node.children[0] || createRouterLeaf(), createRouterLeaf('has_tools')];
-    onChange({ ...node, operator, children });
+    if (operator === node.operator) return;
+    if (operator === 'not' && node.children.length > 1) {
+      // Negate the complete existing expression. Truncating to children[0]
+      // would silently delete conditions when AND/OR is changed to NOT.
+      const inner: RouterGroupNode = { ...node, id: createRouterNodeId('group') };
+      onChange({ ...node, operator: 'not', children: [inner] });
+      return;
+    }
+    onChange({ ...node, operator, children: node.children.length ? node.children : [createRouterLeaf()] });
   };
 
   return (
@@ -239,7 +270,7 @@ export const RouterNodeEditor: React.FC<RouterNodeEditorProps> = ({ node, classi
         </div>
         {node.operator !== 'not' && (
           <div className="router-node__group-actions">
-            <WorkspaceActionButton size="small" icon="plus" onClick={addCondition}>Condition</WorkspaceActionButton>
+            <WorkspaceActionButton size="small" icon="plus" disabled={!unusedConditionType} title={unusedConditionType ? "Add condition" : "Every available condition identity is already used in this gate"} onClick={addCondition}>Condition</WorkspaceActionButton>
             <WorkspaceActionButton size="small" icon="plus" onClick={addGroup}>Group</WorkspaceActionButton>
           </div>
         )}

--- a/src/app/src/components/RouterNodeEditor.tsx
+++ b/src/app/src/components/RouterNodeEditor.tsx
@@ -1,6 +1,172 @@
-import React from 'react';
+import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { Icon } from './Icon';
 import { WorkspaceActionButton } from './WorkspacePanels';
+
+interface RouterSelectOption {
+  value: string;
+  label: string;
+  disabled?: boolean;
+}
+
+interface RouterSelectProps {
+  value: string;
+  options: RouterSelectOption[];
+  onChange: (value: string) => void;
+  ariaLabel?: string;
+  className?: string;
+  disabled?: boolean;
+}
+
+function computeCoords(trigger: HTMLButtonElement) {
+  const r = trigger.getBoundingClientRect();
+  return { top: r.bottom + 4, left: r.left, width: r.width };
+}
+
+export const RouterSelect: React.FC<RouterSelectProps> = ({ value, options, onChange, ariaLabel, className, disabled }) => {
+  const [open, setOpen] = useState(false);
+  const [coords, setCoords] = useState<{ top: number; left: number; width: number } | null>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const popoverRef = useRef<HTMLDivElement>(null);
+  const optionRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  const selected = options.find(o => o.value === value);
+
+  const reposition = useCallback(() => {
+    if (triggerRef.current) setCoords(computeCoords(triggerRef.current));
+  }, []);
+
+  useLayoutEffect(() => {
+    if (!open || !triggerRef.current) return;
+    setCoords(computeCoords(triggerRef.current));
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const closeOnScroll = (e: Event) => {
+      const t = e.target as Node;
+      if (popoverRef.current?.contains(t)) return;
+      setOpen(false);
+    };
+    window.addEventListener('scroll', closeOnScroll, { capture: true, passive: true });
+    window.addEventListener('resize', reposition, { passive: true });
+    return () => {
+      window.removeEventListener('scroll', closeOnScroll, { capture: true });
+      window.removeEventListener('resize', reposition);
+    };
+  }, [open, reposition]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      const t = e.target as Node;
+      if (!triggerRef.current?.contains(t) && !popoverRef.current?.contains(t)) setOpen(false);
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [open]);
+
+  const close = useCallback(() => {
+    setOpen(false);
+    triggerRef.current?.focus();
+  }, []);
+
+  const pick = useCallback((val: string, isDisabled?: boolean) => {
+    if (isDisabled) return;
+    onChange(val);
+    setOpen(false);
+    triggerRef.current?.focus();
+  }, [onChange]);
+
+  const onTriggerKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+      e.preventDefault();
+      if (!open) {
+        setOpen(true);
+        // Focus first (ArrowDown) or last (ArrowUp) enabled option after open
+        window.setTimeout(() => {
+          const enabled = optionRefs.current.filter(Boolean) as HTMLButtonElement[];
+          const target = e.key === 'ArrowDown' ? enabled[0] : enabled[enabled.length - 1];
+          target?.focus();
+        }, 0);
+      } else {
+        const enabled = optionRefs.current.filter(Boolean) as HTMLButtonElement[];
+        const target = e.key === 'ArrowDown' ? enabled[0] : enabled[enabled.length - 1];
+        target?.focus();
+      }
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      e.stopPropagation();
+      setOpen(false);
+    }
+  };
+
+  const onOptionKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>, index: number, opt: RouterSelectOption) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      const next = optionRefs.current.slice(index + 1).find(Boolean) as HTMLButtonElement | undefined;
+      next?.focus();
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      const prev = optionRefs.current.slice(0, index).reverse().find(Boolean) as HTMLButtonElement | undefined;
+      if (prev) prev.focus(); else close();
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      e.stopPropagation();
+      close();
+    } else if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      pick(opt.value, opt.disabled);
+    } else if (e.key === 'Tab') {
+      close();
+    }
+  };
+
+  return (
+    <div className={`router-select${className ? ` ${className}` : ''}`}>
+      <button
+        ref={triggerRef}
+        type="button"
+        className={`router-select__trigger${open ? ' is-open' : ''}`}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-label={ariaLabel}
+        disabled={disabled}
+        onClick={() => setOpen(v => !v)}
+        onKeyDown={onTriggerKeyDown}
+      >
+        <span className={selected ? undefined : 'is-placeholder'}>{selected?.label ?? value}</span>
+        <Icon name="chevron-down" size={12} />
+      </button>
+      {open && coords && createPortal(
+        <div
+          ref={popoverRef}
+          className="router-select__popover"
+          role="listbox"
+          aria-label={ariaLabel}
+          style={{ top: coords.top, left: coords.left, minWidth: coords.width }}
+        >
+          {options.map((opt, index) => (
+            <button
+              ref={el => { optionRefs.current[index] = el; }}
+              type="button"
+              key={opt.value}
+              role="option"
+              aria-selected={opt.value === value}
+              aria-disabled={opt.disabled}
+              tabIndex={-1}
+              className={`router-select__option${opt.value === value ? ' is-selected' : ''}${opt.disabled ? ' is-disabled' : ''}`}
+              onClick={() => pick(opt.value, opt.disabled)}
+              onKeyDown={e => onOptionKeyDown(e, index, opt)}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>,
+        document.body,
+      )}
+    </div>
+  );
+};
 import {
   classifierLabels,
   createRouterGroup,
@@ -32,6 +198,7 @@ interface RouterNodeEditorProps {
   node: RouterNode;
   classifiers: RouterClassifier[];
   onChange: (next: RouterNode) => void;
+  onRemoveSelf?: () => void;
   depth?: number;
 }
 
@@ -109,9 +276,12 @@ const RouterLeafEditor: React.FC<{
       <div className="router-node__leaf-row">
         <label className="router-node__type-field">
           <span className="sr-only">Condition type</span>
-          <select className="select" value={node.type} onChange={event => changeType(event.target.value as RouterLeafType)}>
-            {LEAF_TYPES.map(item => <option key={item.value} value={item.value}>{item.label}</option>)}
-          </select>
+          <RouterSelect
+            value={node.type}
+            options={LEAF_TYPES}
+            onChange={val => changeType(val as RouterLeafType)}
+            ariaLabel="Condition type"
+          />
         </label>
 
         {(node.type === 'keywords_any' || node.type === 'keywords_all') && (
@@ -142,10 +312,11 @@ const RouterLeafEditor: React.FC<{
           />
         )}
         {(node.type === 'has_tools' || node.type === 'has_images') && (
-          <select className="select" value={node.booleanValue === false ? 'false' : 'true'} onChange={event => update({ booleanValue: event.target.value === 'true' })}>
-            <option value="true">is true</option>
-            <option value="false">is false</option>
-          </select>
+          <RouterSelect
+            value={node.booleanValue === false ? 'false' : 'true'}
+            options={[{ value: 'true', label: 'is true' }, { value: 'false', label: 'is false' }]}
+            onChange={val => update({ booleanValue: val === 'true' })}
+          />
         )}
       </div>
 
@@ -153,33 +324,33 @@ const RouterLeafEditor: React.FC<{
         <div className="router-node__details router-node__details--classifier">
           <label>
             <span>Classifier</span>
-            <select
-              className="select"
+            <RouterSelect
               value={node.classifierId ?? ''}
-              onChange={event => {
-                // Keep label omitted when choosing a classifier so the condition
-                // continues to follow that classifier's default_label. Copying the
-                // current default into the rule would silently freeze the old value.
-                update({
-                  classifierId: event.target.value,
-                  label: undefined,
-                });
-              }}
-            >
-              <option value="">Select classifier</option>
-              {classifiers.map(item => <option key={item.id} value={item.id}>{item.id}</option>)}
-            </select>
+              options={[
+                { value: '', label: 'Select classifier' },
+                ...classifiers.map(item => ({ value: item.id, label: item.id })),
+              ]}
+              onChange={val => update({ classifierId: val, label: undefined })}
+              ariaLabel="Classifier"
+            />
           </label>
           <label>
             <span>Label</span>
-            <select className="select" value={node.label ?? ''} onChange={event => update({ label: event.target.value || undefined })}>
-              <option value="" disabled={labels.length > 0 && !selectedClassifier?.defaultLabel}>
-                {selectedClassifier?.defaultLabel
-                  ? `Use classifier default (${selectedClassifier.defaultLabel})`
-                  : labels.length > 0 ? 'Select label' : 'Use classifier output'}
-              </option>
-              {labels.map(label => <option key={label} value={label}>{label}</option>)}
-            </select>
+            <RouterSelect
+              value={node.label ?? ''}
+              options={[
+                {
+                  value: '',
+                  label: selectedClassifier?.defaultLabel
+                    ? `Use classifier default (${selectedClassifier.defaultLabel})`
+                    : labels.length > 0 ? 'Select label' : 'Use classifier output',
+                  disabled: labels.length > 0 && !selectedClassifier?.defaultLabel,
+                },
+                ...labels.map(label => ({ value: label, label })),
+              ]}
+              onChange={val => update({ label: val || undefined })}
+              ariaLabel="Label"
+            />
           </label>
           <ScoreInput label="Min score" value={node.minScore} onChange={minScore => update({ minScore })} />
           <ScoreInput label="Max score" value={node.maxScore} onChange={maxScore => update({ maxScore })} />
@@ -194,23 +365,26 @@ const RouterLeafEditor: React.FC<{
           </label>
           <label>
             <span>Comparator</span>
-            <select
-              className="select"
+            <RouterSelect
               value={node.metadataComparator ?? 'equals'}
-              onChange={event => update({ metadataComparator: event.target.value as RouterMetadataComparator })}
-            >
-              <option value="equals">equals</option>
-              <option value="any">contains any token</option>
-              <option value="exists">exists</option>
-            </select>
+              options={[
+                { value: 'equals', label: 'equals' },
+                { value: 'any', label: 'contains any token' },
+                { value: 'exists', label: 'exists' },
+              ]}
+              onChange={val => update({ metadataComparator: val as RouterMetadataComparator })}
+              ariaLabel="Comparator"
+            />
           </label>
           {(node.metadataComparator ?? 'equals') === 'exists' ? (
             <label>
               <span>Expected</span>
-              <select className="select" value={node.booleanValue === false ? 'false' : 'true'} onChange={event => update({ booleanValue: event.target.value === 'true' })}>
-                <option value="true">present</option>
-                <option value="false">missing</option>
-              </select>
+              <RouterSelect
+                value={node.booleanValue === false ? 'false' : 'true'}
+                options={[{ value: 'true', label: 'present' }, { value: 'false', label: 'missing' }]}
+                onChange={val => update({ booleanValue: val === 'true' })}
+                ariaLabel="Expected"
+              />
             </label>
           ) : node.metadataComparator === 'any' ? (
             <label className="router-node__grow-field">
@@ -235,7 +409,7 @@ const RouterLeafEditor: React.FC<{
   );
 };
 
-export const RouterNodeEditor: React.FC<RouterNodeEditorProps> = ({ node, classifiers, onChange, depth = 0 }) => {
+export const RouterNodeEditor: React.FC<RouterNodeEditorProps> = ({ node, classifiers, onChange, onRemoveSelf, depth = 0 }) => {
   if (node.kind === 'leaf') {
     return <RouterLeafEditor node={node} classifiers={classifiers} onChange={onChange} />;
   }
@@ -257,16 +431,29 @@ export const RouterNodeEditor: React.FC<RouterNodeEditorProps> = ({ node, classi
     onChange({ ...node, operator, children: node.children.length ? node.children : [createRouterLeaf()] });
   };
 
+  const handleRemoveChild = (index: number) => {
+    if (node.children.length === 1 && onRemoveSelf) {
+      onRemoveSelf();
+    } else {
+      onChange(removeChild(node, index));
+    }
+  };
+
   return (
     <div className="router-node router-node--group" style={{ '--router-depth': depth } as React.CSSProperties}>
       <div className="router-node__group-head">
         <div className="router-node__operator">
           <span>Match</span>
-          <select className="select" value={node.operator} onChange={event => changeOperator(event.target.value as RouterGroupNode['operator'])}>
-            <option value="all">ALL conditions</option>
-            <option value="any">ANY condition</option>
-            <option value="not">NOT condition</option>
-          </select>
+          <RouterSelect
+            value={node.operator}
+            options={[
+              { value: 'all', label: 'ALL conditions' },
+              { value: 'any', label: 'ANY condition' },
+              { value: 'not', label: 'NOT condition' },
+            ]}
+            onChange={val => changeOperator(val as RouterGroupNode['operator'])}
+            ariaLabel="Group operator"
+          />
         </div>
         {node.operator !== 'not' && (
           <div className="router-node__group-actions">
@@ -281,13 +468,14 @@ export const RouterNodeEditor: React.FC<RouterNodeEditorProps> = ({ node, classi
             <div className="router-node__child-actions" aria-label={`Condition ${index + 1} controls`}>
               <button type="button" disabled={index === 0} title="Move up" aria-label="Move condition up" onClick={() => onChange(moveChild(node, index, -1))}><Icon name="chevron-up" size={13} /></button>
               <button type="button" disabled={index === node.children.length - 1} title="Move down" aria-label="Move condition down" onClick={() => onChange(moveChild(node, index, 1))}><Icon name="chevron-down" size={13} /></button>
-              <button type="button" title="Remove condition" aria-label="Remove condition" onClick={() => onChange(removeChild(node, index))}><Icon name="trash" size={13} /></button>
+              <button type="button" title="Remove condition" aria-label="Remove condition" onClick={() => handleRemoveChild(index)}><Icon name="trash" size={13} /></button>
             </div>
             <RouterNodeEditor
               node={child}
               classifiers={classifiers}
               depth={depth + 1}
               onChange={next => onChange(replaceChild(node, index, next))}
+              onRemoveSelf={() => handleRemoveChild(index)}
             />
           </div>
         ))}

--- a/src/app/src/components/RouterRuleGraph.tsx
+++ b/src/app/src/components/RouterRuleGraph.tsx
@@ -16,7 +16,9 @@ import {
   isBlankRouterGraphNode,
   removeRouterNodeAtPath,
   replaceRouterNodeAtPath,
+  routerDuplicateConditionConflict,
   routerNodeAtPath,
+  routerReplacementConflictAtPath,
   wrapRouterNode,
   type RouterNodePath,
 } from '../features/router/routerGraph';
@@ -34,8 +36,8 @@ const LEAF_LABELS: Record<RouterLeafType, string> = {
   keywords_any: 'Keywords · any',
   keywords_all: 'Keywords · all',
   regex: 'Regex',
-  min_chars: 'Min characters',
-  max_chars: 'Max characters',
+  min_chars: 'Min UTF-8 bytes',
+  max_chars: 'Max UTF-8 bytes',
   has_tools: 'Has tools',
   has_images: 'Has images',
   classifier: 'Classifier',
@@ -58,6 +60,13 @@ const OPERATOR_LABELS: Record<RouterGroupOperator, string> = {
   any: 'OR',
   not: 'NOT',
 };
+
+
+function exactSummary(value: unknown, fallback: string): string {
+  const raw = String(value ?? '');
+  if (!raw.length) return fallback;
+  return raw === raw.trim() ? raw : JSON.stringify(raw);
+}
 
 const GraphGateShape: React.FC<{ operator: RouterGroupOperator; compact?: boolean }> = ({ operator, compact = false }) => {
   const size = compact ? 24 : 30;
@@ -87,19 +96,22 @@ function leafSummary(node: RouterLeafNode, classifiers: RouterClassifier[]): str
   if (node.type === 'keywords_any' || node.type === 'keywords_all') {
     return String(node.textValue || '').trim() || 'Add keywords';
   }
-  if (node.type === 'regex') return String(node.textValue || '').trim() || 'Add regex';
+  if (node.type === 'regex') return exactSummary(node.textValue, 'Add regex');
   if (node.type === 'min_chars') return `≥ ${node.numberValue ?? 0}`;
   if (node.type === 'max_chars') return `≤ ${node.numberValue ?? 0}`;
   if (node.type === 'has_tools') return node.booleanValue === false ? 'is false' : 'is true';
   if (node.type === 'has_images') return node.booleanValue === false ? 'is false' : 'is true';
   if (node.type === 'metadata') {
-    const key = String(node.metadataKey || '').trim() || 'metadata key';
+    const key = exactSummary(node.metadataKey, 'metadata key');
     const comparator = node.metadataComparator || 'equals';
     if (comparator === 'exists') return `${key} ${node.booleanValue === false ? 'missing' : 'present'}`;
-    return `${key} ${comparator === 'any' ? 'contains' : '='} ${String(node.metadataValues || '').trim() || '…'}`;
+    return `${key} ${comparator === 'any' ? 'contains' : '='} ${exactSummary(node.metadataValues, '…')}`;
   }
   const classifier = classifiers.find(item => item.id === node.classifierId);
-  const label = node.label || classifier?.defaultLabel || classifierLabels(classifier)[0] || 'label';
+  const labels = classifierLabels(classifier);
+  const label = node.label
+    || classifier?.defaultLabel
+    || (labels.length > 0 ? 'Select label' : 'classifier output');
   return `${node.classifierId || 'Select classifier'} · ${label}${node.minScore !== undefined ? ` · ≥ ${node.minScore}` : ''}`;
 }
 
@@ -198,12 +210,18 @@ const GraphNode: React.FC<GraphNodeProps> = ({
   }
 
   return (
-    <div className={`router-graph__group ${selected ? 'is-selected' : ''}`}>
-      <div className="router-graph__group-head" onClick={() => onSelect(path)}>
-        <span className={`router-graph__gate router-graph__gate--${node.operator}`}>
+    <div className={`router-graph__group router-graph__group--${node.operator} ${selected ? 'is-selected' : ''}`}>
+      <div className="router-graph__group-head">
+        <button
+          type="button"
+          className={`router-graph__gate router-graph__gate--${node.operator}`}
+          onClick={() => onSelect(path)}
+          aria-pressed={selected}
+          title={`Select ${OPERATOR_LABELS[node.operator]} gate`}
+        >
           <GraphGateShape operator={node.operator} />
           {OPERATOR_LABELS[node.operator]}
-        </span>
+        </button>
         <span className="router-graph__group-copy">
           {node.operator === 'all' ? 'All child conditions must match' : node.operator === 'any' ? 'Any child condition may match' : 'Negate the child condition'}
         </span>
@@ -245,9 +263,10 @@ interface RouterRuleGraphProps {
   node: RouterNode;
   classifiers: RouterClassifier[];
   onChange: (node: RouterNode) => void;
+  onExpand?: () => void;
 }
 
-export const RouterRuleGraph: React.FC<RouterRuleGraphProps> = ({ node, classifiers, onChange }) => {
+export const RouterRuleGraph: React.FC<RouterRuleGraphProps> = ({ node, classifiers, onChange, onExpand }) => {
   const [toolboxCollapsed, setToolboxCollapsed] = useState(false);
   const [toolboxSearch, setToolboxSearch] = useState('');
   const [selectedPath, setSelectedPath] = useState<RouterNodePath | null>(null);
@@ -259,6 +278,7 @@ export const RouterRuleGraph: React.FC<RouterRuleGraphProps> = ({ node, classifi
   const panStateRef = useRef<{ pointerId: number; x: number; y: number } | null>(null);
   const historyRef = useRef<RouterNode[]>([]);
   const futureRef = useRef<RouterNode[]>([]);
+  const lastEmittedNodeRef = useRef<RouterNode | null>(null);
 
   const selectedNode = selectedPath ? routerNodeAtPath(node, selectedPath) : null;
   const blank = isBlankRouterGraphNode(node);
@@ -267,11 +287,29 @@ export const RouterRuleGraph: React.FC<RouterRuleGraphProps> = ({ node, classifi
     if (selectedPath && !routerNodeAtPath(node, selectedPath)) setSelectedPath(null);
   }, [node, selectedPath]);
 
+  useEffect(() => {
+    // Inline and expanded builders may edit the same rule. If this instance
+    // receives a node it did not emit itself, its undo/redo snapshots belong to
+    // an older tree and must not be allowed to overwrite the external change.
+    if (lastEmittedNodeRef.current === node) {
+      lastEmittedNodeRef.current = null;
+      return;
+    }
+    historyRef.current = [];
+    futureRef.current = [];
+    setSelectedPath(null);
+  }, [node]);
+
+  const emitChange = useCallback((next: RouterNode) => {
+    lastEmittedNodeRef.current = next;
+    onChange(next);
+  }, [onChange]);
+
   const commit = useCallback((next: RouterNode) => {
     historyRef.current = [...historyRef.current.slice(-29), node];
     futureRef.current = [];
-    onChange(next);
-  }, [node, onChange]);
+    emitChange(next);
+  }, [emitChange, node]);
 
   const reject = useCallback((message: string) => {
     setRejection(message);
@@ -300,15 +338,27 @@ export const RouterRuleGraph: React.FC<RouterRuleGraphProps> = ({ node, classifi
   }, [blank, commit, node, reject]);
 
   const removeAtPath = useCallback((path: RouterNodePath) => {
-    commit(removeRouterNodeAtPath(node, path));
+    const next = removeRouterNodeAtPath(node, path);
+    const currentConflict = routerDuplicateConditionConflict(node);
+    const nextConflict = routerDuplicateConditionConflict(next);
+    if (!currentConflict && nextConflict) {
+      reject(nextConflict);
+      return;
+    }
+    commit(next);
     setSelectedPath(null);
-  }, [commit, node]);
+  }, [commit, node, reject]);
 
   const changeOperator = useCallback((path: RouterNodePath, operator: RouterGroupOperator) => {
     const current = routerNodeAtPath(node, path);
-    if (!current || current.kind !== 'group') return;
-    const children = operator === 'not' ? current.children.slice(0, 1) : current.children;
-    commit(replaceRouterNodeAtPath(node, path, { ...current, operator, children }));
+    if (!current || current.kind !== 'group' || current.operator === operator) return;
+    if (operator === 'not' && current.children.length > 1) {
+      // Negate the complete gate rather than dropping every child except the
+      // first. The wrapper preserves the exact AND/OR subtree and all leaves.
+      commit(replaceRouterNodeAtPath(node, path, wrapRouterNode(current, 'not')));
+      return;
+    }
+    commit(replaceRouterNodeAtPath(node, path, { ...current, operator }));
   }, [commit, node]);
 
   const undo = () => {
@@ -317,7 +367,7 @@ export const RouterRuleGraph: React.FC<RouterRuleGraphProps> = ({ node, classifi
     historyRef.current = historyRef.current.slice(0, -1);
     futureRef.current = [node, ...futureRef.current.slice(0, 29)];
     setSelectedPath(null);
-    onChange(previous);
+    emitChange(previous);
   };
 
   const redo = () => {
@@ -326,7 +376,7 @@ export const RouterRuleGraph: React.FC<RouterRuleGraphProps> = ({ node, classifi
     futureRef.current = futureRef.current.slice(1);
     historyRef.current = [...historyRef.current.slice(-29), node];
     setSelectedPath(null);
-    onChange(next);
+    emitChange(next);
   };
 
   const normalizedSearch = toolboxSearch.trim().toLowerCase();
@@ -336,6 +386,7 @@ export const RouterRuleGraph: React.FC<RouterRuleGraphProps> = ({ node, classifi
   const filteredClassifiers = useMemo(() => classifiers.filter(classifier =>
     !normalizedSearch || `${classifier.id} classifier ${classifier.type}`.toLowerCase().includes(normalizedSearch)
   ), [classifiers, normalizedSearch]);
+  const toolboxTargetPath = selectedNode?.kind === 'group' && selectedPath ? selectedPath : [];
 
   const beginDrag = (event: React.DragEvent, data: RouterGraphDragData) => {
     event.dataTransfer.setData(ROUTER_GRAPH_DRAG_MIME, encodeDrag(data));
@@ -400,7 +451,7 @@ export const RouterRuleGraph: React.FC<RouterRuleGraphProps> = ({ node, classifi
           </button>
           {!toolboxCollapsed && (
             <div className="router-graph__toolbox-content">
-              <div className="router-graph__toolbox-title">Logic gates</div>
+              <div className="router-graph__toolbox-title">Logic Gates</div>
               <div className="router-graph__gates">
                 {(['all', 'any', 'not'] as RouterGroupOperator[]).map(operator => {
                   const data: RouterGraphDragData = { kind: 'operator', operator };
@@ -410,7 +461,7 @@ export const RouterRuleGraph: React.FC<RouterRuleGraphProps> = ({ node, classifi
                       draggable
                       key={operator}
                       className={`router-graph__tool router-graph__tool--gate router-graph__tool--${operator}`}
-                      onClick={() => addDataAtPath([], data)}
+                      onClick={() => addDataAtPath(toolboxTargetPath, data)}
                       onDragStart={event => beginDrag(event, data)}
                       title={`Drag ${OPERATOR_LABELS[operator]} onto the graph`}
                     >
@@ -436,7 +487,7 @@ export const RouterRuleGraph: React.FC<RouterRuleGraphProps> = ({ node, classifi
                       draggable
                       key={type}
                       className={`router-graph__tool router-graph__tool--condition router-graph__tool--${type}`}
-                      onClick={() => addDataAtPath([], data)}
+                      onClick={() => addDataAtPath(toolboxTargetPath, data)}
                       onDragStart={event => beginDrag(event, data)}
                       title={`Drag or click to add ${LEAF_LABELS[type]}`}
                     >
@@ -458,7 +509,7 @@ export const RouterRuleGraph: React.FC<RouterRuleGraphProps> = ({ node, classifi
                           draggable
                           key={classifier.id}
                           className="router-graph__tool router-graph__tool--condition router-graph__tool--classifier"
-                          onClick={() => addDataAtPath([], data)}
+                          onClick={() => addDataAtPath(toolboxTargetPath, data)}
                           onDragStart={event => beginDrag(event, data)}
                           title={`Drag or click to add classifier ${classifier.id}`}
                         >
@@ -480,8 +531,13 @@ export const RouterRuleGraph: React.FC<RouterRuleGraphProps> = ({ node, classifi
             <button type="button" disabled={futureRef.current.length === 0} onClick={redo}>Redo</button>
             {!blank && <button type="button" className="is-danger" onClick={() => { commit(createRouterLeaf()); setSelectedPath(null); }}>Clear</button>}
             {rejection && <span className="router-graph__rejection" role="status"><Icon name="alert" size={12} /> {rejection}</span>}
-            <span className="router-graph__toolbar-hint">Drag items from the toolbox. Click a node to edit it. Ctrl/⌘ + wheel zooms.</span>
+            <span className="router-graph__toolbar-hint">Drag items from the toolbox. Select a gate and click a toolbox item to add there. Ctrl/⌘ + wheel zooms.</span>
             <span className="router-graph__toolbar-spacer" />
+            {onExpand && (
+              <button type="button" className="router-graph__expand" onClick={onExpand} title="Expand graph builder" aria-label="Expand graph builder">
+                <Icon name="maximize-2" size={12} />
+              </button>
+            )}
             <button type="button" disabled={zoom <= ZOOM_MIN} onClick={() => setZoom(current => clampZoom(current - ZOOM_STEP))}>−</button>
             <button type="button" className="router-graph__zoom-label" onClick={() => { setZoom(1); setPan({ x: 18, y: 18 }); }}>{Math.round(zoom * 100)}%</button>
             <button type="button" disabled={zoom >= ZOOM_MAX} onClick={() => setZoom(current => clampZoom(current + ZOOM_STEP))}>+</button>
@@ -531,7 +587,7 @@ export const RouterRuleGraph: React.FC<RouterRuleGraphProps> = ({ node, classifi
         <div className="router-graph__inspector">
           <div className="router-graph__inspector-head">
             <div>
-              <strong>Node inspector</strong>
+              <strong>Node Inspector</strong>
               <small>Edit the selected condition or gate without leaving the graph.</small>
             </div>
             <button type="button" onClick={() => setSelectedPath(null)} aria-label="Close node inspector"><Icon name="x" size={13} /></button>
@@ -540,7 +596,15 @@ export const RouterRuleGraph: React.FC<RouterRuleGraphProps> = ({ node, classifi
             <RouterNodeEditor
               node={selectedNode}
               classifiers={classifiers}
-              onChange={next => selectedPath && commit(replaceRouterNodeAtPath(node, selectedPath, next))}
+              onChange={next => {
+                if (!selectedPath) return;
+                const conflict = routerReplacementConflictAtPath(node, selectedPath, next);
+                if (conflict) {
+                  reject(conflict);
+                  return;
+                }
+                commit(replaceRouterNodeAtPath(node, selectedPath, next));
+              }}
             />
           </div>
         </div>

--- a/src/app/src/components/RouterRuleGraph.tsx
+++ b/src/app/src/components/RouterRuleGraph.tsx
@@ -232,9 +232,7 @@ const GraphNode: React.FC<GraphNodeProps> = ({
               <button type="button" className={node.operator === 'any' ? 'is-active' : ''} onClick={() => onChangeOperator(path, 'any')}>OR</button>
             </>
           )}
-          {path.length > 0 && (
-            <button type="button" aria-label="Remove gate" title="Remove gate" onClick={() => onRemove(path)}><Icon name="x" size={11} /></button>
-          )}
+          <button type="button" aria-label="Remove gate" title="Remove gate" onClick={() => onRemove(path)}><Icon name="x" size={11} /></button>
         </div>
       </div>
       <div className="router-graph__children">
@@ -264,9 +262,19 @@ interface RouterRuleGraphProps {
   classifiers: RouterClassifier[];
   onChange: (node: RouterNode) => void;
   onExpand?: () => void;
+  // Full-modal layout: workspace and inspector sit side by side and the
+  // divider between them becomes draggable.
+  expanded?: boolean;
+  // Allows a freshly-mounted expanded instance to inherit committed state from
+  // the inline instance. Without this, a blank keywords_any node (textValue='')
+  // looks identical to the initial empty graph and would be hidden on expand.
+  initialCommitted?: boolean;
 }
 
-export const RouterRuleGraph: React.FC<RouterRuleGraphProps> = ({ node, classifiers, onChange, onExpand }) => {
+const INSPECTOR_MIN_WIDTH = 320;
+const WORKSPACE_MIN_WIDTH = 360;
+
+export const RouterRuleGraph: React.FC<RouterRuleGraphProps> = ({ node, classifiers, onChange, onExpand, expanded = false, initialCommitted }) => {
   const [toolboxCollapsed, setToolboxCollapsed] = useState(false);
   const [toolboxSearch, setToolboxSearch] = useState('');
   const [selectedPath, setSelectedPath] = useState<RouterNodePath | null>(null);
@@ -274,20 +282,39 @@ export const RouterRuleGraph: React.FC<RouterRuleGraphProps> = ({ node, classifi
   const [pan, setPan] = useState({ x: 18, y: 18 });
   const [panning, setPanning] = useState(false);
   const [rejection, setRejection] = useState<string | null>(null);
+  const [inspectorWidth, setInspectorWidth] = useState<number | null>(null);
+  const [resizing, setResizing] = useState(false);
+  const graphRef = useRef<HTMLDivElement>(null);
+  const resizeStateRef = useRef<{ pointerId: number } | null>(null);
   const canvasRef = useRef<HTMLDivElement>(null);
   const panStateRef = useRef<{ pointerId: number; x: number; y: number } | null>(null);
   const historyRef = useRef<RouterNode[]>([]);
   const futureRef = useRef<RouterNode[]>([]);
   const lastEmittedNodeRef = useRef<RouterNode | null>(null);
+  // True once the user has explicitly dropped or committed a node. Prevents a
+  // freshly-dropped blank keywords_any (textValue='') from being hidden by the
+  // isBlankRouterGraphNode check, which also matches the initial default state.
+  // initialCommitted lets the expanded modal inherit committed state from the
+  // inline instance for nodes that look blank but were explicitly placed.
+  const hasCommittedRef = useRef(initialCommitted ?? !isBlankRouterGraphNode(node));
+  const isMountedRef = useRef(false);
 
   const selectedNode = selectedPath ? routerNodeAtPath(node, selectedPath) : null;
-  const blank = isBlankRouterGraphNode(node);
+  const blank = isBlankRouterGraphNode(node) && !hasCommittedRef.current;
 
   useEffect(() => {
     if (selectedPath && !routerNodeAtPath(node, selectedPath)) setSelectedPath(null);
   }, [node, selectedPath]);
 
   useEffect(() => {
+    // Skip on initial mount — hasCommittedRef is correctly seeded by useRef
+    // (using initialCommitted when provided, otherwise derived from the node).
+    // Running on mount would overwrite that with a stale isBlankRouterGraphNode
+    // check and drop a committed-but-empty keywords_any node on the canvas.
+    if (!isMountedRef.current) {
+      isMountedRef.current = true;
+      return;
+    }
     // Inline and expanded builders may edit the same rule. If this instance
     // receives a node it did not emit itself, its undo/redo snapshots belong to
     // an older tree and must not be allowed to overwrite the external change.
@@ -297,6 +324,7 @@ export const RouterRuleGraph: React.FC<RouterRuleGraphProps> = ({ node, classifi
     }
     historyRef.current = [];
     futureRef.current = [];
+    hasCommittedRef.current = !isBlankRouterGraphNode(node);
     setSelectedPath(null);
   }, [node]);
 
@@ -308,6 +336,7 @@ export const RouterRuleGraph: React.FC<RouterRuleGraphProps> = ({ node, classifi
   const commit = useCallback((next: RouterNode) => {
     historyRef.current = [...historyRef.current.slice(-29), node];
     futureRef.current = [];
+    hasCommittedRef.current = true;
     emitChange(next);
   }, [emitChange, node]);
 
@@ -339,15 +368,19 @@ export const RouterRuleGraph: React.FC<RouterRuleGraphProps> = ({ node, classifi
 
   const removeAtPath = useCallback((path: RouterNodePath) => {
     const next = removeRouterNodeAtPath(node, path);
-    const currentConflict = routerDuplicateConditionConflict(node);
-    const nextConflict = routerDuplicateConditionConflict(next);
-    if (!currentConflict && nextConflict) {
-      reject(nextConflict);
+    if (isBlankRouterGraphNode(next)) {
+      // Removal produced the canonical blank leaf — treat as a full reset so
+      // the canvas returns to the empty-state placeholder.
+      historyRef.current = [...historyRef.current.slice(-29), node];
+      futureRef.current = [];
+      hasCommittedRef.current = false;
+      setSelectedPath(null);
+      emitChange(next);
       return;
     }
     commit(next);
     setSelectedPath(null);
-  }, [commit, node, reject]);
+  }, [commit, emitChange, node]);
 
   const changeOperator = useCallback((path: RouterNodePath, operator: RouterGroupOperator) => {
     const current = routerNodeAtPath(node, path);
@@ -441,8 +474,33 @@ export const RouterRuleGraph: React.FC<RouterRuleGraphProps> = ({ node, classifi
     setPanning(false);
   };
 
+  const startResize = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (event.button !== 0) return;
+    event.preventDefault();
+    resizeStateRef.current = { pointerId: event.pointerId };
+    event.currentTarget.setPointerCapture(event.pointerId);
+    setResizing(true);
+  };
+
+  const onResizeMove = (event: React.PointerEvent<HTMLDivElement>) => {
+    const state = resizeStateRef.current;
+    if (!state || state.pointerId !== event.pointerId || !graphRef.current) return;
+    const rect = graphRef.current.getBoundingClientRect();
+    const max = Math.max(INSPECTOR_MIN_WIDTH, rect.width - WORKSPACE_MIN_WIDTH);
+    const next = rect.right - event.clientX;
+    setInspectorWidth(Math.round(Math.min(max, Math.max(INSPECTOR_MIN_WIDTH, next))));
+  };
+
+  const stopResize = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (resizeStateRef.current?.pointerId === event.pointerId && event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+    resizeStateRef.current = null;
+    setResizing(false);
+  };
+
   return (
-    <div className="router-graph">
+    <div className={`router-graph ${resizing ? 'is-resizing' : ''}`} ref={graphRef}>
       <div className={`router-graph__workspace ${toolboxCollapsed ? 'is-toolbox-collapsed' : ''}`}>
         <aside className={`router-graph__toolbox ${toolboxCollapsed ? 'is-collapsed' : ''}`} aria-label="Router condition toolbox">
           <button type="button" className="router-graph__toolbox-toggle" onClick={() => setToolboxCollapsed(current => !current)} aria-expanded={!toolboxCollapsed}>
@@ -529,7 +587,13 @@ export const RouterRuleGraph: React.FC<RouterRuleGraphProps> = ({ node, classifi
           <div className="router-graph__toolbar">
             <button type="button" disabled={historyRef.current.length === 0} onClick={undo}>Undo</button>
             <button type="button" disabled={futureRef.current.length === 0} onClick={redo}>Redo</button>
-            {!blank && <button type="button" className="is-danger" onClick={() => { commit(createRouterLeaf()); setSelectedPath(null); }}>Clear</button>}
+            {!blank && <button type="button" className="is-danger" onClick={() => {
+              historyRef.current = [...historyRef.current.slice(-29), node];
+              futureRef.current = [];
+              hasCommittedRef.current = false;
+              setSelectedPath(null);
+              emitChange(createRouterLeaf());
+            }}>Clear</button>}
             {rejection && <span className="router-graph__rejection" role="status"><Icon name="alert" size={12} /> {rejection}</span>}
             <span className="router-graph__toolbar-hint">Drag items from the toolbox. Select a gate and click a toolbox item to add there. Ctrl/⌘ + wheel zooms.</span>
             <span className="router-graph__toolbar-spacer" />
@@ -583,8 +647,53 @@ export const RouterRuleGraph: React.FC<RouterRuleGraphProps> = ({ node, classifi
         </div>
       </div>
 
+      {selectedNode && expanded && (
+        <div
+          className="router-graph__resizer"
+          role="separator"
+          aria-orientation="vertical"
+          aria-label="Resize node inspector"
+          aria-valuemin={INSPECTOR_MIN_WIDTH}
+          aria-valuemax={INSPECTOR_MIN_WIDTH + (graphRef.current ? Math.max(0, graphRef.current.offsetWidth - WORKSPACE_MIN_WIDTH - INSPECTOR_MIN_WIDTH) : 400)}
+          aria-valuenow={inspectorWidth ?? INSPECTOR_MIN_WIDTH}
+          tabIndex={0}
+          title="Drag to resize · double-click to reset"
+          onPointerDown={startResize}
+          onPointerMove={onResizeMove}
+          onPointerUp={stopResize}
+          onPointerCancel={stopResize}
+          onDoubleClick={() => setInspectorWidth(null)}
+          onKeyDown={e => {
+            const STEP = 20;
+            if (e.key === 'ArrowLeft') {
+              e.preventDefault();
+              if (!graphRef.current) return;
+              const rect = graphRef.current.getBoundingClientRect();
+              const max = Math.max(INSPECTOR_MIN_WIDTH, rect.width - WORKSPACE_MIN_WIDTH);
+              setInspectorWidth(w => Math.round(Math.min(max, Math.max(INSPECTOR_MIN_WIDTH, (w ?? INSPECTOR_MIN_WIDTH) + STEP))));
+            } else if (e.key === 'ArrowRight') {
+              e.preventDefault();
+              setInspectorWidth(w => Math.round(Math.max(INSPECTOR_MIN_WIDTH, (w ?? INSPECTOR_MIN_WIDTH) - STEP)));
+            } else if (e.key === 'Home') {
+              e.preventDefault();
+              setInspectorWidth(null);
+            }
+          }}
+        >
+          <span className="router-graph__resizer-grip" aria-hidden="true">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
+              <circle cx="9" cy="5" r="1.4" /><circle cx="9" cy="12" r="1.4" /><circle cx="9" cy="19" r="1.4" />
+              <circle cx="15" cy="5" r="1.4" /><circle cx="15" cy="12" r="1.4" /><circle cx="15" cy="19" r="1.4" />
+            </svg>
+          </span>
+        </div>
+      )}
+
       {selectedNode && (
-        <div className="router-graph__inspector">
+        <div
+          className="router-graph__inspector"
+          style={expanded && inspectorWidth != null ? { flex: `0 0 ${inspectorWidth}px` } : undefined}
+        >
           <div className="router-graph__inspector-head">
             <div>
               <strong>Node Inspector</strong>

--- a/src/app/src/components/RouterRuleGraph.tsx
+++ b/src/app/src/components/RouterRuleGraph.tsx
@@ -1,0 +1,552 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Icon } from './Icon';
+import RouterNodeEditor from './RouterNodeEditor';
+import {
+  classifierLabels,
+  createRouterLeaf,
+  type RouterClassifier,
+  type RouterGroupOperator,
+  type RouterLeafNode,
+  type RouterLeafType,
+  type RouterNode,
+} from '../features/router/routerTypes';
+import {
+  appendRouterNodeAtPath,
+  createEmptyRouterGraphGroup,
+  isBlankRouterGraphNode,
+  removeRouterNodeAtPath,
+  replaceRouterNodeAtPath,
+  routerNodeAtPath,
+  wrapRouterNode,
+  type RouterNodePath,
+} from '../features/router/routerGraph';
+
+const ROUTER_GRAPH_DRAG_MIME = 'application/x-lemonade-router-node';
+const ZOOM_MIN = 0.5;
+const ZOOM_MAX = 1.8;
+const ZOOM_STEP = 0.15;
+
+type RouterGraphDragData =
+  | { kind: 'operator'; operator: RouterGroupOperator }
+  | { kind: 'leaf'; leafType: RouterLeafType; classifierId?: string };
+
+const LEAF_LABELS: Record<RouterLeafType, string> = {
+  keywords_any: 'Keywords · any',
+  keywords_all: 'Keywords · all',
+  regex: 'Regex',
+  min_chars: 'Min characters',
+  max_chars: 'Max characters',
+  has_tools: 'Has tools',
+  has_images: 'Has images',
+  classifier: 'Classifier',
+  metadata: 'Metadata',
+};
+
+const TOOLBOX_LEAVES: RouterLeafType[] = [
+  'keywords_any',
+  'keywords_all',
+  'regex',
+  'min_chars',
+  'max_chars',
+  'has_tools',
+  'has_images',
+  'metadata',
+];
+
+const OPERATOR_LABELS: Record<RouterGroupOperator, string> = {
+  all: 'AND',
+  any: 'OR',
+  not: 'NOT',
+};
+
+const GraphGateShape: React.FC<{ operator: RouterGroupOperator; compact?: boolean }> = ({ operator, compact = false }) => {
+  const size = compact ? 24 : 30;
+  if (operator === 'all') {
+    return (
+      <svg className="router-graph__gate-shape" viewBox="0 0 56 44" width={size} height={Math.round(size * .78)} aria-hidden="true">
+        <path d="M4 3 L52 3 L52 20 L28 41 L4 20 Z" />
+      </svg>
+    );
+  }
+  if (operator === 'any') {
+    return (
+      <svg className="router-graph__gate-shape" viewBox="0 0 56 40" width={size} height={Math.round(size * .72)} aria-hidden="true">
+        <path d="M28 3 Q52 8 52 20 Q52 32 28 37 Q4 32 4 20 Q4 8 28 3 Z" />
+      </svg>
+    );
+  }
+  return (
+    <svg className="router-graph__gate-shape" viewBox="0 0 44 44" width={size} height={size} aria-hidden="true">
+      <circle cx="22" cy="22" r="18" />
+      <line x1="9" y1="9" x2="35" y2="35" />
+    </svg>
+  );
+};
+
+function leafSummary(node: RouterLeafNode, classifiers: RouterClassifier[]): string {
+  if (node.type === 'keywords_any' || node.type === 'keywords_all') {
+    return String(node.textValue || '').trim() || 'Add keywords';
+  }
+  if (node.type === 'regex') return String(node.textValue || '').trim() || 'Add regex';
+  if (node.type === 'min_chars') return `≥ ${node.numberValue ?? 0}`;
+  if (node.type === 'max_chars') return `≤ ${node.numberValue ?? 0}`;
+  if (node.type === 'has_tools') return node.booleanValue === false ? 'is false' : 'is true';
+  if (node.type === 'has_images') return node.booleanValue === false ? 'is false' : 'is true';
+  if (node.type === 'metadata') {
+    const key = String(node.metadataKey || '').trim() || 'metadata key';
+    const comparator = node.metadataComparator || 'equals';
+    if (comparator === 'exists') return `${key} ${node.booleanValue === false ? 'missing' : 'present'}`;
+    return `${key} ${comparator === 'any' ? 'contains' : '='} ${String(node.metadataValues || '').trim() || '…'}`;
+  }
+  const classifier = classifiers.find(item => item.id === node.classifierId);
+  const label = node.label || classifier?.defaultLabel || classifierLabels(classifier)[0] || 'label';
+  return `${node.classifierId || 'Select classifier'} · ${label}${node.minScore !== undefined ? ` · ≥ ${node.minScore}` : ''}`;
+}
+
+function createGraphLeaf(data: Extract<RouterGraphDragData, { kind: 'leaf' }>): RouterLeafNode {
+  const leaf = createRouterLeaf(data.leafType);
+  if (data.leafType === 'classifier' && data.classifierId) {
+    leaf.classifierId = data.classifierId;
+    leaf.minScore = 0.5;
+  }
+  return leaf;
+}
+
+function encodeDrag(data: RouterGraphDragData): string {
+  return JSON.stringify(data);
+}
+
+function decodeDrag(value: string): RouterGraphDragData | null {
+  try {
+    const parsed = JSON.parse(value);
+    if (!parsed || typeof parsed !== 'object') return null;
+    if (parsed.kind === 'operator' && ['all', 'any', 'not'].includes(parsed.operator)) return parsed as RouterGraphDragData;
+    if (parsed.kind === 'leaf' && typeof parsed.leafType === 'string' && parsed.leafType in LEAF_LABELS) return parsed as RouterGraphDragData;
+  } catch {
+    // Ignore foreign drag payloads.
+  }
+  return null;
+}
+
+interface GraphNodeProps {
+  node: RouterNode;
+  path: RouterNodePath;
+  classifiers: RouterClassifier[];
+  selectedPath: RouterNodePath | null;
+  onSelect: (path: RouterNodePath) => void;
+  onRemove: (path: RouterNodePath) => void;
+  onChangeOperator: (path: RouterNodePath, operator: RouterGroupOperator) => void;
+  onDropData: (path: RouterNodePath, data: RouterGraphDragData) => void;
+}
+
+const GraphDropZone: React.FC<{
+  path: RouterNodePath;
+  label?: string;
+  onDropData: (path: RouterNodePath, data: RouterGraphDragData) => void;
+}> = ({ path, label = 'Drop condition or gate here', onDropData }) => {
+  const [over, setOver] = useState(false);
+  return (
+    <div
+      className={`router-graph__drop-zone ${over ? 'is-over' : ''}`}
+      onDragOver={event => { event.preventDefault(); event.stopPropagation(); event.dataTransfer.dropEffect = 'copy'; setOver(true); }}
+      onDragLeave={() => setOver(false)}
+      onDrop={event => {
+        event.preventDefault();
+        event.stopPropagation();
+        setOver(false);
+        const data = decodeDrag(event.dataTransfer.getData(ROUTER_GRAPH_DRAG_MIME));
+        if (data) onDropData(path, data);
+      }}
+    >
+      <Icon name="plus" size={12} />
+      <span>{label}</span>
+    </div>
+  );
+};
+
+const GraphNode: React.FC<GraphNodeProps> = ({
+  node,
+  path,
+  classifiers,
+  selectedPath,
+  onSelect,
+  onRemove,
+  onChangeOperator,
+  onDropData,
+}) => {
+  const selected = selectedPath != null
+    && path.length === selectedPath.length
+    && path.every((part, index) => part === selectedPath[index]);
+
+  if (node.kind === 'leaf') {
+    return (
+      <div className="router-graph__branch">
+        <button
+          type="button"
+          className={`router-graph__leaf router-graph__leaf--${node.type} ${selected ? 'is-selected' : ''}`}
+          onClick={() => onSelect(path)}
+          title="Click to edit this condition"
+        >
+          <span className="router-graph__leaf-type">{LEAF_LABELS[node.type]}</span>
+          <span className="router-graph__leaf-summary">{leafSummary(node, classifiers)}</span>
+        </button>
+        <button type="button" className="router-graph__remove" aria-label="Remove condition" title="Remove condition" onClick={() => onRemove(path)}>
+          <Icon name="x" size={11} />
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`router-graph__group ${selected ? 'is-selected' : ''}`}>
+      <div className="router-graph__group-head" onClick={() => onSelect(path)}>
+        <span className={`router-graph__gate router-graph__gate--${node.operator}`}>
+          <GraphGateShape operator={node.operator} />
+          {OPERATOR_LABELS[node.operator]}
+        </span>
+        <span className="router-graph__group-copy">
+          {node.operator === 'all' ? 'All child conditions must match' : node.operator === 'any' ? 'Any child condition may match' : 'Negate the child condition'}
+        </span>
+        <div className="router-graph__operator-actions" onClick={event => event.stopPropagation()}>
+          {node.operator !== 'not' && (
+            <>
+              <button type="button" className={node.operator === 'all' ? 'is-active' : ''} onClick={() => onChangeOperator(path, 'all')}>AND</button>
+              <button type="button" className={node.operator === 'any' ? 'is-active' : ''} onClick={() => onChangeOperator(path, 'any')}>OR</button>
+            </>
+          )}
+          {path.length > 0 && (
+            <button type="button" aria-label="Remove gate" title="Remove gate" onClick={() => onRemove(path)}><Icon name="x" size={11} /></button>
+          )}
+        </div>
+      </div>
+      <div className="router-graph__children">
+        {node.children.map((child, index) => (
+          <GraphNode
+            key={child.id}
+            node={child}
+            path={[...path, index]}
+            classifiers={classifiers}
+            selectedPath={selectedPath}
+            onSelect={onSelect}
+            onRemove={onRemove}
+            onChangeOperator={onChangeOperator}
+            onDropData={onDropData}
+          />
+        ))}
+        {(node.operator !== 'not' || node.children.length === 0) && (
+          <GraphDropZone path={path} onDropData={onDropData} />
+        )}
+      </div>
+    </div>
+  );
+};
+
+interface RouterRuleGraphProps {
+  node: RouterNode;
+  classifiers: RouterClassifier[];
+  onChange: (node: RouterNode) => void;
+}
+
+export const RouterRuleGraph: React.FC<RouterRuleGraphProps> = ({ node, classifiers, onChange }) => {
+  const [toolboxCollapsed, setToolboxCollapsed] = useState(false);
+  const [toolboxSearch, setToolboxSearch] = useState('');
+  const [selectedPath, setSelectedPath] = useState<RouterNodePath | null>(null);
+  const [zoom, setZoom] = useState(1);
+  const [pan, setPan] = useState({ x: 18, y: 18 });
+  const [panning, setPanning] = useState(false);
+  const [rejection, setRejection] = useState<string | null>(null);
+  const canvasRef = useRef<HTMLDivElement>(null);
+  const panStateRef = useRef<{ pointerId: number; x: number; y: number } | null>(null);
+  const historyRef = useRef<RouterNode[]>([]);
+  const futureRef = useRef<RouterNode[]>([]);
+
+  const selectedNode = selectedPath ? routerNodeAtPath(node, selectedPath) : null;
+  const blank = isBlankRouterGraphNode(node);
+
+  useEffect(() => {
+    if (selectedPath && !routerNodeAtPath(node, selectedPath)) setSelectedPath(null);
+  }, [node, selectedPath]);
+
+  const commit = useCallback((next: RouterNode) => {
+    historyRef.current = [...historyRef.current.slice(-29), node];
+    futureRef.current = [];
+    onChange(next);
+  }, [node, onChange]);
+
+  const reject = useCallback((message: string) => {
+    setRejection(message);
+    window.setTimeout(() => setRejection(current => current === message ? null : current), 1800);
+  }, []);
+
+  const addDataAtPath = useCallback((targetPath: RouterNodePath, data: RouterGraphDragData) => {
+    const incoming = data.kind === 'operator' ? createEmptyRouterGraphGroup(data.operator) : createGraphLeaf(data);
+    try {
+      if (targetPath.length === 0 && blank) {
+        commit(incoming);
+        setSelectedPath([]);
+        return;
+      }
+      const target = routerNodeAtPath(node, targetPath);
+      if (!target) return;
+      if (targetPath.length === 0 && target.kind === 'leaf' && data.kind === 'operator') {
+        commit(wrapRouterNode(node, data.operator));
+        setSelectedPath([]);
+        return;
+      }
+      commit(appendRouterNodeAtPath(node, targetPath, incoming));
+    } catch (error) {
+      reject(error instanceof Error ? error.message : 'This item cannot be dropped here.');
+    }
+  }, [blank, commit, node, reject]);
+
+  const removeAtPath = useCallback((path: RouterNodePath) => {
+    commit(removeRouterNodeAtPath(node, path));
+    setSelectedPath(null);
+  }, [commit, node]);
+
+  const changeOperator = useCallback((path: RouterNodePath, operator: RouterGroupOperator) => {
+    const current = routerNodeAtPath(node, path);
+    if (!current || current.kind !== 'group') return;
+    const children = operator === 'not' ? current.children.slice(0, 1) : current.children;
+    commit(replaceRouterNodeAtPath(node, path, { ...current, operator, children }));
+  }, [commit, node]);
+
+  const undo = () => {
+    const previous = historyRef.current.at(-1);
+    if (!previous) return;
+    historyRef.current = historyRef.current.slice(0, -1);
+    futureRef.current = [node, ...futureRef.current.slice(0, 29)];
+    setSelectedPath(null);
+    onChange(previous);
+  };
+
+  const redo = () => {
+    const next = futureRef.current[0];
+    if (!next) return;
+    futureRef.current = futureRef.current.slice(1);
+    historyRef.current = [...historyRef.current.slice(-29), node];
+    setSelectedPath(null);
+    onChange(next);
+  };
+
+  const normalizedSearch = toolboxSearch.trim().toLowerCase();
+  const filteredLeaves = useMemo(() => TOOLBOX_LEAVES.filter(type =>
+    !normalizedSearch || LEAF_LABELS[type].toLowerCase().includes(normalizedSearch)
+  ), [normalizedSearch]);
+  const filteredClassifiers = useMemo(() => classifiers.filter(classifier =>
+    !normalizedSearch || `${classifier.id} classifier ${classifier.type}`.toLowerCase().includes(normalizedSearch)
+  ), [classifiers, normalizedSearch]);
+
+  const beginDrag = (event: React.DragEvent, data: RouterGraphDragData) => {
+    event.dataTransfer.setData(ROUTER_GRAPH_DRAG_MIME, encodeDrag(data));
+    event.dataTransfer.effectAllowed = 'copy';
+  };
+
+  const clampZoom = (value: number) => Math.max(ZOOM_MIN, Math.min(ZOOM_MAX, Number(value.toFixed(2))));
+
+  const onWheel = (event: React.WheelEvent<HTMLDivElement>) => {
+    if (!canvasRef.current) return;
+    // Keep the surrounding rule list scrollable. Zoom only when the user
+    // explicitly holds the platform zoom modifier, while the +/- controls
+    // remain available for pointer-only use.
+    if (!event.ctrlKey && !event.metaKey) return;
+    event.preventDefault();
+    const rect = canvasRef.current.getBoundingClientRect();
+    const nextZoom = clampZoom(zoom + (event.deltaY < 0 ? ZOOM_STEP : -ZOOM_STEP));
+    if (nextZoom === zoom) return;
+    const cursorX = event.clientX - rect.left;
+    const cursorY = event.clientY - rect.top;
+    const ratio = nextZoom / zoom;
+    setPan(current => ({
+      x: cursorX - (cursorX - current.x) * ratio,
+      y: cursorY - (cursorY - current.y) * ratio,
+    }));
+    setZoom(nextZoom);
+  };
+
+  const onPointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (event.button !== 0) return;
+    const target = event.target as HTMLElement;
+    if (target.closest('button, input, select, textarea, .router-graph__group, .router-graph__drop-zone')) return;
+    panStateRef.current = { pointerId: event.pointerId, x: event.clientX, y: event.clientY };
+    setPanning(true);
+    event.currentTarget.setPointerCapture(event.pointerId);
+  };
+
+  const onPointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
+    const state = panStateRef.current;
+    if (!state || state.pointerId !== event.pointerId) return;
+    const dx = event.clientX - state.x;
+    const dy = event.clientY - state.y;
+    panStateRef.current = { ...state, x: event.clientX, y: event.clientY };
+    setPan(current => ({ x: current.x + dx, y: current.y + dy }));
+  };
+
+  const stopPanning = (event?: React.PointerEvent<HTMLDivElement>) => {
+    if (event && panStateRef.current?.pointerId === event.pointerId && event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+    panStateRef.current = null;
+    setPanning(false);
+  };
+
+  return (
+    <div className="router-graph">
+      <div className={`router-graph__workspace ${toolboxCollapsed ? 'is-toolbox-collapsed' : ''}`}>
+        <aside className={`router-graph__toolbox ${toolboxCollapsed ? 'is-collapsed' : ''}`} aria-label="Router condition toolbox">
+          <button type="button" className="router-graph__toolbox-toggle" onClick={() => setToolboxCollapsed(current => !current)} aria-expanded={!toolboxCollapsed}>
+            <Icon name={toolboxCollapsed ? 'panel-left-open' : 'panel-left-close'} size={14} />
+            {!toolboxCollapsed && <span>Toolbox</span>}
+          </button>
+          {!toolboxCollapsed && (
+            <div className="router-graph__toolbox-content">
+              <div className="router-graph__toolbox-title">Logic gates</div>
+              <div className="router-graph__gates">
+                {(['all', 'any', 'not'] as RouterGroupOperator[]).map(operator => {
+                  const data: RouterGraphDragData = { kind: 'operator', operator };
+                  return (
+                    <button
+                      type="button"
+                      draggable
+                      key={operator}
+                      className={`router-graph__tool router-graph__tool--gate router-graph__tool--${operator}`}
+                      onClick={() => addDataAtPath([], data)}
+                      onDragStart={event => beginDrag(event, data)}
+                      title={`Drag ${OPERATOR_LABELS[operator]} onto the graph`}
+                    >
+                      <GraphGateShape operator={operator} compact />
+                      <strong>{OPERATOR_LABELS[operator]}</strong>
+                      <small>{operator === 'all' ? 'All match' : operator === 'any' ? 'Any match' : 'Negate'}</small>
+                    </button>
+                  );
+                })}
+              </div>
+
+              <div className="router-graph__toolbox-title">Conditions</div>
+              <div className="router-graph__toolbox-search">
+                <Icon name="search" size={13} />
+                <input value={toolboxSearch} placeholder="Search conditions" onChange={event => setToolboxSearch(event.target.value)} />
+              </div>
+              <div className="router-graph__tools">
+                {filteredLeaves.map(type => {
+                  const data: RouterGraphDragData = { kind: 'leaf', leafType: type };
+                  return (
+                    <button
+                      type="button"
+                      draggable
+                      key={type}
+                      className={`router-graph__tool router-graph__tool--condition router-graph__tool--${type}`}
+                      onClick={() => addDataAtPath([], data)}
+                      onDragStart={event => beginDrag(event, data)}
+                      title={`Drag or click to add ${LEAF_LABELS[type]}`}
+                    >
+                      {LEAF_LABELS[type]}
+                    </button>
+                  );
+                })}
+              </div>
+
+              {classifiers.length > 0 && (
+                <>
+                  <div className="router-graph__toolbox-title">Classifiers</div>
+                  <div className="router-graph__tools">
+                    {filteredClassifiers.map(classifier => {
+                      const data: RouterGraphDragData = { kind: 'leaf', leafType: 'classifier', classifierId: classifier.id };
+                      return (
+                        <button
+                          type="button"
+                          draggable
+                          key={classifier.id}
+                          className="router-graph__tool router-graph__tool--condition router-graph__tool--classifier"
+                          onClick={() => addDataAtPath([], data)}
+                          onDragStart={event => beginDrag(event, data)}
+                          title={`Drag or click to add classifier ${classifier.id}`}
+                        >
+                          <span>clf:</span> {classifier.id}
+                        </button>
+                      );
+                    })}
+                    {filteredClassifiers.length === 0 && normalizedSearch && <div className="router-graph__toolbox-empty">No matching classifiers.</div>}
+                  </div>
+                </>
+              )}
+            </div>
+          )}
+        </aside>
+
+        <div className="router-graph__canvas-shell">
+          <div className="router-graph__toolbar">
+            <button type="button" disabled={historyRef.current.length === 0} onClick={undo}>Undo</button>
+            <button type="button" disabled={futureRef.current.length === 0} onClick={redo}>Redo</button>
+            {!blank && <button type="button" className="is-danger" onClick={() => { commit(createRouterLeaf()); setSelectedPath(null); }}>Clear</button>}
+            {rejection && <span className="router-graph__rejection" role="status"><Icon name="alert" size={12} /> {rejection}</span>}
+            <span className="router-graph__toolbar-hint">Drag items from the toolbox. Click a node to edit it. Ctrl/⌘ + wheel zooms.</span>
+            <span className="router-graph__toolbar-spacer" />
+            <button type="button" disabled={zoom <= ZOOM_MIN} onClick={() => setZoom(current => clampZoom(current - ZOOM_STEP))}>−</button>
+            <button type="button" className="router-graph__zoom-label" onClick={() => { setZoom(1); setPan({ x: 18, y: 18 }); }}>{Math.round(zoom * 100)}%</button>
+            <button type="button" disabled={zoom >= ZOOM_MAX} onClick={() => setZoom(current => clampZoom(current + ZOOM_STEP))}>+</button>
+          </div>
+          <div
+            ref={canvasRef}
+            className={`router-graph__canvas ${panning ? 'is-panning' : ''}`}
+            onWheel={onWheel}
+            onPointerDown={onPointerDown}
+            onPointerMove={onPointerMove}
+            onPointerUp={stopPanning}
+            onPointerCancel={stopPanning}
+            onPointerLeave={event => { if (panStateRef.current) stopPanning(event); }}
+            onDragOver={event => { event.preventDefault(); event.dataTransfer.dropEffect = 'copy'; }}
+            onDrop={event => {
+              event.preventDefault();
+              const data = decodeDrag(event.dataTransfer.getData(ROUTER_GRAPH_DRAG_MIME));
+              if (data) addDataAtPath([], data);
+            }}
+          >
+            {blank ? (
+              <div className="router-graph__empty">
+                <span className="router-graph__empty-icon"><Icon name="router" size={22} /></span>
+                <strong>Build the first condition</strong>
+                <span>Drag a logic gate or condition here, or click an item in the Toolbox.</span>
+                <GraphDropZone path={[]} label="Drop first node here" onDropData={addDataAtPath} />
+              </div>
+            ) : (
+              <div className="router-graph__canvas-transform" style={{ transform: `translate(${pan.x}px, ${pan.y}px) scale(${zoom})` }}>
+                <GraphNode
+                  node={node}
+                  path={[]}
+                  classifiers={classifiers}
+                  selectedPath={selectedPath}
+                  onSelect={setSelectedPath}
+                  onRemove={removeAtPath}
+                  onChangeOperator={changeOperator}
+                  onDropData={addDataAtPath}
+                />
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {selectedNode && (
+        <div className="router-graph__inspector">
+          <div className="router-graph__inspector-head">
+            <div>
+              <strong>Node inspector</strong>
+              <small>Edit the selected condition or gate without leaving the graph.</small>
+            </div>
+            <button type="button" onClick={() => setSelectedPath(null)} aria-label="Close node inspector"><Icon name="x" size={13} /></button>
+          </div>
+          <div className="router-graph__inspector-body">
+            <RouterNodeEditor
+              node={selectedNode}
+              classifiers={classifiers}
+              onChange={next => selectedPath && commit(replaceRouterNodeAtPath(node, selectedPath, next))}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default RouterRuleGraph;

--- a/src/app/src/components/WorkspacePanels.tsx
+++ b/src/app/src/components/WorkspacePanels.tsx
@@ -707,7 +707,9 @@ interface WorkspaceDetailPanelProps {
   leading?: React.ReactNode;
   metadata?: React.ReactNode;
   description?: React.ReactNode;
+  descriptionPlacement?: 'body' | 'identity';
   actions?: React.ReactNode;
+  titleExtras?: React.ReactNode;
   headerExtras?: React.ReactNode;
   onBack?: () => void;
   backLabel?: string;
@@ -726,7 +728,9 @@ export const WorkspaceDetailPanel = React.forwardRef<HTMLElement, WorkspaceDetai
   leading,
   metadata,
   description,
+  descriptionPlacement = 'body',
   actions,
+  titleExtras,
   headerExtras,
   onBack,
   backLabel = 'Back to list',
@@ -744,14 +748,18 @@ export const WorkspaceDetailPanel = React.forwardRef<HTMLElement, WorkspaceDetai
         <Icon name="chevron-right" size={14} className="workspace-detail-panel__back-icon" aria-hidden="true" /> {backLabel}
       </button>
     )}
-    {(title !== undefined || actions || headerExtras) && <header className="workspace-detail-panel__header">
+    {(title !== undefined || actions || titleExtras || headerExtras) && <header className="workspace-detail-panel__header">
       {title !== undefined && (
         <div className="workspace-detail-panel__title-row">
           {leading && <div className="workspace-detail-panel__leading">{leading}</div>}
           <div className="workspace-detail-panel__identity">
             {title}
             {metadata && <WorkspaceMetadataGroup>{metadata}</WorkspaceMetadataGroup>}
+            {descriptionPlacement === 'identity' && description && (
+              <div className="workspace-detail-panel__description workspace-detail-panel__description--identity">{description}</div>
+            )}
           </div>
+          {titleExtras}
           {onClose && (
             <button type="button" className={closeClassName} onClick={onClose} aria-label={closeLabel}>
               <Icon name={closeIcon} size={16} aria-hidden="true" />
@@ -762,7 +770,7 @@ export const WorkspaceDetailPanel = React.forwardRef<HTMLElement, WorkspaceDetai
       {actions && <div className="workspace-detail-panel__action-bar">{actions}</div>}
       {headerExtras}
     </header>}
-    {description && <div className="workspace-detail-panel__description">{description}</div>}
+    {descriptionPlacement === 'body' && description && <div className="workspace-detail-panel__description">{description}</div>}
     {children}
   </section>
 ));

--- a/src/app/src/components/inspect/Modal.tsx
+++ b/src/app/src/components/inspect/Modal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useId, useRef } from 'react';
 import { Icon } from '../Icon';
 
 interface ModalProps {
@@ -20,11 +20,19 @@ export default function Modal({
 }: ModalProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const titleRef = useRef<HTMLHeadingElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+  const generatedTitleId = useId();
+  const titleId = ariaLabelledBy || `inspect-modal-title-${generatedTitleId.replace(/:/g, '')}`;
 
   useEffect(() => {
-    if (isOpen) {
-      titleRef.current?.focus();
-    }
+    if (!isOpen) return;
+    previousFocusRef.current = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    titleRef.current?.focus();
+    return () => {
+      const previous = previousFocusRef.current;
+      previousFocusRef.current = null;
+      if (previous?.isConnected) previous.focus();
+    };
   }, [isOpen]);
 
   useEffect(() => {
@@ -40,12 +48,18 @@ export default function Modal({
           const first = focusable[0];
           const last = focusable[focusable.length - 1];
           if (e.shiftKey) {
-            if (document.activeElement === first) {
+            // The dialog title receives initial focus but is deliberately not
+            // in the normal tab order. Shift+Tab from that title must still
+            // stay inside the modal rather than escaping to the page behind it.
+            if (document.activeElement === first || document.activeElement === titleRef.current) {
               last.focus();
               e.preventDefault();
             }
           } else {
             if (document.activeElement === last) {
+              first.focus();
+              e.preventDefault();
+            } else if (document.activeElement === titleRef.current) {
               first.focus();
               e.preventDefault();
             }
@@ -66,7 +80,7 @@ export default function Modal({
       onClick={onClose}
       role="dialog"
       aria-modal="true"
-      aria-labelledby={ariaLabelledBy}
+      aria-labelledby={titleId}
     >
       <div
         className="inspect-modal-content flex-col"
@@ -74,7 +88,7 @@ export default function Modal({
         style={{ maxWidth }}
       >
         <div className="inspect-modal-header">
-          <h4 id={ariaLabelledBy} ref={titleRef} tabIndex={-1}>
+          <h4 id={titleId} ref={titleRef} tabIndex={-1}>
             {title}
           </h4>
           <button

--- a/src/app/src/components/inspect/Modal.tsx
+++ b/src/app/src/components/inspect/Modal.tsx
@@ -8,6 +8,7 @@ interface ModalProps {
   children: React.ReactNode;
   maxWidth?: string;
   ariaLabelledBy?: string;
+  className?: string;
 }
 
 export default function Modal({
@@ -16,7 +17,8 @@ export default function Modal({
   title,
   children,
   maxWidth = '600px',
-  ariaLabelledBy
+  ariaLabelledBy,
+  className,
 }: ModalProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const titleRef = useRef<HTMLHeadingElement>(null);
@@ -83,7 +85,7 @@ export default function Modal({
       aria-labelledby={titleId}
     >
       <div
-        className="inspect-modal-content flex-col"
+        className={`inspect-modal-content flex-col${className ? ` ${className}` : ''}`}
         onClick={(e) => e.stopPropagation()}
         style={{ maxWidth }}
       >

--- a/src/app/src/features/router/routerGraph.ts
+++ b/src/app/src/features/router/routerGraph.ts
@@ -1,0 +1,103 @@
+import {
+  createRouterLeaf,
+  createRouterNodeId,
+  normalizeRouterNode,
+  type RouterGroupNode,
+  type RouterGroupOperator,
+  type RouterNode,
+} from './routerTypes';
+
+export type RouterNodePath = number[];
+
+export function routerNodeAtPath(root: RouterNode, path: RouterNodePath): RouterNode | null {
+  let current: RouterNode = root;
+  for (const index of path) {
+    if (current.kind !== 'group' || index < 0 || index >= current.children.length) return null;
+    current = current.children[index];
+  }
+  return current;
+}
+
+export function replaceRouterNodeAtPath(root: RouterNode, path: RouterNodePath, replacement: RouterNode): RouterNode {
+  if (path.length === 0) return replacement;
+  if (root.kind !== 'group') return root;
+  const [index, ...rest] = path;
+  if (index < 0 || index >= root.children.length) return root;
+  return {
+    ...root,
+    children: root.children.map((child, childIndex) =>
+      childIndex === index ? replaceRouterNodeAtPath(child, rest, replacement) : child
+    ),
+  };
+}
+
+export function removeRouterNodeAtPath(root: RouterNode, path: RouterNodePath): RouterNode {
+  if (path.length === 0) return createRouterLeaf();
+  if (root.kind !== 'group') return root;
+  const [index, ...rest] = path;
+  if (index < 0 || index >= root.children.length) return root;
+
+  if (rest.length === 0) {
+    if (root.operator === 'not' && root.children.length === 1) {
+      return { ...root, children: [] };
+    }
+    return normalizeRouterNode({
+      ...root,
+      children: root.children.filter((_, childIndex) => childIndex !== index),
+    });
+  }
+
+  return normalizeRouterNode({
+    ...root,
+    children: root.children.map((child, childIndex) =>
+      childIndex === index ? removeRouterNodeAtPath(child, rest) : child
+    ),
+  });
+}
+
+export function createEmptyRouterGraphGroup(operator: RouterGroupOperator): RouterGroupNode {
+  return {
+    id: createRouterNodeId('group'),
+    kind: 'group',
+    operator,
+    children: [],
+  };
+}
+
+export function appendRouterNodeAtPath(root: RouterNode, targetPath: RouterNodePath, child: RouterNode): RouterNode {
+  const target = routerNodeAtPath(root, targetPath);
+  if (!target) return root;
+
+  if (target.kind === 'leaf') {
+    return replaceRouterNodeAtPath(root, targetPath, {
+      id: createRouterNodeId('group'),
+      kind: 'group',
+      operator: 'all',
+      children: [target, child],
+    });
+  }
+
+  if (target.operator === 'not' && target.children.length >= 1) {
+    throw new Error('NOT can contain only one condition.');
+  }
+
+  return replaceRouterNodeAtPath(root, targetPath, {
+    ...target,
+    children: [...target.children, child],
+  });
+}
+
+export function wrapRouterNode(root: RouterNode, operator: RouterGroupOperator): RouterNode {
+  return {
+    id: createRouterNodeId('group'),
+    kind: 'group',
+    operator,
+    children: [root],
+  };
+}
+
+export function isBlankRouterGraphNode(node: RouterNode): boolean {
+  return node.kind === 'leaf'
+    && node.type === 'keywords_any'
+    && String(node.textValue || '').trim().length === 0;
+}

--- a/src/app/src/features/router/routerGraph.ts
+++ b/src/app/src/features/router/routerGraph.ts
@@ -2,6 +2,7 @@ import {
   createRouterLeaf,
   createRouterNodeId,
   normalizeRouterNode,
+  routerConditionIdentity,
   type RouterGroupNode,
   type RouterGroupOperator,
   type RouterNode,
@@ -16,6 +17,55 @@ export function routerNodeAtPath(root: RouterNode, path: RouterNodePath): Router
     current = current.children[index];
   }
   return current;
+}
+
+function duplicateConditionMessage(node: RouterNode): string {
+  if (node.kind !== 'leaf') return 'This condition is already present in this gate.';
+  return `A ${node.type.replace(/_/g, ' ')} condition is already in this gate.`;
+}
+
+function duplicateConditionInChildren(children: RouterNode[], candidate: RouterNode, ignoreIndex = -1): string | null {
+  const identity = routerConditionIdentity(candidate);
+  if (!identity) return null;
+  const duplicate = children.some((child, index) => index !== ignoreIndex && routerConditionIdentity(child) === identity);
+  return duplicate ? duplicateConditionMessage(candidate) : null;
+}
+
+function duplicateConditionInSubtree(node: RouterNode): string | null {
+  if (node.kind !== 'group') return null;
+  for (let index = 0; index < node.children.length; index += 1) {
+    const child = node.children[index];
+    const conflict = duplicateConditionInChildren(node.children, child, index);
+    if (conflict) return conflict;
+    const nestedConflict = duplicateConditionInSubtree(child);
+    if (nestedConflict) return nestedConflict;
+  }
+  return null;
+}
+
+export function routerDuplicateConditionConflict(node: RouterNode): string | null {
+  return duplicateConditionInSubtree(node);
+}
+
+/**
+ * Returns a user-facing reason when replacing a node would create two direct
+ * singleton conditions inside one gate. Parameterized conditions such as regex,
+ * classifier bands, and metadata predicates remain repeatable because they can
+ * express different constraints and cannot be merged losslessly.
+ */
+export function routerReplacementConflictAtPath(
+  root: RouterNode,
+  path: RouterNodePath,
+  replacement: RouterNode,
+): string | null {
+  const internalConflict = duplicateConditionInSubtree(replacement);
+  if (internalConflict) return internalConflict;
+  if (path.length === 0 || replacement.kind !== 'leaf') return null;
+  const parentPath = path.slice(0, -1);
+  const childIndex = path[path.length - 1];
+  const parent = routerNodeAtPath(root, parentPath);
+  if (!parent || parent.kind !== 'group') return null;
+  return duplicateConditionInChildren(parent.children, replacement, childIndex);
 }
 
 export function replaceRouterNodeAtPath(root: RouterNode, path: RouterNodePath, replacement: RouterNode): RouterNode {
@@ -68,7 +118,12 @@ export function appendRouterNodeAtPath(root: RouterNode, targetPath: RouterNodeP
   const target = routerNodeAtPath(root, targetPath);
   if (!target) return root;
 
+  const childConflict = duplicateConditionInSubtree(child);
+  if (childConflict) throw new Error(childConflict);
+
   if (target.kind === 'leaf') {
+    const conflict = duplicateConditionInChildren([target], child);
+    if (conflict) throw new Error(conflict);
     return replaceRouterNodeAtPath(root, targetPath, {
       id: createRouterNodeId('group'),
       kind: 'group',
@@ -80,6 +135,9 @@ export function appendRouterNodeAtPath(root: RouterNode, targetPath: RouterNodeP
   if (target.operator === 'not' && target.children.length >= 1) {
     throw new Error('NOT can contain only one condition.');
   }
+
+  const conflict = duplicateConditionInChildren(target.children, child);
+  if (conflict) throw new Error(conflict);
 
   return replaceRouterNodeAtPath(root, targetPath, {
     ...target,

--- a/src/app/src/features/router/routerGraph.ts
+++ b/src/app/src/features/router/routerGraph.ts
@@ -91,18 +91,18 @@ export function removeRouterNodeAtPath(root: RouterNode, path: RouterNodePath): 
     if (root.operator === 'not' && root.children.length === 1) {
       return { ...root, children: [] };
     }
-    return normalizeRouterNode({
-      ...root,
-      children: root.children.filter((_, childIndex) => childIndex !== index),
-    });
+    // Preserve AND/OR groups even when they drop to 1 child — the graph shows
+    // a validation error prompting the user to add a second condition, and the
+    // gate shape is still visible so the intent is not silently discarded.
+    return { ...root, children: root.children.filter((_, i) => i !== index) };
   }
 
-  return normalizeRouterNode({
+  return {
     ...root,
     children: root.children.map((child, childIndex) =>
       childIndex === index ? removeRouterNodeAtPath(child, rest) : child
     ),
-  });
+  };
 }
 
 export function createEmptyRouterGraphGroup(operator: RouterGroupOperator): RouterGroupNode {

--- a/src/app/src/features/router/routerTypes.ts
+++ b/src/app/src/features/router/routerTypes.ts
@@ -199,6 +199,42 @@ function splitList(value: unknown): string[] {
   return String(value ?? '').split(',').map(item => item.trim()).filter(Boolean);
 }
 
+function routerNodeHasMeaningfulProgress(node: RouterNode): boolean {
+  if (node.kind === 'group') return true;
+  if (node.type !== 'keywords_any') return true;
+  return splitList(node.textValue).length > 0;
+}
+
+export function routerDraftHasRulesProgress(draft: RouterDraft): boolean {
+  if (draft.classifiers.length > 0) return true;
+  if (draft.rules.length === 0) return false;
+  if (draft.rules.length > 1) return true;
+
+  const rule = draft.rules[0];
+  return rule.id !== 'rule-1'
+    || rule.routeTo !== draft.defaultModel
+    || Boolean(rule.outputsText?.trim())
+    || routerNodeHasMeaningfulProgress(rule.condition);
+}
+
+export function routerDraftHasLlmProgress(draft: RouterDraft): boolean {
+  return Boolean(draft.llmRouter.model.trim() || draft.llmRouter.prompt.trim());
+}
+
+export function switchRouterDraftMode(draft: RouterDraft, mode: RouterRoutingMode): RouterDraft {
+  if (mode === draft.mode) return draft;
+  if (mode === 'llm') {
+    return { ...draft, mode: 'llm', rules: [], classifiers: [] };
+  }
+  return {
+    ...draft,
+    mode: 'rules',
+    llmRouter: { model: '', prompt: '' },
+    classifiers: [],
+    rules: [createRouterRule(0, draft.defaultModel)],
+  };
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === 'object' && !Array.isArray(value);
 }
@@ -496,47 +532,147 @@ export function buildRouterPullRequest(draft: RouterDraft): RouterPullRequest {
 
 function parseMatchExpression(expr: unknown): RouterNode {
   if (!isRecord(expr)) throw new Error('Rule match must be an object.');
-  if (Array.isArray(expr.all)) {
-    return { id: createRouterNodeId('group'), kind: 'group', operator: 'all', children: expr.all.map(parseMatchExpression) };
+
+  const logicalKeys = (['all', 'any', 'not'] as const).filter(key => key in expr);
+  if (logicalKeys.length > 1) {
+    throw new Error('Rule match must contain only one logical operator.');
   }
-  if (Array.isArray(expr.any)) {
-    return { id: createRouterNodeId('group'), kind: 'group', operator: 'any', children: expr.any.map(parseMatchExpression) };
-  }
-  if (isRecord(expr.not)) {
-    return { id: createRouterNodeId('group'), kind: 'group', operator: 'not', children: [parseMatchExpression(expr.not)] };
-  }
-  if (Array.isArray(expr.keywords_any)) return { ...createRouterLeaf('keywords_any'), textValue: expr.keywords_any.join(', ') };
-  if (Array.isArray(expr.keywords_all)) return { ...createRouterLeaf('keywords_all'), textValue: expr.keywords_all.join(', ') };
-  if (typeof expr.regex === 'string') return { ...createRouterLeaf('regex'), textValue: expr.regex };
-  if (typeof expr.min_chars === 'number') return { ...createRouterLeaf('min_chars'), numberValue: expr.min_chars };
-  if (typeof expr.max_chars === 'number') return { ...createRouterLeaf('max_chars'), numberValue: expr.max_chars };
-  if (typeof expr.has_tools === 'boolean') return { ...createRouterLeaf('has_tools'), booleanValue: expr.has_tools };
-  if (typeof expr.has_images === 'boolean') return { ...createRouterLeaf('has_images'), booleanValue: expr.has_images };
-  if (typeof expr.classifier === 'string') {
+  if (logicalKeys.length === 1) {
+    if (Object.keys(expr).length !== 1) {
+      throw new Error('Rule match cannot mix logical operators with leaf conditions.');
+    }
+    const logicalKey = logicalKeys[0];
+    if (logicalKey === 'not') {
+      if (!isRecord(expr.not)) throw new Error('Rule match "not" must be an object.');
+      return { id: createRouterNodeId('group'), kind: 'group', operator: 'not', children: [parseMatchExpression(expr.not)] };
+    }
+    const rawChildren = expr[logicalKey];
+    if (!Array.isArray(rawChildren) || rawChildren.length === 0) {
+      throw new Error(`Rule match "${logicalKey}" must be a non-empty array.`);
+    }
     return {
+      id: createRouterNodeId('group'),
+      kind: 'group',
+      operator: logicalKey,
+      children: rawChildren.map(parseMatchExpression),
+    };
+  }
+
+  const children: RouterNode[] = [];
+  const consumed = new Set<string>();
+
+  const parseStringArray = (key: 'keywords_any' | 'keywords_all'): string[] => {
+    const value = expr[key];
+    if (!Array.isArray(value) || value.length === 0) {
+      throw new Error(`Rule match "${key}" must be a non-empty array.`);
+    }
+    if (value.some(item => typeof item !== 'string' || item.length === 0)) {
+      throw new Error(`Rule match "${key}" items must be non-empty strings.`);
+    }
+    return value as string[];
+  };
+
+  if ('keywords_any' in expr) {
+    children.push({ ...createRouterLeaf('keywords_any'), textValue: parseStringArray('keywords_any').join(', ') });
+    consumed.add('keywords_any');
+  }
+  if ('keywords_all' in expr) {
+    children.push({ ...createRouterLeaf('keywords_all'), textValue: parseStringArray('keywords_all').join(', ') });
+    consumed.add('keywords_all');
+  }
+  if ('regex' in expr) {
+    if (typeof expr.regex !== 'string' || !expr.regex.length) throw new Error('Rule match "regex" must be a non-empty string.');
+    children.push({ ...createRouterLeaf('regex'), textValue: expr.regex });
+    consumed.add('regex');
+  }
+  if ('min_chars' in expr) {
+    if (typeof expr.min_chars !== 'number' || !Number.isInteger(expr.min_chars) || expr.min_chars < 0) throw new Error('Rule match "min_chars" must be a non-negative integer.');
+    children.push({ ...createRouterLeaf('min_chars'), numberValue: expr.min_chars });
+    consumed.add('min_chars');
+  }
+  if ('max_chars' in expr) {
+    if (typeof expr.max_chars !== 'number' || !Number.isInteger(expr.max_chars) || expr.max_chars < 0) throw new Error('Rule match "max_chars" must be a non-negative integer.');
+    children.push({ ...createRouterLeaf('max_chars'), numberValue: expr.max_chars });
+    consumed.add('max_chars');
+  }
+  if ('has_tools' in expr) {
+    if (typeof expr.has_tools !== 'boolean') throw new Error('Rule match "has_tools" must be a boolean.');
+    children.push({ ...createRouterLeaf('has_tools'), booleanValue: expr.has_tools });
+    consumed.add('has_tools');
+  }
+  if ('has_images' in expr) {
+    if (typeof expr.has_images !== 'boolean') throw new Error('Rule match "has_images" must be a boolean.');
+    children.push({ ...createRouterLeaf('has_images'), booleanValue: expr.has_images });
+    consumed.add('has_images');
+  }
+  if ('classifier' in expr) {
+    if (typeof expr.classifier !== 'string' || !expr.classifier.length) throw new Error('Rule match "classifier" must be a non-empty string.');
+    if ('label' in expr && (typeof expr.label !== 'string' || !expr.label.length)) throw new Error('Rule match "label" must be a non-empty string.');
+    if ('min_score' in expr && typeof expr.min_score !== 'number') throw new Error('Rule match "min_score" must be a number.');
+    if ('max_score' in expr && typeof expr.max_score !== 'number') throw new Error('Rule match "max_score" must be a number.');
+    children.push({
       ...createRouterLeaf('classifier'),
       classifierId: expr.classifier,
       label: typeof expr.label === 'string' ? expr.label : undefined,
       minScore: typeof expr.min_score === 'number' ? expr.min_score : undefined,
       maxScore: typeof expr.max_score === 'number' ? expr.max_score : undefined,
-    };
+    });
+    consumed.add('classifier');
+    if ('label' in expr) consumed.add('label');
+    if ('min_score' in expr) consumed.add('min_score');
+    if ('max_score' in expr) consumed.add('max_score');
+  } else if ('label' in expr || 'min_score' in expr || 'max_score' in expr) {
+    throw new Error('Rule match classifier label/score fields require a "classifier" condition.');
   }
-  if (isRecord(expr.metadata)) {
+  if ('metadata' in expr) {
+    if (!isRecord(expr.metadata)) throw new Error('Rule match "metadata" must be an object.');
     const metadata = expr.metadata;
-    let comparator: RouterMetadataComparator = 'equals';
-    if ('any' in metadata) comparator = 'any';
-    if ('exists' in metadata) comparator = 'exists';
-    return {
+    const allowedMetadataKeys = new Set(['key', 'equals', 'any', 'exists']);
+    const unsupportedMetadata = Object.keys(metadata).filter(key => !allowedMetadataKeys.has(key));
+    if (unsupportedMetadata.length > 0) {
+      throw new Error(`Unsupported metadata field${unsupportedMetadata.length > 1 ? 's' : ''}: ${unsupportedMetadata.join(', ')}.`);
+    }
+    if (typeof metadata.key !== 'string' || !metadata.key.length) {
+      throw new Error('Rule match metadata requires a non-empty string "key".');
+    }
+    const comparators = (['equals', 'any', 'exists'] as const).filter(key => key in metadata);
+    if (comparators.length !== 1) {
+      throw new Error('Rule match metadata requires exactly one comparator: equals, any, or exists.');
+    }
+    const comparator = comparators[0];
+    if (comparator === 'equals' && typeof metadata.equals !== 'string') {
+      throw new Error('Rule match metadata "equals" must be a string.');
+    }
+    if (comparator === 'any') {
+      if (!Array.isArray(metadata.any) || metadata.any.length === 0) {
+        throw new Error('Rule match metadata "any" must be a non-empty array.');
+      }
+      if (metadata.any.some(item => typeof item !== 'string' || item.length === 0)) {
+        throw new Error('Rule match metadata "any" items must be non-empty strings.');
+      }
+    }
+    if (comparator === 'exists' && typeof metadata.exists !== 'boolean') {
+      throw new Error('Rule match metadata "exists" must be a boolean.');
+    }
+    children.push({
       ...createRouterLeaf('metadata'),
-      metadataKey: typeof metadata.key === 'string' ? metadata.key : '',
+      metadataKey: metadata.key,
       metadataComparator: comparator,
-      metadataValues: comparator === 'any' && Array.isArray(metadata.any)
-        ? metadata.any.join(', ')
-        : comparator === 'equals' ? String(metadata.equals ?? '') : '',
-      booleanValue: comparator === 'exists' ? metadata.exists !== false : undefined,
-    };
+      metadataValues: comparator === 'any'
+        ? (metadata.any as string[]).join(', ')
+        : comparator === 'equals' ? metadata.equals as string : '',
+      booleanValue: comparator === 'exists' ? metadata.exists as boolean : undefined,
+    });
+    consumed.add('metadata');
   }
-  throw new Error('Unsupported or empty rule condition.');
+
+  const unsupported = Object.keys(expr).filter(key => !consumed.has(key));
+  if (unsupported.length > 0) {
+    throw new Error(`Unsupported rule condition field${unsupported.length > 1 ? 's' : ''}: ${unsupported.join(', ')}.`);
+  }
+  if (children.length === 0) throw new Error('Unsupported or empty rule condition.');
+  if (children.length === 1) return children[0];
+  return { id: createRouterNodeId('group'), kind: 'group', operator: 'all', children };
 }
 
 function parseClassifier(value: unknown, index: number): RouterClassifier {

--- a/src/app/src/features/router/routerTypes.ts
+++ b/src/app/src/features/router/routerTypes.ts
@@ -360,7 +360,8 @@ export function normalizeRouterNode(node: RouterNode): RouterNode {
     return { ...node, children: children.slice(0, 1).length ? children.slice(0, 1) : [createRouterLeaf()] };
   }
   if (children.length === 0) return createRouterLeaf();
-  if (children.length === 1) return children[0];
+  // Preserve AND/OR groups even with 1 child so gate structure is not silently
+  // discarded — validation will prompt the user to add a second condition.
   return { ...node, children };
 }
 
@@ -478,7 +479,8 @@ function validateNode(
   }
   if (node.kind === 'group') {
     if (node.operator === 'not' && node.children.length !== 1) errors.push(`${path}: NOT requires exactly one condition.`);
-    if ((node.operator === 'all' || node.operator === 'any') && node.children.length === 0) errors.push(`${path}: ${node.operator.toUpperCase()} requires at least one condition.`);
+    if ((node.operator === 'all' || node.operator === 'any') && node.children.length === 0) errors.push(`${path}: ${node.operator.toUpperCase()} gate requires at least one condition.`);
+    if ((node.operator === 'all' || node.operator === 'any') && node.children.length === 1) errors.push(`${path}: ${node.operator.toUpperCase()} gate needs at least 2 conditions - add another or remove the gate.`);
 
     const directConditions = new Set<string>();
     node.children.forEach((child, index) => {

--- a/src/app/src/features/router/routerTypes.ts
+++ b/src/app/src/features/router/routerTypes.ts
@@ -149,6 +149,27 @@ export function createRouterLeaf(type: RouterLeafType = 'keywords_any'): RouterL
   return base;
 }
 
+const SINGLETON_ROUTER_LEAF_TYPES = new Set<RouterLeafType>([
+  'keywords_any',
+  'keywords_all',
+  'min_chars',
+  'max_chars',
+  'has_tools',
+  'has_images',
+]);
+
+/**
+ * Identity for direct-child conditions that are semantically redundant when
+ * repeated inside one gate. Regex, classifier, and metadata leaves are
+ * intentionally not singletons: two regexes, two different classifier bands,
+ * or multiple metadata predicates can express distinct constraints that cannot
+ * be merged losslessly into one leaf.
+ */
+export function routerConditionIdentity(node: RouterNode): string | null {
+  if (node.kind !== 'leaf' || !SINGLETON_ROUTER_LEAF_TYPES.has(node.type)) return null;
+  return node.type;
+}
+
 export function createRouterGroup(operator: RouterGroupOperator = 'all'): RouterGroupNode {
   return {
     id: createRouterNodeId('group'),
@@ -196,7 +217,9 @@ export function createEmptyRouterDraft(): RouterDraft {
 
 function splitList(value: unknown): string[] {
   if (Array.isArray(value)) return value.map(item => String(item).trim()).filter(Boolean);
-  return String(value ?? '').split(',').map(item => item.trim()).filter(Boolean);
+  // A comma is valid data in server-side keywords/metadata values, so list-valued
+  // rule fields use one item per line in the editor.
+  return String(value ?? '').split(/\r?\n/).map(item => item.trim()).filter(Boolean);
 }
 
 function routerNodeHasMeaningfulProgress(node: RouterNode): boolean {
@@ -221,6 +244,27 @@ export function routerDraftHasLlmProgress(draft: RouterDraft): boolean {
   return Boolean(draft.llmRouter.model.trim() || draft.llmRouter.prompt.trim());
 }
 
+/**
+ * Add or remove a routing candidate while keeping the dependent default/rule
+ * destinations valid. UI affordances (checkboxes, connection-row trash
+ * buttons, future pickers) should all use this transition rather than editing
+ * the candidate array independently.
+ */
+export function toggleRouterDraftCandidate(draft: RouterDraft, modelName: string): RouterDraft {
+  const exists = draft.candidates.includes(modelName);
+  const candidates = exists
+    ? draft.candidates.filter(candidate => candidate !== modelName)
+    : [...draft.candidates, modelName];
+  const defaultModel = candidates.includes(draft.defaultModel)
+    ? draft.defaultModel
+    : (candidates[0] || '');
+  const rules = draft.rules.map(rule => ({
+    ...rule,
+    routeTo: candidates.includes(rule.routeTo) ? rule.routeTo : defaultModel,
+  }));
+  return { ...draft, candidates, defaultModel, rules };
+}
+
 export function switchRouterDraftMode(draft: RouterDraft, mode: RouterRoutingMode): RouterDraft {
   if (mode === draft.mode) return draft;
   if (mode === 'llm') {
@@ -241,9 +285,10 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 export function classifierLabels(classifier: RouterClassifier | undefined): string[] {
   if (!classifier) return [];
-  return classifier.type === 'semantic_similarity'
-    ? Object.keys(classifier.referencePhrases).filter(Boolean)
-    : classifier.labels.filter(Boolean);
+  const labels = classifier.type === 'semantic_similarity'
+    ? Object.keys(classifier.referencePhrases)
+    : classifier.labels;
+  return labels.map(label => label.trim()).filter(Boolean);
 }
 
 export function renameClassifierReference(node: RouterNode, previousId: string, nextId: string): RouterNode {
@@ -277,6 +322,37 @@ export function routerNodeReferencesClassifier(node: RouterNode, classifierId: s
   return node.children.some(child => routerNodeReferencesClassifier(child, classifierId));
 }
 
+function routerNodeComparable(node: RouterNode): unknown {
+  if (node.kind === 'leaf') {
+    const { id: _id, ...rest } = node;
+    return rest;
+  }
+  return {
+    kind: node.kind,
+    operator: node.operator,
+    children: node.children.map(routerNodeComparable),
+  };
+}
+
+/** Stable dirty-state fingerprint that intentionally ignores generated graph IDs. */
+export function routerDraftFingerprint(draft: RouterDraft): string {
+  return JSON.stringify({
+    modelName: draft.modelName || '',
+    name: draft.name,
+    candidates: draft.candidates,
+    defaultModel: draft.defaultModel,
+    mode: draft.mode,
+    llmRouter: draft.llmRouter,
+    classifiers: draft.classifiers,
+    rules: draft.rules.map(rule => ({
+      id: rule.id,
+      routeTo: rule.routeTo,
+      outputsText: rule.outputsText || '',
+      condition: routerNodeComparable(rule.condition),
+    })),
+  });
+}
+
 export function normalizeRouterNode(node: RouterNode): RouterNode {
   if (node.kind === 'leaf') return node;
   const children = node.children.map(normalizeRouterNode).filter(Boolean);
@@ -290,24 +366,27 @@ export function normalizeRouterNode(node: RouterNode): RouterNode {
 
 function nodeToMatchExpression(node: RouterNode): Record<string, unknown> {
   if (node.kind === 'group') {
-    const normalized = normalizeRouterNode(node);
-    if (normalized.kind === 'leaf') return nodeToMatchExpression(normalized);
-    if (normalized.operator === 'not') {
-      return { not: nodeToMatchExpression(normalized.children[0]) };
+    // Preserve valid singleton ALL/ANY groups during serialization. Collapsing a
+    // singleton here can promote its child into the parent gate and create a
+    // duplicate singleton condition that the editor/server correctly rejects on
+    // the next import. The draft has already been validated, so groups are safe
+    // to serialize exactly as authored.
+    if (node.operator === 'not') {
+      return { not: nodeToMatchExpression(node.children[0]) };
     }
-    return { [normalized.operator]: normalized.children.map(nodeToMatchExpression) };
+    return { [node.operator]: node.children.map(nodeToMatchExpression) };
   }
 
   switch (node.type) {
     case 'keywords_any': return { keywords_any: splitList(node.textValue) };
     case 'keywords_all': return { keywords_all: splitList(node.textValue) };
-    case 'regex': return { regex: String(node.textValue || '').trim() };
+    case 'regex': return { regex: String(node.textValue ?? '') };
     case 'min_chars': return { min_chars: Number(node.numberValue) };
     case 'max_chars': return { max_chars: Number(node.numberValue) };
     case 'has_tools': return { has_tools: node.booleanValue !== false };
     case 'has_images': return { has_images: node.booleanValue !== false };
     case 'classifier': {
-      const result: Record<string, unknown> = { classifier: String(node.classifierId || '').trim() };
+      const result: Record<string, unknown> = { classifier: String(node.classifierId || '') };
       if (node.label) result.label = node.label;
       if (node.minScore !== undefined) result.min_score = node.minScore;
       if (node.maxScore !== undefined) result.max_score = node.maxScore;
@@ -315,7 +394,7 @@ function nodeToMatchExpression(node: RouterNode): Record<string, unknown> {
     }
     case 'metadata': {
       const comparator = node.metadataComparator || 'equals';
-      const metadata: Record<string, unknown> = { key: String(node.metadataKey || '').trim() };
+      const metadata: Record<string, unknown> = { key: String(node.metadataKey || '') };
       if (comparator === 'exists') metadata.exists = node.booleanValue !== false;
       else if (comparator === 'any') metadata.any = splitList(node.metadataValues);
       else metadata.equals = String(node.metadataValues ?? '');
@@ -325,7 +404,65 @@ function nodeToMatchExpression(node: RouterNode): Record<string, unknown> {
 }
 
 function nestedUnboundedQuantifier(pattern: string): boolean {
-  return /\((?:[^()\\]|\\.)*[+*](?:[^()\\]|\\.)*\)[+*]/.test(pattern);
+  // Mirror the server's load-time ReDoS safeguard: reject an unbounded
+  // quantifier applied to a group that already contains an unbounded
+  // quantifier. This includes wrapper groups and {m,} forms while ignoring
+  // escaped metacharacters and character classes.
+  const stack: Array<{ hasUnbounded: boolean }> = [];
+  let previousClosedGroup = false;
+  let closedGroupUnbounded = false;
+
+  for (let index = 0; index < pattern.length; index += 1) {
+    const char = pattern[index];
+    if (char === '\\') {
+      index += 1;
+      previousClosedGroup = false;
+      continue;
+    }
+    if (char === '[') {
+      index += 1;
+      if (index < pattern.length && pattern[index] === '^') index += 1;
+      if (index < pattern.length && pattern[index] === ']') index += 1;
+      while (index < pattern.length && pattern[index] !== ']') {
+        if (pattern[index] === '\\') index += 1;
+        index += 1;
+      }
+      previousClosedGroup = false;
+      continue;
+    }
+    if (char === '(') {
+      stack.push({ hasUnbounded: false });
+      previousClosedGroup = false;
+      continue;
+    }
+    if (char === ')') {
+      closedGroupUnbounded = stack.length > 0 && stack[stack.length - 1].hasUnbounded;
+      if (stack.length > 0) stack.pop();
+      if (closedGroupUnbounded && stack.length > 0) stack[stack.length - 1].hasUnbounded = true;
+      previousClosedGroup = true;
+      continue;
+    }
+
+    let unbounded = char === '*' || char === '+';
+    if (char === '{') {
+      let cursor = index + 1;
+      let inner = '';
+      while (cursor < pattern.length && pattern[cursor] !== '}') {
+        inner += pattern[cursor];
+        cursor += 1;
+      }
+      const comma = inner.indexOf(',');
+      if (comma >= 0 && comma + 1 >= inner.length) unbounded = true;
+      index = cursor;
+    }
+
+    if (unbounded) {
+      if (previousClosedGroup && closedGroupUnbounded) return true;
+      if (stack.length > 0) stack[stack.length - 1].hasUnbounded = true;
+    }
+    previousClosedGroup = false;
+  }
+  return false;
 }
 
 function validateNode(
@@ -342,11 +479,20 @@ function validateNode(
   if (node.kind === 'group') {
     if (node.operator === 'not' && node.children.length !== 1) errors.push(`${path}: NOT requires exactly one condition.`);
     if ((node.operator === 'all' || node.operator === 'any') && node.children.length === 0) errors.push(`${path}: ${node.operator.toUpperCase()} requires at least one condition.`);
-    node.children.forEach((child, index) => validateNode(child, classifiers, `${path}.${node.operator}[${index}]`, depth + 1, errors));
+
+    const directConditions = new Set<string>();
+    node.children.forEach((child, index) => {
+      const identity = routerConditionIdentity(child);
+      if (identity && directConditions.has(identity)) {
+        errors.push(`${path}: duplicate ${identity.replace(':', ' ')} conditions are not allowed in the same gate.`);
+      }
+      if (identity) directConditions.add(identity);
+      validateNode(child, classifiers, `${path}.${node.operator}[${index}]`, depth + 1, errors);
+    });
     return;
   }
 
-  const text = String(node.textValue ?? '').trim();
+  const text = String(node.textValue ?? '');
   if ((node.type === 'keywords_any' || node.type === 'keywords_all') && splitList(node.textValue).length === 0) {
     errors.push(`${path}: add at least one keyword.`);
   }
@@ -359,7 +505,7 @@ function validateNode(
   }
   if (node.type === 'min_chars' || node.type === 'max_chars') {
     const value = Number(node.numberValue);
-    if (!Number.isInteger(value) || value < 0) errors.push(`${path}: character bound must be a non-negative integer.`);
+    if (!Number.isInteger(value) || value < 0) errors.push(`${path}: UTF-8 byte bound must be a non-negative integer.`);
   }
   if (node.type === 'classifier') {
     const classifier = classifiers.find(item => item.id === node.classifierId);
@@ -368,7 +514,7 @@ function validateNode(
       return;
     }
     const labels = classifierLabels(classifier);
-    if (node.label && labels.length > 0 && !labels.includes(node.label)) {
+    if (node.label && (labels.length === 0 || !labels.includes(node.label))) {
       errors.push(`${path}: label "${node.label}" is not declared by classifier "${classifier.id}".`);
     }
     if (!node.label && labels.length > 0 && !classifier.defaultLabel) {
@@ -385,7 +531,7 @@ function validateNode(
     }
   }
   if (node.type === 'metadata') {
-    if (!String(node.metadataKey || '').trim()) errors.push(`${path}: metadata key is required.`);
+    if (!String(node.metadataKey ?? '').length) errors.push(`${path}: metadata key is required.`);
     if ((node.metadataComparator || 'equals') === 'any' && splitList(node.metadataValues).length === 0) {
       errors.push(`${path}: metadata "any" requires at least one value.`);
     }
@@ -399,8 +545,8 @@ export function validateRouterDraft(draft: RouterDraft): string[] {
   if (draft.candidates.length === 0) errors.push('Select at least one candidate model.');
   const candidateSet = new Set<string>();
   draft.candidates.forEach((candidate, index) => {
-    const value = candidate.trim();
-    if (!value) errors.push(`Candidate ${index + 1} is empty.`);
+    const value = candidate;
+    if (!value.length) errors.push(`Candidate ${index + 1} is empty.`);
     if (candidateSet.has(value)) errors.push(`Candidate "${value}" is duplicated.`);
     candidateSet.add(value);
   });
@@ -415,26 +561,30 @@ export function validateRouterDraft(draft: RouterDraft): string[] {
   const classifierIds = new Set<string>();
   draft.classifiers.forEach((classifier, index) => {
     const prefix = `Classifier ${index + 1}`;
-    if (!classifier.id.trim()) errors.push(`${prefix}: ID is required.`);
-    if (!SAFE_ROUTER_ID.test(classifier.id)) errors.push(`${prefix}: ID may contain only letters, numbers, dot, underscore, and hyphen.`);
+    if (!classifier.id.length) errors.push(`${prefix}: ID is required.`);
     if (classifierIds.has(classifier.id)) errors.push(`${prefix}: duplicate ID "${classifier.id}".`);
     classifierIds.add(classifier.id);
     if (!classifier.model.trim()) errors.push(`${prefix}: model is required.`);
     if (classifier.type === 'classifier' || classifier.type === 'llm') {
       const labels = classifier.labels.map(label => label.trim()).filter(Boolean);
       if (classifier.type === 'llm' && labels.length === 0) errors.push(`${prefix}: add at least one output label.`);
-      if (new Set(labels).size !== labels.length) errors.push(`${prefix}: labels must be unique.`);
-      if (classifier.defaultLabel && !labels.includes(classifier.defaultLabel)) errors.push(`${prefix}: default label must be declared in labels.`);
+      if (new Set(labels).size !== labels.length) errors.push(`${prefix}: labels must be unique after trimming whitespace.`);
+      const defaultLabel = classifier.defaultLabel?.trim();
+      if (defaultLabel && !labels.includes(defaultLabel)) errors.push(`${prefix}: default label must be declared in labels.`);
       if (classifier.type === 'llm' && !classifier.prompt.trim()) errors.push(`${prefix}: prompt is required for an LLM classifier.`);
     } else {
       const concepts = Object.entries(classifier.referencePhrases);
       if (concepts.length === 0) errors.push(`${prefix}: add at least one semantic concept.`);
+      const normalizedConcepts: string[] = [];
       for (const [concept, phrases] of concepts) {
-        if (!concept.trim()) errors.push(`${prefix}: concept names cannot be empty.`);
+        const normalizedConcept = concept.trim();
+        if (!normalizedConcept) errors.push(`${prefix}: concept names cannot be empty.`);
+        else normalizedConcepts.push(normalizedConcept);
         if (!phrases.map(item => item.trim()).filter(Boolean).length) errors.push(`${prefix}: concept "${concept}" needs at least one phrase.`);
       }
-      const conceptLabels = concepts.map(([concept]) => concept);
-      if (classifier.defaultLabel && !conceptLabels.includes(classifier.defaultLabel)) errors.push(`${prefix}: default label must be one of the concept names.`);
+      if (new Set(normalizedConcepts).size !== normalizedConcepts.length) errors.push(`${prefix}: concept names must be unique after trimming whitespace.`);
+      const defaultLabel = classifier.defaultLabel?.trim();
+      if (defaultLabel && !normalizedConcepts.includes(defaultLabel)) errors.push(`${prefix}: default label must be one of the concept names.`);
     }
   });
 
@@ -465,11 +615,11 @@ export function buildRouterPullRequest(draft: RouterDraft): RouterPullRequest {
   const components = new Set(draft.candidates);
   const mode: RouterRoutingMode = draft.mode === 'llm' ? 'llm' : 'rules';
   if (mode === 'llm') {
-    const routerModel = draft.llmRouter.model.trim();
+    const routerModel = draft.llmRouter.model;
     components.add(routerModel);
     return {
       version: ROUTER_SCHEMA_VERSION,
-      model_name: draft.modelName?.trim() || normalizeRouterModelName(draft.name),
+      model_name: draft.modelName || normalizeRouterModelName(draft.name),
       recipe: ROUTER_RECIPE,
       components: [...components].filter(Boolean),
       routing: {
@@ -478,7 +628,7 @@ export function buildRouterPullRequest(draft: RouterDraft): RouterPullRequest {
         router: {
           type: 'llm',
           model: routerModel,
-          prompt: draft.llmRouter.prompt.trim(),
+          prompt: draft.llmRouter.prompt,
         },
       },
     };
@@ -495,7 +645,7 @@ export function buildRouterPullRequest(draft: RouterDraft): RouterPullRequest {
     if (classifier.type === 'classifier' || classifier.type === 'llm') {
       const labels = [...new Set(classifier.labels.map(label => label.trim()).filter(Boolean))];
       if (labels.length) result.labels = labels;
-      if (classifier.type === 'llm') result.prompt = classifier.prompt.trim();
+      if (classifier.type === 'llm') result.prompt = classifier.prompt;
     } else {
       result.reference_phrases = Object.fromEntries(
         Object.entries(classifier.referencePhrases)
@@ -503,13 +653,14 @@ export function buildRouterPullRequest(draft: RouterDraft): RouterPullRequest {
           .filter(([concept, phrases]) => Boolean(concept) && (phrases as string[]).length > 0),
       );
     }
-    if (classifier.defaultLabel) result.default_label = classifier.defaultLabel;
+    const defaultLabel = classifier.defaultLabel?.trim();
+    if (defaultLabel) result.default_label = defaultLabel;
     return result;
   });
   const rules = draft.rules.map(rule => {
     const result: Record<string, unknown> = {
       id: rule.id,
-      match: nodeToMatchExpression(normalizeRouterNode(rule.condition)),
+      match: nodeToMatchExpression(rule.condition),
       route_to: rule.routeTo,
     };
     if (rule.outputsText?.trim()) result.outputs = JSON.parse(rule.outputsText);
@@ -523,14 +674,15 @@ export function buildRouterPullRequest(draft: RouterDraft): RouterPullRequest {
   if (classifiers.length) routing.classifiers = classifiers;
   return {
     version: ROUTER_SCHEMA_VERSION,
-    model_name: draft.modelName?.trim() || normalizeRouterModelName(draft.name),
+    model_name: draft.modelName || normalizeRouterModelName(draft.name),
     recipe: ROUTER_RECIPE,
     components: [...components].filter(Boolean),
     routing,
   };
 }
 
-function parseMatchExpression(expr: unknown): RouterNode {
+function parseMatchExpression(expr: unknown, depth = 0): RouterNode {
+  if (depth > MAX_ROUTER_TREE_DEPTH) throw new Error(`Rule match nesting exceeds ${MAX_ROUTER_TREE_DEPTH} levels.`);
   if (!isRecord(expr)) throw new Error('Rule match must be an object.');
 
   const logicalKeys = (['all', 'any', 'not'] as const).filter(key => key in expr);
@@ -544,7 +696,7 @@ function parseMatchExpression(expr: unknown): RouterNode {
     const logicalKey = logicalKeys[0];
     if (logicalKey === 'not') {
       if (!isRecord(expr.not)) throw new Error('Rule match "not" must be an object.');
-      return { id: createRouterNodeId('group'), kind: 'group', operator: 'not', children: [parseMatchExpression(expr.not)] };
+      return { id: createRouterNodeId('group'), kind: 'group', operator: 'not', children: [parseMatchExpression(expr.not, depth + 1)] };
     }
     const rawChildren = expr[logicalKey];
     if (!Array.isArray(rawChildren) || rawChildren.length === 0) {
@@ -554,7 +706,7 @@ function parseMatchExpression(expr: unknown): RouterNode {
       id: createRouterNodeId('group'),
       kind: 'group',
       operator: logicalKey,
-      children: rawChildren.map(parseMatchExpression),
+      children: rawChildren.map(child => parseMatchExpression(child, depth + 1)),
     };
   }
 
@@ -569,15 +721,18 @@ function parseMatchExpression(expr: unknown): RouterNode {
     if (value.some(item => typeof item !== 'string' || item.length === 0)) {
       throw new Error(`Rule match "${key}" items must be non-empty strings.`);
     }
+    if ((value as string[]).some(item => item !== item.trim())) {
+      throw new Error(`Rule match "${key}" items cannot have leading or trailing whitespace in GUI3.`);
+    }
     return value as string[];
   };
 
   if ('keywords_any' in expr) {
-    children.push({ ...createRouterLeaf('keywords_any'), textValue: parseStringArray('keywords_any').join(', ') });
+    children.push({ ...createRouterLeaf('keywords_any'), textValue: parseStringArray('keywords_any').join('\n') });
     consumed.add('keywords_any');
   }
   if ('keywords_all' in expr) {
-    children.push({ ...createRouterLeaf('keywords_all'), textValue: parseStringArray('keywords_all').join(', ') });
+    children.push({ ...createRouterLeaf('keywords_all'), textValue: parseStringArray('keywords_all').join('\n') });
     consumed.add('keywords_all');
   }
   if ('regex' in expr) {
@@ -650,6 +805,9 @@ function parseMatchExpression(expr: unknown): RouterNode {
       if (metadata.any.some(item => typeof item !== 'string' || item.length === 0)) {
         throw new Error('Rule match metadata "any" items must be non-empty strings.');
       }
+      if ((metadata.any as string[]).some(item => item !== item.trim())) {
+        throw new Error('Rule match metadata "any" items cannot have leading or trailing whitespace in GUI3.');
+      }
     }
     if (comparator === 'exists' && typeof metadata.exists !== 'boolean') {
       throw new Error('Rule match metadata "exists" must be a boolean.');
@@ -659,7 +817,7 @@ function parseMatchExpression(expr: unknown): RouterNode {
       metadataKey: metadata.key,
       metadataComparator: comparator,
       metadataValues: comparator === 'any'
-        ? (metadata.any as string[]).join(', ')
+        ? (metadata.any as string[]).join('\n')
         : comparator === 'equals' ? metadata.equals as string : '',
       booleanValue: comparator === 'exists' ? metadata.exists as boolean : undefined,
     });
@@ -675,23 +833,84 @@ function parseMatchExpression(expr: unknown): RouterNode {
   return { id: createRouterNodeId('group'), kind: 'group', operator: 'all', children };
 }
 
+function rejectUnknownKeys(value: Record<string, unknown>, allowed: readonly string[], context: string): void {
+  const allowedSet = new Set(allowed);
+  const unknown = Object.keys(value).filter(key => !allowedSet.has(key));
+  if (unknown.length) {
+    throw new Error(`${context} contains unsupported field${unknown.length > 1 ? 's' : ''}: ${unknown.join(', ')}.`);
+  }
+}
+
+function requireString(value: unknown, context: string): string {
+  if (typeof value !== 'string' || value.length === 0) throw new Error(`${context} must be a non-empty string.`);
+  return value;
+}
+
+function requireStringArray(value: unknown, context: string, allowEmpty = false): string[] {
+  if (!Array.isArray(value) || (!allowEmpty && value.length === 0)) {
+    throw new Error(`${context} must be ${allowEmpty ? 'an array' : 'a non-empty array'}.`);
+  }
+  if (value.some(item => typeof item !== 'string' || item.length === 0)) {
+    throw new Error(`${context} items must be non-empty strings.`);
+  }
+  return value as string[];
+}
+
 function parseClassifier(value: unknown, index: number): RouterClassifier {
   if (!isRecord(value)) throw new Error(`Classifier ${index + 1} must be an object.`);
-  const type = String(value.type || '');
+  rejectUnknownKeys(value, ['id', 'type', 'model', 'prompt', 'labels', 'default_label', 'reference_phrases', 'on_error'], `Classifier ${index + 1}`);
+  const id = requireString(value.id, `Classifier ${index + 1} ID`);
+  const type = requireString(value.type, `Classifier ${index + 1} type`);
   if (type !== 'classifier' && type !== 'semantic_similarity' && type !== 'llm') {
-    throw new Error(`Unsupported classifier type "${type}".`);
+    throw new Error(`Unsupported classifier type "${type}". GUI3 can safely edit classifier, semantic_similarity, and llm classifiers only.`);
   }
+  const model = requireString(value.model, `Classifier ${index + 1} model`);
+  if ('on_error' in value && value.on_error !== 'match_true' && value.on_error !== 'match_false') {
+    throw new Error(`Classifier ${index + 1} on_error must be "match_true" or "match_false".`);
+  }
+
   const referencePhrases: Record<string, string[]> = {};
-  if (isRecord(value.reference_phrases)) {
-    for (const [label, phrases] of Object.entries(value.reference_phrases)) referencePhrases[label] = splitList(phrases);
+  if (type === 'semantic_similarity') {
+    if ('labels' in value) throw new Error(`Classifier ${index + 1}: semantic_similarity cannot contain labels.`);
+    if ('prompt' in value) throw new Error(`Classifier ${index + 1}: semantic_similarity prompt is not editable in GUI3.`);
+    if (!isRecord(value.reference_phrases) || Object.keys(value.reference_phrases).length === 0) {
+      throw new Error(`Classifier ${index + 1}: semantic_similarity requires non-empty reference_phrases.`);
+    }
+    for (const [label, phrases] of Object.entries(value.reference_phrases)) {
+      if (!label.length) throw new Error(`Classifier ${index + 1}: semantic concept names cannot be empty.`);
+      if (label !== label.trim()) throw new Error(`Classifier ${index + 1}: semantic concept names cannot have leading or trailing whitespace in GUI3.`);
+      const parsedPhrases = requireStringArray(phrases, `Classifier ${index + 1} concept "${label}"`);
+      if (parsedPhrases.some(phrase => phrase !== phrase.trim())) {
+        throw new Error(`Classifier ${index + 1} concept "${label}" phrases cannot have leading or trailing whitespace in GUI3.`);
+      }
+      referencePhrases[label] = parsedPhrases;
+    }
+  } else {
+    if ('reference_phrases' in value) throw new Error(`Classifier ${index + 1}: ${type} reference_phrases are not editable in GUI3.`);
+    if (type === 'classifier' && 'prompt' in value) {
+      throw new Error(`Classifier ${index + 1}: prompt on a classifier would be lost by GUI3; import is rejected to avoid a lossy save.`);
+    }
   }
+
+  const labels = 'labels' in value ? requireStringArray(value.labels, `Classifier ${index + 1} labels`, type === 'classifier') : [];
+  if (labels.some(label => label !== label.trim())) {
+    throw new Error(`Classifier ${index + 1} labels cannot have leading or trailing whitespace in GUI3.`);
+  }
+  if (type === 'llm' && labels.length === 0) throw new Error(`Classifier ${index + 1}: LLM classifiers require at least one label.`);
+  const prompt = type === 'llm' ? requireString(value.prompt, `Classifier ${index + 1} prompt`) : '';
+  const defaultLabel = typeof value.default_label === 'string' ? value.default_label : undefined;
+  if ('default_label' in value && !defaultLabel) throw new Error(`Classifier ${index + 1} default_label must be a non-empty string.`);
+  if (defaultLabel && defaultLabel !== defaultLabel.trim()) {
+    throw new Error(`Classifier ${index + 1} default_label cannot have leading or trailing whitespace in GUI3.`);
+  }
+
   return {
-    id: String(value.id || `classifier-${index + 1}`),
+    id,
     type,
-    model: String(value.model || ''),
-    prompt: typeof value.prompt === 'string' ? value.prompt : '',
-    labels: splitList(value.labels),
-    defaultLabel: typeof value.default_label === 'string' ? value.default_label : undefined,
+    model,
+    prompt,
+    labels,
+    defaultLabel,
     referencePhrases,
     onError: value.on_error === 'match_true' ? 'match_true' : 'match_false',
   };
@@ -700,58 +919,102 @@ function parseClassifier(value: unknown, index: number): RouterClassifier {
 export function parseRouterPayload(payload: unknown): RouterDraft {
   const root = isRecord(payload) ? payload : null;
   if (!root) throw new Error('Router JSON must be an object.');
+  rejectUnknownKeys(root, ['version', 'model_name', 'recipe', 'components', 'models', 'routing'], 'Router JSON');
   if (root.recipe !== ROUTER_RECIPE) throw new Error(`Expected recipe "${ROUTER_RECIPE}".`);
-  if (String(root.version || '') !== ROUTER_SCHEMA_VERSION) throw new Error(`Only router schema version ${ROUTER_SCHEMA_VERSION} is supported.`);
+  if (root.version !== ROUTER_SCHEMA_VERSION) throw new Error(`Only router schema version ${ROUTER_SCHEMA_VERSION} as a string is supported.`);
+  if ('model_name' in root && typeof root.model_name !== 'string') throw new Error('Router model_name must be a string.');
+  if ('models' in root) {
+    if (!Array.isArray(root.models)) throw new Error('Router models must be an array when present.');
+    if (root.models.length > 0) throw new Error('Embedded models are not editable in GUI3; import is rejected to avoid a lossy save.');
+  }
+  const declaredComponents = 'components' in root
+    ? requireStringArray(root.components, 'Router components')
+    : [];
+
   const routing = isRecord(root.routing) ? root.routing : null;
   if (!routing) throw new Error('Router JSON is missing routing.');
-  const candidates = splitList(routing.candidates);
+  rejectUnknownKeys(routing, ['candidates', 'default_model', 'router', 'classifiers', 'rules'], 'Routing block');
+  const candidates = requireStringArray(routing.candidates, 'routing.candidates');
+  const defaultModel = requireString(routing.default_model, 'routing.default_model');
+
   if ('router' in routing && !isRecord(routing.router)) {
     throw new Error('Natural-language router must be an object.');
   }
   const routerSpec = isRecord(routing.router) ? routing.router : null;
-  if (routerSpec && ('rules' in routing || 'classifiers' in routing)) {
-    throw new Error('Natural-language routing cannot be combined with rules or classifiers.');
+  if (routerSpec) {
+    rejectUnknownKeys(routerSpec, ['type', 'model', 'prompt'], 'Natural-language router');
+    if ('rules' in routing || 'classifiers' in routing) {
+      throw new Error('Natural-language routing cannot be combined with rules or classifiers.');
+    }
+    if (routerSpec.type !== 'llm') throw new Error('Natural-language router type must be "llm".');
   }
-  if (routerSpec && routerSpec.type !== 'llm') throw new Error('Natural-language router type must be "llm".');
 
-  const rulesRaw = routerSpec ? [] : Array.isArray(routing.rules) ? routing.rules : [];
+  if (!routerSpec && !Array.isArray(routing.rules)) throw new Error('routing.rules must be an array.');
+  if (!routerSpec && 'classifiers' in routing && !Array.isArray(routing.classifiers)) throw new Error('routing.classifiers must be an array.');
   const classifiers = routerSpec
     ? []
     : (Array.isArray(routing.classifiers) ? routing.classifiers : []).map(parseClassifier);
+  const rulesRaw = routerSpec ? [] : routing.rules as unknown[];
   const rules = rulesRaw.map((item, index): RouterRule => {
     if (!isRecord(item)) throw new Error(`Rule ${index + 1} must be an object.`);
+    rejectUnknownKeys(item, ['id', 'match', 'route_to', 'outputs'], `Rule ${index + 1}`);
+    const id = requireString(item.id, `Rule ${index + 1} ID`);
+    const routeTo = requireString(item.route_to, `Rule ${index + 1} route_to`);
+    if (!('match' in item)) throw new Error(`Rule ${index + 1} is missing match.`);
+    if ('outputs' in item && !isRecord(item.outputs)) throw new Error(`Rule ${index + 1} outputs must be an object.`);
     return {
-      id: String(item.id || `rule-${index + 1}`),
-      routeTo: String(item.route_to || ''),
+      id,
+      routeTo,
       condition: parseMatchExpression(item.match),
       outputsText: isRecord(item.outputs) ? JSON.stringify(item.outputs, null, 2) : '',
     };
   });
+
   const modelName = typeof root.model_name === 'string' ? root.model_name : undefined;
+  const llmRouter = routerSpec
+    ? {
+        model: requireString(routerSpec.model, 'Natural-language router model'),
+        prompt: requireString(routerSpec.prompt, 'Natural-language router prompt'),
+      }
+    : { model: '', prompt: '' };
   const draft: RouterDraft = {
     modelName,
     name: routerDisplayName(modelName || 'router'),
     candidates,
-    defaultModel: typeof routing.default_model === 'string' ? routing.default_model : '',
+    defaultModel,
     mode: routerSpec ? 'llm' : 'rules',
-    llmRouter: {
-      model: routerSpec && typeof routerSpec.model === 'string' ? routerSpec.model : '',
-      prompt: routerSpec && typeof routerSpec.prompt === 'string' ? routerSpec.prompt : '',
-    },
+    llmRouter,
     classifiers,
-    rules: routerSpec ? [createRouterRule(0, typeof routing.default_model === 'string' ? routing.default_model : '')] : rules,
+    rules: routerSpec ? [createRouterRule(0, defaultModel)] : rules,
   };
   const errors = validateRouterDraft(draft);
   if (errors.length) throw new Error(errors.slice(0, 6).join(' '));
+
+  if (declaredComponents.length > 0) {
+    const expected = new Set<string>(draft.candidates);
+    if (draft.mode === 'llm') expected.add(draft.llmRouter.model);
+    else draft.classifiers.forEach(classifier => expected.add(classifier.model));
+    const declared = new Set(declaredComponents);
+    const extra = [...declared].filter(component => !expected.has(component));
+    const missing = [...expected].filter(component => !declared.has(component));
+    if (extra.length || missing.length) {
+      throw new Error(`Router components do not match editable routing dependencies${extra.length ? `; extra: ${extra.join(', ')}` : ''}${missing.length ? `; missing: ${missing.join(', ')}` : ''}.`);
+    }
+  }
   return draft;
 }
 
 export function routerDraftFromModelInfo(model: ModelInfo): RouterDraft {
-  return parseRouterPayload({
-    version: String((model as any).version || ROUTER_SCHEMA_VERSION),
+  const payload: Record<string, unknown> = {
+    version: (model as any).version ?? ROUTER_SCHEMA_VERSION,
     model_name: String((model as any).model_name || model.name || model.id || ''),
     recipe: String((model as any).recipe || ''),
     components: Array.isArray((model as any).components) ? (model as any).components : [],
     routing: (model as any).routing,
-  });
+  };
+  // Preserve embedded component manifests for the strict round-trip guard. GUI3
+  // cannot safely author them, so silently omitting this field here would let a
+  // server-loaded HF redistribution policy lose data on its next save.
+  if ('models' in (model as any)) payload.models = (model as any).models;
+  return parseRouterPayload(payload);
 }

--- a/src/app/src/styles/styles.css
+++ b/src/app/src/styles/styles.css
@@ -12571,10 +12571,12 @@ a.backend-card__version:focus-visible {
 .router-editor__strategy-option small { color: var(--text-tertiary); font-size: var(--text-xs); line-height: var(--leading-relaxed); }
 .router-editor__form-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: var(--space-3); padding: var(--space-4); }
 .router-editor__form-grid label,
+.router-editor__field,
 .router-node__details label,
 .router-node__compact-field,
 .router-editor__default-model { display: grid; gap: 5px; min-width: 0; color: var(--text-secondary); font-size: var(--text-xs); }
 .router-editor__form-grid label > span,
+.router-editor__field > span,
 .router-node__details label > span,
 .router-node__compact-field > span { display: flex; justify-content: space-between; gap: var(--space-2); }
 .router-editor__form-grid small,
@@ -12610,12 +12612,99 @@ a.backend-card__version:focus-visible {
 .router-editor__default-model { grid-template-columns: minmax(0, 1fr) minmax(180px, 45%); align-items: center; padding: var(--space-3) var(--space-4) var(--space-4); }
 .router-editor__default-model > span { display: grid; }
 .router-editor__classifier-list,
-.router-editor__rule-list { display: grid; gap: var(--space-3); padding: var(--space-4); }
+.router-editor__rule-list {
+  display: grid;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
+}
+.router-editor__classifier-list { max-height: min(58vh, 620px); }
+.router-editor__rule-list { max-height: 326px; align-content: start; padding: var(--space-2); background: var(--surface-1); }
+.router-editor__rules-workspace {
+  display: grid;
+  grid-template-columns: minmax(250px, 300px) minmax(0, 1fr);
+  min-height: 430px;
+  border-top: 1px solid var(--border-subtle);
+}
+.router-editor__rule-list { border-right: 1px solid var(--border-subtle); }
+.router-editor__rule-summary {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: var(--space-1);
+  min-height: 58px;
+  padding: var(--space-1) var(--space-1) var(--space-1) var(--space-2);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--surface-base);
+  transition: border-color 120ms ease, background 120ms ease, opacity 120ms ease;
+}
+.router-editor__rule-summary:hover { border-color: color-mix(in srgb, var(--accent-fg) 28%, var(--border-subtle)); }
+.router-editor__rule-summary.is-selected { border-color: color-mix(in srgb, var(--accent-fg) 58%, var(--border-subtle)); background: color-mix(in srgb, var(--accent-fg) 5%, var(--surface-base)); }
+.router-editor__rule-summary.is-dragging { opacity: .52; }
+.router-editor__rule-summary-main {
+  min-width: 0;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-1);
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+.router-editor__rule-summary-main:focus-visible { outline: 2px solid var(--accent-focus); outline-offset: 1px; }
+.router-editor__rule-summary-copy { min-width: 0; display: grid; gap: 2px; }
+.router-editor__rule-summary-copy strong,
+.router-editor__rule-summary-copy small { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.router-editor__rule-summary-copy strong { color: var(--text-primary); font-size: var(--text-xs); }
+.router-editor__rule-summary-copy small { color: var(--text-tertiary); font-size: var(--type-overline-size); }
+.router-editor__rule-summary .router-editor__rule-actions { margin-left: 0; }
+.router-editor__default-rule {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  gap: var(--space-2);
+  min-height: 46px;
+  padding: var(--space-2) var(--space-3);
+  border: 1px dashed var(--border-subtle);
+  border-radius: var(--radius-md);
+  color: var(--text-tertiary);
+}
+.router-editor__default-rule > span:last-child { min-width: 0; display: grid; gap: 1px; }
+.router-editor__default-rule strong { color: var(--text-secondary); font-size: var(--text-xs); }
+.router-editor__default-rule small { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: var(--type-overline-size); }
+.router-editor__rule-builder { min-width: 0; background: var(--surface-base); }
+.router-editor__rule-builder-head {
+  min-height: 48px;
+  display: flex;
+  align-items: center;
+  padding: var(--space-2) var(--space-4);
+  border-bottom: 1px solid var(--border-subtle);
+  background: var(--surface-1);
+}
+.router-editor__rule-builder-head > div { min-width: 0; display: grid; gap: 2px; }
+.router-editor__rule-builder-head strong { color: var(--text-primary); font-size: var(--text-sm); }
+.router-editor__rule-builder-head span { color: var(--text-tertiary); font-size: var(--text-xs); }
+.router-editor__rule-builder-empty { min-height: 430px; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: var(--space-2); color: var(--text-tertiary); text-align: center; }
+.router-editor__rule-builder-empty .app-icon { color: var(--accent-fg); }
+.router-editor__rule-builder-empty strong { color: var(--text-secondary); font-size: var(--text-sm); }
+.router-editor__rule-builder-empty span { font-size: var(--text-xs); }
 .router-editor__classifier,
 .router-editor__rule { border: 1px solid var(--border-subtle); border-radius: var(--radius-lg); background: var(--surface-base); overflow: hidden; }
+.router-editor__rule { transition: border-color 120ms ease, opacity 120ms ease, box-shadow 120ms ease; }
+.router-editor__rule.is-dragging { opacity: .55; border-color: color-mix(in srgb, var(--accent-fg) 55%, var(--border-subtle)); box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent-fg) 10%, transparent); }
 .router-editor__card-head { display: flex; align-items: center; gap: var(--space-2); min-height: 40px; padding: var(--space-2) var(--space-3); border-bottom: 1px solid var(--border-subtle); background: var(--surface-2); }
 .router-editor__card-head > strong { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: var(--text-sm); }
 .router-editor__card-head > .workspace-action-button { margin-left: auto; }
+.router-editor__drag-handle { display: inline-flex; align-items: center; justify-content: center; width: 24px; height: 24px; border-radius: var(--radius-sm); color: var(--text-tertiary); cursor: grab; user-select: none; }
+.router-editor__drag-handle:hover { color: var(--text-primary); background: var(--surface-3); }
+.router-editor__drag-handle:active { cursor: grabbing; }
 .router-editor__rule-order { display: inline-flex; align-items: center; justify-content: center; width: 22px; height: 22px; border-radius: 50%; color: var(--accent-fg); background: color-mix(in srgb, var(--accent-fg) 12%, transparent); font-size: var(--type-overline-size); font-weight: var(--weight-bold); }
 .router-editor__rule-actions { display: inline-flex; gap: var(--space-0-5); margin-left: auto; }
 .router-editor__rule-actions button { width: 26px; height: 26px; border-radius: var(--radius-sm); }
@@ -12688,6 +12777,264 @@ a.backend-card__version:focus-visible {
 .router-node__wrap-actions { display: flex; align-items: center; justify-content: flex-end; gap: var(--space-1); margin-top: var(--space-2); padding-top: var(--space-2); border-top: 1px dashed var(--border-subtle); color: var(--text-tertiary); font-size: var(--type-overline-size); }
 .router-node__wrap-actions button { min-width: 34px; height: 24px; padding: 0 6px; border: 1px solid var(--border-subtle); border-radius: var(--radius-sm); background: var(--surface-2); color: var(--text-secondary); font-size: var(--type-overline-size); cursor: pointer; }
 .router-node__wrap-actions button:hover { border-color: color-mix(in srgb, var(--accent-fg) 40%, var(--border-subtle)); color: var(--accent-fg); }
+
+/* Searchable model dropdown used by router model-backed signals. */
+.router-model-picker { position: relative; min-width: 0; }
+.router-model-picker__trigger {
+  width: 100%;
+  min-height: var(--control-height-md);
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: var(--space-2);
+  padding: 0 var(--space-3);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--surface-base);
+  color: var(--text-primary);
+  text-align: left;
+  cursor: pointer;
+}
+.router-model-picker__trigger:hover,
+.router-model-picker__trigger.is-open { border-color: color-mix(in srgb, var(--accent-fg) 55%, var(--border-subtle)); }
+.router-model-picker__trigger.is-open { box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent-fg) 12%, transparent); }
+.router-model-picker__trigger > span { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.router-model-picker__trigger .is-placeholder { color: var(--text-tertiary); }
+.router-model-picker__trigger .app-icon { color: var(--text-tertiary); }
+.router-model-picker__popover {
+  z-index: 260;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-lg);
+  background: var(--surface-raised);
+  box-shadow: var(--shadow-lg);
+  overflow: hidden;
+}
+.router-model-picker__search {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  border-bottom: 1px solid var(--border-subtle);
+  color: var(--text-tertiary);
+  background: var(--surface-2);
+}
+.router-model-picker__search input {
+  min-width: 0;
+  flex: 1;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: var(--text-primary);
+  font-size: var(--text-sm);
+}
+.router-model-picker__options { max-height: 250px; overflow-y: auto; padding: var(--space-1); scrollbar-gutter: stable; }
+.router-model-picker__option {
+  width: 100%;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  border: 0;
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--text-secondary);
+  text-align: left;
+  cursor: pointer;
+}
+.router-model-picker__option:hover,
+.router-model-picker__option.is-active { background: var(--surface-2); color: var(--text-primary); }
+.router-model-picker__option.is-selected { background: color-mix(in srgb, var(--accent-fg) 7%, var(--surface-1)); color: var(--text-primary); }
+.router-model-picker__option > span { display: grid; min-width: 0; }
+.router-model-picker__option strong,
+.router-model-picker__option small { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.router-model-picker__option strong { font-size: var(--text-sm); font-weight: var(--weight-semibold); }
+.router-model-picker__option small { color: var(--text-tertiary); font-size: var(--type-overline-size); }
+.router-model-picker__option .app-icon { color: var(--accent-fg); }
+.router-model-picker__empty,
+.router-model-picker__stale { padding: var(--space-3); color: var(--text-tertiary); font-size: var(--text-xs); line-height: var(--leading-relaxed); }
+.router-model-picker__stale { border-top: 1px solid var(--border-subtle); background: color-mix(in srgb, var(--warning) 6%, var(--surface-1)); }
+
+/* GUI3-native success toast. Keeps Save & register feedback visible while the editor is scrolled. */
+.router-editor__toast {
+  position: fixed;
+  z-index: 240;
+  right: var(--space-5);
+  bottom: var(--space-5);
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: var(--space-2);
+  width: min(390px, calc(100vw - 32px));
+  padding: var(--space-3) var(--space-3) var(--space-3) var(--space-4);
+  border: 1px solid color-mix(in srgb, var(--success) 32%, var(--border-subtle));
+  border-radius: var(--radius-lg);
+  background: color-mix(in srgb, var(--success) 8%, var(--surface-raised));
+  box-shadow: var(--shadow-lg);
+  color: var(--text-primary);
+  font-size: var(--text-sm);
+}
+.router-editor__toast > .app-icon { color: var(--success); }
+.router-editor__toast button { display: inline-flex; align-items: center; justify-content: center; width: 28px; height: 28px; border: 0; border-radius: var(--radius-sm); background: transparent; color: var(--text-tertiary); cursor: pointer; }
+.router-editor__toast button:hover { color: var(--text-primary); background: var(--surface-2); }
+.router-confirm-dialog__body { display: grid; grid-template-columns: auto minmax(0, 1fr); align-items: start; gap: var(--space-3); }
+.router-confirm-dialog__body p { margin: 0; color: var(--text-secondary); font-size: var(--text-sm); line-height: var(--leading-relaxed); }
+.router-confirm-dialog__icon { display: inline-flex; align-items: center; justify-content: center; width: 36px; height: 36px; border-radius: 50%; background: var(--danger-soft); color: var(--danger); }
+
+/* Visual rule graph, adapted from GUI2's drag/drop pipeline for GUI3 RouterNode. */
+.router-graph { border-top: 1px solid var(--border-subtle); background: var(--surface-1); }
+.router-graph__workspace {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 210px;
+  grid-template-areas: 'canvas toolbox';
+  min-height: 330px;
+}
+.router-graph__workspace.is-toolbox-collapsed { grid-template-columns: minmax(0, 1fr) 42px; }
+.router-graph__toolbox {
+  grid-area: toolbox;
+  min-width: 0;
+  border-left: 1px solid var(--border-subtle);
+  background: color-mix(in srgb, var(--surface-2) 76%, var(--surface-1));
+}
+.router-graph__toolbox.is-collapsed { width: 42px; }
+.router-graph__toolbox-toggle {
+  width: 100%;
+  min-height: 38px;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: 0 var(--space-3);
+  border: 0;
+  border-bottom: 1px solid var(--border-subtle);
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-semibold);
+  cursor: pointer;
+}
+.router-graph__toolbox-toggle:hover { color: var(--text-primary); background: var(--surface-2); }
+.router-graph__toolbox.is-collapsed .router-graph__toolbox-toggle { justify-content: center; padding: 0; }
+.router-graph__toolbox-content { max-height: 430px; overflow-y: auto; padding: var(--space-3); scrollbar-gutter: stable; }
+.router-graph__toolbox-title { margin: 0 0 var(--space-2); color: var(--text-tertiary); font-size: var(--type-overline-size); font-weight: var(--weight-bold); letter-spacing: .05em; text-transform: uppercase; }
+.router-graph__gates { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: var(--space-1); margin-bottom: var(--space-3); }
+.router-graph__tools { display: grid; gap: var(--space-1); margin-bottom: var(--space-3); }
+.router-graph__tool {
+  min-width: 0;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--surface-base);
+  color: var(--text-secondary);
+  cursor: grab;
+  text-align: left;
+}
+.router-graph__tool:hover { border-color: color-mix(in srgb, var(--accent-fg) 38%, var(--border-subtle)); background: var(--surface-1); color: var(--text-primary); }
+.router-graph__tool:active { cursor: grabbing; }
+.router-graph__tool--gate { display: grid; justify-items: center; gap: 2px; padding: var(--space-2) var(--space-1); text-align: center; color: var(--accent-fg); }
+.router-graph__tool--gate strong { color: var(--accent-fg); font-size: var(--text-xs); }
+.router-graph__tool--gate small { color: var(--text-tertiary); font-size: 9px; }
+.router-graph__gate-shape { display: block; overflow: visible; }
+.router-graph__gate-shape path,
+.router-graph__gate-shape circle { fill: currentColor; fill-opacity: .08; stroke: currentColor; stroke-width: 2; stroke-linejoin: round; }
+.router-graph__gate-shape line { stroke: currentColor; stroke-width: 2; stroke-linecap: round; }
+.router-graph__tool--condition { position: relative; padding: 7px 8px 7px 12px; font-size: var(--text-xs); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.router-graph__tool--condition::before { content: ''; position: absolute; inset: 0 auto 0 0; width: 3px; background: var(--accent-fg); opacity: .72; }
+.router-graph__tool--classifier::before { background: var(--success); }
+.router-graph__tool--classifier > span { color: var(--text-tertiary); }
+.router-graph__toolbox-search { display: flex; align-items: center; gap: var(--space-1); margin-bottom: var(--space-2); padding: 0 var(--space-2); border: 1px solid var(--border-subtle); border-radius: var(--radius-md); color: var(--text-tertiary); background: var(--surface-base); }
+.router-graph__toolbox-search:focus-within { border-color: var(--accent-fg); }
+.router-graph__toolbox-search input { width: 100%; min-width: 0; height: 30px; border: 0; outline: 0; background: transparent; color: var(--text-primary); font-size: var(--text-xs); }
+.router-graph__toolbox-empty { color: var(--text-tertiary); font-size: var(--text-xs); }
+
+.router-graph__canvas-shell { grid-area: canvas; min-width: 0; display: grid; grid-template-rows: auto minmax(0, 1fr); }
+.router-graph__toolbar { display: flex; align-items: center; gap: var(--space-1); min-width: 0; min-height: 38px; padding: 0 var(--space-2); border-bottom: 1px solid var(--border-subtle); background: var(--surface-2); }
+.router-graph__toolbar button,
+.router-graph__operator-actions button,
+.router-graph__inspector-head button {
+  min-height: 26px;
+  padding: 0 var(--space-2);
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-tertiary);
+  font-size: var(--type-overline-size);
+  cursor: pointer;
+}
+.router-graph__toolbar button:hover:not(:disabled),
+.router-graph__operator-actions button:hover,
+.router-graph__inspector-head button:hover { background: var(--surface-3); color: var(--text-primary); }
+.router-graph__toolbar button:disabled { opacity: .35; cursor: default; }
+.router-graph__toolbar button.is-danger:hover { color: var(--danger); background: var(--danger-soft); }
+.router-graph__toolbar-spacer { flex: 1; }
+.router-graph__toolbar-hint { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--text-tertiary); font-size: var(--type-overline-size); }
+.router-graph__zoom-label { min-width: 44px; }
+.router-graph__rejection { display: inline-flex; align-items: center; gap: 4px; color: var(--danger); font-size: var(--type-overline-size); }
+
+.router-graph__canvas {
+  position: relative;
+  min-height: 290px;
+  overflow: hidden;
+  touch-action: none;
+  background-color: var(--surface-base);
+  background-image: radial-gradient(circle, color-mix(in srgb, var(--text-tertiary) 18%, transparent) 1px, transparent 1px);
+  background-size: 18px 18px;
+  cursor: grab;
+}
+.router-graph__canvas.is-panning { cursor: grabbing; }
+.router-graph__canvas-transform { position: absolute; top: 0; left: 0; width: max-content; min-width: 280px; transform-origin: 0 0; }
+.router-graph__empty { min-height: 290px; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: var(--space-2); padding: var(--space-5); color: var(--text-tertiary); text-align: center; }
+.router-graph__empty strong { color: var(--text-secondary); font-size: var(--text-sm); }
+.router-graph__empty > span:not(.router-graph__empty-icon) { max-width: 380px; font-size: var(--text-xs); line-height: var(--leading-relaxed); }
+.router-graph__empty-icon { display: inline-flex; align-items: center; justify-content: center; width: 46px; height: 46px; border: 1px solid color-mix(in srgb, var(--accent-fg) 28%, var(--border-subtle)); border-radius: 50%; background: color-mix(in srgb, var(--accent-fg) 8%, var(--surface-1)); color: var(--accent-fg); }
+
+.router-graph__group { min-width: 260px; padding: var(--space-2); border: 1px solid color-mix(in srgb, var(--accent-fg) 25%, var(--border-subtle)); border-radius: var(--radius-lg); background: color-mix(in srgb, var(--surface-1) 94%, transparent); box-shadow: var(--shadow-sm); }
+.router-graph__group.is-selected { border-color: color-mix(in srgb, var(--accent-fg) 70%, var(--border-subtle)); box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent-fg) 10%, transparent); }
+.router-graph__group-head { display: flex; align-items: center; gap: var(--space-2); min-height: 34px; padding: 0 var(--space-1) var(--space-2); cursor: pointer; }
+.router-graph__gate { display: inline-flex; align-items: center; justify-content: center; gap: 5px; min-width: 70px; height: 30px; padding: 0 8px 0 5px; border: 1px solid color-mix(in srgb, var(--accent-fg) 35%, var(--border-subtle)); border-radius: var(--radius-pill); color: var(--accent-fg); background: color-mix(in srgb, var(--accent-fg) 8%, var(--surface-1)); font-size: var(--type-overline-size); font-weight: var(--weight-bold); }
+.router-graph__gate--not { color: var(--danger); border-color: color-mix(in srgb, var(--danger) 35%, var(--border-subtle)); background: color-mix(in srgb, var(--danger) 7%, var(--surface-1)); }
+.router-graph__group-copy { flex: 1; color: var(--text-tertiary); font-size: var(--type-overline-size); }
+.router-graph__operator-actions { display: inline-flex; gap: 2px; }
+.router-graph__operator-actions button.is-active { color: var(--accent-fg); background: color-mix(in srgb, var(--accent-fg) 10%, var(--surface-2)); }
+.router-graph__children { position: relative; display: grid; gap: var(--space-2); padding: var(--space-2) 0 0 var(--space-4); border-left: 1px solid color-mix(in srgb, var(--accent-fg) 22%, var(--border-subtle)); }
+.router-graph__branch { position: relative; display: grid; grid-template-columns: minmax(190px, 1fr) 24px; align-items: center; gap: var(--space-1); }
+.router-graph__branch::before { content: ''; position: absolute; left: calc(var(--space-4) * -1); top: 50%; width: var(--space-4); border-top: 1px solid color-mix(in srgb, var(--accent-fg) 22%, var(--border-subtle)); }
+.router-graph__leaf { min-width: 0; display: grid; gap: 2px; padding: var(--space-2) var(--space-3); border: 1px solid var(--border-subtle); border-left: 3px solid var(--accent-fg); border-radius: var(--radius-md); background: var(--surface-base); color: var(--text-secondary); text-align: left; cursor: pointer; }
+.router-graph__leaf:hover { border-color: color-mix(in srgb, var(--accent-fg) 42%, var(--border-subtle)); background: var(--surface-1); }
+.router-graph__leaf.is-selected { border-color: color-mix(in srgb, var(--accent-fg) 70%, var(--border-subtle)); box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent-fg) 10%, transparent); }
+.router-graph__leaf--classifier { border-left-color: var(--success); }
+.router-graph__leaf--metadata { border-left-color: var(--warning); }
+.router-graph__leaf-type { font-size: var(--type-overline-size); font-weight: var(--weight-bold); color: var(--text-secondary); }
+.router-graph__leaf-summary { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--text-tertiary); font-size: var(--type-overline-size); }
+.router-graph__remove { display: inline-flex; align-items: center; justify-content: center; width: 22px; height: 22px; border: 0; border-radius: var(--radius-sm); background: transparent; color: var(--text-tertiary); cursor: pointer; }
+.router-graph__remove:hover { color: var(--danger); background: var(--danger-soft); }
+.router-graph__drop-zone { display: flex; align-items: center; justify-content: center; gap: 4px; min-height: 30px; padding: 4px var(--space-2); border: 1px dashed color-mix(in srgb, var(--accent-fg) 28%, var(--border-subtle)); border-radius: var(--radius-md); color: var(--text-tertiary); background: color-mix(in srgb, var(--accent-fg) 2%, transparent); font-size: var(--type-overline-size); transition: 100ms ease; }
+.router-graph__drop-zone.is-over { border-style: solid; border-color: var(--accent-fg); color: var(--accent-fg); background: color-mix(in srgb, var(--accent-fg) 9%, var(--surface-1)); transform: scale(1.01); }
+.router-graph__empty .router-graph__drop-zone { width: min(330px, 100%); margin-top: var(--space-2); }
+
+.router-graph__inspector { border-top: 1px solid var(--border-subtle); background: var(--surface-1); }
+.router-graph__inspector-head { min-height: 42px; display: flex; align-items: center; justify-content: space-between; gap: var(--space-2); padding: var(--space-2) var(--space-3); border-bottom: 1px solid var(--border-subtle); background: var(--surface-2); }
+.router-graph__inspector-head > div { display: grid; gap: 1px; }
+.router-graph__inspector-head strong { font-size: var(--text-xs); }
+.router-graph__inspector-head small { color: var(--text-tertiary); font-size: var(--type-overline-size); }
+.router-graph__inspector-body { padding: var(--space-3); }
+.router-graph__inspector-body .router-node--group { margin: 0; }
+
+@media (max-width: 980px) {
+  .router-editor__rules-workspace { grid-template-columns: minmax(220px, 260px) minmax(0, 1fr); }
+  .router-graph__workspace { grid-template-columns: minmax(0, 1fr) 180px; }
+  .router-graph__toolbar-hint { display: none; }
+}
+@media (max-width: 720px) {
+  .router-editor__rules-workspace { grid-template-columns: 1fr; }
+  .router-editor__rule-list { max-height: 260px; border-right: 0; border-bottom: 1px solid var(--border-subtle); }
+  .router-graph__workspace,
+  .router-graph__workspace.is-toolbox-collapsed { grid-template-columns: 1fr; grid-template-areas: 'canvas' 'toolbox'; }
+  .router-graph__toolbox { border-left: 0; border-top: 1px solid var(--border-subtle); }
+  .router-graph__toolbox.is-collapsed { width: auto; }
+  .router-graph__toolbox-content { max-height: 220px; }
+  .router-graph__gates { grid-template-columns: repeat(3, minmax(90px, 1fr)); }
+  .router-graph__canvas { min-height: 260px; }
+  .router-editor__toast { right: 16px; bottom: 16px; }
+}
 
 /* ── Global model settings ─────────────────────────────────── */
 .global-model-settings {

--- a/src/app/src/styles/styles.css
+++ b/src/app/src/styles/styles.css
@@ -6521,6 +6521,8 @@ optgroup {
 /* 3–5. Collapsible filter groups */
 .model-nav-rail__section { display: flex; flex-direction: column; gap: var(--space-0-5); }
 
+
+
 .model-nav-rail__section-head { margin: 0; }
 
 .model-nav-rail__section-toggle {
@@ -9788,6 +9790,11 @@ optgroup {
   animation: inspectModalSlideUp 240ms cubic-bezier(0.16, 1, 0.3, 1);
 }
 
+.inspect-modal-content--full-height {
+  height: 90vh;
+  width: calc(100vw - 48px);
+}
+
 @keyframes inspectModalSlideUp {
   from { transform: translateY(16px); opacity: 0; }
   to { transform: translateY(0); opacity: 1; }
@@ -12560,7 +12567,8 @@ a.backend-card__version:focus-visible {
 }
 .router-editor__toolbar-row--files { justify-content: flex-end; }
 .router-editor__saved-select { min-width: 0; flex: 1 1 180px; }
-.router-editor__saved-select select { width: 100%; }
+.router-editor__saved-select .router-select,
+.router-editor__saved-select .router-select__trigger { width: 100%; }
 .router-editor__tabs { display: flex; padding: 0 var(--space-5); border-bottom: 1px solid var(--border-subtle); background: var(--surface-1); }
 .router-editor__tabs button { height: 38px; padding: 0 var(--space-3); border: 0; border-bottom: 2px solid transparent; background: transparent; color: var(--text-tertiary); font-size: var(--text-sm); cursor: pointer; }
 .router-editor__tabs button:hover { color: var(--text-primary); }
@@ -12601,6 +12609,59 @@ a.backend-card__version:focus-visible {
 .router-editor .select {
   min-width: 0;
 }
+.router-select { position: relative; min-width: 0; }
+.router-select__trigger {
+  width: 100%;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: var(--space-2);
+  height: var(--control-height-sm);
+  padding: 0 var(--space-3);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  background: var(--surface-base);
+  color: var(--text-primary);
+  font-size: var(--text-sm);
+  font-family: var(--font-sans);
+  text-align: left;
+  cursor: pointer;
+  transition: border-color var(--duration-fast) var(--ease-out);
+}
+.router-select__trigger:hover,
+.router-select__trigger.is-open { border-color: color-mix(in srgb, var(--accent-fg) 55%, var(--border-subtle)); }
+.router-select__trigger.is-open { box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent-fg) 12%, transparent); }
+.router-select__trigger > span { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.router-select__trigger .is-placeholder { color: var(--text-tertiary); }
+.router-select__trigger .app-icon { color: var(--text-tertiary); flex-shrink: 0; }
+.router-select__popover {
+  position: fixed;
+  z-index: 260;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-lg);
+  background: var(--surface-raised);
+  box-shadow: var(--shadow-lg);
+  overflow-y: auto;
+  max-height: min(320px, 40vh);
+  padding: var(--space-1);
+}
+.router-select__option {
+  width: 100%;
+  display: block;
+  padding: var(--space-2) var(--space-3);
+  border: 0;
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  font-family: var(--font-sans);
+  text-align: left;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.router-select__option:hover { background: var(--surface-2); color: var(--text-primary); }
+.router-select__option.is-selected { background: color-mix(in srgb, var(--accent-fg) 7%, var(--surface-1)); color: var(--text-primary); }
+.router-select__option.is-disabled { opacity: 0.45; cursor: default; pointer-events: none; }
 .router-editor .textarea {
   min-height: 90px;
   font-family: var(--font-mono);
@@ -12698,16 +12759,35 @@ a.backend-card__version:focus-visible {
 .router-editor__default-rule small { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: var(--type-overline-size); }
 .router-editor__rule-builder { min-width: 0; background: var(--surface-base); }
 .router-editor__rule-builder-head {
-  min-height: 48px;
+  min-height: 44px;
   display: flex;
   align-items: center;
-  padding: var(--space-2) var(--space-4);
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
   border-bottom: 1px solid var(--border-subtle);
   background: var(--surface-1);
 }
-.router-editor__rule-builder-head > div { min-width: 0; display: grid; gap: 2px; }
-.router-editor__rule-builder-head strong { color: var(--text-primary); font-size: var(--text-sm); }
-.router-editor__rule-builder-head span { color: var(--text-tertiary); font-size: var(--text-xs); }
+.router-editor__rule-builder-label {
+  color: var(--text-tertiary);
+  font-size: var(--text-xs);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+.router-editor__rule-id-input {
+  width: 120px;
+  flex-shrink: 0;
+  font-size: var(--text-xs);
+  padding: 3px var(--space-2);
+  height: 28px;
+}
+.router-editor__rule-route-select {
+  flex: 1 1 0;
+  min-width: 0;
+  max-width: 220px;
+  font-size: var(--text-xs);
+  padding: 0px var(--space-2);
+  height: 28px;
+}
 .router-editor__rule-builder-empty { min-height: 430px; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: var(--space-2); color: var(--text-tertiary); text-align: center; }
 .router-editor__rule-builder-empty .app-icon { color: var(--accent-fg); }
 .router-editor__rule-builder-empty strong { color: var(--text-secondary); font-size: var(--text-sm); }
@@ -12774,8 +12854,9 @@ a.backend-card__version:focus-visible {
               background var(--duration-fast) var(--ease-out);
 }
 .router-editor__rule-summary:hover .router-editor__rule-remove,
-.router-editor__rule-summary:focus-within .router-editor__rule-remove,
-.router-editor__rule-remove:focus { visibility: visible; }
+.router-editor__rule-summary:focus-within .router-editor__rule-remove {
+  visibility: visible;
+}
 .router-editor__rule-actions .router-editor__rule-remove:hover:not(:disabled) {
   color: var(--text-primary);
   background: color-mix(in srgb, var(--text-primary) 8%, transparent);
@@ -12843,7 +12924,8 @@ a.backend-card__version:focus-visible {
   .router-editor .workspace-detail-panel__title-row > .router-editor__toolbar { flex: 1 1 100%; }
   .router-editor__toolbar { flex-wrap: wrap; }
   .router-editor__saved-select { flex: 1 1 180px; }
-  .router-editor__saved-select select { width: 100%; }
+  .router-editor__saved-select .router-select,
+  .router-editor__saved-select .router-select__trigger { width: 100%; }
   .router-editor__form-grid,
   .router-editor__rule-meta,
   .router-editor__strategy { grid-template-columns: 1fr; }
@@ -13312,12 +13394,15 @@ a.backend-card__version:focus-visible {
   min-height: 0;
   overflow: hidden;
   position: relative;
+  transition: grid-template-columns 240ms var(--ease-out);
 }
 
 .workspace-three-panel.workspace--rail-collapsed,
 .workspace-three-panel.context-rail-collapsed {
   --workspace-rail-width: var(--rail-collapsed);
 }
+
+
 
 .workspace-two-panel {
   --detail-chip-gap: 6px;
@@ -13432,6 +13517,8 @@ a.backend-card__version:focus-visible {
   gap: var(--space-1-5);
   flex: 0 0 auto;
 }
+
+
 
 .workspace-list-panel__actions .workspace-action-group {
   gap: var(--space-0-5);
@@ -14160,7 +14247,7 @@ button.workspace-metadata-chip:hover {
   flex-direction: column;
   gap: var(--space-4);
   overflow-y: auto;
-  padding: var(--detail-section-space) var(--detail-gutter);
+  padding: var(--space-3) var(--detail-gutter) var(--detail-section-space);
   scrollbar-gutter: stable;
 }
 
@@ -14528,10 +14615,15 @@ button.workspace-metadata-chip:hover {
   grid-template-columns: minmax(180px, 1fr) minmax(150px, auto);
 }
 .router-editor__connection-main,
-.router-editor__connection-source,
 .router-editor__connection-endpoint {
   display: grid;
   gap: 3px;
+  min-width: 0;
+}
+.router-editor__connection-source {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1-5);
   min-width: 0;
 }
 .router-editor__connection-main > div {
@@ -14573,10 +14665,6 @@ button.workspace-metadata-chip:hover {
   align-items: center;
   justify-content: flex-end;
   gap: var(--space-2);
-}
-.router-editor__connection-source {
-  justify-items: end;
-  text-align: right;
 }
 .router-editor__default-badge {
   display: inline-flex;
@@ -14739,20 +14827,144 @@ button.workspace-metadata-chip:hover {
   margin: 0;
 }
 
-/* Router graph expanded view mirrors GUI2's full-canvas editing mode. */
+/* Router graph expanded view: full-modal 3-column layout.
+   toolbox | canvas | inspector
+   Toolbox is reordered to the left via grid-area so the canvas
+   has the full center, and the inspector gets a clean right panel. */
 .router-editor__graph-modal {
-  width: min(1500px, 100%);
-  max-height: calc(90vh - 66px);
-  padding: var(--space-3);
-  overflow: auto;
+  /* Override inspect-modal-body defaults so the graph fills the modal content.
+     The 1500px cap lives on .inspect-modal-content--full-height (the modal
+     content) so the body fills it fully with no empty space on the right. */
+  width: 100%;
+  flex: 1 1 0;
+  min-height: 0;
+  max-height: none;
+  padding: 0;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
 }
+
 .router-editor__graph-modal .router-graph {
-  min-height: min(680px, calc(90vh - 110px));
+  flex: 1 1 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: row;
+  border-top: 0;
+  overflow: hidden;
 }
+
+/* Workspace becomes just the canvas shell — toolbox breaks out to its own column */
 .router-editor__graph-modal .router-graph__workspace {
-  min-height: min(560px, calc(90vh - 220px));
+  flex: 1 1 0;
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: row;
+}
+
+/* Toolbox on the left; order:-1 pulls it before canvas-shell in visual order */
+.router-editor__graph-modal .router-graph__toolbox {
+  flex: 0 0 auto;
+  order: -1;
+  border-left: 0;
+  border-right: 1px solid var(--border-subtle);
+  width: 210px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+.router-editor__graph-modal .router-graph__toolbox.is-collapsed {
+  width: 42px;
+}
+.router-editor__graph-modal .router-graph__toolbox-content {
+  flex: 1 1 0;
+  min-height: 0;
+  max-height: none;
+  overflow-y: auto;
+}
+
+/* Canvas shell expands to fill all remaining horizontal space */
+.router-editor__graph-modal .router-graph__canvas-shell {
+  flex: 1 1 0;
+  min-width: 0;
+  min-height: 0;
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
 }
 .router-editor__graph-modal .router-graph__canvas,
 .router-editor__graph-modal .router-graph__empty {
-  min-height: min(520px, calc(90vh - 260px));
+  min-height: 0;
+  height: 100%;
+}
+
+/* Inspector slides in from the right — only rendered when a node is selected,
+   so the canvas naturally expands to fill the gap when inspector is absent.
+   It claims the larger share of the modal's extra width (grow 2 vs the
+   workspace's 1) since editing deeply nested nodes is the priority here. */
+.router-editor__graph-modal .router-graph__inspector {
+  flex: 2 1 560px;
+  min-width: 320px;
+  border-top: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: var(--surface-1);
+}
+
+/* Draggable divider between the graph workspace and the node inspector.
+   Only rendered in the expanded modal, so it lives under that scope. */
+.router-editor__graph-modal .router-graph__resizer {
+  flex: 0 0 12px;
+  align-self: stretch;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: col-resize;
+  border-left: 1px solid var(--border-subtle);
+  border-right: 1px solid var(--border-subtle);
+  background: var(--surface-1);
+  touch-action: none;
+  user-select: none;
+}
+.router-editor__graph-modal .router-graph__resizer:hover,
+.router-graph.is-resizing .router-graph__resizer {
+  background: var(--surface-2);
+}
+.router-graph__resizer-grip {
+  display: flex;
+  color: var(--text-tertiary);
+  pointer-events: none;
+}
+.router-editor__graph-modal .router-graph__resizer:hover .router-graph__resizer-grip,
+.router-graph.is-resizing .router-graph__resizer-grip {
+  color: var(--accent-fg);
+}
+/* Suppress the col-resize→text cursor flip and stray selection during a drag. */
+.router-graph.is-resizing,
+.router-graph.is-resizing * {
+  cursor: col-resize !important;
+  user-select: none;
+}
+.router-editor__graph-modal .router-graph__inspector-head {
+  flex-shrink: 0;
+}
+/* Block scroll container: scrolls vertically for tall trees and horizontally
+   for deep ones. min-content tracks (below) plus a min-content floor on the
+   root node let the tree stretch to fill when it fits and grow past the panel
+   (scrolling) when nesting gets deep. */
+.router-editor__graph-modal .router-graph__inspector-body {
+  flex: 1 1 0;
+  min-height: 0;
+  overflow: auto;
+  padding: var(--space-4);
+}
+.router-editor__graph-modal .router-graph__inspector-body .router-node {
+  min-width: auto;
+}
+.router-editor__graph-modal .router-graph__inspector-body > .router-node {
+  min-width: min-content;
+}
+.router-editor__graph-modal .router-graph__inspector-body .router-node__child {
+  grid-template-columns: 26px minmax(min-content, 1fr);
 }

--- a/src/app/src/styles/styles.css
+++ b/src/app/src/styles/styles.css
@@ -12542,18 +12542,32 @@ a.backend-card__version:focus-visible {
   border-bottom: 1px solid var(--border-subtle);
   background: var(--surface-1);
 }
-.router-editor__toolbar-spacer { flex: 1; }
-.router-editor__saved-select { min-width: 0; }
-.router-editor__saved-select select { width: min(230px, 32vw); }
+.router-editor .workspace-detail-panel__title-row > .router-editor__toolbar {
+  flex: 0 1 360px;
+  align-self: flex-start;
+  flex-direction: column;
+  align-items: stretch;
+  padding: 0;
+  border: 0;
+  background: transparent;
+}
+.router-editor__toolbar-row {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--space-2);
+  min-width: 0;
+}
+.router-editor__toolbar-row--files { justify-content: flex-end; }
+.router-editor__saved-select { min-width: 0; flex: 1 1 180px; }
+.router-editor__saved-select select { width: 100%; }
 .router-editor__tabs { display: flex; padding: 0 var(--space-5); border-bottom: 1px solid var(--border-subtle); background: var(--surface-1); }
 .router-editor__tabs button { height: 38px; padding: 0 var(--space-3); border: 0; border-bottom: 2px solid transparent; background: transparent; color: var(--text-tertiary); font-size: var(--text-sm); cursor: pointer; }
 .router-editor__tabs button:hover { color: var(--text-primary); }
 .router-editor__tabs button.is-active { color: var(--text-primary); border-bottom-color: var(--accent-fg); }
 .router-editor__body { min-height: 0; overflow-y: auto; padding: var(--space-4) var(--space-5) var(--space-6); scrollbar-gutter: stable; }
-.router-editor__backend-note,
 .router-editor__message,
 .router-editor__validation { display: flex; align-items: flex-start; gap: var(--space-2); padding: var(--space-3); margin-bottom: var(--space-3); border: 1px solid var(--border-subtle); border-radius: var(--radius-lg); font-size: var(--text-xs); line-height: var(--leading-relaxed); }
-.router-editor__backend-note { color: var(--text-secondary); background: color-mix(in srgb, var(--accent-fg) 5%, var(--surface-1)); }
 .router-editor__section,
 .router-editor__json-panel { margin-bottom: var(--space-4); border: 1px solid var(--border-subtle); border-radius: var(--radius-xl); background: var(--surface-1); overflow: hidden; }
 .router-editor__section-head { display: flex; align-items: flex-start; justify-content: space-between; gap: var(--space-3); padding: var(--space-3) var(--space-4); border-bottom: 1px solid var(--border-subtle); }
@@ -12624,21 +12638,24 @@ a.backend-card__version:focus-visible {
 .router-editor__rule-list { max-height: 326px; align-content: start; padding: var(--space-2); background: var(--surface-1); }
 .router-editor__rules-workspace {
   display: grid;
-  grid-template-columns: minmax(250px, 300px) minmax(0, 1fr);
+  /* Keep the rule rail intentionally compact so the graph remains the primary workspace. */
+  grid-template-columns: minmax(200px, 220px) minmax(0, 1fr);
   min-height: 430px;
   border-top: 1px solid var(--border-subtle);
 }
 .router-editor__rule-list { border-right: 1px solid var(--border-subtle); }
 .router-editor__rule-summary {
+  position: relative;
   display: grid;
   grid-template-columns: auto minmax(0, 1fr) auto;
   align-items: center;
-  gap: var(--space-1);
+  gap: 2px;
   min-height: 58px;
-  padding: var(--space-1) var(--space-1) var(--space-1) var(--space-2);
+  padding: var(--space-1);
   border: 1px solid var(--border-subtle);
   border-radius: var(--radius-md);
   background: var(--surface-base);
+  overflow: hidden;
   transition: border-color 120ms ease, background 120ms ease, opacity 120ms ease;
 }
 .router-editor__rule-summary:hover { border-color: color-mix(in srgb, var(--accent-fg) 28%, var(--border-subtle)); }
@@ -12649,7 +12666,7 @@ a.backend-card__version:focus-visible {
   display: grid;
   grid-template-columns: auto minmax(0, 1fr);
   align-items: center;
-  gap: var(--space-2);
+  gap: var(--space-1);
   padding: var(--space-1);
   border: 0;
   border-radius: var(--radius-sm);
@@ -12702,17 +12719,84 @@ a.backend-card__version:focus-visible {
 .router-editor__card-head { display: flex; align-items: center; gap: var(--space-2); min-height: 40px; padding: var(--space-2) var(--space-3); border-bottom: 1px solid var(--border-subtle); background: var(--surface-2); }
 .router-editor__card-head > strong { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: var(--text-sm); }
 .router-editor__card-head > .workspace-action-button { margin-left: auto; }
-.router-editor__drag-handle { display: inline-flex; align-items: center; justify-content: center; width: 24px; height: 24px; border-radius: var(--radius-sm); color: var(--text-tertiary); cursor: grab; user-select: none; }
+.router-editor__drag-handle { display: inline-flex; align-items: center; justify-content: center; width: 18px; height: 24px; border-radius: var(--radius-sm); color: var(--text-tertiary); cursor: grab; user-select: none; }
 .router-editor__drag-handle:hover { color: var(--text-primary); background: var(--surface-3); }
 .router-editor__drag-handle:active { cursor: grabbing; }
-.router-editor__rule-order { display: inline-flex; align-items: center; justify-content: center; width: 22px; height: 22px; border-radius: 50%; color: var(--accent-fg); background: color-mix(in srgb, var(--accent-fg) 12%, transparent); font-size: var(--type-overline-size); font-weight: var(--weight-bold); }
-.router-editor__rule-actions { display: inline-flex; gap: var(--space-0-5); margin-left: auto; }
-.router-editor__rule-actions button { width: 26px; height: 26px; border-radius: var(--radius-sm); }
+.router-editor__rule-order { display: inline-flex; align-items: center; justify-content: center; width: 20px; height: 20px; border-radius: 50%; color: var(--accent-fg); background: color-mix(in srgb, var(--accent-fg) 12%, transparent); font-size: var(--type-overline-size); font-weight: var(--weight-bold); }
+.router-editor__rule-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  margin-left: auto;
+  /* Match WorkspaceListRow: keep the right edge reserved for the hover action
+     so revealing Delete never reflows the row. */
+  padding-inline-end: 28px;
+}
+.router-editor__rule-actions button { width: 24px; height: 26px; border-radius: var(--radius-sm); }
+.router-editor__rule-stepper {
+  display: grid;
+  grid-template-rows: repeat(2, 13px);
+  width: 18px;
+  height: 26px;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+}
+.router-editor__rule-actions .router-editor__rule-stepper-button {
+  width: 18px;
+  height: 13px;
+  min-height: 0;
+  padding: 0;
+  border: 0;
+  border-radius: 3px;
+  background: transparent;
+}
+.router-editor__rule-actions .router-editor__rule-stepper-button:hover:not(:disabled) {
+  background: var(--surface-3);
+  color: var(--text-primary);
+}
+/* Same right-edge hover action used by WorkspaceListRow: the delete target is
+   an overlay, not a permanently occupied icon slot inside the action cluster. */
+.router-editor__rule-actions .router-editor__rule-remove {
+  position: absolute;
+  inset-block: 0;
+  inset-inline-end: 0;
+  width: 28px;
+  height: auto;
+  padding: 0;
+  border: 0;
+  border-start-end-radius: var(--radius-md);
+  border-end-end-radius: var(--radius-md);
+  background: transparent;
+  color: var(--text-tertiary);
+  visibility: hidden;
+  transition: color var(--duration-fast) var(--ease-out),
+              background var(--duration-fast) var(--ease-out);
+}
+.router-editor__rule-summary:hover .router-editor__rule-remove,
+.router-editor__rule-summary:focus-within .router-editor__rule-remove,
+.router-editor__rule-remove:focus { visibility: visible; }
+.router-editor__rule-actions .router-editor__rule-remove:hover:not(:disabled) {
+  color: var(--text-primary);
+  background: color-mix(in srgb, var(--text-primary) 8%, transparent);
+}
+@media (hover: none), (pointer: coarse) {
+  .router-editor__rule-actions .router-editor__rule-remove { visibility: visible; }
+}
 .router-editor__rule-actions button:disabled,
 .router-node__child-actions button:disabled { opacity: .28; cursor: default; }
 .router-editor__rule-meta { display: grid; grid-template-columns: minmax(0, .8fr) minmax(0, 1.2fr); gap: var(--space-3); padding: var(--space-3); }
 .router-editor__rule-meta label { display: grid; gap: 5px; color: var(--text-secondary); font-size: var(--text-xs); }
 .router-editor__concepts { display: grid; gap: var(--space-2); }
+.router-editor__concept-list {
+  display: grid;
+  gap: var(--space-2);
+  max-height: 300px;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding-right: var(--space-1);
+  scrollbar-gutter: stable;
+}
 .router-editor__mini-head { display: flex; align-items: center; justify-content: space-between; gap: var(--space-2); }
 .router-editor__concept { display: grid; grid-template-columns: minmax(110px, .7fr) minmax(180px, 1.5fr) var(--control-height-sm); gap: var(--space-2); }
 .router-editor__outputs { margin: 0 var(--space-3) var(--space-3); border-top: 1px solid var(--border-subtle); }
@@ -12724,6 +12808,11 @@ a.backend-card__version:focus-visible {
 .router-editor__validation ul { margin: var(--space-2) 0 0 20px; padding: 0; }
 .router-editor__message--error { color: var(--danger); background: var(--danger-soft); }
 .router-editor__message--success { color: var(--success); background: var(--success-soft); }
+.router-editor__copy-button.is-copied {
+  border-color: color-mix(in srgb, var(--success) 42%, var(--border-subtle));
+  color: var(--success);
+  background: var(--success-soft);
+}
 /* Recursive condition tree. */
 .router-node { min-width: 0; }
 .router-node--leaf { padding: var(--space-2); border: 1px solid var(--border-subtle); border-radius: var(--radius-md); background: var(--surface-1); }
@@ -12750,8 +12839,9 @@ a.backend-card__version:focus-visible {
   .router-editor__toolbar,
   .router-editor__tabs,
   .router-editor__body { padding-left: var(--space-3); padding-right: var(--space-3); }
+  .router-editor .workspace-detail-panel__title-row { flex-wrap: wrap; }
+  .router-editor .workspace-detail-panel__title-row > .router-editor__toolbar { flex: 1 1 100%; }
   .router-editor__toolbar { flex-wrap: wrap; }
-  .router-editor__toolbar-spacer { display: none; }
   .router-editor__saved-select { flex: 1 1 180px; }
   .router-editor__saved-select select { width: 100%; }
   .router-editor__form-grid,
@@ -12930,7 +13020,10 @@ a.backend-card__version:focus-visible {
 .router-graph__tool:hover { border-color: color-mix(in srgb, var(--accent-fg) 38%, var(--border-subtle)); background: var(--surface-1); color: var(--text-primary); }
 .router-graph__tool:active { cursor: grabbing; }
 .router-graph__tool--gate { display: grid; justify-items: center; gap: 2px; padding: var(--space-2) var(--space-1); text-align: center; color: var(--accent-fg); }
-.router-graph__tool--gate strong { color: var(--accent-fg); font-size: var(--text-xs); }
+.router-graph__tool--all { color: var(--accent-fg); }
+.router-graph__tool--any { color: var(--success); }
+.router-graph__tool--not { color: var(--danger); }
+.router-graph__tool--gate strong { color: currentColor; font-size: var(--text-xs); }
 .router-graph__tool--gate small { color: var(--text-tertiary); font-size: 9px; }
 .router-graph__gate-shape { display: block; overflow: visible; }
 .router-graph__gate-shape path,
@@ -12964,6 +13057,24 @@ a.backend-card__version:focus-visible {
 .router-graph__inspector-head button:hover { background: var(--surface-3); color: var(--text-primary); }
 .router-graph__toolbar button:disabled { opacity: .35; cursor: default; }
 .router-graph__toolbar button.is-danger:hover { color: var(--danger); background: var(--danger-soft); }
+.router-graph__toolbar button.router-graph__expand {
+  min-width: 30px;
+  padding-inline: 7px;
+  border-color: transparent;
+  background: transparent;
+  color: var(--primary-yellow);
+  box-shadow: none;
+}
+.router-graph__toolbar button.router-graph__expand .app-icon { stroke-width: 2; }
+.router-graph__toolbar button.router-graph__expand:hover:not(:disabled) {
+  border-color: transparent;
+  background: var(--surface-3);
+  color: var(--primary-yellow);
+}
+.router-graph__toolbar button.router-graph__expand:focus-visible {
+  outline: 2px solid var(--accent-focus);
+  outline-offset: 2px;
+}
 .router-graph__toolbar-spacer { flex: 1; }
 .router-graph__toolbar-hint { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--text-tertiary); font-size: var(--type-overline-size); }
 .router-graph__zoom-label { min-width: 44px; }
@@ -12986,17 +13097,19 @@ a.backend-card__version:focus-visible {
 .router-graph__empty > span:not(.router-graph__empty-icon) { max-width: 380px; font-size: var(--text-xs); line-height: var(--leading-relaxed); }
 .router-graph__empty-icon { display: inline-flex; align-items: center; justify-content: center; width: 46px; height: 46px; border: 1px solid color-mix(in srgb, var(--accent-fg) 28%, var(--border-subtle)); border-radius: 50%; background: color-mix(in srgb, var(--accent-fg) 8%, var(--surface-1)); color: var(--accent-fg); }
 
-.router-graph__group { min-width: 260px; padding: var(--space-2); border: 1px solid color-mix(in srgb, var(--accent-fg) 25%, var(--border-subtle)); border-radius: var(--radius-lg); background: color-mix(in srgb, var(--surface-1) 94%, transparent); box-shadow: var(--shadow-sm); }
-.router-graph__group.is-selected { border-color: color-mix(in srgb, var(--accent-fg) 70%, var(--border-subtle)); box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent-fg) 10%, transparent); }
-.router-graph__group-head { display: flex; align-items: center; gap: var(--space-2); min-height: 34px; padding: 0 var(--space-1) var(--space-2); cursor: pointer; }
-.router-graph__gate { display: inline-flex; align-items: center; justify-content: center; gap: 5px; min-width: 70px; height: 30px; padding: 0 8px 0 5px; border: 1px solid color-mix(in srgb, var(--accent-fg) 35%, var(--border-subtle)); border-radius: var(--radius-pill); color: var(--accent-fg); background: color-mix(in srgb, var(--accent-fg) 8%, var(--surface-1)); font-size: var(--type-overline-size); font-weight: var(--weight-bold); }
-.router-graph__gate--not { color: var(--danger); border-color: color-mix(in srgb, var(--danger) 35%, var(--border-subtle)); background: color-mix(in srgb, var(--danger) 7%, var(--surface-1)); }
+.router-graph__group { --router-gate-color: var(--accent-fg); min-width: 260px; padding: var(--space-2); border: 1px solid color-mix(in srgb, var(--router-gate-color) 28%, var(--border-subtle)); border-radius: var(--radius-lg); background: color-mix(in srgb, var(--router-gate-color) 3%, var(--surface-1)); box-shadow: var(--shadow-sm); }
+.router-graph__group--all { --router-gate-color: var(--accent-fg); }
+.router-graph__group--any { --router-gate-color: var(--success); }
+.router-graph__group--not { --router-gate-color: var(--danger); }
+.router-graph__group.is-selected { border-color: color-mix(in srgb, var(--router-gate-color) 72%, var(--border-subtle)); box-shadow: 0 0 0 2px color-mix(in srgb, var(--router-gate-color) 11%, transparent); }
+.router-graph__group-head { display: flex; align-items: center; gap: var(--space-2); min-height: 34px; padding: 0 var(--space-1) var(--space-2); }
+.router-graph__gate { appearance: none; font: inherit; cursor: pointer; display: inline-flex; align-items: center; justify-content: center; gap: 5px; min-width: 70px; height: 30px; padding: 0 8px 0 5px; border: 1px solid color-mix(in srgb, var(--router-gate-color) 38%, var(--border-subtle)); border-radius: var(--radius-pill); color: var(--router-gate-color); background: color-mix(in srgb, var(--router-gate-color) 9%, var(--surface-1)); font-size: var(--type-overline-size); font-weight: var(--weight-bold); }
 .router-graph__group-copy { flex: 1; color: var(--text-tertiary); font-size: var(--type-overline-size); }
 .router-graph__operator-actions { display: inline-flex; gap: 2px; }
-.router-graph__operator-actions button.is-active { color: var(--accent-fg); background: color-mix(in srgb, var(--accent-fg) 10%, var(--surface-2)); }
-.router-graph__children { position: relative; display: grid; gap: var(--space-2); padding: var(--space-2) 0 0 var(--space-4); border-left: 1px solid color-mix(in srgb, var(--accent-fg) 22%, var(--border-subtle)); }
+.router-graph__operator-actions button.is-active { color: var(--router-gate-color); background: color-mix(in srgb, var(--router-gate-color) 10%, var(--surface-2)); }
+.router-graph__children { position: relative; display: grid; gap: var(--space-2); padding: var(--space-2) 0 0 var(--space-4); border-left: 1px solid color-mix(in srgb, var(--router-gate-color) 25%, var(--border-subtle)); }
 .router-graph__branch { position: relative; display: grid; grid-template-columns: minmax(190px, 1fr) 24px; align-items: center; gap: var(--space-1); }
-.router-graph__branch::before { content: ''; position: absolute; left: calc(var(--space-4) * -1); top: 50%; width: var(--space-4); border-top: 1px solid color-mix(in srgb, var(--accent-fg) 22%, var(--border-subtle)); }
+.router-graph__branch::before { content: ''; position: absolute; left: calc(var(--space-4) * -1); top: 50%; width: var(--space-4); border-top: 1px solid color-mix(in srgb, var(--router-gate-color) 25%, var(--border-subtle)); }
 .router-graph__leaf { min-width: 0; display: grid; gap: 2px; padding: var(--space-2) var(--space-3); border: 1px solid var(--border-subtle); border-left: 3px solid var(--accent-fg); border-radius: var(--radius-md); background: var(--surface-base); color: var(--text-secondary); text-align: left; cursor: pointer; }
 .router-graph__leaf:hover { border-color: color-mix(in srgb, var(--accent-fg) 42%, var(--border-subtle)); background: var(--surface-1); }
 .router-graph__leaf.is-selected { border-color: color-mix(in srgb, var(--accent-fg) 70%, var(--border-subtle)); box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent-fg) 10%, transparent); }
@@ -13019,7 +13132,7 @@ a.backend-card__version:focus-visible {
 .router-graph__inspector-body .router-node--group { margin: 0; }
 
 @media (max-width: 980px) {
-  .router-editor__rules-workspace { grid-template-columns: minmax(220px, 260px) minmax(0, 1fr); }
+  .router-editor__rules-workspace { grid-template-columns: minmax(200px, 220px) minmax(0, 1fr); }
   .router-graph__workspace { grid-template-columns: minmax(0, 1fr) 180px; }
   .router-graph__toolbar-hint { display: none; }
 }
@@ -13731,6 +13844,13 @@ a.backend-card__version:focus-visible {
   line-height: var(--leading-relaxed);
 }
 
+.workspace-detail-panel__description--identity {
+  max-width: 70ch;
+  padding: 0;
+  color: var(--text-tertiary);
+  font-size: var(--text-xs);
+}
+
 .workspace-detail-panel__description > :first-child { margin-top: 0; }
 .workspace-detail-panel__description > :last-child { margin-bottom: 0; }
 
@@ -14375,29 +14495,37 @@ button.workspace-metadata-chip:hover {
   border-top: 1px solid var(--border-subtle);
 }
 .router-editor__connections > .router-editor__mini-head {
-  align-items: flex-start;
+  align-items: center;
 }
 .router-editor__connections > .router-editor__mini-head > span {
   color: var(--text-secondary);
   font-size: var(--text-sm);
   font-weight: var(--weight-semibold);
 }
-.router-editor__connections > .router-editor__mini-head > small {
-  max-width: 52ch;
-  color: var(--text-tertiary);
-  font-size: var(--text-xs);
-  text-align: right;
+.router-editor__connection-list {
+  display: grid;
+  gap: var(--space-2);
+  max-height: 258px;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding-right: var(--space-1);
+  scrollbar-gutter: stable;
 }
 .router-editor__connection {
   display: grid;
-  grid-template-columns: minmax(180px, 1.15fr) minmax(130px, .65fr) minmax(220px, 1.35fr);
+  grid-template-columns: minmax(180px, 1fr) minmax(180px, 1.25fr) minmax(150px, auto);
   align-items: center;
   gap: var(--space-3);
   min-width: 0;
-  padding: var(--space-3);
+  min-height: 58px;
+  padding: var(--space-2) var(--space-3);
   border: 1px solid var(--border-subtle);
   border-radius: var(--radius-md);
   background: var(--surface-base);
+}
+.router-editor__connection--internal,
+.router-editor__connection--unresolved {
+  grid-template-columns: minmax(180px, 1fr) minmax(150px, auto);
 }
 .router-editor__connection-main,
 .router-editor__connection-source,
@@ -14422,7 +14550,6 @@ button.workspace-metadata-chip:hover {
   color: var(--text-primary);
   font-size: var(--text-sm);
 }
-.router-editor__connection-main small,
 .router-editor__connection-source small,
 .router-editor__connection-endpoint small {
   overflow: hidden;
@@ -14439,6 +14566,17 @@ button.workspace-metadata-chip:hover {
 .router-editor__connection-endpoint > .workspace-action-button {
   justify-self: start;
   margin-top: var(--space-1);
+}
+.router-editor__connection-trailing {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--space-2);
+}
+.router-editor__connection-source {
+  justify-items: end;
+  text-align: right;
 }
 .router-editor__default-badge {
   display: inline-flex;
@@ -14528,9 +14666,18 @@ button.workspace-metadata-chip:hover {
   .router-collection-settings__connection {
     grid-template-columns: minmax(0, 1fr) minmax(130px, .7fr);
   }
+  .router-editor__connection--internal,
+  .router-editor__connection--unresolved {
+    grid-template-columns: minmax(0, 1fr) minmax(130px, .7fr);
+  }
   .router-editor__connection-endpoint,
   .router-collection-settings__endpoint {
-    grid-column: 1 / -1;
+    grid-column: 1;
+    grid-row: 2;
+  }
+  .router-editor__connection-trailing {
+    grid-column: 2;
+    grid-row: 1 / span 2;
   }
 }
 
@@ -14542,19 +14689,27 @@ button.workspace-metadata-chip:hover {
     grid-column: 2;
     justify-self: start;
   }
-  .router-editor__connections > .router-editor__mini-head {
-    display: grid;
-  }
-  .router-editor__connections > .router-editor__mini-head > small {
-    text-align: left;
-  }
   .router-editor__connection,
   .router-collection-settings__connection {
     grid-template-columns: 1fr;
   }
+  .router-editor__connection--internal,
+  .router-editor__connection--unresolved {
+    grid-template-columns: 1fr;
+  }
   .router-editor__connection-endpoint,
   .router-collection-settings__endpoint {
-    grid-column: auto;
+    grid-column: 1;
+    grid-row: auto;
+  }
+  .router-editor__connection-trailing {
+    grid-column: 1;
+    grid-row: auto;
+    justify-content: space-between;
+  }
+  .router-editor__connection-source {
+    justify-items: start;
+    text-align: left;
   }
   .router-editor__endpoint-editor {
     grid-template-columns: 1fr 1fr;
@@ -14582,4 +14737,22 @@ button.workspace-metadata-chip:hover {
 }
 .router-editor__insecure-opt-in input {
   margin: 0;
+}
+
+/* Router graph expanded view mirrors GUI2's full-canvas editing mode. */
+.router-editor__graph-modal {
+  width: min(1500px, 100%);
+  max-height: calc(90vh - 66px);
+  padding: var(--space-3);
+  overflow: auto;
+}
+.router-editor__graph-modal .router-graph {
+  min-height: min(680px, calc(90vh - 110px));
+}
+.router-editor__graph-modal .router-graph__workspace {
+  min-height: min(560px, calc(90vh - 220px));
+}
+.router-editor__graph-modal .router-graph__canvas,
+.router-editor__graph-modal .router-graph__empty {
+  min-height: min(520px, calc(90vh - 260px));
 }

--- a/src/app/tests/a11y.spec.ts
+++ b/src/app/tests/a11y.spec.ts
@@ -63,7 +63,7 @@ async function openCustomModelEditor(
   await page.waitForSelector('.custom-model-form');
 
   if (mode === 'omni-collection') {
-    await page.getByRole('button', { name: 'Omni collection', exact: true }).click();
+    await page.getByRole('button', { name: 'Omni Collection', exact: true }).click();
   }
 }
 
@@ -1885,8 +1885,8 @@ test.describe('Accessibility — master-detail model view (#2355 Slice 1)', () =
     await openCustomModels.click();
 
     const typeGroup = page.getByRole('group', { name: 'Custom model type' });
-    const customBtn = typeGroup.getByRole('button', { name: 'Custom model', exact: true });
-    const omniBtn = typeGroup.getByRole('button', { name: 'Omni collection', exact: true });
+    const customBtn = typeGroup.getByRole('button', { name: 'Custom Model', exact: true });
+    const omniBtn = typeGroup.getByRole('button', { name: 'Omni Collection', exact: true });
     await expect(typeGroup).toBeVisible();
     await expect(customBtn).toBeVisible();
     await expect(omniBtn).toBeVisible();

--- a/src/app/tests/router-editor.runtime.cjs
+++ b/src/app/tests/router-editor.runtime.cjs
@@ -5,7 +5,7 @@ const ts = require('typescript');
 
 const root = path.resolve(__dirname, '..');
 
-function loadTypeScriptModule(filename) {
+function loadTypeScriptModule(filename, dependencyOverrides = {}) {
   const source = fs.readFileSync(filename, 'utf8');
   const compiled = ts.transpileModule(source, {
     compilerOptions: {
@@ -22,9 +22,12 @@ function loadTypeScriptModule(filename) {
     (compiled.diagnostics || []).map(d => ts.flattenDiagnosticMessageText(d.messageText, '\n')).join('\n'),
   );
   const module = { exports: {} };
+  const localRequire = (request) => Object.prototype.hasOwnProperty.call(dependencyOverrides, request)
+    ? dependencyOverrides[request]
+    : require(request);
   Function('exports', 'require', 'module', '__filename', '__dirname', compiled.outputText)(
     module.exports,
-    require,
+    localRequire,
     module,
     filename,
     path.dirname(filename),
@@ -32,23 +35,54 @@ function loadTypeScriptModule(filename) {
   return module.exports;
 }
 
+function assertTypeScriptSyntax(filename) {
+  const source = fs.readFileSync(filename, 'utf8');
+  const compiled = ts.transpileModule(source, {
+    compilerOptions: {
+      target: ts.ScriptTarget.ES2020,
+      module: ts.ModuleKind.CommonJS,
+      esModuleInterop: true,
+      jsx: ts.JsxEmit.ReactJSX,
+    },
+    fileName: filename,
+    reportDiagnostics: true,
+  });
+  assert.equal(
+    (compiled.diagnostics || []).length,
+    0,
+    (compiled.diagnostics || []).map(d => ts.flattenDiagnosticMessageText(d.messageText, '\n')).join('\n'),
+  );
+}
+
 const routerTypesPath = path.join(root, 'src/features/router/routerTypes.ts');
 const managerPath = path.join(root, 'src/components/ModelManager.tsx');
 const listPath = path.join(root, 'src/components/ModelListPanel.tsx');
 const editorPath = path.join(root, 'src/components/RouterEditorPanel.tsx');
 const nodeEditorPath = path.join(root, 'src/components/RouterNodeEditor.tsx');
+const graphPath = path.join(root, 'src/components/RouterRuleGraph.tsx');
+const graphUtilsPath = path.join(root, 'src/features/router/routerGraph.ts');
+const modelPickerPath = path.join(root, 'src/components/RouterModelPicker.tsx');
+const stylesPath = path.join(root, 'src/styles/styles.css');
 const connectionPath = path.join(root, 'src/features/router/routerConnections.ts');
 const detailPath = path.join(root, 'src/components/ModelDetailPanel.tsx');
 const apiPath = path.join(root, 'src/api.ts');
 
 const router = loadTypeScriptModule(routerTypesPath);
+const graphUtils = loadTypeScriptModule(graphUtilsPath, { './routerTypes': router });
 const connections = loadTypeScriptModule(connectionPath);
 const managerSource = fs.readFileSync(managerPath, 'utf8');
 const listSource = fs.readFileSync(listPath, 'utf8');
 const editorSource = fs.readFileSync(editorPath, 'utf8');
 const nodeEditorSource = fs.readFileSync(nodeEditorPath, 'utf8');
+const graphSource = fs.readFileSync(graphPath, 'utf8');
+const modelPickerSource = fs.readFileSync(modelPickerPath, 'utf8');
+const stylesSource = fs.readFileSync(stylesPath, 'utf8');
 const detailSource = fs.readFileSync(detailPath, 'utf8');
 const apiSource = fs.readFileSync(apiPath, 'utf8');
+
+assertTypeScriptSyntax(editorPath);
+assertTypeScriptSyntax(graphPath);
+assertTypeScriptSyntax(modelPickerPath);
 
 const draft = {
   name: 'Fast or smart',
@@ -174,6 +208,33 @@ const unary = {
 };
 assert.equal(router.normalizeRouterNode(unary).kind, 'leaf', 'one-child groups must collapse instead of becoming invalid');
 
+const graphRoot = router.createRouterLeaf('has_tools');
+const graphWithSibling = graphUtils.appendRouterNodeAtPath(graphRoot, [], router.createRouterLeaf('has_images'));
+assert.equal(graphWithSibling.kind, 'group', 'dropping a second leaf on a leaf must create a visual AND gate');
+assert.equal(graphWithSibling.operator, 'all');
+assert.equal(graphWithSibling.children.length, 2);
+const graphNestedGate = graphUtils.createEmptyRouterGraphGroup('any');
+const graphWithGate = graphUtils.appendRouterNodeAtPath(graphWithSibling, [], graphNestedGate);
+assert.equal(graphWithGate.children.length, 3, 'dropping a gate on a root group must append it as a child');
+const graphWithNestedLeaf = graphUtils.appendRouterNodeAtPath(graphWithGate, [2], router.createRouterLeaf('regex'));
+assert.equal(graphUtils.routerNodeAtPath(graphWithNestedLeaf, [2, 0]).type, 'regex');
+assert.throws(
+  () => {
+    const notGate = graphUtils.createEmptyRouterGraphGroup('not');
+    const withChild = graphUtils.appendRouterNodeAtPath(notGate, [], router.createRouterLeaf('has_tools'));
+    graphUtils.appendRouterNodeAtPath(withChild, [], router.createRouterLeaf('has_images'));
+  },
+  /NOT can contain only one condition/,
+  'graph drag/drop must not create an invalid multi-child NOT gate',
+);
+assert.equal(graphUtils.isBlankRouterGraphNode(router.createRouterLeaf()), true, 'the seeded empty rule should render as an empty graph canvas');
+assert.equal(graphUtils.removeRouterNodeAtPath(graphWithSibling, [1]).kind, 'leaf', 'removing a sibling should normalize a one-child gate');
+const notWithChild = graphUtils.appendRouterNodeAtPath(graphUtils.createEmptyRouterGraphGroup('not'), [], router.createRouterLeaf('has_tools'));
+const emptiedNot = graphUtils.removeRouterNodeAtPath(notWithChild, [0]);
+assert.equal(emptiedNot.kind, 'group');
+assert.equal(emptiedNot.operator, 'not');
+assert.equal(emptiedNot.children.length, 0, 'removing a NOT child should leave a valid graph drop target instead of inserting a hidden placeholder condition');
+
 const renamedLabelTree = router.renameClassifierLabelReference(
   draft.rules[1].condition,
   'topic',
@@ -285,10 +346,13 @@ assert.match(nodeEditorSource, /metadataComparator/);
 assert.match(nodeEditorSource, /normalizeRouterNode/);
 assert.match(nodeEditorSource, />AND<|>AND<\/button>/, 'a leaf must be wrappable into a compound rule');
 assert.match(editorSource, /Switching modes clears incompatible configuration after confirmation/);
-assert.match(editorSource, /routerDraftHasRulesProgress\(draft\)[\s\S]*window\.confirm/, 'rules-to-LLM mode changes must warn before clearing meaningful work');
-assert.match(editorSource, /routerDraftHasLlmProgress\(draft\)[\s\S]*window\.confirm/, 'LLM-to-rules mode changes must warn before clearing meaningful work');
-assert.match(editorSource, /switchRouterDraftMode\(current, 'llm'\)/, 'switching to LLM must use the tested destructive transition helper');
-assert.match(editorSource, /switchRouterDraftMode\(current, 'rules'\)/, 'switching to rules must use the tested destructive transition helper');
+assert.doesNotMatch(editorSource, /window\.confirm/, 'router editor confirmations must use GUI3-native dialogs rather than browser confirm');
+assert.match(editorSource, /routerDraftHasRulesProgress\(draft\)[\s\S]*kind: 'switch-llm'/, 'rules-to-LLM mode changes must open a branded warning before clearing meaningful work');
+assert.match(editorSource, /routerDraftHasLlmProgress\(draft\)[\s\S]*kind: 'switch-rules'/, 'LLM-to-rules mode changes must open a branded warning before clearing meaningful work');
+assert.match(editorSource, /routerDraftHasRulesProgress\(draft\) \|\| routerDraftHasLlmProgress\(draft\)[\s\S]*kind: 'reset'/, 'New must warn only when the draft contains meaningful router progress');
+assert.match(editorSource, /switchRouterDraftMode\(current, mode\)/, 'confirmed mode changes must use the tested destructive transition helper');
+assert.match(editorSource, /<Modal[\s\S]*router-confirm-dialog-title/, 'destructive router actions must render through the GUI3 modal surface');
+assert.match(editorSource, /router-editor__toast[\s\S]*role="status"/, 'successful registration feedback must remain visible in a bottom-right status toast');
 assert.match(editorSource, /api\.modelDetail\(modelNameValue\)/, 'editing a server router must fetch its full model detail before parsing the policy');
 const detailCallIndex = editorSource.indexOf('api.modelDetail(modelNameValue)');
 const localFallbackIndex = editorSource.indexOf('if ((initialModel as any).routing)', detailCallIndex);
@@ -296,7 +360,24 @@ assert.ok(detailCallIndex >= 0 && localFallbackIndex > detailCallIndex, 'cached 
 assert.match(editorSource, /const embeddingModels = useMemo[\s\S]*normalized === 'embedding' \|\| normalized === 'embeddings'/, 'semantic similarity picker must use explicitly labelled embedding models');
 assert.match(editorSource, /const classifierModels = useMemo[\s\S]*classification/, 'text classifier picker must only expose classification models');
 assert.doesNotMatch(editorSource, /explicit\.length \? explicit : models/, 'embedding picker must not fall back to every model');
-assert.match(editorSource, /classifier\.type === 'llm' \? candidateModels : classifierModels/, 'classifier pickers must use type-specific model lists');
+assert.match(editorSource, /models=\{classifier\.type === 'semantic_similarity' \? embeddingModels : classifier\.type === 'llm' \? candidateModels : classifierModels\}/, 'classifier pickers must use type-specific model lists');
+assert.ok((editorSource.match(/<RouterModelPicker/g) || []).length >= 2, 'NL router and classifier model fields must use searchable model pickers');
+assert.match(modelPickerSource, /router-model-picker__search/, 'model picker must expose a search field inside the dropdown');
+assert.match(modelPickerSource, /role="combobox"/, 'model picker search must expose combobox semantics');
+assert.match(modelPickerSource, /model\.labels/, 'model picker search should match model labels as well as names');
+assert.match(modelPickerSource, /createPortal[\s\S]*document\.body/, 'searchable model menus must escape capped list overflow via a portal');
+assert.match(editorSource, /<RouterRuleGraph/, 'ordered rules must use the visual GUI3 graph builder');
+assert.match(editorSource, /router-editor__rules-workspace[\s\S]*router-editor__rule-list[\s\S]*router-editor__rule-builder/, 'rules must use the GUI2-style compact-list plus selected-canvas pipeline instead of embedding a canvas in every rule');
+assert.match(editorSource, /selectedRuleIndex/, 'the visual pipeline must keep one selected rule bound to the graph canvas');
+assert.match(graphSource, /application\/x-lemonade-router-node/, 'graph builder must use an isolated drag payload type');
+assert.match(graphSource, /draggable[\s\S]*Logic gates|Logic gates[\s\S]*draggable/, 'graph toolbox must provide draggable logic gates');
+assert.match(graphSource, /onDrop=\{event =>/, 'graph canvas must accept drag/drop input');
+assert.match(graphSource, /setPan[\s\S]*setZoom|setZoom[\s\S]*setPan/, 'graph canvas must retain GUI2-style pan and zoom controls');
+assert.match(graphSource, /RouterNodeEditor/, 'selected graph nodes must remain fully editable through the existing validated node editor');
+assert.match(editorSource, /router-editor__drag-handle[\s\S]*draggable/, 'ordered rules must be draggable for reordering while keeping keyboard move controls');
+assert.match(stylesSource, /router-editor__classifier-list \{ max-height:[\s\S]*router-editor__rule-list \{ max-height:/, 'classifier and rule lists must be height-capped with internal scrolling');
+assert.match(stylesSource, /router-editor__classifier-list,[\s\S]*router-editor__rule-list[\s\S]*overflow-y: auto/, 'router lists must scroll internally rather than expanding without bound');
+assert.match(stylesSource, /router-editor__rules-workspace[\s\S]*grid-template-columns/, 'rule layout must preserve the compact-list plus graph-canvas split on desktop');
 
 
 const providerRows = [{

--- a/src/app/tests/router-editor.runtime.cjs
+++ b/src/app/tests/router-editor.runtime.cjs
@@ -62,6 +62,8 @@ const nodeEditorPath = path.join(root, 'src/components/RouterNodeEditor.tsx');
 const graphPath = path.join(root, 'src/components/RouterRuleGraph.tsx');
 const graphUtilsPath = path.join(root, 'src/features/router/routerGraph.ts');
 const modelPickerPath = path.join(root, 'src/components/RouterModelPicker.tsx');
+const workspacePanelsPath = path.join(root, 'src/components/WorkspacePanels.tsx');
+const modalPath = path.join(root, 'src/components/inspect/Modal.tsx');
 const stylesPath = path.join(root, 'src/styles/styles.css');
 const connectionPath = path.join(root, 'src/features/router/routerConnections.ts');
 const detailPath = path.join(root, 'src/components/ModelDetailPanel.tsx');
@@ -76,6 +78,8 @@ const editorSource = fs.readFileSync(editorPath, 'utf8');
 const nodeEditorSource = fs.readFileSync(nodeEditorPath, 'utf8');
 const graphSource = fs.readFileSync(graphPath, 'utf8');
 const modelPickerSource = fs.readFileSync(modelPickerPath, 'utf8');
+const workspacePanelsSource = fs.readFileSync(workspacePanelsPath, 'utf8');
+const modalSource = fs.readFileSync(modalPath, 'utf8');
 const stylesSource = fs.readFileSync(stylesPath, 'utf8');
 const detailSource = fs.readFileSync(detailPath, 'utf8');
 const apiSource = fs.readFileSync(apiPath, 'utf8');
@@ -83,6 +87,10 @@ const apiSource = fs.readFileSync(apiPath, 'utf8');
 assertTypeScriptSyntax(editorPath);
 assertTypeScriptSyntax(graphPath);
 assertTypeScriptSyntax(modelPickerPath);
+assertTypeScriptSyntax(workspacePanelsPath);
+assertTypeScriptSyntax(nodeEditorPath);
+assertTypeScriptSyntax(modalPath);
+assertTypeScriptSyntax(managerPath);
 
 const draft = {
   name: 'Fast or smart',
@@ -116,7 +124,7 @@ const draft = {
           { id: 'size', kind: 'leaf', type: 'max_chars', numberValue: 1000 },
           {
             id: 'meta', kind: 'leaf', type: 'metadata', metadataKey: 'task_class',
-            metadataComparator: 'any', metadataValues: 'quick, routine',
+            metadataComparator: 'any', metadataValues: 'quick\nroutine',
           },
         ],
       },
@@ -134,6 +142,36 @@ const draft = {
 };
 
 assert.deepEqual(router.validateRouterDraft(draft), []);
+const duplicateConditionDraft = structuredClone(draft);
+duplicateConditionDraft.rules[0].condition = {
+  id: 'duplicate-gate',
+  kind: 'group',
+  operator: 'all',
+  children: [
+    { ...router.createRouterLeaf('has_tools'), booleanValue: true },
+    { ...router.createRouterLeaf('has_tools'), booleanValue: false },
+  ],
+};
+assert.match(
+  router.validateRouterDraft(duplicateConditionDraft).join('\n'),
+  /duplicate has_tools conditions are not allowed/i,
+  'draft validation must reject duplicate direct conditions even when they arrive through import/load rather than graph interaction',
+);
+const distinctMetadataDraft = structuredClone(draft);
+distinctMetadataDraft.rules[0].condition = {
+  id: 'metadata-gate-validation',
+  kind: 'group',
+  operator: 'all',
+  children: [
+    { ...router.createRouterLeaf('metadata'), metadataKey: 'tier', metadataComparator: 'equals', metadataValues: 'pro' },
+    { ...router.createRouterLeaf('metadata'), metadataKey: 'region', metadataComparator: 'equals', metadataValues: 'eu' },
+  ],
+};
+assert.doesNotMatch(
+  router.validateRouterDraft(distinctMetadataDraft).join('\n'),
+  /duplicate metadata/i,
+  'different metadata keys are distinct condition identities and must remain valid in one gate',
+);
 const payload = router.buildRouterPullRequest(draft);
 assert.equal(payload.version, '1');
 assert.equal(payload.recipe, 'collection.router');
@@ -153,6 +191,41 @@ assert.equal(parsed.rules.length, 2);
 assert.equal(parsed.mode, 'rules');
 assert.equal(parsed.classifiers[0].type, 'semantic_similarity');
 assert.equal(parsed.rules[0].condition.operator, 'all');
+
+const commaListPayload = {
+  version: '1', model_name: 'user.CommaLists', recipe: 'collection.router', components: ['model-a'],
+  routing: { candidates: ['model-a'], default_model: 'model-a', rules: [{
+    id: 'rule-1',
+    match: { all: [
+      { keywords_any: ['hello, world', 'plain'] },
+      { metadata: { key: 'tags', any: ['red,blue', 'green'] } },
+    ] },
+    route_to: 'model-a',
+  }] },
+};
+const commaListDraft = router.parseRouterPayload(commaListPayload);
+const commaListBuilt = router.buildRouterPullRequest(commaListDraft);
+assert.deepEqual(commaListBuilt.routing.rules[0].match.all[0].keywords_any, ['hello, world', 'plain'], 'comma-containing keywords must remain one value through GUI3');
+assert.deepEqual(commaListBuilt.routing.rules[0].match.all[1].metadata.any, ['red,blue', 'green'], 'comma-containing metadata tokens must remain one value through GUI3');
+const commaClassifierPayload = {
+  version: '1', model_name: 'user.CommaClassifier', recipe: 'collection.router',
+  components: ['model-a', 'llm-helper', 'embed-helper'],
+  routing: { candidates: ['model-a'], default_model: 'model-a', classifiers: [
+    { id: 'risk', type: 'llm', model: 'llm-helper', prompt: 'Classify.', labels: ['SAFE,LOCAL', 'RISKY'], default_label: 'SAFE,LOCAL', on_error: 'match_false' },
+    { id: 'topic', type: 'semantic_similarity', model: 'embed-helper', reference_phrases: { greeting: ['hello, world', 'hi'] }, on_error: 'match_false' },
+  ], rules: [
+    { id: 'r1', match: { classifier: 'risk', label: 'SAFE,LOCAL' }, route_to: 'model-a' },
+    { id: 'r2', match: { classifier: 'topic', label: 'greeting' }, route_to: 'model-a' },
+  ] },
+};
+const commaClassifierBuilt = router.buildRouterPullRequest(router.parseRouterPayload(commaClassifierPayload));
+assert.deepEqual(commaClassifierBuilt.routing.classifiers[0].labels, ['SAFE,LOCAL', 'RISKY'], 'comma-containing classifier labels must round-trip as single labels');
+assert.deepEqual(commaClassifierBuilt.routing.classifiers[1].reference_phrases.greeting, ['hello, world', 'hi'], 'comma-containing semantic phrases must round-trip as single phrases');
+assert.throws(() => router.parseRouterPayload({ ...commaListPayload, version: 1 }), /version 1 as a string/, "numeric schema versions must not be silently normalized to the server\'s string version");
+assert.throws(() => router.parseRouterPayload({
+  ...commaListPayload,
+  routing: { ...commaListPayload.routing, rules: [{ ...commaListPayload.routing.rules[0], match: { keywords_any: [' padded '] } }] },
+}), /leading or trailing whitespace/, 'import must reject list values GUI3 would normalize on save instead of silently changing semantics');
 
 const nlPayload = {
   version: '1', model_name: 'user.nl', recipe: 'collection.router', components: ['a', 'router-model'],
@@ -235,6 +308,78 @@ assert.equal(emptiedNot.kind, 'group');
 assert.equal(emptiedNot.operator, 'not');
 assert.equal(emptiedNot.children.length, 0, 'removing a NOT child should leave a valid graph drop target instead of inserting a hidden placeholder condition');
 
+assert.throws(
+  () => graphUtils.appendRouterNodeAtPath(graphWithSibling, [], router.createRouterLeaf('has_tools')),
+  /already in this gate/,
+  'a graph gate must reject a duplicate deterministic condition type',
+);
+const classifierGate = {
+  id: 'classifier-gate', kind: 'group', operator: 'all', children: [
+    { ...router.createRouterLeaf('classifier'), id: 'clf-a', classifierId: 'topic' },
+    { ...router.createRouterLeaf('classifier'), id: 'clf-b', classifierId: 'risk' },
+  ],
+};
+assert.equal(
+  graphUtils.appendRouterNodeAtPath(classifierGate, [], { ...router.createRouterLeaf('classifier'), classifierId: 'third' }).children.length,
+  3,
+  'different classifier IDs remain independent conditions even though they share the classifier leaf type',
+);
+assert.equal(
+  graphUtils.appendRouterNodeAtPath(classifierGate, [], { ...router.createRouterLeaf('classifier'), classifierId: 'topic', label: 'code', minScore: 0.9 }).children.length,
+  3,
+  'classifier leaves are parameterized score/label predicates and may repeat when their constraints differ',
+);
+const metadataGate = {
+  id: 'metadata-gate', kind: 'group', operator: 'any', children: [
+    { ...router.createRouterLeaf('metadata'), id: 'meta-a', metadataKey: 'tier', metadataComparator: 'equals', metadataValues: 'pro' },
+    { ...router.createRouterLeaf('metadata'), id: 'meta-b', metadataKey: 'region', metadataComparator: 'equals', metadataValues: 'eu' },
+  ],
+};
+assert.equal(
+  graphUtils.routerReplacementConflictAtPath(metadataGate, [1], { ...router.createRouterLeaf('metadata'), metadataKey: 'tier', metadataComparator: 'exists' }),
+  null,
+  'metadata leaves are parameterized predicates and multiple constraints on the same key must remain expressible',
+);
+const regexGate = {
+  id: 'regex-gate', kind: 'group', operator: 'all', children: [
+    { ...router.createRouterLeaf('regex'), id: 'regex-a', textValue: '^foo' },
+  ],
+};
+assert.equal(
+  graphUtils.appendRouterNodeAtPath(regexGate, [], { ...router.createRouterLeaf('regex'), textValue: 'bar$' }).children.length,
+  2,
+  'multiple regex predicates are not mergeable and must remain legal in one gate',
+);
+const duplicateInspectorGroup = {
+  id: 'inspector-group', kind: 'group', operator: 'all', children: [
+    { ...router.createRouterLeaf('has_tools'), id: 'tools-a' },
+    { ...router.createRouterLeaf('has_tools'), id: 'tools-b' },
+  ],
+};
+assert.match(
+  graphUtils.routerReplacementConflictAtPath(graphWithSibling, [], duplicateInspectorGroup) || '',
+  /has tools condition is already in this gate/,
+  'group edits from the inspector must not bypass duplicate-condition protection',
+);
+const collapseCanCreateDuplicate = {
+  id: 'outer', kind: 'group', operator: 'all', children: [
+    { ...router.createRouterLeaf('has_tools'), id: 'outer-tools' },
+    {
+      id: 'inner', kind: 'group', operator: 'all', children: [
+        { ...router.createRouterLeaf('has_tools'), id: 'inner-tools' },
+        { ...router.createRouterLeaf('has_images'), id: 'inner-images' },
+      ],
+    },
+  ],
+};
+assert.equal(graphUtils.routerDuplicateConditionConflict(collapseCanCreateDuplicate), null);
+const collapsedIntoDuplicate = graphUtils.removeRouterNodeAtPath(collapseCanCreateDuplicate, [1, 1]);
+assert.match(
+  graphUtils.routerDuplicateConditionConflict(collapsedIntoDuplicate) || '',
+  /has tools condition is already in this gate/,
+  'normalizing a nested one-child group can surface a duplicate into its parent gate',
+);
+
 const renamedLabelTree = router.renameClassifierLabelReference(
   draft.rules[1].condition,
   'topic',
@@ -277,6 +422,47 @@ assert.deepEqual(switchedBackToRules.llmRouter, { model: '', prompt: '' });
 assert.equal(switchedBackToRules.rules.length, 1);
 assert.equal(switchedBackToRules.rules[0].routeTo, switchedBackToRules.defaultModel);
 
+const candidateTransitionDraft = structuredClone(draft);
+candidateTransitionDraft.defaultModel = 'user.smart';
+candidateTransitionDraft.rules[0].routeTo = 'user.smart';
+const removedDefaultCandidate = router.toggleRouterDraftCandidate(candidateTransitionDraft, 'user.smart');
+assert.deepEqual(removedDefaultCandidate.candidates, ['user.fast']);
+assert.equal(removedDefaultCandidate.defaultModel, 'user.fast', 'removing the default candidate must promote a remaining valid candidate');
+assert.equal(removedDefaultCandidate.rules[0].routeTo, 'user.fast', 'rules targeting a removed candidate must be repaired to the new default');
+const removedLastCandidate = router.toggleRouterDraftCandidate(removedDefaultCandidate, 'user.fast');
+assert.equal(removedLastCandidate.defaultModel, '');
+assert.ok(removedLastCandidate.rules.every(rule => rule.routeTo === ''), 'removing the last candidate must not leave dangling rule destinations');
+
+
+// Self-review: generated node IDs must not make an otherwise unchanged draft dirty.
+const fingerprintA = structuredClone(draft);
+const fingerprintB = structuredClone(draft);
+fingerprintB.rules[0].condition.id = 'different-root-id';
+fingerprintB.rules[0].condition.children[0].id = 'different-leaf-id';
+assert.equal(router.routerDraftFingerprint(fingerprintA), router.routerDraftFingerprint(fingerprintB));
+fingerprintB.rules[0].routeTo = 'user.smart';
+assert.notEqual(router.routerDraftFingerprint(fingerprintA), router.routerDraftFingerprint(fingerprintB));
+
+// The server restricts rule IDs but classifier IDs are arbitrary non-empty strings.
+const serverCompatibleClassifierId = structuredClone(draft);
+serverCompatibleClassifierId.classifiers[0].id = 'risk/topic';
+serverCompatibleClassifierId.rules[1].condition.classifierId = 'risk/topic';
+assert.deepEqual(router.validateRouterDraft(serverCompatibleClassifierId), []);
+assert.equal(router.buildRouterPullRequest(serverCompatibleClassifierId).routing.classifiers[0].id, 'risk/topic');
+const invalidRuleId = structuredClone(draft);
+invalidRuleId.rules[0].id = 'bad/rule';
+assert.match(router.validateRouterDraft(invalidRuleId).join('\n'), /letters, numbers, dot, underscore, and hyphen/);
+
+// Whitespace normalization must keep default labels aligned with emitted labels/concepts.
+const normalizedLabelsDraft = structuredClone(llmClassifierDraft);
+const riskClassifier = normalizedLabelsDraft.classifiers.find(item => item.id === 'risk');
+riskClassifier.labels = [' SAFE ', 'RISKY'];
+riskClassifier.defaultLabel = ' SAFE ';
+const normalizedLabelsPayload = router.buildRouterPullRequest(normalizedLabelsDraft);
+const normalizedRisk = normalizedLabelsPayload.routing.classifiers.find(item => item.id === 'risk');
+assert.deepEqual(normalizedRisk.labels, ['SAFE', 'RISKY']);
+assert.equal(normalizedRisk.default_label, 'SAFE');
+
 const implicitAllPayload = {
   version: '1',
   model_name: 'user.implicit-all',
@@ -299,6 +485,47 @@ assert.equal(implicitAllDraft.rules[0].condition.children.length, 2, 'implicit-a
 assert.deepEqual(router.buildRouterPullRequest(implicitAllDraft).routing.rules[0].match, {
   all: [{ keywords_any: ['code'] }, { has_tools: true }],
 });
+
+// A valid nested singleton gate must survive save/import. If serialization
+// collapses the inner ALL, the two keywords_any leaves become direct siblings
+// and the saved payload is rejected as a duplicate on its next import.
+const singletonGateRoundTripDraft = structuredClone(draft);
+singletonGateRoundTripDraft.rules = [{
+  id: 'singleton-roundtrip',
+  routeTo: 'user.fast',
+  outputsText: '',
+  condition: {
+    id: 'outer-any',
+    kind: 'group',
+    operator: 'any',
+    children: [
+      { ...router.createRouterLeaf('keywords_any'), id: 'direct-keywords', textValue: 'foo' },
+      {
+        id: 'singleton-all',
+        kind: 'group',
+        operator: 'all',
+        children: [
+          { ...router.createRouterLeaf('keywords_any'), id: 'nested-keywords', textValue: 'bar' },
+        ],
+      },
+    ],
+  },
+}];
+assert.deepEqual(router.validateRouterDraft(singletonGateRoundTripDraft), []);
+const singletonGatePayload = router.buildRouterPullRequest(singletonGateRoundTripDraft);
+assert.deepEqual(singletonGatePayload.routing.rules[0].match, {
+  any: [
+    { keywords_any: ['foo'] },
+    { all: [{ keywords_any: ['bar'] }] },
+  ],
+}, 'save must preserve singleton gates instead of promoting their child into a duplicate parent condition');
+const singletonGateParsed = router.parseRouterPayload(singletonGatePayload);
+assert.deepEqual(router.validateRouterDraft(singletonGateParsed), []);
+assert.deepEqual(
+  router.buildRouterPullRequest(singletonGateParsed).routing.rules[0].match,
+  singletonGatePayload.routing.rules[0].match,
+  'valid router drafts must remain stable across build -> parse -> build',
+);
 assert.throws(
   () => router.parseRouterPayload({
     ...implicitAllPayload,
@@ -332,6 +559,81 @@ assert.throws(
   'unknown metadata operators must fail closed instead of being silently dropped',
 );
 
+// Self-review: imports must fail closed at every schema layer instead of silently
+// dropping data that GUI3 cannot round-trip.
+assert.throws(
+  () => router.parseRouterPayload({ ...implicitAllPayload, future_root: true }),
+  /Router JSON contains unsupported field/,
+);
+assert.throws(
+  () => router.parseRouterPayload({ ...implicitAllPayload, models: [{ model_name: 'embedded' }] }),
+  /Embedded models are not editable/,
+);
+assert.throws(
+  () => router.routerDraftFromModelInfo({ ...implicitAllPayload, id: implicitAllPayload.model_name, models: [{ model_name: 'embedded' }] }),
+  /Embedded models are not editable/,
+  'server detail loading must not bypass the embedded-model round-trip guard',
+);
+assert.throws(
+  () => router.parseRouterPayload({ ...implicitAllPayload, components: ['user.fast', 'unused.helper'] }),
+  /components do not match editable routing dependencies/,
+);
+assert.throws(
+  () => router.parseRouterPayload({
+    ...implicitAllPayload,
+    routing: { ...implicitAllPayload.routing, future_routing: true },
+  }),
+  /Routing block contains unsupported field/,
+);
+assert.throws(
+  () => router.parseRouterPayload({
+    ...implicitAllPayload,
+    routing: { ...implicitAllPayload.routing, rules: [{ ...implicitAllPayload.routing.rules[0], future_rule: true }] },
+  }),
+  /Rule 1 contains unsupported field/,
+);
+const strictClassifierPayload = {
+  version: '1', model_name: 'user.strict-classifier', recipe: 'collection.router',
+  components: ['user.fast', 'user.classifier'],
+  routing: {
+    candidates: ['user.fast'], default_model: 'user.fast',
+    classifiers: [{ id: 'risk/topic', type: 'classifier', model: 'user.classifier', labels: ['SAFE'], on_error: 'match_false' }],
+    rules: [{ id: 'safe-rule', match: { classifier: 'risk/topic', label: 'SAFE' }, route_to: 'user.fast' }],
+  },
+};
+assert.equal(router.parseRouterPayload(strictClassifierPayload).classifiers[0].id, 'risk/topic');
+assert.throws(
+  () => router.parseRouterPayload({
+    ...strictClassifierPayload,
+    routing: { ...strictClassifierPayload.routing, classifiers: [{ ...strictClassifierPayload.routing.classifiers[0], on_error: 'sometimes' }] },
+  }),
+  /on_error must be/,
+);
+assert.throws(
+  () => router.parseRouterPayload({
+    ...strictClassifierPayload,
+    routing: { ...strictClassifierPayload.routing, classifiers: [{ ...strictClassifierPayload.routing.classifiers[0], future_classifier: true }] },
+  }),
+  /Classifier 1 contains unsupported field/,
+);
+assert.throws(
+  () => router.parseRouterPayload({
+    ...strictClassifierPayload,
+    routing: { ...strictClassifierPayload.routing, classifiers: { nope: true } },
+  }),
+  /routing.classifiers must be an array/,
+);
+let deepMatch = { has_tools: true };
+for (let i = 0; i < router.MAX_ROUTER_TREE_DEPTH + 2; i += 1) deepMatch = { not: deepMatch };
+assert.throws(
+  () => router.parseRouterPayload({
+    ...implicitAllPayload,
+    routing: { ...implicitAllPayload.routing, rules: [{ ...implicitAllPayload.routing.rules[0], match: deepMatch }] },
+  }),
+  /nesting exceeds/,
+);
+
+
 assert.match(listSource, /onOpenRouter/);
 assert.match(listSource, /onOpenRouter && \([\s\S]*?icon="router"/);
 assert.match(managerSource, /<RouterEditorPanel/);
@@ -339,17 +641,18 @@ assert.match(managerSource, /showRouterEditor \?/);
 assert.match(managerSource, /await onRegister|handleRegisterRouter/);
 assert.match(editorSource, /Save & register/);
 assert.match(editorSource, /await onRegister\(nextRequest\)[\s\S]*upsertRouterRecord/, 'local persistence must happen only after server registration succeeds');
-assert.match(editorSource, /Natural-language router/);
+assert.match(editorSource, /Natural-Language Router|Natural-language router/);
 assert.match(editorSource, /addClassifier\('llm'\)/);
 assert.doesNotMatch(editorSource, /issue #2405|remain hidden/i);
 assert.match(nodeEditorSource, /metadataComparator/);
 assert.match(nodeEditorSource, /normalizeRouterNode/);
 assert.match(nodeEditorSource, />AND<|>AND<\/button>/, 'a leaf must be wrappable into a compound rule');
+assert.match(nodeEditorSource, /unusedGroupLeafType/, 'group inspector add/change helpers must seed a condition type that is not already in the gate');
 assert.match(editorSource, /Switching modes clears incompatible configuration after confirmation/);
 assert.doesNotMatch(editorSource, /window\.confirm/, 'router editor confirmations must use GUI3-native dialogs rather than browser confirm');
 assert.match(editorSource, /routerDraftHasRulesProgress\(draft\)[\s\S]*kind: 'switch-llm'/, 'rules-to-LLM mode changes must open a branded warning before clearing meaningful work');
 assert.match(editorSource, /routerDraftHasLlmProgress\(draft\)[\s\S]*kind: 'switch-rules'/, 'LLM-to-rules mode changes must open a branded warning before clearing meaningful work');
-assert.match(editorSource, /routerDraftHasRulesProgress\(draft\) \|\| routerDraftHasLlmProgress\(draft\)[\s\S]*kind: 'reset'/, 'New must warn only when the draft contains meaningful router progress');
+assert.match(editorSource, /if \(isDirty\)[\s\S]*kind: 'reset'/, 'New must warn whenever it would discard changes relative to the loaded/saved baseline');
 assert.match(editorSource, /switchRouterDraftMode\(current, mode\)/, 'confirmed mode changes must use the tested destructive transition helper');
 assert.match(editorSource, /<Modal[\s\S]*router-confirm-dialog-title/, 'destructive router actions must render through the GUI3 modal surface');
 assert.match(editorSource, /router-editor__toast[\s\S]*role="status"/, 'successful registration feedback must remain visible in a bottom-right status toast');
@@ -370,14 +673,146 @@ assert.match(editorSource, /<RouterRuleGraph/, 'ordered rules must use the visua
 assert.match(editorSource, /router-editor__rules-workspace[\s\S]*router-editor__rule-list[\s\S]*router-editor__rule-builder/, 'rules must use the GUI2-style compact-list plus selected-canvas pipeline instead of embedding a canvas in every rule');
 assert.match(editorSource, /selectedRuleIndex/, 'the visual pipeline must keep one selected rule bound to the graph canvas');
 assert.match(graphSource, /application\/x-lemonade-router-node/, 'graph builder must use an isolated drag payload type');
-assert.match(graphSource, /draggable[\s\S]*Logic gates|Logic gates[\s\S]*draggable/, 'graph toolbox must provide draggable logic gates');
+assert.match(graphSource, /draggable[\s\S]*Logic Gates|Logic Gates[\s\S]*draggable/, 'graph toolbox must provide draggable logic gates');
 assert.match(graphSource, /onDrop=\{event =>/, 'graph canvas must accept drag/drop input');
 assert.match(graphSource, /setPan[\s\S]*setZoom|setZoom[\s\S]*setPan/, 'graph canvas must retain GUI2-style pan and zoom controls');
 assert.match(graphSource, /RouterNodeEditor/, 'selected graph nodes must remain fully editable through the existing validated node editor');
+assert.match(graphSource, /function exactSummary[\s\S]*JSON\.stringify\(raw\)/, 'graph summaries must expose leading/trailing whitespace when it is part of regex or metadata semantics');
+assert.match(graphSource, /className=\{`router-graph__gate[\s\S]*aria-pressed=\{selected\}/, 'graph gates must be keyboard-focusable controls so nested toolbox insertion is a real non-drag alternative');
+assert.match(graphSource, /routerReplacementConflictAtPath/, 'node edits must enforce the same duplicate-condition rule as graph drops');
+assert.match(graphSource, /routerDuplicateConditionConflict\(next\)/, 'node removal must reject normalization that would create a duplicate condition in the parent gate');
 assert.match(editorSource, /router-editor__drag-handle[\s\S]*draggable/, 'ordered rules must be draggable for reordering while keeping keyboard move controls');
 assert.match(stylesSource, /router-editor__classifier-list \{ max-height:[\s\S]*router-editor__rule-list \{ max-height:/, 'classifier and rule lists must be height-capped with internal scrolling');
 assert.match(stylesSource, /router-editor__classifier-list,[\s\S]*router-editor__rule-list[\s\S]*overflow-y: auto/, 'router lists must scroll internally rather than expanding without bound');
 assert.match(stylesSource, /router-editor__rules-workspace[\s\S]*grid-template-columns/, 'rule layout must preserve the compact-list plus graph-canvas split on desktop');
+
+// Review round 2: keep the router surface compact without regressing data safety.
+assert.match(workspacePanelsSource, /descriptionPlacement\?: 'body' \| 'identity'/, 'detail panels need an opt-in description placement next to identity metadata');
+assert.match(editorSource, /descriptionPlacement="identity"/, 'router description must sit beside the collection.router metadata in the header');
+assert.match(workspacePanelsSource, /titleExtras\?: React\.ReactNode/, 'detail panels need a title-row slot for compact editor actions');
+assert.match(editorSource, /titleExtras=\{\([\s\S]*router-editor__toolbar/, 'router New/import/export controls must occupy the title-row space freed by the removed generic close button');
+assert.doesNotMatch(editorSource, /onClose=\{onClose\}/, 'router detail must not render the redundant generic close icon when a Close action already exists');
+assert.doesNotMatch(editorSource, /router-editor__backend-note/, 'redundant router backend explainer must stay removed');
+assert.match(editorSource, />JSON Preview</, 'router view labels should use title case');
+assert.match(editorSource, /<h3>Candidate Models<\/h3>/);
+assert.match(editorSource, /<span>Default Model /);
+assert.match(stylesSource, /router-editor__connection-list[\s\S]*max-height:[\s\S]*overflow-y: auto/, 'connected models must show a compact 3-4 row viewport with internal scroll');
+assert.match(editorSource, /title="Remove candidate"[\s\S]*toggleCandidate\(connection\.modelName\)|toggleCandidate\(connection\.modelName\)[\s\S]*title="Remove candidate"/, 'candidate connections need a direct remove affordance using the safe candidate transition');
+assert.match(editorSource, /Removed \${name}; \${updates\.join\('; '\)}/, 'candidate removal must surface automatic default/rule-target repairs instead of changing routing behavior silently');
+assert.match(editorSource, /toggleRouterDraftCandidate\(current, name\)/, 'all candidate removal entry points must share the tested repair transition');
+assert.doesNotMatch(editorSource, /External endpoints are provider-wide and affect every model from that provider/, 'provider-wide helper copy was explicitly removed by review');
+assert.doesNotMatch(editorSource, /Managed by Lemonade|Local registered model|Routing target/, 'connection rows must not repeat internal/target metadata');
+assert.match(stylesSource, /router-editor__connection-trailing[\s\S]*justify-content: flex-end/, 'source badge and backend/provider details must align at the right edge');
+assert.match(editorSource, /router-editor__concept-list/, 'semantic concepts need their own capped scrolling viewport');
+assert.match(stylesSource, /router-editor__concept-list[\s\S]*max-height:[\s\S]*overflow-y: auto/, 'semantic concepts must not grow the classifier card without bound');
+assert.match(editorSource, /jsonCopied \? 'check' : 'copy'/, 'JSON copy control must replace the icon with an in-place success state');
+assert.match(editorSource, /jsonCopied \? 'Copied' : 'Copy'/, 'JSON copy control must expose the temporary Copied label');
+assert.doesNotMatch(editorSource, /JSON copied\./, 'copy feedback must not use the distant global toast');
+assert.match(stylesSource, /router-graph__tool--any \{ color: var\(--success\)/, 'OR gates must be green');
+assert.match(stylesSource, /router-graph__tool--not \{ color: var\(--danger\)/, 'NOT gates must be red');
+assert.match(stylesSource, /router-graph__tool--all \{ color: var\(--accent-fg\)/, 'AND gates must use the blue/accent color');
+assert.match(editorSource, /onExpand=\{\(\) => setExpandedRuleIndex\(selectedRuleIndex\)\}/, 'graph builder needs an explicit expand action');
+assert.match(editorSource, /router-graph-expanded-title[\s\S]*router-editor__graph-modal[\s\S]*<RouterRuleGraph/, 'expanded graph editing must render a real editable graph in the GUI3 modal surface');
+assert.doesNotMatch(editorSource, /<h3>Natural-language router<\/h3>|<h3>Natural-Language Router<\/h3>/, 'NL mode must not repeat its strategy label as a section heading');
+assert.doesNotMatch(editorSource, /The selected model must return exactly one candidate\. Invalid output falls back to the default model\./, 'misleading NL-router helper copy must stay removed');
+
+
+// Maintainer self-review contracts beyond the explicit review list.
+assert.match(graphSource, /lastEmittedNodeRef[\s\S]*historyRef\.current = \[\][\s\S]*futureRef\.current = \[\]/, 'external graph changes must invalidate stale per-instance undo/redo history');
+assert.match(graphSource, /wrapRouterNode\(current, 'not'\)/, 'changing a multi-child gate to NOT must wrap the full subtree rather than truncate children');
+assert.match(nodeEditorSource, /Negate the complete existing expression[\s\S]*children: \[inner\]/, 'inspector AND\/OR to NOT conversion must preserve the complete existing subtree');
+assert.match(graphSource, /toolboxTargetPath = selectedNode\?\.kind === 'group'/, 'keyboard\/touch toolbox clicks must target a selected nested gate rather than only the root');
+assert.match(nodeEditorSource, /label: undefined/, 'choosing a classifier should continue following default_label instead of freezing the current default into the rule');
+assert.match(nodeEditorSource, /labels\.length > 0 \? 'Select label' : 'Use classifier output'/, 'classifier label picker must not claim a default exists when the classifier has none');
+assert.match(graphSource, /labels\.length > 0 \? 'Select label' : 'classifier output'/, 'graph summary must surface a missing classifier label instead of pretending the first label is the default');
+
+const labelLessClassifierDraft = router.createEmptyRouterDraft();
+labelLessClassifierDraft.name = 'LabelGuard';
+labelLessClassifierDraft.candidates = ['model-a'];
+labelLessClassifierDraft.defaultModel = 'model-a';
+labelLessClassifierDraft.classifiers = [{
+  ...router.createRouterClassifier(0, 'classifier'),
+  id: 'dynamic', model: 'classifier-model', labels: [], defaultLabel: undefined,
+}];
+labelLessClassifierDraft.rules = [{
+  ...router.createRouterRule(0, 'model-a'),
+  condition: { ...router.createRouterLeaf('classifier'), classifierId: 'dynamic', label: 'UNDECLARED' },
+}];
+assert.match(router.validateRouterDraft(labelLessClassifierDraft).join(' '), /label .* is not declared by classifier/i, 'explicit classifier labels must be rejected when the classifier declares no labels, matching the server parser');
+const regexSafetyDraft = router.createEmptyRouterDraft();
+regexSafetyDraft.name = 'RegexSafety';
+regexSafetyDraft.candidates = ['model-a'];
+regexSafetyDraft.defaultModel = 'model-a';
+regexSafetyDraft.rules = [{ ...router.createRouterRule(0, 'model-a'), condition: { ...router.createRouterLeaf('regex'), textValue: '((a+))+' } }];
+assert.match(router.validateRouterDraft(regexSafetyDraft).join(' '), /nested unbounded quantifier/, 'GUI3 must catch wrapper-group nested quantifiers rejected by the C++ server');
+regexSafetyDraft.rules[0].condition = { ...router.createRouterLeaf('regex'), textValue: '(a+){2,}' };
+assert.match(router.validateRouterDraft(regexSafetyDraft).join(' '), /nested unbounded quantifier/, 'GUI3 must catch unbounded brace quantifiers rejected by the C++ server');
+regexSafetyDraft.rules[0].condition = { ...router.createRouterLeaf('regex'), textValue: '(a+){2,4}' };
+assert.doesNotMatch(router.validateRouterDraft(regexSafetyDraft).join(' '), /nested unbounded quantifier/, 'bounded outer quantifiers should remain allowed, matching the server safeguard');
+regexSafetyDraft.rules[0].condition = { ...router.createRouterLeaf('regex'), textValue: ' ^hello $ ' };
+assert.equal(router.buildRouterPullRequest(regexSafetyDraft).routing.rules[0].match.regex, ' ^hello $ ', 'regex whitespace is authored semantics and must round-trip exactly');
+
+const exactPromptDraft = router.createEmptyRouterDraft();
+exactPromptDraft.name = 'ExactPrompt';
+exactPromptDraft.candidates = ['model-a'];
+exactPromptDraft.defaultModel = 'model-a';
+exactPromptDraft.mode = 'llm';
+exactPromptDraft.llmRouter = { model: 'router-model', prompt: '  route deliberately  ' };
+assert.equal(router.buildRouterPullRequest(exactPromptDraft).routing.router.prompt, '  route deliberately  ', 'NL router prompt whitespace must not be silently normalized on save');
+
+const exactIdentityPayload = {
+  version: '1', model_name: 'user.ExactIdentity', recipe: 'collection.router',
+  components: ['model-a', 'classifier-model'],
+  routing: {
+    candidates: ['model-a'], default_model: 'model-a',
+    classifiers: [{ id: ' risk/topic ', type: 'classifier', model: 'classifier-model', labels: ['OK'], default_label: 'OK' }],
+    rules: [{ id: 'rule-1', match: { all: [
+      { classifier: ' risk/topic ', label: 'OK' },
+      { metadata: { key: ' task_class ', equals: 'coding' } },
+    ] }, route_to: 'model-a' }],
+  },
+};
+const exactIdentityDraft = router.parseRouterPayload(exactIdentityPayload);
+const exactIdentityBuilt = router.buildRouterPullRequest(exactIdentityDraft);
+assert.equal(exactIdentityBuilt.routing.classifiers[0].id, ' risk/topic ', 'imported classifier IDs must retain exact server-side identity');
+assert.equal(exactIdentityBuilt.routing.rules[0].match.all[0].classifier, ' risk/topic ', 'classifier references must not be trimmed independently from classifier IDs');
+assert.equal(exactIdentityBuilt.routing.rules[0].match.all[1].metadata.key, ' task_class ', 'metadata keys are exact strings and must survive import/save without trimming');
+assert.match(nodeEditorSource, /Minimum UTF-8 bytes|Maximum UTF-8 bytes/, 'min_chars\/max_chars UI must describe the server\'s UTF-8-byte semantics accurately');
+assert.match(nodeEditorSource, /One keyword per line/, 'keyword conditions must use a delimiter that preserves commas inside server-valid keywords');
+assert.match(nodeEditorSource, /Values <small>one per line<\/small>/, 'metadata any values must preserve commas by using one value per line');
+assert.match(editorSource, /One reference phrase per line/, 'semantic reference phrases must preserve commas instead of using comma-separated authoring');
+assert.match(editorSource, /Output Labels <small>one per line<\/small>/, 'classifier labels must preserve commas by using one label per line');
+assert.match(editorSource, /CommittedTextInput[\s\S]*commitClassifierId/, 'classifier IDs must commit atomically rather than rewriting references on every keystroke');
+assert.match(editorSource, /Classifier \${index \+ 1} ID`\} normalize=\{input => input\}/, 'classifier identity fields must preserve exact whitespace instead of normalizing merely on blur');
+assert.match(editorSource, /cancelCommitRef[\s\S]*event\.key === 'Escape'[\s\S]*cancelCommitRef\.current = true/, 'Escape in commit-on-blur identity fields must cancel the pending blur commit rather than save discarded text');
+assert.match(editorSource, /const copied = document\.execCommand\('copy'\)[\s\S]*if \(!copied\) throw/, 'clipboard fallback must only report success when the browser accepts the copy operation');
+assert.match(editorSource, /Classifier ID .*already in use/, 'classifier rename commits must reject collisions before rewriting rule references');
+assert.match(editorSource, /commitSemanticConceptName/, 'semantic concept renames must commit atomically to avoid key-remount and reference corruption');
+assert.match(editorSource, /defaultLabel: classifier\.defaultLabel === concept \? undefined : classifier\.defaultLabel/, 'removing an unrelated semantic concept must not clear a still-valid default label');
+assert.match(editorSource, /normalized\.includes\(classifier\.defaultLabel\)[\s\S]*classifier\.defaultLabel[\s\S]*undefined/, 'editing output labels must preserve a default label while it remains valid');
+assert.doesNotMatch(editorSource, /key=\{`\$\{classifier\.id\}-\$\{index\}`\}/, 'editable classifier IDs must not be used as React keys');
+assert.doesNotMatch(editorSource, /key=\{`\$\{concept\}-\$\{conceptIndex\}`\}/, 'editable concept names must not be used as React keys');
+assert.match(editorSource, /routerDraftFingerprint\(draft\)[\s\S]*const isDirty/, 'editor must track a semantic dirty baseline that ignores generated graph node IDs');
+assert.match(editorSource, /requestClose[\s\S]*Close router editor\?/, 'closing with unsaved changes must require an explicit discard confirmation');
+assert.match(editorSource, /Import router JSON\?[\s\S]*discard the unsaved changes/, 'import must not silently replace an edited draft');
+assert.match(editorSource, /Load another router\?[\s\S]*discard the unsaved changes/, 'saved-router switching must not silently replace an edited draft');
+assert.match(editorSource, /submittedFingerprint[\s\S]*routerDraftFingerprint\(current\) === submittedFingerprint/, 'save completion must preserve edits made while registration is in flight');
+assert.match(editorSource, /server registration already succeeded|server registration already succeeded/i, 'local cache failures after a successful server registration must not be reported as registration failures');
+assert.match(editorSource, /const \[deleting, setDeleting\][\s\S]*pending\.kind === 'delete'[\s\S]*Keep the modal\/focus trap mounted/, 'router deletion must keep its confirmation modal mounted while the server mutation is in flight');
+assert.match(editorSource, /disabled=\{deleting\}[\s\S]*Deleting…/, 'delete confirmation actions must be disabled while deletion is in flight to prevent duplicate mutations');
+assert.match(editorSource, /initialModelKeyRef[\s\S]*draftFingerprintRef\.current === baselineAtDetailStart/, 'late model-detail responses must not overwrite edits made while loading');
+assert.match(editorSource, /detailParseError[\s\S]*initialModelKeyRef\.current = null|initialModelKeyRef\.current = null[\s\S]*detailParseError/, 'failed detail parsing must clear the load key so a later model refresh can retry');
+assert.match(modelPickerSource, /closeAndRestoreFocus[\s\S]*triggerRef\.current\?\.focus\(\)/, 'portaled model picker must restore keyboard focus to its trigger after Escape or selection');
+assert.match(modalSource, /const titleId = ariaLabelledBy \|\|/, 'modals must always have an accessible programmatic title even when callers omit an id');
+assert.match(modalSource, /previousFocusRef[\s\S]*previous\?\.isConnected[\s\S]*previous\.focus\(\)/, 'modal close must restore focus to the invoking control when possible');
+assert.match(modalSource, /document\.activeElement === titleRef\.current[\s\S]*last\.focus\(\)/, 'Shift+Tab from the initially focused modal title must remain trapped inside the dialog');
+assert.match(editorSource, /const resetDraft = \(\) => \{[\s\S]*Keep the last processed initial-model key/, 'New must preserve the processed opener key so same-router refreshes cannot silently rehydrate it');
+assert.match(editorSource, /baselineFingerprintRef\.current = '__imported-router__';[\s\S]*Preserve the processed initial-model key/, 'Import must preserve the processed opener key so background refreshes cannot replace imported work');
+assert.match(managerSource, /Router local cache cleanup failed[\s\S]*setRouterModels\(current => current\.filter/, 'server-side router deletion must remain truthful even if local cache cleanup fails');
+assert.match(managerSource, /Lemonade is disconnected so the server definition was not deleted/, 'offline router deletion must not pretend the persistent server definition was removed');
+assert.match(editorSource, /deletionWarning[\s\S]*setSavedRecords\(current => current\.filter/, 'a successful server delete with cache-cleanup failure must not immediately resurrect the stale router in the editor dropdown');
+assert.match(managerSource, /routerDeleteCandidate[\s\S]*<Modal[\s\S]*Delete router definition\?/, 'router deletion from the model list must use the same branded modal surface instead of native confirm');
+assert.doesNotMatch(managerSource, /if \(!confirm\(`Delete router definition/, 'router-specific model-list delete must not regress to a browser confirm dialog');
 
 
 const providerRows = [{
@@ -408,13 +843,50 @@ assert.equal(connections.validateProviderEndpoint('http://server.example/v1', tr
 assert.match(connections.validateProviderEndpoint('file:///tmp/model') || '', /http/);
 assert.match(connections.validateProviderEndpoint('https://user:secret@example.com/v1') || '', /credentials/);
 
-assert.match(editorSource, /Connected model topology/, 'router editor must expose connected model sources');
-assert.match(editorSource, /Edit endpoint/, 'external provider endpoints must be editable from the router editor');
+assert.match(editorSource, /Connected Model Topology/, 'router editor must expose connected model sources');
+assert.match(editorSource, /Edit Endpoint/, 'external provider endpoints must be editable from the router editor');
 assert.match(editorSource, /api\.installCloudProvider/, 'endpoint edits must use the provider registry API');
 assert.match(apiSource, /allow_insecure_http: allowInsecureHttp/, 'provider endpoint edits must preserve explicit insecure HTTP policy');
 assert.match(detailSource, /Router settings/, 'saved routers need a router-specific settings summary');
 assert.match(detailSource, /Connected models/, 'saved routers must show connected model topology');
 assert.match(detailSource, /isRouterCollection[\s\S]*collection\.router/, 'router collections must use the persistent settings tab');
 assert.match(managerSource, /openRouterEditor\(model\)/, 'editing a saved router must reopen the router editor');
+
+
+
+// Self-review: LLM-classifier prompts and connected component identities are
+// authored/server-exact strings and must not be trimmed during save/display.
+{
+  const draft = router.createEmptyRouterDraft();
+  draft.name = 'ExactClassifierPrompt';
+  draft.candidates = [' candidate/exact '];
+  draft.defaultModel = ' candidate/exact ';
+  draft.classifiers = [{
+    id: 'risk',
+    type: 'llm',
+    model: ' helper/exact ',
+    prompt: '  classify deliberately  ',
+    labels: ['SAFE'],
+    defaultLabel: 'SAFE',
+    referencePhrases: {},
+    onError: 'match_false',
+  }];
+  draft.rules = [{
+    id: 'rule-1',
+    routeTo: ' candidate/exact ',
+    condition: { ...router.createRouterLeaf('classifier'), classifierId: 'risk', label: 'SAFE' },
+    outputsText: '',
+  }];
+  const payload = router.buildRouterPullRequest(draft);
+  assert.equal(payload.routing.classifiers[0].prompt, '  classify deliberately  ');
+  assert.deepEqual(payload.routing.candidates, [' candidate/exact ']);
+  assert(payload.components.includes(' candidate/exact '));
+  assert(payload.components.includes(' helper/exact '));
+  const rebuilt = router.buildRouterPullRequest(router.parseRouterPayload(payload));
+  assert.equal(rebuilt.routing.classifiers[0].prompt, '  classify deliberately  ', 'LLM-classifier prompt whitespace must survive parse/build round-trip');
+}
+assert.match(editorSource, /Model\/component identifiers are exact server identities/);
+assert.match(editorSource, /exact component identity[\s\S]{0,180}modelName: candidate/);
+assert.doesNotMatch(editorSource, /const normalized = name\.trim\(\);[\s\S]{0,120}names\.add\(normalized\)/);
 
 console.log('GUI3 router editor contract checks passed.');

--- a/src/app/tests/router-editor.runtime.cjs
+++ b/src/app/tests/router-editor.runtime.cjs
@@ -183,6 +183,94 @@ const renamedLabelTree = router.renameClassifierLabelReference(
 assert.equal(renamedLabelTree.label, 'coding', 'semantic concept renames must update rule references');
 assert.equal(router.routerNodeReferencesClassifier(renamedLabelTree, 'topic'), true);
 
+const untouchedEmptyDraft = router.createEmptyRouterDraft();
+untouchedEmptyDraft.name = 'Empty';
+untouchedEmptyDraft.candidates = ['user.fast'];
+untouchedEmptyDraft.defaultModel = 'user.fast';
+untouchedEmptyDraft.rules[0].routeTo = 'user.fast';
+assert.equal(router.routerDraftHasRulesProgress(untouchedEmptyDraft), false, 'the seeded empty rule is not meaningful progress');
+untouchedEmptyDraft.rules[0].condition.textValue = 'code';
+assert.equal(router.routerDraftHasRulesProgress(untouchedEmptyDraft), true, 'edited rule content must trigger a switch warning');
+const classifierOnlyProgress = router.createEmptyRouterDraft();
+classifierOnlyProgress.classifiers.push(router.createRouterClassifier(0, 'classifier'));
+assert.equal(router.routerDraftHasRulesProgress(classifierOnlyProgress), true, 'classifier-only work must trigger a switch warning');
+assert.equal(router.routerDraftHasLlmProgress({ ...untouchedEmptyDraft, llmRouter: { model: '', prompt: '' } }), false);
+assert.equal(router.routerDraftHasLlmProgress({ ...untouchedEmptyDraft, llmRouter: { model: 'user.fast', prompt: '' } }), true);
+assert.equal(router.routerDraftHasLlmProgress({ ...untouchedEmptyDraft, llmRouter: { model: '', prompt: 'route carefully' } }), true);
+
+const rulesWithProgress = {
+  ...untouchedEmptyDraft,
+  rules: [{ ...untouchedEmptyDraft.rules[0], condition: { ...untouchedEmptyDraft.rules[0].condition, textValue: 'code' } }],
+  classifiers: [router.createRouterClassifier(0, 'classifier')],
+};
+const switchedToLlm = router.switchRouterDraftMode(rulesWithProgress, 'llm');
+assert.equal(switchedToLlm.mode, 'llm');
+assert.deepEqual(switchedToLlm.rules, []);
+assert.deepEqual(switchedToLlm.classifiers, []);
+const switchedBackToRules = router.switchRouterDraftMode({
+  ...switchedToLlm,
+  llmRouter: { model: 'user.router', prompt: 'pick a model' },
+}, 'rules');
+assert.equal(switchedBackToRules.mode, 'rules');
+assert.deepEqual(switchedBackToRules.llmRouter, { model: '', prompt: '' });
+assert.equal(switchedBackToRules.rules.length, 1);
+assert.equal(switchedBackToRules.rules[0].routeTo, switchedBackToRules.defaultModel);
+
+const implicitAllPayload = {
+  version: '1',
+  model_name: 'user.implicit-all',
+  recipe: 'collection.router',
+  components: ['user.fast'],
+  routing: {
+    candidates: ['user.fast'],
+    default_model: 'user.fast',
+    rules: [{
+      id: 'compound-leaf',
+      match: { keywords_any: ['code'], has_tools: true },
+      route_to: 'user.fast',
+    }],
+  },
+};
+const implicitAllDraft = router.parseRouterPayload(implicitAllPayload);
+assert.equal(implicitAllDraft.rules[0].condition.kind, 'group');
+assert.equal(implicitAllDraft.rules[0].condition.operator, 'all');
+assert.equal(implicitAllDraft.rules[0].condition.children.length, 2, 'implicit-all parsing must preserve every leaf condition');
+assert.deepEqual(router.buildRouterPullRequest(implicitAllDraft).routing.rules[0].match, {
+  all: [{ keywords_any: ['code'] }, { has_tools: true }],
+});
+assert.throws(
+  () => router.parseRouterPayload({
+    ...implicitAllPayload,
+    routing: { ...implicitAllPayload.routing, rules: [{ ...implicitAllPayload.routing.rules[0], match: { keywords_any: ['code'], future_condition: true } }] },
+  }),
+  /Unsupported rule condition field/,
+  'unknown conditions must fail closed instead of being silently dropped',
+);
+assert.throws(
+  () => router.parseRouterPayload({
+    ...implicitAllPayload,
+    routing: { ...implicitAllPayload.routing, rules: [{ ...implicitAllPayload.routing.rules[0], match: { all: [{ has_tools: true }], has_images: true } }] },
+  }),
+  /cannot mix logical operators with leaf conditions/,
+  'logical operators must not be normalized together with leaf conditions because the server rejects that shape',
+);
+assert.throws(
+  () => router.parseRouterPayload({
+    ...implicitAllPayload,
+    routing: { ...implicitAllPayload.routing, rules: [{ ...implicitAllPayload.routing.rules[0], match: { metadata: { key: 'tier', equals: 'pro', exists: true } } }] },
+  }),
+  /requires exactly one comparator/,
+  'metadata must preserve the server requirement of exactly one comparator',
+);
+assert.throws(
+  () => router.parseRouterPayload({
+    ...implicitAllPayload,
+    routing: { ...implicitAllPayload.routing, rules: [{ ...implicitAllPayload.routing.rules[0], match: { metadata: { key: 'tier', equals: 'pro', future_operator: true } } }] },
+  }),
+  /Unsupported metadata field/,
+  'unknown metadata operators must fail closed instead of being silently dropped',
+);
+
 assert.match(listSource, /onOpenRouter/);
 assert.match(listSource, /onOpenRouter && \([\s\S]*?icon="router"/);
 assert.match(managerSource, /<RouterEditorPanel/);
@@ -196,7 +284,19 @@ assert.doesNotMatch(editorSource, /issue #2405|remain hidden/i);
 assert.match(nodeEditorSource, /metadataComparator/);
 assert.match(nodeEditorSource, /normalizeRouterNode/);
 assert.match(nodeEditorSource, />AND<|>AND<\/button>/, 'a leaf must be wrappable into a compound rule');
-assert.match(editorSource, /Switching modes keeps the other configuration intact/);
+assert.match(editorSource, /Switching modes clears incompatible configuration after confirmation/);
+assert.match(editorSource, /routerDraftHasRulesProgress\(draft\)[\s\S]*window\.confirm/, 'rules-to-LLM mode changes must warn before clearing meaningful work');
+assert.match(editorSource, /routerDraftHasLlmProgress\(draft\)[\s\S]*window\.confirm/, 'LLM-to-rules mode changes must warn before clearing meaningful work');
+assert.match(editorSource, /switchRouterDraftMode\(current, 'llm'\)/, 'switching to LLM must use the tested destructive transition helper');
+assert.match(editorSource, /switchRouterDraftMode\(current, 'rules'\)/, 'switching to rules must use the tested destructive transition helper');
+assert.match(editorSource, /api\.modelDetail\(modelNameValue\)/, 'editing a server router must fetch its full model detail before parsing the policy');
+const detailCallIndex = editorSource.indexOf('api.modelDetail(modelNameValue)');
+const localFallbackIndex = editorSource.indexOf('if ((initialModel as any).routing)', detailCallIndex);
+assert.ok(detailCallIndex >= 0 && localFallbackIndex > detailCallIndex, 'cached local routing may only be used after the authoritative detail request fails');
+assert.match(editorSource, /const embeddingModels = useMemo[\s\S]*normalized === 'embedding' \|\| normalized === 'embeddings'/, 'semantic similarity picker must use explicitly labelled embedding models');
+assert.match(editorSource, /const classifierModels = useMemo[\s\S]*classification/, 'text classifier picker must only expose classification models');
+assert.doesNotMatch(editorSource, /explicit\.length \? explicit : models/, 'embedding picker must not fall back to every model');
+assert.match(editorSource, /classifier\.type === 'llm' \? candidateModels : classifierModels/, 'classifier pickers must use type-specific model lists');
 
 
 const providerRows = [{


### PR DESCRIPTION
Current UI router code was not yet confirm with the gui2 development.
This PR addressed that issue.

**Changes:**
Fixes router editor edge cases around switching routing modes and loading existing configurations.

* Warn before clearing existing rules or Natural Language Router progress
* Preserve implicit-AND match expressions correctly
* Tighten classifier and embedding model filtering
* Load the full router configuration when editing an existing router
* Add regression coverage for the affected cases
