### PR TITLE
feat(llamacpp): auto-detect draft GGUF companions

### DIFF
--- a/docs/guide/configuration/custom-models.md
+++ b/docs/guide/configuration/custom-models.md
@@ -88,7 +88,7 @@ Supported registration flags:
 | `--source SOURCE` | Remote registry for every checkpoint in this model: `huggingface` (default) or `modelscope`. |
 | `--checkpoint TYPE CHECKPOINT` | Add a checkpoint entry. Repeat for multi-file models such as `main` + `mmproj` or `main` + `vae`. |
 | `--recipe RECIPE` | Recipe to associate with the new `user.*` model. Common values: <!-- BEGIN GENERATED: recipe-values -->`llamacpp`, `whispercpp`, `moonshine`, `kokoro`, `sd-cpp`, `flm`, `ryzenai-llm`, `vllm`, `thenoise`, `thinksound`, `acestep`, `onnxruntime`, `trellis`, `openmoss`, `collection.omni`<!-- END GENERATED: recipe-values -->. |
-| `--label LABEL` | Add a label to the new model. Repeatable. Valid labels include `coding`, `embeddings`, `hot`, `mtp`, `reasoning`, `reranking`, `tool-calling`, `vision`. |
+| `--label LABEL` | Add a label to the new model. Repeatable. Valid labels include `coding`, `dflash`, `embeddings`, `hot`, `mtp`, `reasoning`, `reranking`, `tool-calling`, `vision`. |
 | `--components MODEL [MODEL ...]` | Components for an omni collection (see below). Use with `--recipe collection.omni`. |
 
 ### Register an omni collection

--- a/src/cpp/cli/hf_pull.cpp
+++ b/src/cpp/cli/hf_pull.cpp
@@ -427,6 +427,19 @@ int registry_pull_flow(lemonade::LemonadeClient& client,
         pull_body["mmproj"] = variants_response["mmproj_files"][0];
     }
 
+    if (variants_response.contains("draft_files") &&
+        variants_response["draft_files"].is_array()) {
+        if (variants_response["draft_files"].size() == 1) {
+            pull_body["checkpoints"] = json::object();
+            pull_body["checkpoints"]["main"] = pull_body["checkpoint"];
+            pull_body["checkpoints"]["draft"] =
+                checkpoint + ":" + variants_response["draft_files"][0].get<std::string>();
+        } else if (variants_response["draft_files"].size() > 1) {
+            std::cerr << "warning: multiple draft GGUF companions found; "
+                      << "not selecting one automatically" << std::endl;
+        }
+    }
+
     std::cout << "Pulling " << pull_body["checkpoint"].get<std::string>()
               << " as " << model_name << std::endl;
 

--- a/src/cpp/cli/main.cpp
+++ b/src/cpp/cli/main.cpp
@@ -50,6 +50,7 @@
 
 static const std::vector<std::string> VALID_LABELS = {
     "coding",
+    "dflash",
     "embeddings",
     "hot",
     "mtp",

--- a/src/cpp/include/lemon/hf_variants.h
+++ b/src/cpp/include/lemon/hf_variants.h
@@ -28,6 +28,7 @@ struct GgufVariantSet {
     std::vector<GgufVariant> variants;
     std::vector<std::string> mmproj_files;  // Bare filenames of mmproj-*.gguf files.
     std::vector<std::string> draft_files;   // Bare filenames of recognized draft GGUF companions.
+    std::string draft_label;                // Label that activates the single recognized draft companion.
 };
 
 // Enumerate GGUF variants from a normalized repository file list.

--- a/src/cpp/include/lemon/hf_variants.h
+++ b/src/cpp/include/lemon/hf_variants.h
@@ -28,7 +28,6 @@ struct GgufVariantSet {
     std::vector<GgufVariant> variants;
     std::vector<std::string> mmproj_files;  // Bare filenames of mmproj-*.gguf files.
     std::vector<std::string> draft_files;   // Bare filenames of recognized draft GGUF companions.
-    std::string draft_label;                // Label that activates the single recognized draft companion.
 };
 
 // Enumerate GGUF variants from a normalized repository file list.

--- a/src/cpp/include/lemon/hf_variants.h
+++ b/src/cpp/include/lemon/hf_variants.h
@@ -27,6 +27,7 @@ struct GgufVariant {
 struct GgufVariantSet {
     std::vector<GgufVariant> variants;
     std::vector<std::string> mmproj_files;  // Bare filenames of mmproj-*.gguf files.
+    std::vector<std::string> draft_files;   // Bare filenames of recognized draft GGUF companions.
 };
 
 // Enumerate GGUF variants from a normalized repository file list.

--- a/src/cpp/server/backends/llamacpp/llamacpp_server.cpp
+++ b/src/cpp/server/backends/llamacpp/llamacpp_server.cpp
@@ -137,16 +137,14 @@ static bool is_llamacpp_cuda_backend(const std::string& backend) {
     return backend == "cuda";
 }
 
-static std::string draft_checkpoint_label(std::string checkpoint) {
+static bool is_dflash_draft_checkpoint(std::string checkpoint) {
     std::transform(checkpoint.begin(), checkpoint.end(), checkpoint.begin(),
                    [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
     size_t separator = checkpoint.find_last_of("/:\\");
     std::string filename = separator == std::string::npos
                                ? checkpoint
                                : checkpoint.substr(separator + 1);
-    if (filename.rfind("dflash-", 0) == 0 || filename == "dflash.gguf") return "dflash";
-    if (filename.rfind("mtp-", 0) == 0) return "mtp";
-    return {};
+    return filename.rfind("dflash-", 0) == 0 || filename == "dflash.gguf";
 }
 
 static std::string trim_version_prefix(const std::string& version) {
@@ -384,17 +382,12 @@ void LlamaCppServer::load(const std::string& model_name,
     }
     push_reserved(reserved_flags, "--mmproj", std::vector<std::string>{"-mm", "-mmu", "--mmproj-url", "--no-mmproj", "--mmproj-auto", "--no-mmproj-auto"});
 
-    const bool uses_dflash =
+    const bool has_dflash_label =
         std::find(model_info.labels.begin(), model_info.labels.end(), "dflash") != model_info.labels.end();
-    const bool uses_mtp =
-        std::find(model_info.labels.begin(), model_info.labels.end(), "mtp") != model_info.labels.end();
-    const std::string draft_label =
-        draft_path.empty() ? std::string() : draft_checkpoint_label(model_info.checkpoint("draft"));
+    const bool is_dflash_draft =
+        !draft_path.empty() && is_dflash_draft_checkpoint(model_info.checkpoint("draft"));
     const bool use_draft_checkpoint =
-        !draft_path.empty() &&
-        (draft_label.empty() ||
-         (draft_label == "dflash" && uses_dflash) ||
-         (draft_label == "mtp" && uses_mtp));
+        !draft_path.empty() && (!is_dflash_draft || has_dflash_label);
 
     if (use_draft_checkpoint) {
         push_arg(args, reserved_flags, "--model-draft", draft_path);
@@ -404,7 +397,10 @@ void LlamaCppServer::load(const std::string& model_name,
     // Use legacy reasoning formatting
     push_overridable_arg(args, llamacpp_args, "--reasoning-format", "auto");
 
-    if (uses_dflash && use_draft_checkpoint) {
+    const bool uses_mtp =
+        std::find(model_info.labels.begin(), model_info.labels.end(), "mtp") != model_info.labels.end();
+
+    if (is_dflash_draft && has_dflash_label) {
         LOG(INFO, "LlamaCpp") << "Model uses DFlash, adding draft decoding defaults" << std::endl;
         push_overridable_arg(args, llamacpp_args, "--spec-type", "draft-dflash");
     } else if (uses_mtp) {

--- a/src/cpp/server/backends/llamacpp/llamacpp_server.cpp
+++ b/src/cpp/server/backends/llamacpp/llamacpp_server.cpp
@@ -9,6 +9,7 @@
 #include "lemon/gguf_reader.h"
 #include "lemon/model_manager.h"
 #include <algorithm>
+#include <cctype>
 #include <filesystem>
 #include <regex>
 #include <system_error>
@@ -134,6 +135,16 @@ static bool is_llamacpp_rocm_backend(const std::string& backend) {
 
 static bool is_llamacpp_cuda_backend(const std::string& backend) {
     return backend == "cuda";
+}
+
+static bool is_dflash_draft_checkpoint(std::string checkpoint) {
+    std::transform(checkpoint.begin(), checkpoint.end(), checkpoint.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+    size_t separator = checkpoint.find_last_of("/:\\");
+    std::string filename = separator == std::string::npos
+                               ? checkpoint
+                               : checkpoint.substr(separator + 1);
+    return filename.rfind("dflash-", 0) == 0 || filename == "dflash.gguf";
 }
 
 static std::string trim_version_prefix(const std::string& version) {
@@ -379,7 +390,15 @@ void LlamaCppServer::load(const std::string& model_name,
     // Use legacy reasoning formatting
     push_overridable_arg(args, llamacpp_args, "--reasoning-format", "auto");
 
-    if (std::find(model_info.labels.begin(), model_info.labels.end(), "mtp") != model_info.labels.end()) {
+    const bool uses_dflash = !draft_path.empty() &&
+        is_dflash_draft_checkpoint(model_info.checkpoint("draft"));
+    const bool uses_mtp =
+        std::find(model_info.labels.begin(), model_info.labels.end(), "mtp") != model_info.labels.end();
+
+    if (uses_dflash) {
+        LOG(INFO, "LlamaCpp") << "Model uses DFlash, adding draft decoding defaults" << std::endl;
+        push_overridable_arg(args, llamacpp_args, "--spec-type", "draft-dflash");
+    } else if (uses_mtp) {
         LOG(INFO, "LlamaCpp") << "Model uses MTP, adding draft decoding defaults" << std::endl;
         push_overridable_arg(args, llamacpp_args, "--spec-type", "draft-mtp");
         push_overridable_arg(args, llamacpp_args, "--spec-draft-n-max", "3");

--- a/src/cpp/server/backends/llamacpp/llamacpp_server.cpp
+++ b/src/cpp/server/backends/llamacpp/llamacpp_server.cpp
@@ -137,14 +137,16 @@ static bool is_llamacpp_cuda_backend(const std::string& backend) {
     return backend == "cuda";
 }
 
-static bool is_dflash_draft_checkpoint(std::string checkpoint) {
+static std::string draft_checkpoint_label(std::string checkpoint) {
     std::transform(checkpoint.begin(), checkpoint.end(), checkpoint.begin(),
                    [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
     size_t separator = checkpoint.find_last_of("/:\\");
     std::string filename = separator == std::string::npos
                                ? checkpoint
                                : checkpoint.substr(separator + 1);
-    return filename.rfind("dflash-", 0) == 0 || filename == "dflash.gguf";
+    if (filename.rfind("dflash-", 0) == 0 || filename == "dflash.gguf") return "dflash";
+    if (filename.rfind("mtp-", 0) == 0) return "mtp";
+    return {};
 }
 
 static std::string trim_version_prefix(const std::string& version) {
@@ -382,7 +384,19 @@ void LlamaCppServer::load(const std::string& model_name,
     }
     push_reserved(reserved_flags, "--mmproj", std::vector<std::string>{"-mm", "-mmu", "--mmproj-url", "--no-mmproj", "--mmproj-auto", "--no-mmproj-auto"});
 
-    if (!draft_path.empty()) {
+    const bool uses_dflash =
+        std::find(model_info.labels.begin(), model_info.labels.end(), "dflash") != model_info.labels.end();
+    const bool uses_mtp =
+        std::find(model_info.labels.begin(), model_info.labels.end(), "mtp") != model_info.labels.end();
+    const std::string draft_label =
+        draft_path.empty() ? std::string() : draft_checkpoint_label(model_info.checkpoint("draft"));
+    const bool use_draft_checkpoint =
+        !draft_path.empty() &&
+        (draft_label.empty() ||
+         (draft_label == "dflash" && uses_dflash) ||
+         (draft_label == "mtp" && uses_mtp));
+
+    if (use_draft_checkpoint) {
         push_arg(args, reserved_flags, "--model-draft", draft_path);
     }
     push_reserved(reserved_flags, "--model-draft", std::vector<std::string>{"-md", "--spec-draft-model"});
@@ -390,12 +404,7 @@ void LlamaCppServer::load(const std::string& model_name,
     // Use legacy reasoning formatting
     push_overridable_arg(args, llamacpp_args, "--reasoning-format", "auto");
 
-    const bool uses_dflash = !draft_path.empty() &&
-        is_dflash_draft_checkpoint(model_info.checkpoint("draft"));
-    const bool uses_mtp =
-        std::find(model_info.labels.begin(), model_info.labels.end(), "mtp") != model_info.labels.end();
-
-    if (uses_dflash) {
+    if (uses_dflash && use_draft_checkpoint) {
         LOG(INFO, "LlamaCpp") << "Model uses DFlash, adding draft decoding defaults" << std::endl;
         push_overridable_arg(args, llamacpp_args, "--spec-type", "draft-dflash");
     } else if (uses_mtp) {

--- a/src/cpp/server/hf_variants.cpp
+++ b/src/cpp/server/hf_variants.cpp
@@ -35,17 +35,12 @@ bool contains_ci(const std::string& s, const std::string& needle) {
     return to_lower(s).find(to_lower(needle)) != std::string::npos;
 }
 
-std::string draft_companion_label(const std::string& path) {
+bool is_draft_companion(const std::string& path) {
     std::string filename = to_lower(path);
     size_t slash = filename.find_last_of('/');
     if (slash != std::string::npos) filename = filename.substr(slash + 1);
-    if (filename.rfind("dflash-", 0) == 0 || filename == "dflash.gguf") return "dflash";
-    if (filename.rfind("mtp-", 0) == 0) return "mtp";
-    return {};
-}
-
-bool is_draft_companion(const std::string& path) {
-    return !draft_companion_label(path).empty();
+    return filename.rfind("dflash-", 0) == 0 || filename == "dflash.gguf" ||
+           filename.rfind("mtp-", 0) == 0;
 }
 
 // Quant token extractor. Recognizes the variants we actually see in
@@ -131,9 +126,6 @@ GgufVariantSet enumerate_gguf_variants(
     }
     std::sort(result.mmproj_files.begin(), result.mmproj_files.end());
     std::sort(result.draft_files.begin(), result.draft_files.end());
-    if (result.draft_files.size() == 1) {
-        result.draft_label = draft_companion_label(result.draft_files.front());
-    }
 
     // Group by top-level folder vs root files.
     std::map<std::string, std::vector<std::string>> folder_groups;
@@ -396,7 +388,6 @@ nlohmann::json fetch_pull_variants(const std::string& checkpoint,
     // Suggested labels.
     std::vector<std::string> labels;
     if (!vset.mmproj_files.empty()) add_label(labels, "vision");
-    if (!vset.draft_label.empty()) add_label(labels, vset.draft_label);
     {
         std::string id_lower = to_lower(checkpoint);
         if (id_lower.find("embed") != std::string::npos) add_label(labels, "embeddings");

--- a/src/cpp/server/hf_variants.cpp
+++ b/src/cpp/server/hf_variants.cpp
@@ -35,12 +35,17 @@ bool contains_ci(const std::string& s, const std::string& needle) {
     return to_lower(s).find(to_lower(needle)) != std::string::npos;
 }
 
-bool is_draft_companion(const std::string& path) {
+std::string draft_companion_label(const std::string& path) {
     std::string filename = to_lower(path);
     size_t slash = filename.find_last_of('/');
     if (slash != std::string::npos) filename = filename.substr(slash + 1);
-    return filename.rfind("dflash-", 0) == 0 || filename == "dflash.gguf" ||
-           filename.rfind("mtp-", 0) == 0;
+    if (filename.rfind("dflash-", 0) == 0 || filename == "dflash.gguf") return "dflash";
+    if (filename.rfind("mtp-", 0) == 0) return "mtp";
+    return {};
+}
+
+bool is_draft_companion(const std::string& path) {
+    return !draft_companion_label(path).empty();
 }
 
 // Quant token extractor. Recognizes the variants we actually see in
@@ -126,6 +131,9 @@ GgufVariantSet enumerate_gguf_variants(
     }
     std::sort(result.mmproj_files.begin(), result.mmproj_files.end());
     std::sort(result.draft_files.begin(), result.draft_files.end());
+    if (result.draft_files.size() == 1) {
+        result.draft_label = draft_companion_label(result.draft_files.front());
+    }
 
     // Group by top-level folder vs root files.
     std::map<std::string, std::vector<std::string>> folder_groups;
@@ -388,6 +396,7 @@ nlohmann::json fetch_pull_variants(const std::string& checkpoint,
     // Suggested labels.
     std::vector<std::string> labels;
     if (!vset.mmproj_files.empty()) add_label(labels, "vision");
+    if (!vset.draft_label.empty()) add_label(labels, vset.draft_label);
     {
         std::string id_lower = to_lower(checkpoint);
         if (id_lower.find("embed") != std::string::npos) add_label(labels, "embeddings");

--- a/src/cpp/server/hf_variants.cpp
+++ b/src/cpp/server/hf_variants.cpp
@@ -35,6 +35,14 @@ bool contains_ci(const std::string& s, const std::string& needle) {
     return to_lower(s).find(to_lower(needle)) != std::string::npos;
 }
 
+bool is_draft_companion(const std::string& path) {
+    std::string filename = to_lower(path);
+    size_t slash = filename.find_last_of('/');
+    if (slash != std::string::npos) filename = filename.substr(slash + 1);
+    return filename.rfind("dflash-", 0) == 0 || filename == "dflash.gguf" ||
+           filename.rfind("mtp-", 0) == 0;
+}
+
 // Quant token extractor. Recognizes the variants we actually see in
 // production GGUF repos (see src/cpp/resources/server_models.json), including
 // the `UD-` Unsloth Dynamic prefix and the `_XL` "extra-large" suffix that
@@ -101,19 +109,23 @@ GgufVariantSet enumerate_gguf_variants(
         return it == size_by_file.end() ? 0 : it->second;
     };
 
-    // Partition into mmproj vs regular gguf files.
+    // Companion GGUFs must not become selectable main-model variants.
     std::vector<std::string> gguf_files;
     for (const auto& f : repo_files) {
         std::string f_lower = to_lower(f);
         if (!ends_with(f_lower, ".gguf")) continue;
+        size_t slash = f.find_last_of('/');
+        std::string bare = slash == std::string::npos ? f : f.substr(slash + 1);
         if (f_lower.find("mmproj") != std::string::npos) {
-            size_t slash = f.find_last_of('/');
-            result.mmproj_files.push_back(slash == std::string::npos ? f : f.substr(slash + 1));
+            result.mmproj_files.push_back(bare);
+        } else if (is_draft_companion(f)) {
+            result.draft_files.push_back(bare);
         } else {
             gguf_files.push_back(f);
         }
     }
     std::sort(result.mmproj_files.begin(), result.mmproj_files.end());
+    std::sort(result.draft_files.begin(), result.draft_files.end());
 
     // Group by top-level folder vs root files.
     std::map<std::string, std::vector<std::string>> folder_groups;
@@ -289,6 +301,7 @@ nlohmann::json fetch_pull_variants(const std::string& checkpoint,
         out["suggested_name"] = suggested_name;
         out["suggested_labels"] = nlohmann::json::array();
         out["mmproj_files"] = nlohmann::json::array();
+        out["draft_files"] = nlohmann::json::array();
         out["variants"] = nlohmann::json::array({vj});
         return out;
     }
@@ -354,6 +367,7 @@ nlohmann::json fetch_pull_variants(const std::string& checkpoint,
         out["suggested_name"] = suggested_name;
         out["suggested_labels"] = nlohmann::json::array();
         out["mmproj_files"] = nlohmann::json::array();
+        out["draft_files"] = nlohmann::json::array();
         out["variants"] = nlohmann::json::array();
         if (manifest.contains("size") && manifest["size"].is_number()) {
             out["size"] = manifest["size"];
@@ -388,6 +402,7 @@ nlohmann::json fetch_pull_variants(const std::string& checkpoint,
     out["suggested_name"] = suggested_name;
     out["suggested_labels"] = labels;
     out["mmproj_files"] = vset.mmproj_files;
+    out["draft_files"] = vset.draft_files;
 
     nlohmann::json variants_json = nlohmann::json::array();
     for (const auto& v : vset.variants) {

--- a/test/cpp/test_hf_variants.cpp
+++ b/test/cpp/test_hf_variants.cpp
@@ -140,7 +140,8 @@ int main() {
                       "got " + join_names(set));
         result.expect("DFlash companion is reported separately",
                       set.draft_files.size() == 1 &&
-                          set.draft_files[0] == "dflash-kquant.gguf",
+                          set.draft_files[0] == "dflash-kquant.gguf" &&
+                          set.draft_label == "dflash",
                       "draft count = " + std::to_string(set.draft_files.size()));
         result.expect("mmproj remains reported separately",
                       set.mmproj_files.size() == 1 &&
@@ -166,8 +167,20 @@ int main() {
         });
         result.expect("MTP companion is reported as a draft",
                       set.variants.size() == 1 && set.variants[0].name == "Q4_K_M" &&
-                          set.draft_files.size() == 1 && set.draft_files[0] == "mtp-Gemma.gguf",
+                          set.draft_files.size() == 1 && set.draft_files[0] == "mtp-Gemma.gguf" &&
+                          set.draft_label == "mtp",
                       "got " + join_names(set));
+    }
+
+    {
+        auto set = lemon::enumerate_gguf_variants({
+            "Model-Q8_0.gguf",
+            "dflash-kquant.gguf",
+            "mtp-Model.gguf",
+        });
+        result.expect("Multiple draft companions do not choose an activation label",
+                      set.draft_files.size() == 2 && set.draft_label.empty(),
+                      "draft count = " + std::to_string(set.draft_files.size()));
     }
 
     {

--- a/test/cpp/test_hf_variants.cpp
+++ b/test/cpp/test_hf_variants.cpp
@@ -129,6 +129,55 @@ int main() {
                       "got " + join_names(set));
     }
 
+    {
+        auto set = lemon::enumerate_gguf_variants({
+            "Muse-Glimmer-30B-Q8_0.gguf",
+            "mmproj-Muse-Glimmer-30B-BF16.gguf",
+            "dflash-kquant.gguf",
+        });
+        result.expect("DFlash companion is not exposed as a main variant",
+                      set.variants.size() == 1 && set.variants[0].name == "Q8_0",
+                      "got " + join_names(set));
+        result.expect("DFlash companion is reported separately",
+                      set.draft_files.size() == 1 &&
+                          set.draft_files[0] == "dflash-kquant.gguf",
+                      "draft count = " + std::to_string(set.draft_files.size()));
+        result.expect("mmproj remains reported separately",
+                      set.mmproj_files.size() == 1 &&
+                          set.mmproj_files[0] == "mmproj-Muse-Glimmer-30B-BF16.gguf",
+                      "mmproj count = " + std::to_string(set.mmproj_files.size()));
+    }
+
+    {
+        auto set = lemon::enumerate_gguf_variants({
+            "model.gguf",
+            "dflash-kquant.gguf",
+        });
+        result.expect("DFlash does not break unquantized model fallback",
+                      set.variants.size() == 1 && set.variants[0].name == "model.gguf" &&
+                          set.draft_files.size() == 1,
+                      "got " + join_names(set));
+    }
+
+    {
+        auto set = lemon::enumerate_gguf_variants({
+            "Gemma-Q4_K_M.gguf",
+            "mtp-Gemma.gguf",
+        });
+        result.expect("MTP companion is reported as a draft",
+                      set.variants.size() == 1 && set.variants[0].name == "Q4_K_M" &&
+                          set.draft_files.size() == 1 && set.draft_files[0] == "mtp-Gemma.gguf",
+                      "got " + join_names(set));
+    }
+
+    {
+        auto set = lemon::enumerate_gguf_variants({"My-MTP-Model-Q8_0.gguf"});
+        result.expect("MTP in a main-model name is not treated as a draft",
+                      set.variants.size() == 1 && set.variants[0].name == "Q8_0" &&
+                          set.draft_files.empty(),
+                      "got " + join_names(set));
+    }
+
     printf("\n%d passed, %d failed\n", result.passed, result.failed);
     return result.failed == 0 ? 0 : 1;
 }

--- a/test/cpp/test_hf_variants.cpp
+++ b/test/cpp/test_hf_variants.cpp
@@ -140,8 +140,7 @@ int main() {
                       "got " + join_names(set));
         result.expect("DFlash companion is reported separately",
                       set.draft_files.size() == 1 &&
-                          set.draft_files[0] == "dflash-kquant.gguf" &&
-                          set.draft_label == "dflash",
+                          set.draft_files[0] == "dflash-kquant.gguf",
                       "draft count = " + std::to_string(set.draft_files.size()));
         result.expect("mmproj remains reported separately",
                       set.mmproj_files.size() == 1 &&
@@ -167,8 +166,7 @@ int main() {
         });
         result.expect("MTP companion is reported as a draft",
                       set.variants.size() == 1 && set.variants[0].name == "Q4_K_M" &&
-                          set.draft_files.size() == 1 && set.draft_files[0] == "mtp-Gemma.gguf" &&
-                          set.draft_label == "mtp",
+                          set.draft_files.size() == 1 && set.draft_files[0] == "mtp-Gemma.gguf",
                       "got " + join_names(set));
     }
 
@@ -178,8 +176,8 @@ int main() {
             "dflash-kquant.gguf",
             "mtp-Model.gguf",
         });
-        result.expect("Multiple draft companions do not choose an activation label",
-                      set.draft_files.size() == 2 && set.draft_label.empty(),
+        result.expect("Multiple draft companions are all reported",
+                      set.draft_files.size() == 2,
                       "draft count = " + std::to_string(set.draft_files.size()));
     }
 


### PR DESCRIPTION
## Summary

* Detect `dflash-*.gguf`, `dflash.gguf`, and `mtp-*.gguf` draft companions during GGUF registry discovery.
* Automatically register a single detected companion as the model's `draft` checkpoint during `lemonade pull`.
* Allow detected DFlash draft checkpoints to be enabled with the `dflash` label, while preserving the existing `draft` checkpoint type and MTP behavior.
* Keep draft companions out of the normal quantization/variant list.
* Avoid guessing when a repository contains multiple possible draft companions.
* Add regression coverage for DFlash, MTP draft companions, unquantized main models, and MTP-looking main filenames.

## Why

Custom GGUF repositories can contain a main model, an `mmproj`, and a separate draft model. Lemonade already supports `draft` checkpoints and passes them to llama.cpp using `--model-draft`, but registry pulls did not automatically discover and register DFlash or separate MTP draft companions.

This connects the existing draft-checkpoint support to registry discovery and keeps the current MTP behavior intact.

For a repository such as `unsloth/Muse-Glimmer-30B-GGUF`, a pull like:

```bash
lemonade pull unsloth/Muse-Glimmer-30B-GGUF:Q8_0
```

can now automatically associate the main model, multimodal projector, and `dflash-kquant.gguf` draft model.

