### PR TITLE
GUI3 fix: eject icon replaced

### DIFF
--- a/src/app/src/components/localIcons.tsx
+++ b/src/app/src/components/localIcons.tsx
@@ -22,7 +22,7 @@ export const LOCAL_ICON_DEFINITIONS: Record<string, LocalIconDefinition> = {
   },
   "eject": {
     "viewBox": "0 0 24 24",
-    "body": "<path d=\"m5 12 7-7 7 7\"></path><path d=\"M5 19h14\"></path>"
+    "body": "<path d=\"M4 13a1 1 0 0 1-.72-1.695l7.257-7.668a2 2 0 0 1 2.926 0l7.256 7.668A1 1 0 0 1 20 13z\"></path><rect x=\"3\" y=\"17\" width=\"18\" height=\"4\" rx=\"1\"></rect>"
   },
   "external-link": {
     "viewBox": "0 0 24 24",


### PR DESCRIPTION
<img width="403" height="90" alt="image" src="https://github.com/user-attachments/assets/b2b11881-624d-4f95-a812-5035c533e33a" />

That's the real deal.