### PR TITLE
feat(models): add Muse Glimmer 30B to the model catalog

### DIFF
--- a/docs/dev/backends-reference.md
+++ b/docs/dev/backends-reference.md
@@ -207,7 +207,7 @@ the generator instead. Prose outside the markers is preserved. -->
 |-------|-----------|--------|
 | `kokoro-v1` | 0.354 | tts |
 
-#### `llamacpp` — Llama.cpp GPU (87 models)
+#### `llamacpp` — Llama.cpp GPU (88 models)
 
 | Model | Size (GB) | Labels |
 |-------|-----------|--------|
@@ -249,6 +249,7 @@ the generator instead. Prose outside the markers is preserved. -->
 | `MiniCPM4.1-8B-GGUF` | 4.97 | reasoning |
 | `MiniCPM5-1B-GGUF` | 0.69 | hot, reasoning |
 | `Ministral-3-3B-Instruct-2512-GGUF` | 2.99 | vision |
+| `Muse-Glimmer-30B-GGUF` | 19.9 | hot, tool-calling, vision, reasoning, llamacpp, dflash |
 | `Nemotron-3-Nano-30B-A3B-GGUF` | 22.8 | — |
 | `Phi-4-mini-instruct-GGUF` | 2.49 | — |
 | `Playable1-GGUF` | 4.68 | coding |

--- a/src/cpp/resources/server_models.json
+++ b/src/cpp/resources/server_models.json
@@ -617,6 +617,23 @@
         ],
         "size": 3.15
     },
+    "Muse-Glimmer-30B-GGUF": {
+        "checkpoints": {
+            "main": "unsloth/Muse-Glimmer-30B-GGUF:UD-Q4_K_XL",
+            "draft": "unsloth/Muse-Glimmer-30B-GGUF:dflash-kquant.gguf",
+            "mmproj": "unsloth/Muse-Glimmer-30B-GGUF:mmproj-Muse-Glimmer-30B-BF16.gguf"
+        },
+        "recipe": "llamacpp",
+        "suggested": true,
+        "labels": [
+            "hot",
+            "tool-calling",
+            "vision",
+            "reasoning",
+            "llamacpp"
+        ],
+        "size": 21.4
+    },
     "MiniCPM-o-4.5-Vision-GGUF": {
         "source": "modelscope",
         "checkpoint": "OpenBMB/MiniCPM-o-4_5-gguf:MiniCPM-o-4_5-Q4_K_M.gguf",

--- a/src/cpp/resources/server_models.json
+++ b/src/cpp/resources/server_models.json
@@ -630,7 +630,8 @@
             "tool-calling",
             "vision",
             "reasoning",
-            "llamacpp"
+            "llamacpp",
+            "dflash"
         ],
         "size": 21.4
     },

--- a/src/cpp/resources/server_models.json
+++ b/src/cpp/resources/server_models.json
@@ -633,7 +633,7 @@
             "llamacpp",
             "dflash"
         ],
-        "size": 21.4
+        "size": 19.9
     },
     "MiniCPM-o-4.5-Vision-GGUF": {
         "source": "modelscope",


### PR DESCRIPTION
Adds `Muse-Glimmer-30B-GGUF` as a built-in model, as promised by the [Muse Glimmer blog post](https://lemonade-server.ai/news/muse-glimmer.html) (#3033), which states the model ships built-in in the August 12 release.

Uses the `checkpoints` form so the vision projector and the DFlash draft companion are pinned explicitly — the repo ships three mmproj candidates, and #3051 added DFlash discovery.

**Requires a llama.cpp re-pin before this is functional.** The current `b10360` pin (#3053, published Aug 11 13:17 UTC) includes upstream `model: Muse Glimmer Support` (ggml-org/llama.cpp#26841) but predates two follow-up fixes:

| Upstream PR | Merged (UTC) | In b10360 |
|---|---|---|
| #26841 Muse Glimmer Support | Aug 10 11:07 | yes |
| #26879 fix tool call detection after EOM | Aug 11 20:15 | no |
| #26900 disallow integer dflash sliding_window_pattern | Aug 12 11:24 | no |

#26879 affects tool calling (the model's agentic path) and #26900 affects the dflash draft path this entry uses. Latest upstream is `b10375` (Aug 12 12:18 UTC), which covers all three.

The `hot` label means `validate_llamacpp.py` will exercise this model, so a `validate_llamacpp` `workflow_dispatch` run after this merges will both re-pin and produce validation evidence.

Size `21.4` is the sum of main (15.88 GB) + mmproj BF16 (3.85 GB) + dflash (1.63 GB); flag if the convention is main-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)