### PR TITLE
GUI3 fix: moved model name copy button from chat to models

### DIFF
--- a/src/app/src/components/ChatView.tsx
+++ b/src/app/src/components/ChatView.tsx
@@ -742,35 +742,6 @@ async function wavVoiceSampleToBase64(file: File): Promise<string> {
 
 
 
-const CopyInlineButton: React.FC<{ text: string; title?: string; className?: string }> = ({ text, title = 'Copy', className = '' }) => {
-  const [copied, setCopied] = useState(false);
-  const disabled = !text;
-  const handleClick = async (event: React.MouseEvent<HTMLButtonElement>) => {
-    event.preventDefault();
-    event.stopPropagation();
-    if (disabled) return;
-    try {
-      await copyTextToClipboard(text);
-      setCopied(true);
-      window.setTimeout(() => setCopied(false), 1200);
-    } catch {
-      setCopied(false);
-    }
-  };
-  return (
-    <button
-      type="button"
-      className={`copy-inline${copied ? ' copy-inline--copied' : ''}${className ? ` ${className}` : ''}`}
-      onClick={handleClick}
-      disabled={disabled}
-      title={copied ? 'Copied' : title}
-      aria-label={copied ? 'Copied' : title}
-    >
-      {copied ? <Icon name="check" size={13} /> : <Icon name="copy" size={13} />}
-    </button>
-  );
-};
-
 function friendlyErrorMessage(error: unknown): string {
   if (error && typeof error === 'object') {
     const value = error as { userMessage?: unknown; message?: unknown };
@@ -3327,7 +3298,6 @@ ${finalText}`
                   <div className="message__body">
                     <div className="message__author-row">
                       <div className="message__author">{modelDisplayName(currentModelSnapshot)}</div>
-                      {currentModelSnapshot?.name && <CopyInlineButton text={currentModelSnapshot.name} title="Copy model name" className="copy-inline--author" />}
                     </div>
                     {streamingThinking && (
                       <details className="message__thinking" open={streaming.thinkingExpanded}>
@@ -3385,7 +3355,6 @@ ${finalText}`
                   <div className="message__body">
                     <div className="message__author-row">
                       <div className="message__author">{modelDisplayName(currentModelSnapshot)}</div>
-                      {currentModelSnapshot?.name && <CopyInlineButton text={currentModelSnapshot.name} title="Copy model name" className="copy-inline--author" />}
                     </div>
                     <div className="message__content message__content--pending">
                       <span className="streaming-cursor" aria-hidden="true" />
@@ -4218,7 +4187,6 @@ const EmptyState: React.FC<EmptyStateProps> = ({ loadedModels, currentModel, onM
                       >
                         {m.model_name}
                       </button>
-                      <CopyInlineButton text={m.model_name} title="Copy model name" />
                     </div>
                     <div className="active-card__meta">{m.recipe || 'runtime'} · {m.checkpoint || 'default'}</div>
                   </div>
@@ -4424,7 +4392,6 @@ const MessageBubble: React.FC<{ message: Message; activeModel: ModelSnapshot | n
       <div className="message__body">
         <div className="message__author-row">
           <div className="message__author">{message.isError ? 'Lemonade' : modelDisplayName(displayModel)}</div>
-          {!message.isError && displayModel?.name && <CopyInlineButton text={displayModel.name} title="Copy model name" className="copy-inline--author" />}
         </div>
         {message.thinking && (
           <details

--- a/src/app/src/components/ModelDetailPanel.tsx
+++ b/src/app/src/components/ModelDetailPanel.tsx
@@ -9,6 +9,7 @@ import MarkdownIt from 'markdown-it';
 import DOMPurify from 'dompurify';
 import type { ModelInfo, LoadedModel, ModelFileInfo, HFModelResult, ModelRegistryProvider, PullVariantsResult, CloudProviderRow } from '../api';
 import api from '../api';
+import { copyTextToClipboard } from '../clipboard';
 import { capabilityFromModelInfo, capabilityLabel } from '../modelCapabilities';
 import {
   modelBaseTuningForModel, loadModelTuning, saveModelTuning, resetModelTuning,
@@ -38,6 +39,33 @@ function mdName(m: ModelInfo | null | undefined): string {
   if (!m) return '';
   return String((m as any).model_name ?? m.name ?? m.id ?? '').trim();
 }
+
+const CopyModelNameButton: React.FC<{ modelName: string }> = ({ modelName }) => {
+  const [copied, setCopied] = useState(false);
+
+  const handleClick = async () => {
+    try {
+      await copyTextToClipboard(modelName);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1200);
+    } catch {
+      setCopied(false);
+    }
+  };
+
+  const label = copied ? `Copied model name: ${modelName}` : `Copy model name: ${modelName}`;
+  return (
+    <button
+      type="button"
+      className={`model-detail-panel__copy-name${copied ? ' model-detail-panel__copy-name--copied' : ''}`}
+      onClick={handleClick}
+      title={label}
+      aria-label={label}
+    >
+      <Icon name={copied ? 'check' : 'copy'} size={12} aria-hidden="true" />
+    </button>
+  );
+};
 
 function isImageOnlyModel(model: ModelInfo | null | undefined): boolean {
   return model ? capabilityFromModelInfo(model) === 'image' : false;
@@ -2224,9 +2252,12 @@ export const ModelDetailPanel: React.FC<ModelDetailPanelProps> = ({
       className="model-detail-panel"
       ariaLabel={`Model details: ${name}`}
       title={(
-        <h2 className="workspace-detail-panel__title model-detail-panel__name" ref={panelHeadingRef} tabIndex={-1} id="detail-panel-heading">
-          {model.display_name || name}
-        </h2>
+        <div className="model-detail-panel__title-line">
+          <h2 className="workspace-detail-panel__title model-detail-panel__name" ref={panelHeadingRef} tabIndex={-1} id="detail-panel-heading">
+            {model.display_name || name}
+          </h2>
+          <CopyModelNameButton key={name} modelName={name} />
+        </div>
       )}
       metadata={detailMetadata}
       actions={detailActions}

--- a/src/app/src/styles/styles.css
+++ b/src/app/src/styles/styles.css
@@ -5296,14 +5296,6 @@ optgroup {
   background: var(--success-soft);
 }
 
-.copy-inline--author {
-  width: 20px;
-  height: 20px;
-  min-width: 20px;
-  font-size: var(--text-xs);
-  transform: translateY(-1px);
-}
-
 .message__actions {
   display: flex;
   align-items: center;
@@ -7558,6 +7550,45 @@ optgroup {
 
 .model-detail-panel__name:focus-visible {
   outline: none;
+}
+
+.model-detail-panel__title-line {
+  min-width: 0;
+  width: fit-content;
+  max-width: 100%;
+  display: flex;
+  align-items: flex-start;
+  justify-self: start;
+  gap: 2px;
+}
+
+.model-detail-panel__title-line .model-detail-panel__name {
+  min-width: 0;
+  flex: 0 1 auto;
+}
+
+.model-detail-panel__copy-name {
+  width: 18px;
+  height: 18px;
+  min-width: 18px;
+  margin-top: -3px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  border-radius: var(--radius-sm);
+  color: var(--text-tertiary);
+  transition: background var(--duration-fast) var(--ease-out),
+              color var(--duration-fast) var(--ease-out);
+}
+
+.model-detail-panel__copy-name:hover {
+  background: var(--surface-2);
+  color: var(--text-primary);
+}
+
+.model-detail-panel__copy-name--copied {
+  color: var(--success);
 }
 
 .model-detail-panel__error {


### PR DESCRIPTION
Opted to remove it competently from chat and towards the model tab where this specific function is more suitable, I think.

<img width="522" height="116" alt="image" src="https://github.com/user-attachments/assets/5c259567-ffcf-4925-9dcb-a86ca132afe8" />
<img width="517" height="92" alt="image" src="https://github.com/user-attachments/assets/343d41b4-3336-4ce5-8562-15d44c36a671" />

Closes #3045 