### PR TITLE
fix(ui): remove em dashes from user-facing text

### DIFF
--- a/src/app/src/api.ts
+++ b/src/app/src/api.ts
@@ -1131,7 +1131,7 @@ class LemonadeAPI {
           : 'The server requires an API key or rejected the current one. Enter the matching key in Settings, then reconnect.'
         : resp.status === 403 && serverMessage.toLowerCase() === 'origin not allowed'
           ? originNotAllowedMessage(this.baseUrl)
-          : `${url} returned ${resp.status} ${statusText}${serverMessage ? ` — ${serverMessage}` : ''}`;
+          : `${url} returned ${resp.status} ${statusText}${serverMessage ? `: ${serverMessage}` : ''}`;
       throw err;
     }
     return resp;

--- a/src/app/src/components/ChatView.tsx
+++ b/src/app/src/components/ChatView.tsx
@@ -3004,7 +3004,7 @@ ${finalText}`
             ? (!!inputValue.trim() && !openMossDescribeUnavailable && !openMossCloneUnavailable)
             : (!!inputValue.trim() || pendingImages.length > 0 || (canUseAudioInput && pendingAudioFiles.length > 0)));
   const composerPlaceholder = !currentModel
-    ? 'Draft a message — connect and load a model to send…'
+    ? 'Draft a message. Connect and load a model to send…'
     : currentCapability === 'omni'
       ? `Message ${currentModel} through the Omni collection…`
       : currentCapability === 'chat' && supportsChatImageInput && supportsChatAudioInput

--- a/src/app/src/components/Dashboard.tsx
+++ b/src/app/src/components/Dashboard.tsx
@@ -450,7 +450,7 @@ const Dashboard: React.FC<DashboardProps> = ({ isActive }) => {
           ) : (
             <div className="dash2-card">
               <h2 className="dash2-card__h">Last Inference</h2>
-              <div className="dash2-empty">No inference data yet — send a request to see stats</div>
+              <div className="dash2-empty">No inference data yet. Send a request to see stats.</div>
             </div>
           )}
         </div>

--- a/src/app/src/components/LogViewer.tsx
+++ b/src/app/src/components/LogViewer.tsx
@@ -487,7 +487,7 @@ const LogViewer: React.FC<LogViewerProps> = ({ embedded = false }) => {
               </button>
             ))}
             {logSources.hiddenCount > 0 && (
-              <p className="workspace-filter-list__note">{logSources.hiddenCount} less active {logSources.hiddenCount === 1 ? 'source' : 'sources'} not shown — search to find them.</p>
+              <p className="workspace-filter-list__note">{logSources.hiddenCount} less active {logSources.hiddenCount === 1 ? 'source' : 'sources'} not shown. Search to find them.</p>
             )}
           </div>
         </div>

--- a/src/app/src/components/ModelDetailPanel.tsx
+++ b/src/app/src/components/ModelDetailPanel.tsx
@@ -801,7 +801,7 @@ const HfOverviewTab: React.FC<{
           )}
           {hfVariants.variants.length > 0 ? (
             <div className="hf-detail__overview-section">
-              <span className="hf-detail__overview-label">Variants — select one</span>
+              <span className="hf-detail__overview-label">Variants (select one)</span>
               {selectedVariant && (
                 <div className="hf-detail__gguf-primary-action">
                   <WorkspaceActionButton

--- a/src/app/src/components/WorkspaceCatalogLayout.tsx
+++ b/src/app/src/components/WorkspaceCatalogLayout.tsx
@@ -81,7 +81,7 @@ export function WorkspaceCatalogLayout<Id extends string>({
               aria-current={activeFilter === filter.id ? 'true' : undefined}
               aria-label={filter.label}
               aria-describedby={filter.description ? `${panelId}-${filter.id}-description` : undefined}
-              title={filter.description ? `${filter.label} — ${filter.description}` : filter.label}
+              title={filter.description ? `${filter.label}: ${filter.description}` : filter.label}
               onClick={() => { onFilterChange(filter.id); mobileRail.close(); }}
             >
               <Icon className="workspace-filter-list__icon" name={filter.icon} size={14} />

--- a/src/app/src/components/inspect/TraceList.tsx
+++ b/src/app/src/components/inspect/TraceList.tsx
@@ -129,7 +129,7 @@ export default function TraceList({
         <div className="inspect-rail__capture-group-row">
           <div className="inspect-rail__capture-label-group">
             <span className="inspect-rail__capture-label">Auto-capture inferences</span>
-            <span className="inspect-rail__capture-sublabel">Enables OTel on demand — no server-side storage</span>
+            <span className="inspect-rail__capture-sublabel">Enables OTel on demand, with no server-side storage</span>
             <span className={`capture-badge ${getBadgeClass()}`}>
               <span className="capture-badge__dot"></span>
               {getBadgeLabel()}

--- a/src/app/src/hooks/useChatStreaming.ts
+++ b/src/app/src/hooks/useChatStreaming.ts
@@ -41,21 +41,21 @@ function summarizeResult(toolName: string, data: Record<string, unknown>): strin
       if (counts.registry) return `${counts.registry} registry model(s)`;
       return 'Model inventory retrieved';
     }
-    case 'get_model_info': return `${(data as any).display_name || (data as any).name || (data as any).id || 'model'} — ${((data as any).recipes || []).length} recipe(s)`;
+    case 'get_model_info': return `${(data as any).display_name || (data as any).name || (data as any).id || 'model'}: ${((data as any).recipes || []).length} recipe(s)`;
     case 'load_model': return 'Model loaded';
     case 'unload_model': return 'Model unloaded';
     case 'get_loaded_models': {
       const loaded = (data as any).loaded;
       return Array.isArray(loaded) ? `${loaded.length} model(s) loaded` : JSON.stringify(data).slice(0, 80);
     }
-    case 'get_server_health': return `${data.status} — ${data.loaded_models} model(s)`;
+    case 'get_server_health': return `${data.status}: ${data.loaded_models} model(s)`;
     case 'pull_model': {
       const anyData = data as any;
       if (anyData.status === 'needs_choice') {
         const items = anyData.choices || anyData.candidates || anyData.variants || [];
         return Array.isArray(items) ? `Needs choice: ${items.slice(0, 4).map((item: any) => item.id || item.name || item).join(', ')}` : 'Needs choice';
       }
-      return `${anyData.status || 'download complete'}${anyData.model ? ` — ${anyData.model}` : ''}`;
+      return `${anyData.status || 'download complete'}${anyData.model ? `: ${anyData.model}` : ''}`;
     }
     case 'delete_model': return 'Model deleted';
     case 'get_system_info': {
@@ -201,7 +201,7 @@ export function useChatStreaming(
             try {
               toolRound++;
               if (toolRound > MAX_TOOL_ROUNDS) {
-                onError(convoId, 'Too many tool call rounds — stopping to prevent loops.');
+                onError(convoId, 'Too many tool call rounds. Stopping to prevent loops.');
                 cleanup(convoId);
                 resolve();
                 return;

--- a/src/app/src/index.html
+++ b/src/app/src/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="color-scheme" content="dark light" />
-  <title>lemonade — UI redesign prototype</title>
+  <title>lemonade: UI redesign prototype</title>
   <script>
     window.__LEMONADE_DOCUMENT_START_MS__ = performance.now();
     try {

--- a/src/app/src/index.html
+++ b/src/app/src/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="color-scheme" content="dark light" />
-  <title>lemonade: UI redesign prototype</title>
+  <title>Lemonade App</title>
   <script>
     window.__LEMONADE_DOCUMENT_START_MS__ = performance.now();
     try {

--- a/src/app/src/tools/lemonadeTools.ts
+++ b/src/app/src/tools/lemonadeTools.ts
@@ -439,7 +439,7 @@ function linesForSystemInfo(summary: Record<string, any>): string {
   const devices = summary.devices || {};
   for (const [kind, items] of Object.entries(devices)) {
     const labels = Array.isArray(items)
-      ? items.map((item: any) => `${item.name}${item.available === false ? ' (unavailable)' : ''}${Array.isArray(item.details) && item.details.length ? ` — ${item.details.join(', ')}` : ''}`)
+      ? items.map((item: any) => `${item.name}${item.available === false ? ' (unavailable)' : ''}${Array.isArray(item.details) && item.details.length ? `: ${item.details.join(', ')}` : ''}`)
       : [];
     if (labels.length) lines.push(`${kind}: ${labels.join('; ')}`);
   }
@@ -663,12 +663,12 @@ export async function executeTool(call: ToolCall): Promise<ToolResult> {
             : 'Answer the user with the model status, capability, size/context, checkpoint, and recipe/backend options. If they asked to load it, call load_model next.',
         };
         const display = [
-          `${summary.name || summary.id} — ${summary.status}, ${summary.capability}`,
+          `${summary.name || summary.id}: ${summary.status}, ${summary.capability}`,
           summary.size ? `Size: ${summary.size}` : '',
           result.context_window ? `Context: ${result.context_window}` : '',
           result.checkpoint ? `Checkpoint: ${result.checkpoint}` : '',
           Array.isArray(summary.recipes) && summary.recipes.length ? `Recipes: ${summary.recipes.join(', ')}` : '',
-          componentSummaries.length ? `Components:\n${componentSummaries.map(component => `- ${component.name || component.id} — ${component.status}, ${component.capability}`).join('\n')}` : '',
+          componentSummaries.length ? `Components:\n${componentSummaries.map(component => `- ${component.name || component.id}: ${component.status}, ${component.capability}`).join('\n')}` : '',
         ].filter(Boolean).join('\n');
         return toolPayload(call, result, display || 'Model info retrieved');
       }
@@ -753,7 +753,7 @@ export async function executeTool(call: ToolCall): Promise<ToolResult> {
           answer_instruction: 'List the currently loaded model names with recipe/device/type. If none are loaded, say none are loaded.',
         };
         const display = loaded.length
-          ? loaded.map(m => `${m.model} — ${m.recipe || 'recipe unknown'}${m.device ? ` on ${m.device}` : ''} (${m.type || 'type unknown'})`).join('\n')
+          ? loaded.map(m => `${m.model}: ${m.recipe || 'recipe unknown'}${m.device ? ` on ${m.device}` : ''} (${m.type || 'type unknown'})`).join('\n')
           : 'No models are currently loaded';
         return toolPayload(call, result, display);
       }
@@ -771,7 +771,7 @@ export async function executeTool(call: ToolCall): Promise<ToolResult> {
         const display = [
           `Server: ${h.status} (${h.version})`,
           `Loaded: ${h.all_models_loaded.length}`,
-          ...h.all_models_loaded.slice(0, 6).map(m => `${m.model_name} — ${m.recipe || 'recipe unknown'}${m.device ? ` on ${m.device}` : ''}`),
+          ...h.all_models_loaded.slice(0, 6).map(m => `${m.model_name}: ${m.recipe || 'recipe unknown'}${m.device ? ` on ${m.device}` : ''}`),
         ].join('\n');
         return toolPayload(call, result, display);
       }
@@ -799,7 +799,7 @@ export async function executeTool(call: ToolCall): Promise<ToolResult> {
               candidates,
               answer_instruction: 'Ask the user which Hugging Face checkpoint to download. Use ask_question with the candidate ids as choices.',
             };
-            return toolPayload(call, result, candidates.length ? `Choose a Hugging Face checkpoint:\n${candidates.map(c => `${c.id} — ${c.downloads || 0} downloads`).join('\n')}` : `No Hugging Face GGUF checkpoints found for "${query}"`, candidates.length === 0);
+            return toolPayload(call, result, candidates.length ? `Choose a Hugging Face checkpoint:\n${candidates.map(c => `${c.id}: ${c.downloads || 0} downloads`).join('\n')}` : `No Hugging Face GGUF checkpoints found for "${query}"`, candidates.length === 0);
           }
           const variants = await api.pullVariants(hfCheckpoint);
           const chosen = chooseHfVariant(variants, variant);
@@ -814,7 +814,7 @@ export async function executeTool(call: ToolCall): Promise<ToolResult> {
               variants: choices,
               answer_instruction: 'Ask the user which GGUF variant/file to download. Use ask_question with the variant names as choices.',
             };
-            return toolPayload(call, result, choices.length ? `Choose a GGUF variant for ${hfCheckpoint}:\n${choices.map(c => `${c.name} — ${c.file}`).join('\n')}` : `No downloadable variants found for ${hfCheckpoint}`, choices.length === 0);
+            return toolPayload(call, result, choices.length ? `Choose a GGUF variant for ${hfCheckpoint}:\n${choices.map(c => `${c.name}: ${c.file}`).join('\n')}` : `No downloadable variants found for ${hfCheckpoint}`, choices.length === 0);
           }
           const localName = requested && !requested.includes('/') ? requested : defaultHfLocalName(variants, hfCheckpoint);
           const pullResult = await pullWithProgress(localName, { checkpoint: `${hfCheckpoint}:${chosen.name}`, recipe });
@@ -874,7 +874,7 @@ export async function executeTool(call: ToolCall): Promise<ToolResult> {
           candidates,
           answer_instruction: 'No registry match was found. Ask the user which Hugging Face GGUF checkpoint to download. Use ask_question with the candidate ids as choices.',
         };
-        return toolPayload(call, result, candidates.length ? `No registry match. Hugging Face candidates:\n${candidates.map(c => `${c.id} — ${c.downloads || 0} downloads`).join('\n')}` : `No registry or Hugging Face GGUF candidates found for "${query}"`, candidates.length === 0);
+        return toolPayload(call, result, candidates.length ? `No registry match. Hugging Face candidates:\n${candidates.map(c => `${c.id}: ${c.downloads || 0} downloads`).join('\n')}` : `No registry or Hugging Face GGUF candidates found for "${query}"`, candidates.length === 0);
       }
 
       case 'delete_model': {

--- a/src/cpp/server/backends/cloud/cloud_server.cpp
+++ b/src/cpp/server/backends/cloud/cloud_server.cpp
@@ -803,7 +803,7 @@ std::vector<ModelInfo> CloudServer::discover_models(const std::string& provider,
     if (response.status_code != 200) {
         LOG(WARNING, "Cloud") << "GET " << url << " returned HTTP "
                               << response.status_code
-                              << " — no models discovered for provider '" << provider
+                              << ", no models discovered for provider '" << provider
                               << "'. Body: " << response.body.substr(0, 200) << std::endl;
         return models;
     }

--- a/src/cpp/server/backends/onnxruntime/onnxruntime_server.cpp
+++ b/src/cpp/server/backends/onnxruntime/onnxruntime_server.cpp
@@ -66,7 +66,7 @@ std::string capture_startup_error(const std::string& executable,
         std::ostringstream detail;
         detail << "exited with code " << exit_code;
         if (exit_code == static_cast<int>(0xC0000135)) {
-            detail << " (STATUS_DLL_NOT_FOUND — a required library is missing "
+            detail << " (STATUS_DLL_NOT_FOUND: a required library is missing "
                       "from the backend install directory)";
         }
         std::error_code ec;
@@ -175,7 +175,7 @@ void OnnxRuntimeServer::load(const std::string& model_name,
         throw std::runtime_error(
             "Ambiguous model layout under '" + model_path + "': " +
             std::to_string(candidates.size()) +
-            " complete model directories found — keep exactly one:" + listing);
+            " complete model directories found. Keep exactly one:" + listing);
     }
     model_path = path_to_utf8(candidates.front());
     LOG(INFO, "OnnxRuntimeServer") << "Using model: " << model_path << std::endl;

--- a/src/cpp/server/backends/vllm/vllm_server.cpp
+++ b/src/cpp/server/backends/vllm/vllm_server.cpp
@@ -515,7 +515,7 @@ void VLLMServer::load(const std::string& model_name,
         // A common cause on gfx1151 is a kernel without the CWSR fix, which makes
         // any GPU dispatch hang or fault. Point users to the docs in that case.
         if (needs_gfx1151_cwsr_fix()) {
-            err += ". Your kernel may be missing the gfx1151 CWSR fix — "
+            err += ". Your kernel may be missing the gfx1151 CWSR fix; "
                    "see https://lemonade-server.ai/gfx1151_linux.html";
         }
         throw std::runtime_error(err);


### PR DESCRIPTION
Em dashes in UI copy read as AI-generated. This rewrites every user-visible string that used one to plain punctuation.

- Renderer copy: window title, composer placeholder, empty/error states, filter tooltips, variant label, HTTP error detail.
- Tool-call result summaries rendered in chat (`lemonadeTools.ts`, `useChatStreaming.ts`).
- Four backend error messages that surface in the UI (cloud, vLLM, ONNX Runtime).

Left alone: the em dash used as the empty-value placeholder glyph in tables and stat tiles (a normal typographic convention, not prose), and code comments.

`tsc --noEmit` and a `lemond` build both pass.

Closes #3066
Closes https://github.com/lemonade-sdk/lemonade/issues/3000

🤖 Generated with [Claude Code](https://claude.com/claude-code)