### PR TITLE
GUI3 fix: options block escape sequences and light-theme button contrast

### DIFF
--- a/src/app/src/components/ChatView.tsx
+++ b/src/app/src/components/ChatView.tsx
@@ -4275,11 +4275,11 @@ const ToolCallsDisplay: React.FC<{ calls: ToolCallEntry[]; onOptionSelect?: (tex
                   ))}
                 </div>
                 {selectedChoice && (
-                  <div className="options-block__confirmation">\u2713 You chose: {selectedChoice}</div>
+                  <div className="options-block__confirmation">✓ You chose: {selectedChoice}</div>
                 )}
                 {!selectedChoice && allowCustom && (
                   <div className="options-block__custom">
-                    <input className="options-block__input" placeholder="Or type your own\u2026"
+                    <input className="options-block__input" placeholder="Or type your own…"
                       onKeyDown={e => { if (e.key === 'Enter' && (e.target as HTMLInputElement).value.trim()) { handleSelect((e.target as HTMLInputElement).value.trim()); } }} />
                     <button className="options-block__submit" onClick={e => {
                       const input = (e.target as HTMLElement).previousElementSibling as HTMLInputElement;

--- a/src/app/src/styles/critical.generated.css
+++ b/src/app/src/styles/critical.generated.css
@@ -328,7 +328,7 @@
   border: 0;
   padding: 0;
   cursor: pointer;
-  
+
   outline: 0;
 }input, textarea {
   font: inherit;
@@ -1475,7 +1475,7 @@
   outline: none;
 }.composer__input:focus,
 .composer__input:focus-visible {
-  
+
   outline-style: none;
   outline-width: 0;
   outline-offset: 0;
@@ -1787,18 +1787,18 @@ option:checked {
   transition: all 0.15s ease;
 }.options-block__btn:hover {
   background: var(--accent);
-  color: var(--bg-primary);
+  color: var(--accent-on);
   border-color: var(--accent-fg);
 }.options-block__btn:active {
   transform: scale(0.97);
 }.options-block__btn--selected {
   background: var(--accent);
-  color: var(--bg-primary);
+  color: var(--accent-on);
   border-color: var(--accent-fg);
   cursor: default;
 }.options-block__btn--selected:hover {
   background: var(--accent);
-  color: var(--bg-primary);
+  color: var(--accent-on);
   border-color: var(--accent-fg);
 }.options-block__btn:disabled {
   opacity: 0.4;
@@ -1824,7 +1824,7 @@ option:checked {
   border-color: var(--accent-fg);
 }.options-block__submit {
   background: var(--accent);
-  color: var(--bg-primary);
+  color: var(--accent-on);
   border: none;
   border-radius: var(--radius-sm);
   padding: var(--space-1) var(--space-3);

--- a/src/app/src/styles/styles.css
+++ b/src/app/src/styles/styles.css
@@ -4498,7 +4498,7 @@ optgroup {
 
 .options-block__btn:hover {
   background: var(--accent);
-  color: var(--bg-primary);
+  color: var(--accent-on);
   border-color: var(--accent-fg);
 }
 
@@ -4508,14 +4508,14 @@ optgroup {
 
 .options-block__btn--selected {
   background: var(--accent);
-  color: var(--bg-primary);
+  color: var(--accent-on);
   border-color: var(--accent-fg);
   cursor: default;
 }
 
 .options-block__btn--selected:hover {
   background: var(--accent);
-  color: var(--bg-primary);
+  color: var(--accent-on);
   border-color: var(--accent-fg);
 }
 
@@ -4553,7 +4553,7 @@ optgroup {
 
 .options-block__submit {
   background: var(--accent);
-  color: var(--bg-primary);
+  color: var(--accent-on);
   border: none;
   border-radius: var(--radius-sm);
   padding: var(--space-1) var(--space-3);

--- a/src/app/tests/ui-regression-contracts.runtime.cjs
+++ b/src/app/tests/ui-regression-contracts.runtime.cjs
@@ -58,6 +58,20 @@ for (const filename of collectTsx(path.join(root, 'src'))) {
   visit(sourceFile);
 }
 
+// The accent stays yellow in both themes but every --bg-* token flips from
+// near-black to near-white, so accent-background text must come from --accent-on.
+const accentBackground = /background(?:-color)?:\s*var\(--accent(?:-hover|-strong)?\)/;
+const themeFlippedText = /color:\s*var\(--bg-[\w-]+\)/;
+
+for (const stylesheet of ['src/styles/styles.css', 'src/styles/critical.generated.css']) {
+  const css = fs.readFileSync(path.join(root, stylesheet), 'utf8');
+  for (const [, selector, body] of css.matchAll(/([^{}]+)\{([^{}]*)\}/g)) {
+    if (accentBackground.test(body) && themeFlippedText.test(body)) {
+      assert.fail(`${stylesheet}: ${selector.trim().split('\n').pop().trim()} puts theme-flipped text on an accent background; use var(--accent-on)`);
+    }
+  }
+}
+
 assert.match(sources.app, /<span className="titlebar__brand-name">lemonade<\/span>/);
 assert.match(sources.app, /type="search"[\s\S]*?role="combobox"[\s\S]*?aria-expanded=\{navigationSearchOpen\}/);
 assert.match(sources.app, /aria-activedescendant=/);

--- a/src/app/tests/ui-regression-contracts.runtime.cjs
+++ b/src/app/tests/ui-regression-contracts.runtime.cjs
@@ -34,6 +34,30 @@ for (const [key, filename] of Object.entries(files)) {
   assert.equal(errors.length, 0, errors.map(d => ts.flattenDiagnosticMessageText(d.messageText, '\n')).join('\n'));
 }
 
+// JSX text and JSX attribute strings are not JavaScript string literals: a `\uXXXX`
+// sequence there reaches the user verbatim instead of the character it names.
+const jsxEscape = /\\(?:u\{[0-9a-fA-F]+\}|u[0-9a-fA-F]{4}|x[0-9a-fA-F]{2})/;
+const collectTsx = dir => fs.readdirSync(dir, { withFileTypes: true }).flatMap(entry => {
+  const full = path.join(dir, entry.name);
+  if (entry.isDirectory()) return collectTsx(full);
+  return entry.isFile() && full.endsWith('.tsx') ? [full] : [];
+});
+
+for (const filename of collectTsx(path.join(root, 'src'))) {
+  const sourceFile = ts.createSourceFile(filename, fs.readFileSync(filename, 'utf8'), ts.ScriptTarget.ES2022, true, ts.ScriptKind.TSX);
+  const visit = node => {
+    if (ts.isJsxText(node) || (ts.isStringLiteral(node) && node.parent && ts.isJsxAttribute(node.parent))) {
+      const found = node.getText(sourceFile).match(jsxEscape);
+      if (found) {
+        const { line } = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
+        assert.fail(`${path.relative(root, filename)}:${line + 1} renders "${found[0]}" literally; write the character itself`);
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+}
+
 assert.match(sources.app, /<span className="titlebar__brand-name">lemonade<\/span>/);
 assert.match(sources.app, /type="search"[\s\S]*?role="combobox"[\s\S]*?aria-expanded=\{navigationSearchOpen\}/);
 assert.match(sources.app, /aria-activedescendant=/);


### PR DESCRIPTION
Two rendering bugs in the tool-call options block.

**Escape sequences shown verbatim (#3068).** The block wrote `…` and `✓` in JSX text and a JSX attribute. Those are not JavaScript string literals and do not process backslash escapes, so users saw the raw sequence. Replaced with the literal characters, matching the 86 other literal `…` uses in the renderer.

**White text on a yellow button in the light theme.** The Send button and the choice buttons took their text color from `--bg-primary`, which is near-black in dark (`#0E0E0B`) but near-white in light (`#fdfbf6`). Switched all four accent-background rules to `--accent-on` (`#000000` in both themes, already used 13× elsewhere for this exact purpose). `critical.generated.css` is updated to match, since it is committed and inlined into the web app's first paint.

<img width="1642" height="332" alt="image" src="https://github.com/user-attachments/assets/90cfbf39-e798-4b28-a951-c6716adf4e01" />

Both guarded by new static checks in `ui-regression-contracts.runtime.cjs`, each verified to fail on the pre-fix source:
- An AST walk over all 42 renderer `.tsx` files rejecting `\uXXXX`/`\xXX` inside JSX text or JSX attribute strings.
- A stylesheet scan rejecting any rule that paints an accent background and takes its text color from a theme-flipped `--bg-*` token.

Final result:

<img width="1656" height="716" alt="image" src="https://github.com/user-attachments/assets/efb7de57-9b0b-4b43-8cef-d4d6e973d7a6" />


Closes #3068

🤖 Generated with [Claude Code](https://claude.com/claude-code)
