### PR TITLE
GUI3 fix: make plus and tools more detectable

### DIFF
--- a/src/app/src/components/ChatView.tsx
+++ b/src/app/src/components/ChatView.tsx
@@ -3892,17 +3892,17 @@ ${finalText}`
                 >
                   <span className="composer__add-icon"><Icon name="paperclip" size={16} /></span>
                   <span className="composer__add-text">
-                    <strong>Add photos & files</strong>
+                    <strong>Add files</strong>
                     <small>{isOpenMossCloneMode
-                      ? 'Upload a WAV voice sample'
+                      ? 'WAV audio file'
                       : currentCapability === 'model3d'
-                        ? 'Upload a reference image'
+                        ? 'PNG, JPEG, BMP, or GIF image'
                         : acceptsImageAttachments && acceptsAudioAttachments
-                          ? 'Upload images or audio'
+                          ? 'Images and audio files'
                           : acceptsImageAttachments
-                            ? 'Upload images'
+                            ? 'Images'
                             : acceptsAudioAttachments
-                              ? 'Upload audio'
+                              ? 'Audio files'
                               : 'Not available for this model'}</small>
                   </span>
                 </button>

--- a/src/app/src/components/ChatView.tsx
+++ b/src/app/src/components/ChatView.tsx
@@ -3876,7 +3876,7 @@ ${finalText}`
               aria-haspopup={mcpPickerOpen ? 'dialog' : 'menu'}
               aria-expanded={addMenuOpen}
             >
-              <Icon name="plus" size={18} />
+              <Icon name="plus" size={20} />
             </button>
             {addMenuOpen && !mcpPickerOpen && (
               <div className="composer__add-menu" role="menu" aria-label="Add to chat">

--- a/src/app/src/components/EffectiveSettingsModal.tsx
+++ b/src/app/src/components/EffectiveSettingsModal.tsx
@@ -421,7 +421,13 @@ const EffectiveSettingsModal: React.FC<EffectiveSettingsModalProps> = ({
               <div className="effective-settings__row">
                 <span className="effective-settings__row-label">MCP servers</span>
                 <span className="effective-settings__row-value">{!mcpEnabled ? 'Off' : (mcpServerIds.length > 0 ? mcpServerIds.join(', ') : 'Built-in Lemonade')}</span>
-                <span className="effective-settings__source effective-settings__source--generic">Setting</span>
+                <span
+                  className="effective-settings__source effective-settings__source--generic effective-settings__source--chat-add"
+                  title="Configured from the chat + menu"
+                >
+                  <Icon name="plus" size={11} />
+                  <span>Menu</span>
+                </span>
               </div>
               {resolved && (
                 <div className="effective-settings__row">

--- a/src/app/src/styles/styles.css
+++ b/src/app/src/styles/styles.css
@@ -1702,6 +1702,7 @@ input[type="checkbox"]:disabled {
   flex-shrink: 0;
 }
 
+.composer__send .app-icon { stroke-width: 2; }
 .composer__send:hover { background: var(--accent-hover); }
 [data-theme="light"] .composer__send:hover { filter: brightness(0.85) saturate(1.5); }
 .composer__send:disabled { opacity: 0.3; cursor: default; }
@@ -3529,9 +3530,10 @@ optgroup {
 /* ---------- 480px — phone --------------------------------- */
 @media (max-width: 480px) {
 
-  /* ── Composer: increase send/stop to 44 px touch targets ── */
+  /* ── Composer: keep primary and add actions at 44 px touch targets ── */
   .composer__send,
-  .composer__stop {
+  .composer__stop,
+  .composer__add-trigger {
     width: 44px;
     height: 44px;
     flex-shrink: 0;
@@ -4644,10 +4646,48 @@ optgroup {
 }
 
 .composer__add-trigger {
-  width: 32px;
-  height: 32px;
+  width: 38px;
+  height: 38px;
+  padding: 0;
   justify-content: center;
-  border-radius: var(--radius-pill);
+  border: 0;
+  border-radius: var(--radius-lg);
+  background: transparent;
+  color: var(--text-secondary);
+  transition:
+    color var(--duration-fast) var(--ease-out),
+    background var(--duration-fast) var(--ease-out);
+}
+
+.composer__add-trigger .app-icon {
+  stroke-width: 2.25;
+}
+
+.composer__add-trigger:hover:not(:disabled) {
+  color: var(--text-primary);
+  background: color-mix(
+    in srgb,
+    var(--text-primary) 7%,
+    transparent
+  );
+}
+
+.composer__add-trigger:focus-visible {
+  color: var(--text-primary);
+  background: color-mix(
+    in srgb,
+    var(--text-primary) 7%,
+    transparent
+  );
+}
+
+.composer__add-trigger[aria-expanded='true'] {
+  color: var(--text-primary);
+  background: color-mix(
+    in srgb,
+    var(--text-primary) 9%,
+    transparent
+  );
 }
 
 .composer__add-menu {
@@ -13767,6 +13807,9 @@ button.workspace-metadata-chip:hover {
 
 .effective-settings__source {
   justify-self: end;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
   font-size: var(--type-caption-size);
   padding: 1px var(--space-2);
   border-radius: var(--radius-pill);
@@ -13774,6 +13817,10 @@ button.workspace-metadata-chip:hover {
   color: var(--text-secondary);
   background: var(--surface-2);
   border: 1px solid var(--border-subtle);
+}
+
+.effective-settings__source--chat-add .app-icon {
+  stroke-width: 2;
 }
 
 .effective-settings__source--generic {

--- a/src/app/tests/a11y.spec.ts
+++ b/src/app/tests/a11y.spec.ts
@@ -2974,7 +2974,7 @@ test.describe('Accessibility — model-detail Files tab (#2428)', () => {
 // Add menu, tools entry, and Logs toggle must remain accessible. Range: A185–A187.
 
 test.describe('Chat toolbar accessibility', () => {
-  async function goToChatWithLoadedModel(page: Page): Promise<void> {
+  async function goToChatWithLoadedModel(page: Page, inputModalities: string[] = []): Promise<void> {
     await page.route('**/api/v1/health**', async route =>
       route.fulfill({
         contentType: 'application/json',
@@ -2993,6 +2993,7 @@ test.describe('Chat toolbar accessibility', () => {
               last_use: Date.now(),
               labels: ['llm'],
               capabilities: ['chat'],
+              input_modalities: inputModalities,
             },
           ],
         }),
@@ -3003,7 +3004,14 @@ test.describe('Chat toolbar accessibility', () => {
         contentType: 'application/json',
         body: JSON.stringify({
           data: [
-            { id: 'Llama-3.1-8B-Instruct', name: 'Llama-3.1-8B-Instruct', labels: ['llm'], recipe: 'llamacpp', downloaded: true },
+            {
+              id: 'Llama-3.1-8B-Instruct',
+              name: 'Llama-3.1-8B-Instruct',
+              labels: ['llm'],
+              recipe: 'llamacpp',
+              downloaded: true,
+              input_modalities: inputModalities,
+            },
           ],
         }),
       }),
@@ -3058,6 +3066,18 @@ test.describe('Chat toolbar accessibility', () => {
     await expect(menu).toBeVisible();
     await expect(toolsEntry).toBeVisible();
     await expect(toolsEntry).toBeFocused();
+  });
+
+  test('A187a — Add files describes the attachment types supported by the selected model', async ({ page }) => {
+    await goToChatWithLoadedModel(page, ['text', 'image', 'audio']);
+    await page.getByRole('button', { name: /Add files, photos, or tools/i }).click();
+
+    const addFilesEntry = page.getByRole('menu', { name: 'Add to chat' })
+      .locator('.composer__add-row')
+      .filter({ hasText: 'Add files' });
+    await expect(addFilesEntry.locator('strong')).toHaveText('Add files');
+    await expect(addFilesEntry.locator('small')).toHaveText('Images and audio files');
+    await expect(addFilesEntry).not.toContainText(/Upload images|Add photos & files/i);
   });
 
   test('A187b — external MCP remains selectable inside the unified tools flow', async ({ page }) => {


### PR DESCRIPTION
Makes the plus more visible and detectable. Small change, huge difference.

<img width="887" height="128" alt="image" src="https://github.com/user-attachments/assets/b868190b-4424-4f4e-8c58-dc86827ba891" />

Setting is unclear since there is no "Setting" at all.

<img width="757" height="59" alt="image" src="https://github.com/user-attachments/assets/fbeb06fd-3c4e-4dfb-8abc-28163db9f363" />


Try it out locally...


Also added a fix that fits well the review together:

<img width="719" height="527" alt="image" src="https://github.com/user-attachments/assets/d42dd2cb-131e-457f-9b40-f970c93ffbe4" />
<img width="712" height="323" alt="image" src="https://github.com/user-attachments/assets/2011bd53-0945-4627-8485-4e8e265829f4" />

<img width="702" height="276" alt="image" src="https://github.com/user-attachments/assets/eef6456a-9d51-4430-84df-a785d290bcdb" />

