### PR TITLE
fix(gui3): router correct integration

### DIFF
--- a/src/app/package.json
+++ b/src/app/package.json
@@ -38,7 +38,8 @@
     "test:ui-regressions": "node tests/ui-regression-contracts.runtime.cjs && node tests/backend-manager-lifecycle.runtime.cjs",
     "test:model-nav-filters": "node tests/model-nav-filter-layout.runtime.cjs",
     "test:model-state": "node tests/model-state-deduplication.runtime.cjs",
-    "test:download-polling": "node tests/download-polling-lifecycle.runtime.cjs"
+    "test:download-polling": "node tests/download-polling-lifecycle.runtime.cjs",
+    "test:router-load": "node tests/router-load-regression.runtime.cjs"
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.11.3",

--- a/src/app/src/api.ts
+++ b/src/app/src/api.ts
@@ -320,6 +320,7 @@ export interface ChatCompletionStats {
   tokens: number;
   reasoningTokens: number;
   reasoningElapsedMs: number | null;
+  route?: Record<string, unknown> | null;
 }
 
 export interface LiveStreamStats {
@@ -1412,6 +1413,12 @@ class LemonadeAPI {
     await this._assertModelNotDownloading(modelName);
     const target = modelName.trim().toLowerCase();
     const cachedModelInfo = modelInfo || this.allModels.find(model => modelInfoKey(model).toLowerCase() === target) || null;
+    const cachedRecipe = String((cachedModelInfo as any)?.recipe || '').trim().toLowerCase();
+    if (cachedRecipe === 'collection.router' || cachedRecipe.startsWith('collection.router.')) {
+      // Router definitions are server-owned. "Load" is a readiness operation only;
+      // never write a possibly stale cached definition back to /models/register here.
+      return { model_name: modelName, status: 'ready', mode: 'router', virtual: true };
+    }
     const { recipeOptionsForModel } = await import(
       /* webpackChunkName: "model-configuration" */ './modelConfiguration'
     );
@@ -1432,6 +1439,16 @@ class LemonadeAPI {
   async effectiveLoadCommand(modelName: string, recipeOptions?: Record<string, unknown>, modelInfo?: ModelInfo | null): Promise<EffectiveLoadCommand> {
     const target = modelName.trim().toLowerCase();
     const cachedModelInfo = modelInfo || this.allModels.find(model => modelInfoKey(model).toLowerCase() === target) || null;
+    const cachedRecipe = String((cachedModelInfo as any)?.recipe || '').trim().toLowerCase();
+    if (cachedRecipe === 'collection.router' || cachedRecipe.startsWith('collection.router.')) {
+      return {
+        model_name: modelName,
+        recipe: 'collection.router',
+        backend: 'virtual',
+        options: {},
+        args: [],
+      };
+    }
     const { recipeOptionsForModel } = await import(
       /* webpackChunkName: "model-configuration" */ './modelConfiguration'
     );
@@ -1441,6 +1458,14 @@ class LemonadeAPI {
   }
 
   async unloadModel(modelName?: string): Promise<unknown> {
+    if (modelName) {
+      const target = modelName.trim().toLowerCase();
+      const info = this.allModels.find(model => modelInfoKey(model).toLowerCase() === target) || null;
+      const recipe = String((info as any)?.recipe || '').trim().toLowerCase();
+      if (recipe === 'collection.router' || recipe.startsWith('collection.router.')) {
+        return { model_name: modelName, status: 'not_applicable', mode: 'router', virtual: true };
+      }
+    }
     const body = modelName ? { model_name: modelName } : {};
     const result = await this._json('/api/v1/unload', { method: 'POST', body });
     this._notifyModelsChanged();
@@ -1466,8 +1491,14 @@ class LemonadeAPI {
     recipeOptions?: Record<string, unknown>,
     modelInfo?: ModelInfo | null,
   ): Promise<unknown> {
+    const target = modelName.trim().toLowerCase();
+    const info = modelInfo || this.allModels.find(model => modelInfoKey(model).toLowerCase() === target) || null;
+    const recipe = String((info as any)?.recipe || '').trim().toLowerCase();
+    if (recipe === 'collection.router' || recipe.startsWith('collection.router.')) {
+      return this.loadModel(modelName, undefined, info);
+    }
     await this.unloadModel(modelName);
-    return this.loadModel(modelName, recipeOptions, modelInfo);
+    return this.loadModel(modelName, recipeOptions, info);
   }
 
   async deleteModel(modelName: string): Promise<unknown> {
@@ -2371,6 +2402,7 @@ class LemonadeAPI {
     let reasoningStartTime: number | null = null;
     let reasoningEndTime: number | null = null;
     let reasoningClosed = false;
+    let routeDecision: Record<string, unknown> | null = null;
 
     const reasoningElapsedMs = (now: number): number | null => {
       if (reasoningStartTime == null) return null;
@@ -2393,6 +2425,7 @@ class LemonadeAPI {
         tokens: tokenCount,
         reasoningTokens: reasoningTokenCount,
         reasoningElapsedMs: reasoningElapsedMs(now),
+        route: routeDecision,
       };
     };
 
@@ -2420,7 +2453,10 @@ class LemonadeAPI {
         /* webpackChunkName: "model-configuration" */ './modelConfiguration'
       );
       const requestModelInfo = this.allModels.find(candidate => modelInfoKey(candidate).toLowerCase() === model.trim().toLowerCase()) || null;
+      const requestRecipe = String((requestModelInfo as any)?.recipe || '').trim().toLowerCase();
+      const isRouterRequest = requestRecipe === 'collection.router' || requestRecipe.startsWith('collection.router.');
       const body: Record<string, unknown> = { model, messages, stream: true, ...samplingForModel(model, requestModelInfo), ...(params || {}) };
+      if (isRouterRequest && body.route_trace === undefined) body.route_trace = true;
       if (tools && tools.length > 0) body.tools = tools;
       const resp = await this._fetch('/api/v1/chat/completions', {
         method: 'POST',
@@ -2461,10 +2497,13 @@ class LemonadeAPI {
           }
           try {
             const chunk = JSON.parse(payload);
-            // Detect server-side error in SSE stream
+            if (isObject(chunk.x_lemonade_route)) routeDecision = { ...chunk.x_lemonade_route };
+            // If the Router already selected a candidate, keep that attribution in surfaced errors.
             if (chunk.error) {
               clearInterval(statsInterval);
-              onError?.(new Error(chunk.error.message || 'Server streaming error'));
+              const baseMessage = chunk.error.message || 'Server streaming error';
+              const routeTo = String(routeDecision?.route_to || '').trim();
+              onError?.(new Error(routeTo ? `${baseMessage} (Router selected ${routeTo}.)` : baseMessage));
               return;
             }
             respId = chunk.id || respId;

--- a/src/app/src/components/ChatView.tsx
+++ b/src/app/src/components/ChatView.tsx
@@ -48,6 +48,7 @@ import { CHAT_HISTORY_PREFERENCE_EVENT, loadChatHistoryPreference } from '../fea
 import type { DownloadListItem } from '../features/downloadManager/downloadStore';
 import { findModelInfoByName, getAudioTranscriptionComponent, getPrimaryChatComponent, getVisionChatComponent, isCollectionModel } from '../features/collections/collectionModels';
 import { LEMONADE_MCP_SERVER_ID, LEMONADE_MCP_TOOL_COUNT, MAX_MCP_SERVER_SELECTION, type McpServerToolOption } from '../tools/mcpMetadata';
+import { isRouterModelInfo, preflightRouter, routerPreflightError } from '../features/router/routerRuntime';
 import { TTS_SETTINGS_EVENT, loadTtsPlaybackSettings, ttsVoiceFromRecipeOptions } from '../features/audio/ttsSettings';
 import {
   LEMONADE_DEFAULT_CHAT_MODELS,
@@ -847,6 +848,18 @@ function friendlyChatError(message: string): string {
   return `I couldn't complete that request.\n\n${cleaned}`;
 }
 
+function friendlyRouterChatError(message: string): string {
+  const base = friendlyChatError(message);
+  const lower = message.toLowerCase();
+  const selected = /\(Router selected (.+)\.\)\s*$/i.exec(message)?.[1]?.trim();
+  const hint = selected
+    ? `The Router policy resolved successfully and selected ${selected}. The failure is in that candidate/helper path rather than in the Router policy itself.`
+    : /collection\.router|route[_ -]?policy|unresolv|no backend|unroutable/.test(lower)
+      ? 'The server did not resolve the Router policy. Check that every candidate/classifier/helper is registered and supported on this hardware; the Router itself has no backend process to load.'
+      : 'The Router itself has no backend process to load. Check the server error above for the selected candidate/classifier/helper, and verify every referenced component is registered and available.';
+  return `${base}\n\nRouter diagnostic: ${hint}`;
+}
+
 const ChatView: React.FC<ChatViewProps> = ({ currentModel: selectedModel, loadedModels, serverModels, connectionStatus, onModelSelect, onOpenModelDetails, onRefresh }) => {
   const [fallbackModelOverride, setFallbackModelOverride] = useState<string | null>(null);
   const [preferredDefaultModelName, setPreferredDefaultModelName] = useState(() => loadPreferredDefaultModelName());
@@ -1349,12 +1362,13 @@ const ChatView: React.FC<ChatViewProps> = ({ currentModel: selectedModel, loaded
     [currentKnownModelInfo, currentLoadedModel],
   );
   const supportsChatImageInput = useMemo(() => {
+    if (isRouterRecipe(currentRecipe)) return true;
     if (currentIsOmniCollection) {
       return Boolean(getVisionChatComponent(currentKnownModelInfo, knownModelInfos));
     }
     return currentCapability === 'chat'
       && modelSupportsChatImageInput(currentKnownModelInfo, currentLoadedModel);
-  }, [currentCapability, currentKnownModelInfo, currentLoadedModel, knownModelInfos]);
+  }, [currentCapability, currentKnownModelInfo, currentLoadedModel, currentRecipe, knownModelInfos]);
 
   const defaultImageSettings = useMemo(
     () => imageDefaultsForModel(
@@ -1465,7 +1479,7 @@ const ChatView: React.FC<ChatViewProps> = ({ currentModel: selectedModel, loaded
     knownModelInfos.forEach(info => {
       const name = String((info as any).model_name || info.name || info.id || '').trim();
       const capability = capabilityFromModelInfo(info);
-      if (!modelIsDownloaded(info) || activeDownloadForModel(downloadItems, name)) return;
+      if ((!modelIsDownloaded(info) && !isRouterModelInfo(info)) || activeDownloadForModel(downloadItems, name)) return;
       const configuredDefault = lemonadeDefaultModel(name);
       addOption({
         name,
@@ -1475,8 +1489,8 @@ const ChatView: React.FC<ChatViewProps> = ({ currentModel: selectedModel, loaded
         downloaded: true,
         audioInput: modelSupportsChatAudioInput(info, null),
         info,
-        detail: configuredDefault ? 'Downloaded · loads when you send' : 'Downloaded · click to load',
-        deferredUntilSend: Boolean(configuredDefault),
+        detail: isRouterModelInfo(info) ? 'Router · routes when you send' : (configuredDefault ? 'Downloaded · loads when you send' : 'Downloaded · click to load'),
+        deferredUntilSend: isRouterModelInfo(info) || Boolean(configuredDefault),
       });
     });
 
@@ -1681,12 +1695,16 @@ const ChatView: React.FC<ChatViewProps> = ({ currentModel: selectedModel, loaded
   }, [modelPickerOpen]);
 
   useEffect(() => {
-    const selectedStillUsable = selectedModel && loadedModels.some(m => m.model_name === selectedModel && canSelectInComposer(m));
+    const selectedInfo = selectedModel ? findModelInfoByName(knownModelInfos, selectedModel) : null;
+    const selectedStillUsable = Boolean(selectedModel) && (
+      loadedModels.some(m => m.model_name === selectedModel && canSelectInComposer(m))
+      || isRouterModelInfo(selectedInfo)
+    );
     const selectedDefault = lemonadeDefaultModel(selectedModel);
     if (selectedStillUsable || selectedDefault || !selectedModel || loadedModels.length === 0) return;
     const preferred = selectPreferredLoadedModel(loadedModels);
     if (preferred && canSelectInComposer(preferred)) onModelSelect(preferred.model_name);
-  }, [loadedModels, onModelSelect, selectedModel]);
+  }, [knownModelInfos, loadedModels, onModelSelect, selectedModel]);
 
   const updateConversation = useCallback((id: string, updater: (c: Conversation) => Conversation) => {
     setConversations(prev => prev.map(c => c.id === id ? updater(c) : c));
@@ -1725,6 +1743,16 @@ const ChatView: React.FC<ChatViewProps> = ({ currentModel: selectedModel, loaded
       // available (for example during a short reconnect window).
     }
     const target = info || findModelInfoByName(knownModelInfos, modelName) || null;
+    if (isRouterModelInfo(target)) {
+      const fresh = await api.models(true).catch(() => ({ data: knownModelInfos }));
+      const available = [...fresh.data, ...knownModelInfos].filter((item, index, list) => {
+        const name = modelInfoName(item).toLowerCase();
+        return !!name && list.findIndex(candidate => modelInfoName(candidate).toLowerCase() === name) === index;
+      });
+      const preflight = preflightRouter(target, available, currentLoaded);
+      if (!preflight.ok) throw new Error(routerPreflightError(preflight));
+      return { mode: 'router', status: 'ready', virtual: true };
+    }
     return loadWithGlobalModelPolicy({
       loadedModels: currentLoaded,
       allModels: knownModelInfos,
@@ -1806,6 +1834,21 @@ const ChatView: React.FC<ChatViewProps> = ({ currentModel: selectedModel, loaded
 
     let freshModels = await api.models(true).catch(() => ({ data: knownModelInfos }));
     let info = findModelInfoByName(freshModels.data, modelName) || initialInfo;
+
+    if (isRouterModelInfo(info)) {
+      const available = [...freshModels.data, ...knownModelInfos].filter((item, index, list) => {
+        const name = modelInfoName(item).toLowerCase();
+        return !!name && list.findIndex(candidate => modelInfoName(candidate).toLowerCase() === name) === index;
+      });
+      const preflight = preflightRouter(info, available, health.all_models_loaded || []);
+      if (!preflight.ok) throw new Error(routerPreflightError(preflight));
+      saveLastReadyModelName(modelName);
+      setLastReadyModelName(modelName);
+      setFallbackModelOverride(null);
+      onModelSelect(modelName);
+      return snapshotFromModelInfo(info) || snapshotFromName(modelName, health.all_models_loaded || [])!;
+    }
+
     const existingFinished = await waitForExistingModelDownload(modelName, convoId);
     if (existingFinished) {
       freshModels = await api.models(true).catch(() => freshModels);
@@ -1953,7 +1996,7 @@ const ChatView: React.FC<ChatViewProps> = ({ currentModel: selectedModel, loaded
     const model = streamModelsRef.current[convoId] || null;
     delete streamModelsRef.current[convoId];
     appendAssistantMessage(convoId, {
-      content: friendlyChatError(message),
+      content: isRouterModelInfo(model as any) ? friendlyRouterChatError(message) : friendlyChatError(message),
       model,
       isError: true,
     });
@@ -2861,8 +2904,9 @@ ${finalText}`
         false,
       );
     } catch (error) {
+      const errorMessage = friendlyErrorMessage(error);
       appendAssistantMessage(convoId, {
-        content: friendlyChatError(friendlyErrorMessage(error)),
+        content: isRouterModelInfo(initialSnapshot as any) ? friendlyRouterChatError(errorMessage) : friendlyChatError(errorMessage),
         model: initialSnapshot,
         isError: true,
       });
@@ -4702,6 +4746,11 @@ const MessageBubble: React.FC<{ message: Message; activeModel: ModelSnapshot | n
             <span>{message.stats.tps} tok/s</span>
             {message.stats.ttft && <span>{(Number(message.stats.ttft) / 1000).toFixed(2)}s TTFT</span>}
             <span>{message.stats.tokens} tokens</span>
+            {message.stats.route && String((message.stats.route as any).route_to || '').trim() && (
+              <span title={`Router route: ${String((message.stats.route as any).matched_rule || 'default')}`}>
+                Routed → {String((message.stats.route as any).route_to)}
+              </span>
+            )}
           </div>
         )}
         <div className="message__actions" aria-label="Message actions">

--- a/src/app/src/components/ModelDetailPanel.tsx
+++ b/src/app/src/components/ModelDetailPanel.tsx
@@ -2687,16 +2687,38 @@ export const ModelDetailPanel: React.FC<ModelDetailPanelProps> = ({
             {isLoadingThis ? 'Working…' : 'Unload'}
           </WorkspaceActionButton>
         </>
-      ) : isDownloaded ? (
-        <WorkspaceActionButton
-          appearance="primary"
-          icon="play"
-          onClick={() => loadWithShownConfiguration(onLoad, model)}
-          disabled={isLoadingThis}
-          aria-label={isLoadingThis ? `Loading ${name}…` : `Load ${name}`}
-        >
-          {isLoadingThis ? 'Loading…' : 'Load'}
-        </WorkspaceActionButton>
+      ) : (isDownloaded || isRouterCollection) ? (
+        isRouterCollection ? (
+          <>
+            <WorkspaceActionButton
+              appearance="quiet"
+              icon="sliders-horizontal"
+              onClick={() => setActiveTab('settings')}
+              title="Review Router policy and components"
+            >
+              Router settings
+            </WorkspaceActionButton>
+            <WorkspaceActionButton
+              appearance="primary"
+              icon="play"
+              onClick={() => onLoad(model)}
+              disabled={isLoadingThis}
+              aria-label={isLoadingThis ? `Preparing Router ${name}…` : `Use Router ${name}`}
+            >
+              {isLoadingThis ? 'Preparing…' : 'Use Router'}
+            </WorkspaceActionButton>
+          </>
+        ) : (
+          <WorkspaceActionButton
+            appearance="primary"
+            icon="play"
+            onClick={() => loadWithShownConfiguration(onLoad, model)}
+            disabled={isLoadingThis}
+            aria-label={isLoadingThis ? `Loading ${name}…` : `Load ${name}`}
+          >
+            {isLoadingThis ? 'Loading…' : 'Load'}
+          </WorkspaceActionButton>
+        )
       ) : (
         <>
           <WorkspaceActionButton appearance="primary" icon="download" onClick={() => loadWithShownConfiguration(onPullAndLoad, model)} aria-label={`Get and load ${name}`}>

--- a/src/app/src/components/ModelManager.tsx
+++ b/src/app/src/components/ModelManager.tsx
@@ -25,6 +25,7 @@ import {WorkspaceActionButton, WorkspaceActionGroup, WorkspaceDetailPanel, Works
 import Modal from './inspect/Modal';
 
 import { ROUTER_RECIPE, routerDisplayName, type RouterPullRequest } from '../features/router/routerTypes';
+import { isRouterModelInfo, preflightRouter, routerPreflightError } from '../features/router/routerRuntime';
 import {
   GLOBAL_MODEL_SETTINGS_EVENT,
   automaticUpdateIsDue,
@@ -1549,6 +1550,19 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
   };
 
 
+  const ensureServerRouterReady = async (name: string): Promise<ModelInfo> => {
+    const fresh = await api.models(true);
+    const key = name.trim().toLowerCase();
+    const serverRouter = fresh.data.find(candidate => modelName(candidate).toLowerCase() === key) || null;
+    if (!isRouterModelInfo(serverRouter)) {
+      throw new Error(`Router ${name} is not registered on the server. Save it before using it.`);
+    }
+    const health = await api.health().catch(() => null);
+    const preflight = preflightRouter(serverRouter, fresh.data, health?.all_models_loaded || []);
+    if (!preflight.ok) throw new Error(routerPreflightError(preflight));
+    return serverRouter;
+  };
+
   const loadModelRuntime = async (
     target: ModelInfo | string,
     visited = new Set<string>(),
@@ -1561,6 +1575,11 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
     visited.add(key);
 
     const info = typeof target === 'string' ? findCurrentModel(name) : target;
+    if (isRouterModelInfo(info)) {
+      await ensureServerRouterReady(name);
+      visited.delete(key);
+      return;
+    }
     const components = info && isCollectionModel(info) ? getCollectionComponents(info) : [];
 
     if (components.length > 0) {
@@ -1606,7 +1625,11 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
     setLoadError(null);
     setLoadingModel(name);
     try {
-      await loadWithGlobalPolicy(model, overrideOptions);
+      if (isRouterModelInfo(model)) {
+        await ensureServerRouterReady(name);
+      } else {
+        await loadWithGlobalPolicy(model, overrideOptions);
+      }
       await refresh();
       onModelSelect(name);
     } catch (err) {
@@ -1947,6 +1970,50 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
     displayName?: string,
   ): Promise<void> => {
     if (!api.isConnected) throw new Error('Connect to the Lemonade server before saving a router.');
+
+    const registered = new Set<string>();
+    const registering = new Set<string>();
+    const registerCustomDependency = async (component: ModelInfo): Promise<void> => {
+      const name = modelName(component);
+      const key = name.toLowerCase();
+      if (!name || registered.has(key) || !modelIsCustom(component)) return;
+      if (registering.has(key)) throw new Error(`Circular custom component reference: ${name}`);
+      registering.add(key);
+      if (isCollectionModel(component)) {
+        for (const nestedName of getCollectionComponents(component)) {
+          const nested = findCurrentModel(nestedName);
+          if (nested) await registerCustomDependency(nested);
+        }
+      }
+      await api.registerModelDefinition(canonicalCustomModelName(component), customRegistrationOptions(component));
+      registering.delete(key);
+      registered.add(key);
+    };
+
+    for (const componentName of request.components) {
+      const component = findCurrentModel(componentName);
+      if (component) await registerCustomDependency(component);
+    }
+
+    const routerInfo = {
+      id: request.model_name,
+      name: request.model_name,
+      model_name: request.model_name,
+      display_name: displayName?.trim() || routerDisplayName(request.model_name),
+      recipe: request.recipe,
+      type: 'chat',
+      labels: ['custom', 'router', 'chat'],
+      downloaded: true,
+      custom: true,
+      version: request.version,
+      components: request.components,
+      routing: request.routing,
+    } as ModelInfo;
+    const fresh = await api.models(true).catch(() => ({ data: allModels }));
+    const health = await api.health().catch(() => null);
+    const preflight = preflightRouter(routerInfo, fresh.data, health?.all_models_loaded || loadedModels);
+    if (!preflight.ok) throw new Error(routerPreflightError(preflight));
+
     await api.registerModelDefinition(request.model_name, {
       version: request.version,
       recipe: request.recipe,

--- a/src/app/src/components/RouterEditorPanel.tsx
+++ b/src/app/src/components/RouterEditorPanel.tsx
@@ -40,6 +40,7 @@ import {
   providerEndpointNeedsInsecureOptIn,
   validateProviderEndpoint,
 } from '../features/router/routerConnections';
+import { preflightRouter } from '../features/router/routerRuntime';
 
 function modelName(model: ModelInfo | null | undefined): string {
   if (!model) return '';
@@ -783,6 +784,11 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
       setError(buildError instanceof Error ? buildError.message : 'Router validation failed.');
       return;
     }
+    const dependencyPreflight = preflightRouter(nextRequest as any, models, []);
+    if (!dependencyPreflight.ok) {
+      setError(dependencyPreflight.errors.join(' '));
+      return;
+    }
     setSaving(true);
     try {
       await onRegister(nextRequest, submittedDraft.name.trim());
@@ -794,7 +800,7 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
       const savedModel = routerRequestToModelInfo(nextRequest, savedDraft);
 
       setDraft(current => {
-        // If the user edited while /pull was in flight, preserve those newer
+        // If the user edited while server registration was in flight, preserve those newer
         // edits. Only attach the now-authoritative model ID. If nothing changed,
         // commit the exact submitted snapshot as the clean baseline.
         if (routerDraftFingerprint(current) === submittedFingerprint) return savedDraft;

--- a/src/app/src/features/router/routerRuntime.ts
+++ b/src/app/src/features/router/routerRuntime.ts
@@ -1,0 +1,142 @@
+import type { LoadedModel, ModelInfo } from '../../api';
+import { ROUTER_RECIPE } from './routerTypes';
+
+export type RouterDependencyRole = 'candidate' | 'default' | 'classifier' | 'llm-router' | 'component';
+
+export interface RouterDependencyStatus {
+  name: string;
+  roles: RouterDependencyRole[];
+  present: boolean;
+  downloaded: boolean;
+  loaded: boolean;
+  recipe?: string;
+}
+
+export interface RouterPreflightResult {
+  ok: boolean;
+  errors: string[];
+  warnings: string[];
+  dependencies: RouterDependencyStatus[];
+}
+
+function record(value: unknown): Record<string, any> | null {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, any> : null;
+}
+
+export function routerModelName(model: ModelInfo | LoadedModel | null | undefined): string {
+  const value = model as any;
+  return String(value?.model_name || value?.name || value?.id || '').trim();
+}
+
+export function isRouterModelInfo<T extends ModelInfo | LoadedModel>(
+  model: T | null | undefined,
+): model is T {
+  const recipe = String((model as any)?.recipe || '')
+    .trim()
+    .toLowerCase();
+  return recipe === ROUTER_RECIPE
+    || recipe.startsWith(`${ROUTER_RECIPE}.`);
+}
+
+function isDownloaded(model: ModelInfo | null | undefined): boolean {
+  if (!model) return false;
+  const value = model as any;
+  if (value.downloaded === true || value.is_downloaded === true || value.local === true || value.installed === true) return true;
+  const status = String(value.status || value.state || '').toLowerCase();
+  if (['downloaded', 'ready', 'local', 'installed'].includes(status)) return true;
+  return Array.isArray(value.labels) && value.labels.some((label: unknown) => ['downloaded', 'ready', 'local', 'installed'].includes(String(label).toLowerCase()));
+}
+
+export function routerDependencies(model: ModelInfo | null | undefined): Array<{ name: string; roles: RouterDependencyRole[] }> {
+  if (!isRouterModelInfo(model)) return [];
+  const value = model as any;
+  const routing = record(value.routing) || {};
+  const roles = new Map<string, { name: string; roles: Set<RouterDependencyRole> }>();
+  const add = (raw: unknown, role: RouterDependencyRole) => {
+    const name = String(raw || '').trim();
+    if (!name) return;
+    const key = name.toLowerCase();
+    const current = roles.get(key) || { name, roles: new Set<RouterDependencyRole>() };
+    current.roles.add(role);
+    roles.set(key, current);
+  };
+
+  (Array.isArray(value.components) ? value.components : []).forEach((name: unknown) => add(name, 'component'));
+  (Array.isArray(routing.candidates) ? routing.candidates : []).forEach((name: unknown) => add(name, 'candidate'));
+  add(routing.default_model, 'default');
+  add(record(routing.router)?.model, 'llm-router');
+  (Array.isArray(routing.classifiers) ? routing.classifiers : []).forEach((item: unknown) => add(record(item)?.model, 'classifier'));
+
+  return [...roles.values()].map(item => ({ name: item.name, roles: [...item.roles] }));
+}
+
+export function preflightRouter(
+  model: ModelInfo | null | undefined,
+  availableModels: readonly ModelInfo[],
+  loadedModels: readonly LoadedModel[] = [],
+): RouterPreflightResult {
+  if (!isRouterModelInfo(model)) return { ok: true, errors: [], warnings: [], dependencies: [] };
+  const value = model as any;
+  const routing = record(value.routing);
+  const errors: string[] = [];
+  const warnings: string[] = [];
+  const candidates = routing && Array.isArray(routing.candidates) ? routing.candidates.map(String).map(v => v.trim()).filter(Boolean) : [];
+  const defaultModel = String(routing?.default_model || '').trim();
+  const routerBlock = record(routing?.router);
+  const rules = routing && Array.isArray(routing.rules) ? routing.rules : [];
+  const classifiers = routing && Array.isArray(routing.classifiers) ? routing.classifiers : [];
+  if (!routing) errors.push('Router routing policy is missing.');
+  if (candidates.length === 0) errors.push('Router has no candidate models.');
+  if (!defaultModel) errors.push('Router has no default model.');
+  if (defaultModel && candidates.length > 0 && !candidates.some(name => name.toLowerCase() === defaultModel.toLowerCase())) {
+    errors.push(`Default model ${defaultModel} is not in routing.candidates.`);
+  }
+  if (routerBlock) {
+    if (String(routerBlock.type || '').trim().toLowerCase() !== 'llm') errors.push('routing.router.type must be "llm".');
+    if (!String(routerBlock.model || '').trim()) errors.push('LLM Router helper model is missing.');
+    if (rules.length > 0 || classifiers.length > 0) errors.push('routing.router cannot be combined with routing.rules or routing.classifiers.');
+  } else if (routing && rules.length === 0) {
+    errors.push('Rule Router has no routing.rules.');
+  }
+  for (const rawRule of rules) {
+    const rule = record(rawRule);
+    const target = String(rule?.route_to || '').trim();
+    if (!target) errors.push('A Router rule is missing route_to.');
+    else if (!candidates.some(name => name.toLowerCase() === target.toLowerCase())) errors.push(`Rule target ${target} is not in routing.candidates.`);
+  }
+
+  const available = new Map<string, ModelInfo>();
+  availableModels.forEach(item => {
+    const name = routerModelName(item);
+    if (name) available.set(name.toLowerCase(), item);
+  });
+  const loaded = new Set(loadedModels.map(item => routerModelName(item).toLowerCase()).filter(Boolean));
+  const components = new Set((Array.isArray(value.components) ? value.components : []).map((item: unknown) => String(item).trim().toLowerCase()).filter(Boolean));
+
+  const dependencies = routerDependencies(model).map(dep => {
+    const found = available.get(dep.name.toLowerCase()) || null;
+    const status: RouterDependencyStatus = {
+      ...dep,
+      present: !!found,
+      downloaded: isDownloaded(found),
+      loaded: loaded.has(dep.name.toLowerCase()),
+      recipe: found ? String((found as any).recipe || '') || undefined : undefined,
+    };
+    if (!found) errors.push(`Referenced ${dep.roles.join('/')} model ${dep.name} is not present in the Lemonade model registry.`);
+    if (dep.roles.some(role => role !== 'component') && !components.has(dep.name.toLowerCase())) {
+      errors.push(`Referenced ${dep.roles.filter(role => role !== 'component').join('/')} model ${dep.name} is missing from Router components.`);
+    }
+    const foundRecipe = String((found as any)?.recipe || '').toLowerCase();
+    if (found && !status.downloaded && foundRecipe !== 'cloud' && !foundRecipe.startsWith('cloud.')) {
+      errors.push(`${dep.name} is referenced by the Router but is not downloaded/local. Download or register it before using this Router.`);
+    }
+    return status;
+  });
+
+  return { ok: errors.length === 0, errors: [...new Set(errors)], warnings: [...new Set(warnings)], dependencies };
+}
+
+export function routerPreflightError(result: RouterPreflightResult): string {
+  if (result.ok) return '';
+  return `Router is not ready: ${result.errors.join(' ')}`;
+}

--- a/src/app/src/hooks/useChatStreaming.ts
+++ b/src/app/src/hooks/useChatStreaming.ts
@@ -49,8 +49,8 @@ function summarizeResult(toolName: string, data: Record<string, unknown>): strin
       return 'Model inventory retrieved';
     }
     case 'get_model_info': return `${(data as any).display_name || (data as any).name || (data as any).id || 'model'}: ${((data as any).recipes || []).length} recipe(s)`;
-    case 'load_model': return 'Model loaded';
-    case 'unload_model': return 'Model unloaded';
+    case 'load_model': return (data as any).mode === 'router' ? 'Router ready' : 'Model loaded';
+    case 'unload_model': return (data as any).mode === 'router' ? 'Router has no runtime to unload' : 'Model unloaded';
     case 'get_loaded_models': {
       const loaded = (data as any).loaded;
       return Array.isArray(loaded) ? `${loaded.length} model(s) loaded` : JSON.stringify(data).slice(0, 80);

--- a/src/app/src/tools/lemonadeTools.ts
+++ b/src/app/src/tools/lemonadeTools.ts
@@ -5,6 +5,8 @@
 import api, { searchHuggingFace, HFModelResult, PullVariantsResult } from '../api';
 import { getCollectionComponents, isCollectionModel } from '../features/collections/collectionModels';
 import { capabilityFromLoaded, deploymentKindFromLabels, modelStructure } from '../modelCapabilities';
+import { routerRegistrationOptions } from '../features/router/routerStore';
+import { preflightRouter, routerPreflightError } from '../features/router/routerRuntime';
 
 /* ── Tool schemas (OpenAI function calling format) ─────────────── */
 
@@ -28,7 +30,7 @@ export const LEMONADE_TOOLS: ToolFunction[] = [
         properties: {
           query: { type: 'string', description: 'Optional case-insensitive model-name filter. Use when the user mentions a model family/name such as Flux, Gemma, Qwen, Llama, Whisper, or SD.' },
           status: { type: 'string', enum: ['local', 'loaded', 'downloaded', 'registry', 'all'], description: 'Which models to return. Default: local. Use registry/all only when the user explicitly asks what can be downloaded.' },
-          capability: { type: 'string', description: 'Optional capability filter: chat, image, audio/transcription, audio-generation, tts, model3d, embedding, reranking, omni.' },
+          capability: { type: 'string', description: 'Optional capability/mode filter: chat, router, image, audio/transcription, audio-generation, tts, model3d, embedding, reranking, omni. Router models are chat-capable but can be selected explicitly with router.' },
           limit: { type: 'number', description: 'Maximum returned items per section. Default 30.' },
         },
         required: [],
@@ -39,7 +41,7 @@ export const LEMONADE_TOOLS: ToolFunction[] = [
     type: 'function',
     function: {
       name: 'get_model_info',
-      description: 'Get detailed info about one specific model: downloaded state, labels/capability, size, context window, checkpoint, and available recipes/backends. Use this for any user question about a named model and before load_model when recipe/device is unclear. Do not answer a named-model question from list_models alone.',
+      description: 'Get detailed info about one specific model: downloaded state, labels/capability, size, context window, checkpoint, available recipes/backends, and Router routing metadata when recipe=collection.router. Use this for any user question about a named model and before load_model when recipe/device is unclear. Do not answer a named-model question from list_models alone.',
       parameters: {
         type: 'object',
         properties: {
@@ -53,7 +55,7 @@ export const LEMONADE_TOOLS: ToolFunction[] = [
     type: 'function',
     function: {
       name: 'load_model',
-      description: 'Load a downloaded/local model into the server for inference. A recipe defines the inference backend: llamacpp (GPU/CPU via llama.cpp — backends: vulkan, rocm, metal, cpu), flm (NPU via FastFlowLM), ryzenai-llm (hybrid NPU). Combined forms like "llamacpp-vulkan" or "llamacpp-cpu" select a backend. If the user asks for CPU, pass backend/device=cpu. If multiple recipes are available and the user did not choose, call get_model_info and ask_question first.',
+      description: 'Load a downloaded/local model into the server for inference. A recipe defines the inference backend: llamacpp (GPU/CPU via llama.cpp — backends: vulkan, rocm, metal, cpu), flm (NPU via FastFlowLM), ryzenai-llm (hybrid NPU). Combined forms like "llamacpp-vulkan" or "llamacpp-cpu" select a backend. Router models (recipe=collection.router) are virtual orchestration policies: load_model validates/registers them for use but never starts a backend process for the Router itself. Do not assign a backend/device to the Router. If the user asks for CPU, pass backend/device=cpu for ordinary models. If multiple recipes are available and the user did not choose, call get_model_info and ask_question first.',
       parameters: {
         type: 'object',
         properties: {
@@ -102,7 +104,7 @@ export const LEMONADE_TOOLS: ToolFunction[] = [
     type: 'function',
     function: {
       name: 'pull_model',
-      description: 'Download a model to local storage. First try Lemonade registry names; if no registry match exists, this tool can search Hugging Face GGUF checkpoints and download one when a checkpoint/variant is specified or one clear option exists. Use ask_question if several registry or Hugging Face variants are returned as choices. Models must be pulled before load_model can run.',
+      description: 'Download a model artifact to local storage. First try Lemonade registry names; if no registry match exists, this tool can search Hugging Face GGUF checkpoints and download one when a checkpoint/variant is specified or one clear option exists. Router definitions (recipe=collection.router) are registered configurations, not downloadable model artifacts, so inspect them with get_model_info instead. Use ask_question if several registry or Hugging Face variants are returned as choices. Models must be pulled before load_model can run.',
       parameters: {
         type: 'object',
         properties: {
@@ -121,7 +123,7 @@ export const LEMONADE_TOOLS: ToolFunction[] = [
     type: 'function',
     function: {
       name: 'delete_model',
-      description: 'Delete a downloaded model from local storage, freeing disk space.',
+      description: 'Delete a downloaded model from local storage, freeing disk space. For collection types like Router only registered definition is removed.',
       parameters: {
         type: 'object',
         properties: {
@@ -228,8 +230,36 @@ function lowerLabels(model: AnyModel | null | undefined): string[] {
   return Array.isArray(model?.labels) ? model.labels.map((label: unknown) => String(label).toLowerCase()) : [];
 }
 
+function isRouterModel(model: AnyModel | null | undefined): boolean {
+  return !!model && modelStructure(asString(model.recipe)) === 'router';
+}
+
+function withLocalRouterModels(models: AnyModel[]): AnyModel[] {
+  // Current GUI3 stores Router definitions in lemond; api.models(true) is the source of truth.
+  return models;
+}
+
+function routerRoutingSummary(model: AnyModel | null | undefined): Record<string, unknown> | undefined {
+  if (!isRouterModel(model) || !model?.routing || typeof model.routing !== 'object' || Array.isArray(model.routing)) return undefined;
+  const routing = model.routing as Record<string, any>;
+  const candidates = Array.isArray(routing.candidates) ? routing.candidates.map((item: unknown) => String(item)).filter(Boolean) : [];
+  const llmRouter = routing.router && typeof routing.router === 'object' && !Array.isArray(routing.router)
+    ? routing.router as Record<string, unknown>
+    : null;
+  return {
+    mode: llmRouter ? 'llm' : 'rules',
+    candidates,
+    default_model: asString(routing.default_model) || undefined,
+    llm_router_model: llmRouter ? asString(llmRouter.model) || undefined : undefined,
+    classifier_count: Array.isArray(routing.classifiers) ? routing.classifiers.length : 0,
+    rule_count: Array.isArray(routing.rules) ? routing.rules.length : 0,
+  };
+}
+
 function isDownloaded(model: AnyModel | null | undefined): boolean {
   if (!model) return false;
+  // A Router is a server-registered virtual definition, so local availability does not depend on a weights artifact.
+  if (isRouterModel(model)) return true;
   if (model.downloaded === true) return true;
   return lowerLabels(model).some(label => ['downloaded', 'local', 'installed', 'ready'].includes(label));
 }
@@ -253,6 +283,7 @@ function recipeNames(model: AnyModel | null | undefined): string[] {
 
 function normalizeCapabilityFilter(value: unknown): string {
   const raw = asString(value).toLowerCase();
+  if (['router', 'routing'].includes(raw)) return 'router';
   if (['audio/transcription', 'transcription', 'stt', 'asr', 'speech-to-text'].includes(raw)) return 'audio';
   if (['music', 'sfx', 'music-and-sfx', 'music & sfx', 'audio_generation'].includes(raw)) return 'audio-generation';
   if (['3d', '3d-generation', 'image-to-3d'].includes(raw)) return 'model3d';
@@ -288,6 +319,8 @@ function modelSummary(model: AnyModel, loaded?: AnyLoadedModel | null): Record<s
     name: displayName(model),
     status: loaded ? 'loaded' : (isDownloaded(model) ? 'downloaded' : 'registry'),
     capability: capabilityForModel(model),
+    deployment_capability: isRouterModel(model) ? 'chat' : capabilityForModel(model),
+    mode: isRouterModel(model) ? 'router' : undefined,
     size: formatSize(model.size) || model.size,
     recipe: asString(model.recipe) || undefined,
     recipes: recipeNames(model),
@@ -567,17 +600,22 @@ export async function executeTool(call: ToolCall): Promise<ToolResult> {
         const status = (asString(args.status) || 'local').toLowerCase();
         const capability = normalizeCapabilityFilter(args.capability);
         const limit = Math.max(1, Math.min(100, Math.round(asNumber(args.limit) || 30)));
-        const all = (data.data as AnyModel[]).filter(model => {
-          if (!includesQuery(model, query)) return false;
-          if (capability && capabilityForModel(model) !== capability) return false;
-          return true;
-        });
+        const registryModels = withLocalRouterModels(data.data as AnyModel[]);
+        const matchesCapability = (model: AnyModel): boolean => !capability
+          || (capability === 'router'
+            ? isRouterModel(model)
+            : capability === 'chat'
+              ? (capabilityForModel(model) === 'chat' || isRouterModel(model))
+              : capabilityForModel(model) === capability);
+        const all = registryModels.filter(model => includesQuery(model, query) && matchesCapability(model));
         const loadedItems = loaded
-          .filter(model => !query || asString(model.model_name).toLowerCase().includes(query.toLowerCase()))
           .map(model => {
-            const registry = all.find(info => modelName(info).toLowerCase() === asString(model.model_name).toLowerCase());
-            return modelSummary(registry || { id: model.model_name, name: model.model_name, recipe: model.recipe, type: model.type }, model);
-          });
+            const registry = registryModels.find(info => modelName(info).toLowerCase() === asString(model.model_name).toLowerCase());
+            const info = registry || { id: model.model_name, name: model.model_name, recipe: model.recipe, type: model.type };
+            return { model, info };
+          })
+          .filter(({ info }) => includesQuery(info, query) && matchesCapability(info))
+          .map(({ model, info }) => modelSummary(info, model));
         const downloaded = all.filter(model => !loadedNames.has(modelName(model).toLowerCase()) && isDownloaded(model)).map(model => modelSummary(model));
         const registry = all.filter(model => !loadedNames.has(modelName(model).toLowerCase()) && !isDownloaded(model)).map(model => modelSummary(model));
         const wanted = status === 'loaded' ? { loaded: loadedItems.slice(0, limit) }
@@ -590,7 +628,7 @@ export async function executeTool(call: ToolCall): Promise<ToolResult> {
           query: query || undefined,
           capability: capability || undefined,
           counts: {
-            total_registry_known: data.data.length,
+            total_registry_known: registryModels.length,
             matching_total: all.length,
             loaded: loadedItems.length,
             downloaded: downloaded.length,
@@ -613,10 +651,11 @@ export async function executeTool(call: ToolCall): Promise<ToolResult> {
         const data = await api.models(true);
         const health = await api.health().catch(() => null);
         const loaded = health?.all_models_loaded || [];
-        const resolved = resolveModel(data.data as AnyModel[], loaded, args.model_name);
+        const registryModels = withLocalRouterModels(data.data as AnyModel[]);
+        const resolved = resolveModel(registryModels, loaded, args.model_name);
         if (!resolved) {
           const requested = asString(args.model_name);
-          const matches = registryMatches(data.data as AnyModel[], loaded, requested).slice(0, 8);
+          const matches = registryMatches(registryModels, loaded, requested).slice(0, 8);
           const result = {
             error: `Model not found: ${requested || '(missing model_name)'}`,
             suggestions: matches.map(model => modelSummary(model, loadedFor(model, loaded))),
@@ -624,13 +663,13 @@ export async function executeTool(call: ToolCall): Promise<ToolResult> {
           };
           return toolPayload(call, result, matches.length ? `Model not found exactly. Suggestions:\n${modelChoiceLines(matches, loaded).join('\n')}` : 'Model not found', true);
         }
-        const detail = await api.modelDetail(modelName(resolved)).catch(() => resolved);
+        const detail = await api.modelDetail(modelName(resolved)).catch(() => resolved) || resolved;
         const loadedItem = loadedFor(resolved, loaded);
         const summary = modelSummary(detail as AnyModel, loadedItem);
         const detailComponentNames = getCollectionComponents(detail as any);
         const componentNames = detailComponentNames.length > 0 ? detailComponentNames : getCollectionComponents(resolved as any);
         const componentSummaries: Array<Record<string, unknown>> = await Promise.all(componentNames.map(async componentName => {
-          const component = resolveModel(data.data as AnyModel[], loaded, componentName);
+          const component = resolveModel(registryModels, loaded, componentName);
           const componentLoaded = component
             ? loadedFor(component, loaded)
             : loaded.find(item => asString(item.model_name).toLowerCase() === componentName.toLowerCase()) || null;
@@ -644,6 +683,10 @@ export async function executeTool(call: ToolCall): Promise<ToolResult> {
           };
         }));
         const componentCapabilities = Array.from(new Set(componentSummaries.map(component => String(component.capability || '')).filter(Boolean)));
+        const routerModel = isRouterModel(detail as AnyModel) || isRouterModel(resolved);
+        const router = routerRoutingSummary(detail as AnyModel) || routerRoutingSummary(resolved);
+        const routerSource = isRouterModel(detail as AnyModel) && (detail as AnyModel).routing ? detail : resolved;
+        const routerPreflight = routerModel ? preflightRouter(routerSource as any, registryModels as any, loaded as any) : undefined;
         const result = {
           ...summary,
           raw_name: modelName(detail as AnyModel),
@@ -652,6 +695,9 @@ export async function executeTool(call: ToolCall): Promise<ToolResult> {
           checkpoint: (detail as AnyModel).checkpoint,
           context_window: (detail as AnyModel).max_context_window || (detail as AnyModel).context_length || (detail as AnyModel).n_ctx,
           recipe_options: extractRecipeBackendOptions(detail as AnyModel),
+          is_router: Boolean(routerModel),
+          router,
+          router_preflight: routerPreflight,
           is_collection: isCollectionModel(detail as any) || componentSummaries.length > 0,
           collection_components: componentSummaries.length > 0 ? componentSummaries : undefined,
           collection_capabilities: componentCapabilities.length > 0 ? componentCapabilities : undefined,
@@ -674,27 +720,67 @@ export async function executeTool(call: ToolCall): Promise<ToolResult> {
         const data = await api.models(true).catch(() => ({ data: [] as AnyModel[] }));
         const health = await api.health().catch(() => null);
         const loaded = health?.all_models_loaded || [];
-        const resolved = resolveModel(data.data as AnyModel[], loaded, args.model_name);
+        const registryModels = withLocalRouterModels(data.data as AnyModel[]);
+        const resolved = resolveModel(registryModels, loaded, args.model_name);
         const targetModelName = resolved ? modelName(resolved) : asString(args.model_name);
         if (!targetModelName) {
           return toolPayload(call, { error: 'Missing model_name. Use list_models with a query to resolve a downloaded model first.' }, 'Error: missing model name', true);
         }
+        if (isRouterModel(resolved)) {
+          const serverHasRouter = (data.data as AnyModel[]).some(model => modelName(model).toLowerCase() === targetModelName.toLowerCase());
+          if (!serverHasRouter) {
+            const registration = routerRegistrationOptions(resolved as any);
+            if (!registration) {
+              return toolPayload(call, { error: 'Router definition is incomplete and cannot be registered.', model: targetModelName, mode: 'router' }, 'Router definition is incomplete', true);
+            }
+            await api.registerModelDefinition(targetModelName, registration);
+          }
+          const fresh = await api.models(true).catch(() => data);
+          const available = withLocalRouterModels(fresh.data as AnyModel[]);
+          const preflight = preflightRouter(resolved as any, available as any, loaded as any);
+          if (!preflight.ok) {
+            const message = routerPreflightError(preflight);
+            return toolPayload(call, { error: message, status: 'blocked', model: targetModelName, mode: 'router', dependencies: preflight.dependencies, warnings: preflight.warnings }, message, true);
+          }
+          const ignored = (args.recipe || args.backend || args.device || args.n_ctx || args.n_gpu_layers)
+            ? { recipe: args.recipe, backend: args.backend || args.device, n_ctx: args.n_ctx, n_gpu_layers: args.n_gpu_layers }
+            : undefined;
+          return toolPayload(call, {
+            status: 'ready',
+            model: targetModelName,
+            mode: 'router',
+            virtual: true,
+            dependencies: preflight.dependencies,
+            warnings: preflight.warnings,
+            ignored_router_options: ignored,
+            answer_instruction: 'Tell the user the Router is registered and ready. It is a virtual policy and is invoked by using its model name in chat; no Router backend process was loaded. If a routed request later fails, inspect the named candidate/classifier/helper model.',
+          }, `Router ${targetModelName} is ready`);
+        }
+
         const opts: Record<string, unknown> = {};
+        const routerModel = isRouterModel(resolved);
         const recipeArg = typeof args.recipe === 'string' ? args.recipe.trim().toLowerCase() : '';
         const backendArg = typeof args.backend === 'string' ? args.backend.trim().toLowerCase()
           : (typeof args.device === 'string' ? args.device.trim().toLowerCase() : '');
         let recipe = recipeArg === 'sd_cpp' ? 'sd-cpp' : recipeArg === 'ryzenai_llm' ? 'ryzenai-llm' : recipeArg;
         let backend = backendArg;
 
-        const llamacppMatch = /^llamacpp[-_:](cpu|vulkan|rocm|metal|cuda|gpu)$/i.exec(recipeArg);
+        // Router is an orchestration recipe. Backend/device/context tuning belongs
+        // to the candidate models selected by the Router, not to the Router itself.
+        if (routerModel) {
+          recipe = '';
+          backend = '';
+        }
+
+        const llamacppMatch = !routerModel ? /^llamacpp[-_:](cpu|vulkan|rocm|metal|cuda|gpu)$/i.exec(recipeArg) : null;
         if (llamacppMatch) {
           recipe = 'llamacpp';
           backend = llamacppMatch[1].toLowerCase();
         }
-        if (backend === 'gpu' && (!recipe || recipe === 'llamacpp')) backend = 'vulkan';
+        if (!routerModel && backend === 'gpu' && (!recipe || recipe === 'llamacpp')) backend = 'vulkan';
 
-        if (recipe) opts.recipe = recipe;
-        if (backend) {
+        if (!routerModel && recipe) opts.recipe = recipe;
+        if (!routerModel && backend) {
           if (recipe === 'llamacpp' || !recipe) {
             opts.llamacpp_backend = backend;
             if (backend === 'cpu') opts.llamacpp_device = 'cpu';
@@ -716,21 +802,37 @@ export async function executeTool(call: ToolCall): Promise<ToolResult> {
             opts.trellis_backend = backend;
           }
         }
-        if (args.n_ctx) opts.n_ctx = args.n_ctx;
-        if (args.n_gpu_layers) opts.n_gpu_layers = args.n_gpu_layers;
+        if (!routerModel && args.n_ctx) opts.n_ctx = args.n_ctx;
+        if (!routerModel && args.n_gpu_layers) opts.n_gpu_layers = args.n_gpu_layers;
         const response = await api.loadModel(targetModelName, Object.keys(opts).length > 0 ? opts : undefined, resolved as any || null);
         const result = {
           status: 'loaded',
           model: targetModelName,
+          mode: routerModel ? 'router' : undefined,
           options: opts,
+          ignored_router_options: routerModel && (recipeArg || backendArg || args.n_ctx || args.n_gpu_layers)
+            ? { recipe: recipeArg || undefined, backend: backendArg || undefined, n_ctx: args.n_ctx, n_gpu_layers: args.n_gpu_layers }
+            : undefined,
           response,
-          answer_instruction: 'Tell the user the model was loaded, including the model name and selected recipe/backend if any.',
+          answer_instruction: routerModel
+            ? 'Tell the user the Router was loaded/selected. Explain that backend/device options do not apply to the Router itself; routing chooses candidate models per request.'
+            : 'Tell the user the model was loaded, including the model name and selected recipe/backend if any.',
         };
-        return toolPayload(call, result, `Loaded ${targetModelName}${Object.keys(opts).length ? ` with ${shortJson(opts, 120)}` : ''}`);
+        return toolPayload(call, result, routerModel
+          ? `Loaded Router ${targetModelName}`
+          : `Loaded ${targetModelName}${Object.keys(opts).length ? ` with ${shortJson(opts, 120)}` : ''}`);
       }
 
       case 'unload_model': {
         const requested = asString(args.model_name) || undefined;
+        if (requested) {
+          const data = await api.models(true).catch(() => ({ data: [] as AnyModel[] }));
+          const resolved = resolveModel(withLocalRouterModels(data.data as AnyModel[]), [], requested);
+          if (isRouterModel(resolved)) {
+            const result = { status: 'not_applicable', model: requested, mode: 'router', virtual: true, answer_instruction: 'Explain that a Router is a virtual routing policy and has no backend process of its own to unload. Candidate models may be unloaded separately.' };
+            return toolPayload(call, result, `Router ${requested} has no runtime process to unload`);
+          }
+        }
         const response = await api.unloadModel(requested);
         const result = { status: 'unloaded', model: requested || 'most recently used model', response, answer_instruction: 'Tell the user which model was unloaded.' };
         return toolPayload(call, result, `Unloaded ${requested || 'most recently used model'}`);
@@ -761,7 +863,7 @@ export async function executeTool(call: ToolCall): Promise<ToolResult> {
           status: h.status,
           version: h.version,
           loaded_models: h.all_models_loaded.length,
-          loaded: h.all_models_loaded.map(m => ({ model: m.model_name, recipe: m.recipe, device: m.device, type: m.type })),
+          loaded: h.all_models_loaded.map(m => ({ model: m.model_name, recipe: m.recipe, device: m.device, type: m.type, mode: isRouterModel(m as AnyModel) ? 'router' : undefined })),
           max_models: h.max_models,
           answer_instruction: 'Summarize server status/version, loaded model count/names, and resource limits.',
         };
@@ -831,7 +933,8 @@ export async function executeTool(call: ToolCall): Promise<ToolResult> {
         const data = await api.models(true);
         const health = await api.health().catch(() => null);
         const loaded = health?.all_models_loaded || [];
-        const matches = registryMatches(data.data as AnyModel[], loaded, requested || query);
+        const registryModels = withLocalRouterModels(data.data as AnyModel[]);
+        const matches = registryMatches(registryModels, loaded, requested || query);
         if (matches.length > 1) {
           const choices = matches.slice(0, 8).map(model => modelName(model));
           const result = {
@@ -846,6 +949,15 @@ export async function executeTool(call: ToolCall): Promise<ToolResult> {
         }
         if (matches.length === 1) {
           const target = modelName(matches[0]);
+          if (isRouterModel(matches[0])) {
+            const result = {
+              error: `${target} is a registered Router definition, not a downloadable model artifact.`,
+              model: target,
+              mode: 'router',
+              answer_instruction: 'Tell the user this Router is already a registered configuration. Use get_model_info to inspect it or load_model to use it; do not try to download it.',
+            };
+            return toolPayload(call, result, `${target} is a Router definition; nothing to download.`, true);
+          }
           const pullResult = await pullWithProgress(target);
           const result = {
             status: 'downloaded',
@@ -877,9 +989,21 @@ export async function executeTool(call: ToolCall): Promise<ToolResult> {
       case 'delete_model': {
         const requested = asString(args.model_name);
         if (!requested) return toolPayload(call, { error: 'Missing model_name.' }, 'Error: missing model name', true);
+        const data = await api.models(true).catch(() => ({ data: [] as AnyModel[] }));
+        const health = await api.health().catch(() => null);
+        const resolved = resolveModel(data.data as AnyModel[], health?.all_models_loaded || [], requested);
+        const routerModel = isRouterModel(resolved);
         const response = await api.deleteModel(requested);
-        const result = { status: 'deleted', model: requested, response, answer_instruction: 'Tell the user the model was deleted from local storage.' };
-        return toolPayload(call, result, `Deleted ${requested}`);
+        const result = {
+          status: 'deleted',
+          model: requested,
+          mode: routerModel ? 'router' : undefined,
+          response,
+          answer_instruction: routerModel
+            ? 'Tell the user the registered Router definition was deleted. There was no Router runtime process or downloadable Router artifact to remove.'
+            : 'Tell the user the model was deleted from local storage.',
+        };
+        return toolPayload(call, result, `Deleted ${routerModel ? 'Router ' : ''}${requested}`);
       }
 
       case 'get_system_info': {

--- a/src/app/src/tools/mcpRuntime.ts
+++ b/src/app/src/tools/mcpRuntime.ts
@@ -532,7 +532,8 @@ function buildLemonadeRuntime(
     tools,
     systemPrompt: [
       'The Lemon-Tools MCP server controls local models and multimodal backends.',
-      'Use management tools for models, recipes, hardware, downloads, and health.',
+      'Use management tools for models, recipes, hardware, downloads, health, and Router models.',
+      'Router models use recipe=collection.router and are virtual Chat orchestration policies. Inspect them with get_model_info, list them with capability=router when useful, and never assign a backend/device to or expect a loaded runtime process for the Router itself. load_model validates/registers Router readiness; actual dispatch happens when chat/completions uses the Router model name.',
       'Use generate_image/edit_image for images, generate_audio for music or sound, text_to_speech for speech, and transcribe_audio for attached audio.',
       'For text-to-3D call generate_3d with prompt: it MUST generate the reference image first and then reconstruct that image as a GLB. For image-to-3D pass or reuse the attached image.',
       'Do not invent local model names; use list_models/get_model_info when model selection is unclear.',

--- a/src/app/tests/fixtures/mcp-runtime-entry.ts
+++ b/src/app/tests/fixtures/mcp-runtime-entry.ts
@@ -47,13 +47,39 @@ async function main(): Promise<void> {
     { id: 'image-edit-model', name: 'image-edit-model', downloaded: true, labels: ['image', 'image-edit'], recipe: 'sd-cpp' },
     { id: 'remote-image-model', name: 'remote-image-model', downloaded: false, labels: ['image'], recipe: 'sd-cpp' },
     { id: '3d-model', name: '3d-model', downloaded: true, labels: ['3d'], recipe: 'trellis' },
+    { id: 'fast-chat', name: 'fast-chat', downloaded: true, labels: ['chat'], recipe: 'llamacpp', type: 'chat' },
+    { id: 'smart-chat', name: 'smart-chat', downloaded: true, labels: ['chat'], recipe: 'llamacpp', type: 'chat' },
+    {
+      id: 'user.router', name: 'user.router', display_name: 'Test Router', downloaded: true, labels: ['custom', 'router', 'chat'],
+      recipe: 'collection.router', type: 'chat', components: ['fast-chat', 'smart-chat'],
+      routing: {
+        candidates: ['fast-chat', 'smart-chat'],
+        default_model: 'smart-chat',
+        rules: [{ route_to: 'fast-chat', match: { max_chars: 300 } }],
+      },
+    },
   ];
   Object.defineProperty(api, 'loadedModels', { configurable: true, get: () => [] });
   Object.defineProperty(api, 'allModels', { configurable: true, get: () => modelInfos });
-  (api as any).health = async () => ({ status: 'ok', version: 'test', all_models_loaded: [] });
+  (api as any).health = async () => ({ status: 'ok', version: 'test', all_models_loaded: [{ model_name: 'image-model', recipe: 'sd-cpp', type: 'image', device: 'gpu' }] });
   (api as any).models = async () => ({ data: modelInfos });
+  (api as any).modelDetail = async (name: string) => modelInfos.find(model => model.id === name || model.name === name) || { id: name, name };
   const calls: string[] = [];
-  (api as any).loadModel = async (name: string) => { calls.push(`load:${name}`); };
+  const loadRequests: Array<{ name: string; options?: Record<string, unknown> }> = [];
+  const unloadRequests: string[] = [];
+  const registrationRequests: Array<{ name: string; options?: Record<string, unknown> }> = [];
+  (api as any).loadModel = async (name: string, options?: Record<string, unknown>) => {
+    calls.push(`load:${name}`);
+    loadRequests.push({ name, options });
+  };
+  (api as any).unloadModel = async (name?: string) => {
+    unloadRequests.push(name || '');
+    return { unloaded: name };
+  };
+  (api as any).registerModelDefinition = async (name: string, options?: Record<string, unknown>) => {
+    registrationRequests.push({ name, options });
+    return { registered: name };
+  };
   (api as any).imageGeneration = async (name: string, prompt: string) => {
     calls.push(`image:${name}`);
     assert.match(prompt, /studio lighting/);
@@ -67,10 +93,93 @@ async function main(): Promise<void> {
 
   const lemonade = await buildSelectedMcpRuntime(['lemonade']);
   assert.ok(lemonade);
+  assert.match(lemonade!.systemPrompt || '', /collection\.router/, 'builtin Lemonade guidance must explain Router semantics');
+
+  const routerList = await lemonade!.execute({
+    id: 'call-router-list', type: 'function',
+    function: { name: 'list_models', arguments: JSON.stringify({ capability: 'router', status: 'local' }) },
+  });
+  assert.notEqual(routerList.error, true);
+  const routerListData = JSON.parse(routerList.content);
+  assert.deepEqual(routerListData.loaded, []);
+  assert.deepEqual(routerListData.downloaded.map((model: any) => model.id), ['user.router']);
+  assert.equal(routerListData.downloaded[0].capability, 'router');
+  assert.equal(routerListData.downloaded[0].deployment_capability, 'chat');
+  assert.equal(routerListData.downloaded[0].mode, 'router');
+
+  const chatList = await lemonade!.execute({
+    id: 'call-chat-list', type: 'function',
+    function: { name: 'list_models', arguments: JSON.stringify({ capability: 'chat', status: 'local' }) },
+  });
+  const chatListData = JSON.parse(chatList.content);
+  assert.deepEqual(chatListData.loaded, [], 'loaded models from other capabilities must not leak through the filter');
+  const routerInChat = chatListData.downloaded.find((model: any) => model.id === 'user.router');
+  assert.equal(routerInChat?.deployment_capability, 'chat', 'Router must remain deployable through chat while retaining Router identity');
+  assert.ok(chatListData.downloaded.filter((model: any) => model.id !== 'user.router').every((model: any) => model.capability === 'chat'), 'chat filtering must not leak unrelated modes');
+
+  const routerInfo = await lemonade!.execute({
+    id: 'call-router-info', type: 'function',
+    function: { name: 'get_model_info', arguments: JSON.stringify({ model_name: 'user.router' }) },
+  });
+  const routerInfoData = JSON.parse(routerInfo.content);
+  assert.equal(routerInfoData.is_router, true);
+  assert.equal(routerInfoData.capability, 'router');
+  assert.equal(routerInfoData.deployment_capability, 'chat');
+  assert.equal(routerInfoData.mode, 'router');
+  assert.equal(routerInfoData.router.mode, 'rules');
+  assert.equal(routerInfoData.router.default_model, 'smart-chat');
+  assert.deepEqual(routerInfoData.router.candidates, ['fast-chat', 'smart-chat']);
+
+  const routerLoad = await lemonade!.execute({
+    id: 'call-router-load', type: 'function',
+    function: { name: 'load_model', arguments: JSON.stringify({ model_name: 'user.router', recipe: 'llamacpp-cpu', backend: 'cpu', n_ctx: 8192 }) },
+  });
+  const routerLoadData = JSON.parse(routerLoad.content);
+  assert.notEqual(routerLoad.error, true);
+  assert.equal(routerLoadData.mode, 'router');
+  assert.equal(routerLoadData.status, 'ready');
+  assert.equal(routerLoadData.virtual, true);
+  assert.equal(loadRequests.some(request => request.name === 'user.router'), false, 'Router readiness must never POST /load for collection.router');
+  assert.equal(routerLoadData.ignored_router_options.backend, 'cpu');
+  assert.ok(Array.isArray(routerLoadData.dependencies));
+  assert.ok(routerLoadData.dependencies.some((dependency: any) => dependency.name === 'fast-chat' && dependency.present));
+
+  const routerUnload = await lemonade!.execute({
+    id: 'call-router-unload', type: 'function',
+    function: { name: 'unload_model', arguments: JSON.stringify({ model_name: 'user.router' }) },
+  });
+  const routerUnloadData = JSON.parse(routerUnload.content);
+  assert.notEqual(routerUnload.error, true);
+  assert.equal(routerUnloadData.status, 'not_applicable');
+  assert.equal(routerUnloadData.mode, 'router');
+  assert.equal(unloadRequests.length, 0, 'Router unload must not call the runtime unload endpoint');
+
+  const routerPull = await lemonade!.execute({
+    id: 'call-router-pull', type: 'function',
+    function: { name: 'pull_model', arguments: JSON.stringify({ model_name: 'user.router' }) },
+  });
+  assert.equal(routerPull.error, true);
+  assert.match(routerPull.content, /registered Router definition/);
+
+  let deletedModel = '';
+  (api as any).deleteModel = async (name: string) => {
+    deletedModel = name;
+    return { deleted: name };
+  };
+  const routerDelete = await lemonade!.execute({
+    id: 'call-router-delete', type: 'function',
+    function: { name: 'delete_model', arguments: JSON.stringify({ model_name: 'user.router' }) },
+  });
+  const routerDeleteData = JSON.parse(routerDelete.content);
+  assert.notEqual(routerDelete.error, true);
+  assert.equal(routerDeleteData.mode, 'router');
+  assert.equal(deletedModel, 'user.router', 'Router deletion must call the server definition delete endpoint');
+
   const generate3d = lemonade!.tools.find(tool => (tool as any).function?.name === 'generate_3d');
   assert.ok(generate3d);
+  calls.length = 0;
   const generated = await lemonade!.execute({ id: 'call-3d', type: 'function', function: { name: 'generate_3d', arguments: JSON.stringify({ prompt: 'a small turbine' }) } });
-  assert.equal(generated.error, undefined);
+  assert.notEqual(generated.error, true);
   assert.deepEqual(generated.artifacts?.map(item => item.type), ['image', 'model3d']);
   assert.deepEqual(calls, ['load:image-model', 'image:image-model', 'load:3d-model', '3d:3d-model']);
 
@@ -88,7 +197,7 @@ async function main(): Promise<void> {
     type: 'function',
     function: { name: 'edit_image', arguments: JSON.stringify({ prompt: 'make it blue' }) },
   });
-  assert.equal(edited.error, undefined);
+  assert.notEqual(edited.error, true);
   assert.equal(edited.artifacts?.[0]?.url, 'data:image/png;base64,ZWRpdGVk');
 
   const wrongCapability = await lemonade!.execute({

--- a/src/app/tests/router-load-regression.runtime.cjs
+++ b/src/app/tests/router-load-regression.runtime.cjs
@@ -1,0 +1,151 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const ts = require('typescript');
+
+function transpile(sourcePath, outputPath) {
+  const source = fs.readFileSync(sourcePath, 'utf8');
+  const result = ts.transpileModule(source, {
+    compilerOptions: { target: ts.ScriptTarget.ES2020, module: ts.ModuleKind.CommonJS },
+    fileName: sourcePath,
+    reportDiagnostics: true,
+  });
+  const errors = (result.diagnostics || []).filter(d => d.category === ts.DiagnosticCategory.Error);
+  assert.equal(errors.length, 0, errors.map(d => ts.flattenDiagnosticMessageText(d.messageText, '\n')).join('\n'));
+  fs.writeFileSync(outputPath, result.outputText);
+}
+
+const root = path.resolve(__dirname, '..');
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gui3-router-runtime-'));
+try {
+  transpile(path.join(root, 'src/features/router/routerTypes.ts'), path.join(tmp, 'routerTypes.js'));
+  transpile(path.join(root, 'src/features/router/routerRuntime.ts'), path.join(tmp, 'routerRuntime.js'));
+  const runtime = require(path.join(tmp, 'routerRuntime.js'));
+
+  const router = {
+    id: 'user.router', model_name: 'user.router', recipe: 'collection.router', downloaded: true,
+    components: ['fast-chat', 'smart-chat', 'route-classifier'],
+    routing: {
+      candidates: ['fast-chat', 'smart-chat'],
+      default_model: 'smart-chat',
+      classifiers: [{ id: 'intent', type: 'classifier', model: 'route-classifier' }],
+      rules: [{ id: 'intent-route', match: { classifier: 'intent', label: 'match', min_score: 0.5 }, route_to: 'fast-chat' }],
+    },
+  };
+  const models = [
+    router,
+    { id: 'fast-chat', model_name: 'fast-chat', downloaded: true, recipe: 'llamacpp' },
+    { id: 'smart-chat', model_name: 'smart-chat', downloaded: true, recipe: 'llamacpp' },
+    { id: 'route-classifier', model_name: 'route-classifier', downloaded: true, recipe: 'llamacpp' },
+  ];
+  const ok = runtime.preflightRouter(router, models, []);
+  assert.equal(ok.ok, true, ok.errors.join(' '));
+  assert.deepEqual(ok.dependencies.find(d => d.name === 'route-classifier').roles.sort(), ['classifier', 'component']);
+
+  const missingClassifier = runtime.preflightRouter(router, models.filter(m => m.model_name !== 'route-classifier'), []);
+  assert.equal(missingClassifier.ok, false);
+  assert.match(runtime.routerPreflightError(missingClassifier), /route-classifier/);
+  assert.match(runtime.routerPreflightError(missingClassifier), /not present/i);
+
+  const notDownloaded = runtime.preflightRouter(router, models.map(m => m.model_name === 'route-classifier' ? { ...m, downloaded: false } : m), []);
+  assert.equal(notDownloaded.ok, false);
+  assert.match(runtime.routerPreflightError(notDownloaded), /not downloaded\/local/i);
+
+  const badDefault = runtime.preflightRouter({ ...router, routing: { ...router.routing, default_model: 'other-chat' } }, models, []);
+  assert.equal(badDefault.ok, false);
+  assert.match(runtime.routerPreflightError(badDefault), /not in routing\.candidates/i);
+
+  const chat = fs.readFileSync(path.join(root, 'src/components/ChatView.tsx'), 'utf8');
+  assert.match(chat, /deferredUntilSend: isRouterModelInfo\(info\) \|\| Boolean\(configuredDefault\)/);
+  const routerGuard = chat.indexOf('if (isRouterModelInfo(info)) {', chat.indexOf('const ensureChatModelReady'));
+  const ordinaryLoad = chat.indexOf('await loadModelWithPolicy(modelName', routerGuard);
+  assert.ok(routerGuard >= 0 && ordinaryLoad > routerGuard, 'Chat readiness must handle Router before ordinary /load');
+  assert.match(chat.slice(routerGuard, ordinaryLoad), /preflightRouter/);
+
+  assert.match(chat, /isRouterModelInfo\(selectedInfo\)/, 'Router selection must remain usable without all_models_loaded');
+  assert.match(chat, /<ModelModeIcons capability=\{currentCapability\} recipe=\{currentRecipe\}/, 'chat must render model identity through the current ModelModeIcons path');
+  const styles = fs.readFileSync(path.join(root, 'src/styles/styles.css'), 'utf8');
+  assert.match(styles, /\.composer__model-mode--router\s*\{[^}]*color:\s*var\(--cap-router\)/, 'Router chat mode must use the shared Router task token');
+
+  const apiSource = fs.readFileSync(path.join(root, 'src/api.ts'), 'utf8');
+  assert.match(apiSource, /route_trace/);
+  assert.match(apiSource, /Router selected/);
+  const registrationStart = apiSource.indexOf('async registerModelDefinition');
+  const registrationEnd = apiSource.indexOf('async pullModel', registrationStart);
+  assert.ok(registrationStart >= 0 && registrationEnd > registrationStart, 'registerModelDefinition source must be inspectable');
+  const registrationSource = apiSource.slice(registrationStart, registrationEnd);
+  assert.match(registrationSource, /\/api\/v1\/models\/register/, 'definition registration must use /models/register');
+  assert.doesNotMatch(registrationSource, /\/api\/v1\/pull/, 'definition registration must never fall back to /pull');
+
+  const loadStart = apiSource.indexOf('async loadModel(');
+  const loadEnd = apiSource.indexOf('async effectiveLoadCommand', loadStart);
+  assert.ok(loadStart >= 0 && loadEnd > loadStart, 'loadModel source must be inspectable');
+  const loadSource = apiSource.slice(loadStart, loadEnd);
+  assert.doesNotMatch(loadSource, /registerModelDefinition/, 'Router load must never write a cached Router definition back to the server');
+  assert.match(loadSource, /status: 'ready', mode: 'router', virtual: true/, 'Router load must remain a virtual readiness no-op');
+
+  const editor = fs.readFileSync(path.join(root, 'src/components/RouterEditorPanel.tsx'), 'utf8');
+  assert.match(editor, /const dependencyPreflight = preflightRouter\(nextRequest as any, models, \[\]\)/);
+  assert.match(editor, /if \(!dependencyPreflight\.ok\)/, 'Router editor must block registration when a dependency preflight fails');
+  const editorSaveStart = editor.indexOf('const save = async () => {');
+  const serverAck = editor.indexOf('await onRegister(nextRequest, submittedDraft.name.trim());', editorSaveStart);
+  assert.ok(editorSaveStart >= 0 && serverAck > editorSaveStart, 'Router editor must wait for server registration acknowledgement');
+  assert.doesNotMatch(editor, /upsertRouterRecord\(/, 'server-owned Router definitions must not be written to browser storage');
+
+  const routerStore = fs.readFileSync(path.join(root, 'src/features/router/routerStore.ts'), 'utf8');
+  assert.doesNotMatch(routerStore, /localStorage\./, 'Router definitions are server-owned and must not persist in browser storage');
+  assert.doesNotMatch(routerStore, /ROUTER_RECORDS_CHANGED_EVENT/, 'server-owned Router definitions do not need a browser-storage event bus');
+  assert.match(routerStore, /export function loadRouterRecords\(\): RouterRecord\[\] \{\s*return \[\];\s*\}/, 'legacy Router record loader must remain a no-op compatibility shim');
+
+  const manager = fs.readFileSync(path.join(root, 'src/components/ModelManager.tsx'), 'utf8');
+  const readyStart = manager.indexOf('const ensureServerRouterReady = async');
+  const runtimeStart = manager.indexOf('const loadModelRuntime = async');
+  assert.ok(readyStart >= 0 && runtimeStart > readyStart, 'model manager must define a server-fresh Router readiness helper before runtime loading');
+  const readySource = manager.slice(readyStart, runtimeStart);
+  assert.match(readySource, /await api\.models\(true\)/, 'Router readiness must refresh the server registry');
+  assert.match(readySource, /preflightRouter\(serverRouter, fresh\.data/, 'Router readiness must preflight the fresh server-owned Router definition');
+  assert.doesNotMatch(readySource, /registerModelDefinition/, 'Router readiness must be read-only');
+
+  const runtimeRouterGuard = manager.indexOf('if (isRouterModelInfo(info)) {', runtimeStart);
+  const runtimeRouterEnd = manager.indexOf('const components =', runtimeRouterGuard);
+  assert.ok(runtimeStart >= 0 && runtimeRouterGuard > runtimeStart && runtimeRouterEnd > runtimeRouterGuard, 'model manager must treat Router as virtual before collection/runtime loading');
+  const runtimeRouterSource = manager.slice(runtimeRouterGuard, runtimeRouterEnd);
+  assert.match(runtimeRouterSource, /ensureServerRouterReady\(name\)/, 'runtime Router path must use server-fresh readiness');
+  assert.doesNotMatch(runtimeRouterSource, /registerModelDefinition/, 'runtime Router path must never overwrite the server definition');
+
+  const handleLoadStart = manager.indexOf('const handleLoad = async');
+  const handleUnloadStart = manager.indexOf('const handleUnload = async', handleLoadStart);
+  const handleLoadSource = manager.slice(handleLoadStart, handleUnloadStart);
+  assert.match(handleLoadSource, /ensureServerRouterReady\(name\)/, 'Use Router click must read/validate the server definition');
+  assert.doesNotMatch(handleLoadSource, /registerModelDefinition/, 'Use Router click must never write a stale local Router definition');
+  assert.match(handleLoadSource, /loadWithGlobalPolicy\(model, overrideOptions\)/, 'ordinary models must preserve the new-base load-options path');
+
+  const saveStart = manager.indexOf('const handleRegisterRouter = async');
+  const saveEnd = manager.indexOf('const handleRouterSaved', saveStart);
+  const saveSource = manager.slice(saveStart, saveEnd);
+  assert.match(saveSource, /await api\.registerModelDefinition\(request\.model_name/, 'explicit Router save remains the definition write path');
+  assert.doesNotMatch(manager, /ROUTER_RECORDS_CHANGED_EVENT/, 'model manager must use server state instead of browser Router events');
+  assert.match(
+    manager,
+    /registerModelDefinition\(canonicalCustomModelName\(component\), customRegistrationOptions\(component\)\)/,
+    'Custom Router dependencies must register with their canonical user.* definition name',
+  );
+  assert.match(manager, /const preflight = preflightRouter\(routerInfo, fresh\.data/, 'Router save must preflight dependencies against fresh server registry data');
+
+  assert.match(chat, /if \(isRouterRecipe\(currentRecipe\)\) return true;/, 'router chat must accept images so has_images rules are reachable');
+  assert.match(chat, /const modeSupportsMcp = modeSupportsChatCompletions;/, 'router chat must retain MCP/Lemonade tool support');
+  assert.match(chat, /streaming\.send\(convoId, requestModelName, chatMessages, toolRuntime, thinkingMode\)/, 'selected tools must reach router chat requests through the current streaming signature');
+
+  const tools = fs.readFileSync(path.join(root, 'src/tools/lemonadeTools.ts'), 'utf8');
+  const loadCase = tools.slice(tools.indexOf("case 'load_model'"), tools.indexOf("case 'unload_model'"));
+  const special = loadCase.indexOf('if (isRouterModel(resolved))');
+  const runtimeLoad = loadCase.indexOf('api.loadModel');
+  assert.ok(special >= 0 && runtimeLoad > special, 'Tool must finish Router readiness branch before ordinary api.loadModel');
+  assert.match(loadCase.slice(special, runtimeLoad), /status: 'ready'/);
+  assert.match(loadCase.slice(special, runtimeLoad), /preflightRouter/);
+
+  console.log('GUI3 Router load regression checks passed.');
+} finally {
+  fs.rmSync(tmp, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Summary

Fixes GUI3 router handling across Chat and Lemonade Tools.

* Treat `collection.router` as a virtual router instead of a directly loaded runtime model
* Add router dependency/preflight checks with clearer candidate/classifier errors
* Make Lemonade model tools router-aware for list/info/load/unload/delete
* Keep router selection/state in sync across Chat and Models
* Fix router routing trace/error attribution
* Fix Router task color in Chat

Designed to merge separately from #3050.

## Validation

* Router load regression tests
* Router editor tests
* Lemonade/MCP tool runtime tests
* Router SSE / route trace tests
* TypeScript transpile checks
