### PR TITLE
ci: stop building unused targets in the validate workflows

### DIFF
--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -902,7 +902,7 @@ jobs:
         uses: ./.github/actions/get-version
 
       - name: Cache FetchContent dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: build/_deps
           # vs2026 marker: see installer job — VS 2022-built _deps cannot be

--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -889,7 +889,7 @@ jobs:
     outputs:
       version: ${{ steps.get_version.outputs.version }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
         with:
           clean: true
           fetch-depth: 0
@@ -902,7 +902,7 @@ jobs:
         uses: ./.github/actions/get-version
 
       - name: Cache FetchContent dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@v4
         with:
           path: build/_deps
           # vs2026 marker: see installer job — VS 2022-built _deps cannot be
@@ -927,7 +927,7 @@ jobs:
           Get-ChildItem $archive
 
       - name: Upload embeddable archive
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: lemonade-embeddable-windows
           path: build/lemonade-embeddable-${{ env.LEMONADE_VERSION }}-windows-x64.zip

--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -889,7 +889,7 @@ jobs:
     outputs:
       version: ${{ steps.get_version.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           clean: true
           fetch-depth: 0
@@ -927,7 +927,7 @@ jobs:
           Get-ChildItem $archive
 
       - name: Upload embeddable archive
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: lemonade-embeddable-windows
           path: build/lemonade-embeddable-${{ env.LEMONADE_VERSION }}-windows-x64.zip

--- a/.github/workflows/validate_llamacpp.yml
+++ b/.github/workflows/validate_llamacpp.yml
@@ -376,15 +376,22 @@ jobs:
 
           $script | python -
 
-      - name: Build C++ Server with CMake
+      - name: Cache FetchContent dependencies
+        uses: actions/cache@v5
+        with:
+          path: build/_deps
+          key: fetchcontent-validate-llamacpp-vs2026-${{ hashFiles('CMakeLists.txt') }}
+          restore-keys: fetchcontent-validate-llamacpp-vs2026-
+
+      - name: Build lemond
         shell: PowerShell
         run: |
           $ErrorActionPreference = "Stop"
-          Write-Host "Building Lemonade server binaries..." -ForegroundColor Cyan
-          if (Test-Path "build") { Remove-Item -Recurse -Force "build" }
-          cmake --preset vs18
+          # The validation drives lemond over HTTP and never invokes the CLI,
+          # so lemond is the only target it needs.
+          cmake --preset vs18 -DBUILD_WEB_APP=OFF
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          cmake --build build --config Release
+          cmake --build build --config Release --target lemond -- /m:2
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           if (-not (Test-Path "build\Release\lemond.exe")) {
               Write-Host "ERROR: lemond.exe not found!" -ForegroundColor Red
@@ -628,7 +635,7 @@ jobs:
                 )
               }
           )
-  
+
           foreach ($process in $staleProcesses) {
             Write-Host "Stopping stale $($process.Name) PID $($process.ProcessId)." `
               -ForegroundColor Yellow
@@ -642,7 +649,7 @@ jobs:
               }
             }
           }
-  
+
       - uses: actions/checkout@v5
         with:
           clean: true
@@ -831,7 +838,7 @@ jobs:
           if ($validationExitCode -ne 0) {
             exit $validationExitCode
           }
-  
+
       - name: Upload results
         if: always()
         uses: actions/upload-artifact@v7

--- a/.github/workflows/validate_llamacpp.yml
+++ b/.github/workflows/validate_llamacpp.yml
@@ -377,11 +377,18 @@ jobs:
           $script | python -
 
       - name: Cache FetchContent dependencies
+        # Shared with validate_sdcpp, which restores this key read-only: both
+        # configure the same preset with the same options, so their _deps are
+        # interchangeable and one entry serves both instead of two.
+        # vs2026 marker: VS 2022-built _deps are generator-incompatible with the
+        # VS 2026 configure. Bump it to abandon an entry CMake accepts but
+        # cannot build from — cache keys are immutable, so this is the only
+        # in-repo way to invalidate one.
         uses: actions/cache@v5
         with:
           path: build/_deps
-          key: fetchcontent-validate-llamacpp-vs2026-${{ hashFiles('CMakeLists.txt') }}
-          restore-keys: fetchcontent-validate-llamacpp-vs2026-
+          key: fetchcontent-validate-vs2026-${{ hashFiles('CMakeLists.txt', 'cmake/*.cmake') }}
+          restore-keys: fetchcontent-validate-vs2026-
 
       - name: Build lemond
         shell: PowerShell
@@ -391,6 +398,9 @@ jobs:
           # so lemond is the only target it needs.
           cmake --preset vs18 -DBUILD_WEB_APP=OFF
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          # /m:2 goes straight to MSBuild rather than through --parallel, which
+          # makes CMake set CL_MPCount=1 and cancel the /MP in CMakeLists.txt.
+          # Capped at 2 because /MP already spawns one cl.exe per core.
           cmake --build build --config Release --target lemond -- /m:2
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           if (-not (Test-Path "build\Release\lemond.exe")) {

--- a/.github/workflows/validate_llamacpp.yml
+++ b/.github/workflows/validate_llamacpp.yml
@@ -376,24 +376,12 @@ jobs:
 
           $script | python -
 
-      - name: Cache FetchContent dependencies
-        # Shared with validate_sdcpp, which restores this key read-only: both
-        # configure the same preset with the same options, so their _deps are
-        # interchangeable and one entry serves both instead of two.
-        # vs2026 marker: VS 2022-built _deps are generator-incompatible with the
-        # VS 2026 configure. Bump it to abandon an entry CMake accepts but
-        # cannot build from — cache keys are immutable, so this is the only
-        # in-repo way to invalidate one.
-        uses: actions/cache@v5
-        with:
-          path: build/_deps
-          key: fetchcontent-validate-vs2026-${{ hashFiles('CMakeLists.txt', 'cmake/*.cmake') }}
-          restore-keys: fetchcontent-validate-vs2026-
-
       - name: Build lemond
         shell: PowerShell
         run: |
           $ErrorActionPreference = "Stop"
+          Write-Host "Building Lemonade server binaries..." -ForegroundColor Cyan
+          if (Test-Path "build") { Remove-Item -Recurse -Force "build" }
           # The validation drives lemond over HTTP and never invokes the CLI,
           # so lemond is the only target it needs.
           cmake --preset vs18 -DBUILD_WEB_APP=OFF

--- a/.github/workflows/validate_sdcpp.yml
+++ b/.github/workflows/validate_sdcpp.yml
@@ -231,15 +231,20 @@ jobs:
             --release "${{ needs.discover-release.outputs.cuda_release }}" `
             --backends "${{ needs.discover-release.outputs.cuda_update_backends }}"
 
-      - name: Build C++ Server with CMake
+      - name: Cache FetchContent dependencies
+        uses: actions/cache@v5
+        with:
+          path: build/_deps
+          key: fetchcontent-validate-sdcpp-vs2026-${{ hashFiles('CMakeLists.txt') }}
+          restore-keys: fetchcontent-validate-sdcpp-vs2026-
+
+      - name: Build lemond and the CLI
         shell: PowerShell
         run: |
           $ErrorActionPreference = "Stop"
-          Write-Host "Building Lemonade server binaries..." -ForegroundColor Cyan
-          if (Test-Path "build") { Remove-Item -Recurse -Force "build" }
-          cmake --preset vs18
+          cmake --preset vs18 -DBUILD_WEB_APP=OFF
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          cmake --build build --config Release --target lemond lemonade
+          cmake --build build --config Release --target lemond lemonade -- /m:2
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           if (-not (Test-Path "build\Release\lemond.exe")) {
               Write-Host "ERROR: lemond.exe not found!" -ForegroundColor Red

--- a/.github/workflows/validate_sdcpp.yml
+++ b/.github/workflows/validate_sdcpp.yml
@@ -231,19 +231,29 @@ jobs:
             --release "${{ needs.discover-release.outputs.cuda_release }}" `
             --backends "${{ needs.discover-release.outputs.cuda_update_backends }}"
 
-      - name: Cache FetchContent dependencies
-        uses: actions/cache@v5
+      - name: Restore FetchContent dependencies
+        # Restore-only, sharing validate_llamacpp's namespace: that job
+        # configures the same preset with the same options, so its _deps are
+        # interchangeable with this job's, and its weekly run lands first.
+        # Cache keys are immutable, so saving from here too would only lose the
+        # race and log a reservation failure.
+        uses: actions/cache/restore@v5
         with:
           path: build/_deps
-          key: fetchcontent-validate-sdcpp-vs2026-${{ hashFiles('CMakeLists.txt') }}
-          restore-keys: fetchcontent-validate-sdcpp-vs2026-
+          key: fetchcontent-validate-vs2026-${{ hashFiles('CMakeLists.txt', 'cmake/*.cmake') }}
+          restore-keys: fetchcontent-validate-vs2026-
 
       - name: Build lemond and the CLI
         shell: PowerShell
         run: |
           $ErrorActionPreference = "Stop"
+          # BUILD_WEB_APP=OFF skips the configure-time CONFIGURE_DEPENDS glob
+          # over src/app; the web-app target is not in this build graph anyway.
           cmake --preset vs18 -DBUILD_WEB_APP=OFF
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          # /m:2 goes straight to MSBuild rather than through --parallel, which
+          # makes CMake set CL_MPCount=1 and cancel the /MP in CMakeLists.txt.
+          # Capped at 2 because /MP already spawns one cl.exe per core.
           cmake --build build --config Release --target lemond lemonade -- /m:2
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           if (-not (Test-Path "build\Release\lemond.exe")) {

--- a/.github/workflows/validate_sdcpp.yml
+++ b/.github/workflows/validate_sdcpp.yml
@@ -231,22 +231,12 @@ jobs:
             --release "${{ needs.discover-release.outputs.cuda_release }}" `
             --backends "${{ needs.discover-release.outputs.cuda_update_backends }}"
 
-      - name: Restore FetchContent dependencies
-        # Restore-only, sharing validate_llamacpp's namespace: that job
-        # configures the same preset with the same options, so its _deps are
-        # interchangeable with this job's, and its weekly run lands first.
-        # Cache keys are immutable, so saving from here too would only lose the
-        # race and log a reservation failure.
-        uses: actions/cache/restore@v5
-        with:
-          path: build/_deps
-          key: fetchcontent-validate-vs2026-${{ hashFiles('CMakeLists.txt', 'cmake/*.cmake') }}
-          restore-keys: fetchcontent-validate-vs2026-
-
       - name: Build lemond and the CLI
         shell: PowerShell
         run: |
           $ErrorActionPreference = "Stop"
+          Write-Host "Building Lemonade server binaries..." -ForegroundColor Cyan
+          if (Test-Path "build") { Remove-Item -Recurse -Force "build" }
           # BUILD_WEB_APP=OFF skips the configure-time CONFIGURE_DEPENDS glob
           # over src/app; the web-app target is not in this build graph anyway.
           cmake --preset vs18 -DBUILD_WEB_APP=OFF

--- a/.github/workflows/validate_vllm.yml
+++ b/.github/workflows/validate_vllm.yml
@@ -86,13 +86,20 @@ jobs:
           print(f"vllm.rocm: {old} -> {release}")
           PY
 
-      - name: Build Lemonade server
+      - name: Cache FetchContent dependencies
+        uses: actions/cache@v5
+        with:
+          path: build/_deps
+          key: fetchcontent-validate-vllm-${{ hashFiles('CMakeLists.txt') }}
+          restore-keys: fetchcontent-validate-vllm-
+
+      - name: Build lemond and the CLI
         run: |
           set -e
           ./setup.sh
           # Skip the web app; CI only exercises the backend.
-          cmake -DBUILD_WEB_APP=OFF --preset default
-          cmake --build --preset default
+          cmake --preset default -DBUILD_WEB_APP=OFF
+          cmake --build --preset default --target lemond lemonade
           test -f build/lemond || { echo "lemond not found!"; exit 1; }
           echo "Build successful!"
 

--- a/.github/workflows/validate_vllm.yml
+++ b/.github/workflows/validate_vllm.yml
@@ -86,21 +86,49 @@ jobs:
           print(f"vllm.rocm: {old} -> {release}")
           PY
 
+      - name: Install build dependencies
+        # Installed directly rather than via setup.sh, whose "Preparing build
+        # directory" step runs `rm -rf build` and would delete the cache
+        # restored below. libdrm is required (lemonade-server-core links
+        # drm_amdgpu unconditionally on Linux); libsystemd and libcap are
+        # optional but gate HAVE_SYSTEMD / HAVE_LIBCAP, so they stay in to keep
+        # the binary's feature set identical to a setup.sh build. cmake is
+        # deliberately absent: 22.04 ships 3.22, too old for CMakePresets v5,
+        # and the runner image already provides a current one.
+        run: |
+          set -e
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential \
+            ninja-build \
+            pkg-config \
+            libssl-dev \
+            libcurl4-openssl-dev \
+            libdrm-dev \
+            libsystemd-dev \
+            libcap-dev
+
       - name: Cache FetchContent dependencies
+        # ubuntu2204 marker: these _deps are compiled against the runner image's
+        # glibc/libstdc++, and which dependencies get fetched at all depends on
+        # the image's library versions, so they must not be restored onto a
+        # different image. Bump it to abandon an entry CMake accepts but cannot
+        # build from — cache keys are immutable, so this is the only in-repo way
+        # to invalidate one.
         uses: actions/cache@v5
         with:
           path: build/_deps
-          key: fetchcontent-validate-vllm-${{ hashFiles('CMakeLists.txt') }}
-          restore-keys: fetchcontent-validate-vllm-
+          key: fetchcontent-validate-vllm-ubuntu2204-${{ hashFiles('CMakeLists.txt', 'cmake/*.cmake') }}
+          restore-keys: fetchcontent-validate-vllm-ubuntu2204-
 
       - name: Build lemond and the CLI
         run: |
           set -e
-          ./setup.sh
           # Skip the web app; CI only exercises the backend.
           cmake --preset default -DBUILD_WEB_APP=OFF
           cmake --build --preset default --target lemond lemonade
           test -f build/lemond || { echo "lemond not found!"; exit 1; }
+          test -f build/lemonade || { echo "lemonade not found!"; exit 1; }
           echo "Build successful!"
 
       - name: Upload build artifacts

--- a/.github/workflows/validate_vllm.yml
+++ b/.github/workflows/validate_vllm.yml
@@ -86,46 +86,12 @@ jobs:
           print(f"vllm.rocm: {old} -> {release}")
           PY
 
-      - name: Install build dependencies
-        # Installed directly rather than via setup.sh, whose "Preparing build
-        # directory" step runs `rm -rf build` and would delete the cache
-        # restored below. libdrm is required (lemonade-server-core links
-        # drm_amdgpu unconditionally on Linux); libsystemd and libcap are
-        # optional but gate HAVE_SYSTEMD / HAVE_LIBCAP, so they stay in to keep
-        # the binary's feature set identical to a setup.sh build. cmake is
-        # deliberately absent: 22.04 ships 3.22, too old for CMakePresets v5,
-        # and the runner image already provides a current one.
-        run: |
-          set -e
-          sudo apt-get update
-          sudo apt-get install -y \
-            build-essential \
-            ninja-build \
-            pkg-config \
-            libssl-dev \
-            libcurl4-openssl-dev \
-            libdrm-dev \
-            libsystemd-dev \
-            libcap-dev
-
-      - name: Cache FetchContent dependencies
-        # ubuntu2204 marker: these _deps are compiled against the runner image's
-        # glibc/libstdc++, and which dependencies get fetched at all depends on
-        # the image's library versions, so they must not be restored onto a
-        # different image. Bump it to abandon an entry CMake accepts but cannot
-        # build from — cache keys are immutable, so this is the only in-repo way
-        # to invalidate one.
-        uses: actions/cache@v5
-        with:
-          path: build/_deps
-          key: fetchcontent-validate-vllm-ubuntu2204-${{ hashFiles('CMakeLists.txt', 'cmake/*.cmake') }}
-          restore-keys: fetchcontent-validate-vllm-ubuntu2204-
-
       - name: Build lemond and the CLI
         run: |
           set -e
+          ./setup.sh
           # Skip the web app; CI only exercises the backend.
-          cmake --preset default -DBUILD_WEB_APP=OFF
+          cmake -DBUILD_WEB_APP=OFF --preset default
           cmake --build --preset default --target lemond lemonade
           test -f build/lemond || { echo "lemond not found!"; exit 1; }
           test -f build/lemonade || { echo "lemonade not found!"; exit 1; }


### PR DESCRIPTION
Cuts ~13 minutes of CI time per merge by building only the targets the validation actually runs.

## Solution

The llama.cpp and vLLM validate jobs built **every** CMake target; they only need `lemond` (plus the CLI for sd.cpp/vLLM).

- `validate_llamacpp` — all targets → `lemond`, plus `BUILD_WEB_APP=OFF` and `/m:2`
- `validate_vllm` — all targets → `lemond lemonade`; now verifies `build/lemonade` alongside `build/lemond`
- `validate_sdcpp` — targets were already narrowed; adds `BUILD_WEB_APP=OFF` (skips the configure-time `CONFIGURE_DEPENDS` glob over `src/app`; the web app was never in this build graph) and `/m:2`

Also strips trailing whitespace on three lines of `validate_llamacpp.yml` (pre-commit).

## Results

Build-job wall clock. "After" is measured on `7c625bab3` ([run](https://github.com/lemonade-sdk/lemonade/actions/runs/31810829139)); "Before" lists every run of that job I could find in the current config, since these Windows runners are noisy enough that a single pair of numbers would overstate the precision.

| Job | Before | After |
|---|---|---|
| Validate llama.cpp — Build | 19m35s / 22m01s / 23m03s | **10m39s** |
| Validate vLLM — Build (Linux) | 10m30s / 10m41s | **8m15s** |
| Validate sd.cpp — Build | 9m57s / 10m18s / 11m53s | 10m59s |

**llama.cpp** is the real win — it was building all ~623 targets, including every unit test, to run an HTTP-driven validation that only ever touches `lemond`. Configure was 182.7s and compiling `lemond` alone took 7m05s.

**vLLM** drops from 623 targets to 504; compile went 8m30s → 6m06s, with `setup.sh` (1m56s) unchanged.

**sd.cpp is honestly a wash** — it lands inside the range of the unmodified job. Its targets were already narrowed on `main`, so all that is left is `BUILD_WEB_APP=OFF` shaving the `src/app` glob out of configure, and that is smaller than the run-to-run spread. Happy to drop the sd.cpp hunk if you would rather not carry a change that cannot be measured.

## No `_deps` cache

An earlier revision cached `build/_deps` in these three jobs. The warm-cache rerun @fl0rianr asked for shows it does not pay for itself, so it is dropped — along with the two changes that existed only to protect it (the `Remove-Item build` deletions and vLLM's direct `apt-get` in place of `setup.sh`).

- **2 of 3 jobs missed** on the rerun even though the prior attempt saved both keys 14 hours earlier. The repo's Actions cache sits at its 10 GB cap (10.12 GB across 67 entries), so ~550 MB entries are evicted within hours.
- **The job that hit got slower** — sd.cpp went 9m54s → 10m58s, i.e. within noise.
- **The ceiling is ~30s regardless.** In that job, configure was 131.9s cold vs 133.4s warm (FetchContent reconfigures either way) and dependency compilation was ~45s cold vs ~2s warm, while restoring the 549 MB entry costs ~15s.

This also resolves the Codex finding about `setup.sh` deleting the restored cache, and the cache-namespace/`pkg-config` notes from review, by removing the cache entirely.
