### PR TITLE
Add route_only request option: routing decision without inference (dry-route)

### DIFF
--- a/docs/api/lemonade.md
+++ b/docs/api/lemonade.md
@@ -93,10 +93,10 @@ Malformed requests (invalid JSON, missing `input`/`text`, non-string fields, non
 <sub>![Status](https://img.shields.io/badge/status-experimental-orange)</sub>
 
 Naming a registered `collection.router` model in the `model` field of a
-`chat/completions` or `completions` request triggers the routing engine: the
-server picks a candidate by the policy's first-matching rule (fail-open to
-`default_model`) and forwards the request to it. No dedicated endpoint or `"auto"`
-model is involved.
+`chat/completions`, `completions`, or `responses` request triggers the routing
+engine: the server picks a candidate by the policy's first-matching rule
+(fail-open to `default_model`) and forwards the request to it. No dedicated
+endpoint or `"auto"` model is involved.
 
 The decision is reported on the response:
 
@@ -105,6 +105,13 @@ The decision is reported on the response:
   response body: `{ route_to, matched_rule, default_used, outputs, trace[] }`
   (`route_to` is the candidate that answered). For streaming responses it is
   attached to the first SSE event.
+- Request field **`route_only: true`** (dry-route) returns the decision instead
+  of running a completion: `{ requested_model, selected_model, routed,
+  decision }`. The selected candidate is not loaded, `stream` is ignored, and
+  `route_trace` composes as above. A registered non-router model answers
+  `routed: false`; an unknown model or a dispatch failure returns the same
+  error a real request would. A non-boolean `route_only` value is rejected
+  with `400`.
 
 See [Router Policies](../dev/router-policy.md) for authoring the policy.
 

--- a/docs/dev/router-policy.md
+++ b/docs/dev/router-policy.md
@@ -212,11 +212,15 @@ is **not** loaded and no completion runs:
 ```
 
 The `x-lemonade-route` header is set as usual, `decision.trace` appears when
-`"route_trace": true` is also sent, and `stream` is ignored. On a model that is
-not a router collection the response is
+`"route_trace": true` is also sent, and `stream` is ignored. On a **registered**
+model that is not a router collection the response is
 `{"requested_model": m, "selected_model": m, "routed": false}` — uniform for
-callers sweeping mixed model lists. Use this for policy debugging and CI,
-pre-estimating a workload's local/cloud split, and router evaluation harnesses.
+callers sweeping mixed model lists. `routed: false` means exactly that; an
+unknown model or a router whose dispatch fails returns the same error a real
+request would, and a non-boolean `route_only` value fails closed with `400`
+(never silently degrading into a real completion). Use this for policy
+debugging and CI, pre-estimating a workload's local/cloud split, and router
+evaluation harnesses.
 
 Related: `POST /api/v1/routing/validate` evaluates an **unregistered policy
 document** against caller-supplied features (`prompt`, `has_tools`,

--- a/docs/dev/router-policy.md
+++ b/docs/dev/router-policy.md
@@ -192,6 +192,38 @@ also carries an **`x_lemonade_route`** object:
 `route_to` is the candidate that actually answered. For streaming responses the
 same object is attached to the first SSE event as `x_lemonade_route`.
 
+## Dry-route: decision without inference
+
+Add `"route_only": true` to a `chat/completions`, `completions`, or `responses`
+request and the server runs dispatch exactly as it would for a real request —
+rules, classifiers, LLM-as-router; classifier helper models load as usual — then
+returns the decision instead of forwarding to a backend. The selected candidate
+is **not** loaded and no completion runs:
+
+```json
+{
+  "requested_model": "user.My-Router",
+  "selected_model": "Big-GGUF",
+  "routed": true,
+  "decision": { "version": "1", "route_to": "Big-GGUF",
+                "matched_rule": "coding-or-long-to-big",
+                "default_used": false, "outputs": {} }
+}
+```
+
+The `x-lemonade-route` header is set as usual, `decision.trace` appears when
+`"route_trace": true` is also sent, and `stream` is ignored. On a model that is
+not a router collection the response is
+`{"requested_model": m, "selected_model": m, "routed": false}` — uniform for
+callers sweeping mixed model lists. Use this for policy debugging and CI,
+pre-estimating a workload's local/cloud split, and router evaluation harnesses.
+
+Related: `POST /api/v1/routing/validate` evaluates an **unregistered policy
+document** against caller-supplied features (`prompt`, `has_tools`,
+`metadata`). `route_only` answers the complementary question — what the
+server would do with a real request against a **registered** router, including
+the request-feature extraction a live request gets.
+
 ## Cloud candidates
 
 A candidate may be a cloud model — the router derives the route category from the

--- a/src/cpp/include/lemon/server.h
+++ b/src/cpp/include/lemon/server.h
@@ -124,6 +124,9 @@ private:
     // If request_json addresses a collection.router model, rewrite its "model"
     // field in place to the engine-selected candidate and return the Decision.
     // No-op otherwise.
+    void respond_route_only(const nlohmann::json& request_json,
+                            const std::optional<RouterDispatchResult>& dispatch,
+                            httplib::Response& res);
     std::optional<RouterDispatchResult> apply_router_collection_dispatch(
         nlohmann::json& request_json);
     // Union of routing-helper models across every active router collection's

--- a/src/cpp/include/lemon/server.h
+++ b/src/cpp/include/lemon/server.h
@@ -124,9 +124,12 @@ private:
     // If request_json addresses a collection.router model, rewrite its "model"
     // field in place to the engine-selected candidate and return the Decision.
     // No-op otherwise.
-    void respond_route_only(const nlohmann::json& request_json,
-                            const std::optional<RouterDispatchResult>& dispatch,
-                            httplib::Response& res);
+    // Fully handles a route_only request: flag validation (fails closed on
+    // non-boolean values), a single model resolution reused for dispatch, and
+    // the decision or error response. Returns true when a response was written
+    // (the caller must return); false when the request is not route_only (a
+    // literal `false` is erased and normal forwarding proceeds).
+    bool try_respond_route_only(nlohmann::json& request_json, httplib::Response& res);
     std::optional<RouterDispatchResult> apply_router_collection_dispatch(
         nlohmann::json& request_json);
     // Union of routing-helper models across every active router collection's

--- a/src/cpp/resources/schemas/README.md
+++ b/src/cpp/resources/schemas/README.md
@@ -9,7 +9,7 @@ decision `trace` — never in the engine.
 | Schema | Describes |
 |--------|-----------|
 | `route_policy.schema.json` | The `routing` block embedded in a `collection.router` collection JSON. Invoked like `collection.omni`: point the OpenAI `model` field at the collection name. |
-| `request.schema.json` | The request-side extension fields on the OpenAI chat body: `metadata` (string-valued routing inputs) and the optional `route_trace`. Validates only those fields (`additionalProperties: true`); no `version` (rides on the stock OpenAI request). |
+| `request.schema.json` | The request-side extension fields on the OpenAI chat body: `metadata` (string-valued routing inputs), the optional `route_trace`, and the optional `route_only` dry-route mode (decision without inference). Validates only those fields (`additionalProperties: true`); no `version` (rides on the stock OpenAI request). |
 | `decision.schema.json` | The `x_lemonade_route` decision object attached additively to the chat response. |
 
 ## Versioning

--- a/src/cpp/resources/schemas/request.schema.json
+++ b/src/cpp/resources/schemas/request.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://lemonade-sdk.github.io/schemas/request.schema.json",
   "title": "Lemonade routing request extension",
-  "description": "The lemonade-specific fields a client adds to a standard OpenAI chat-completions body when addressing a collection.router model: routing inputs on `metadata` and the optional `route_trace` opt-in. Validates ONLY these extension fields — the rest of the OpenAI body (model, messages, ...) passes through untouched (additionalProperties: true). No `version` field: this rides on the stock OpenAI request for maximum drop-in, so there is no document the client versions.",
+  "description": "The lemonade-specific fields a client adds to a standard OpenAI chat-completions body when addressing a collection.router model: routing inputs on `metadata`, the optional `route_trace` opt-in, and the optional `route_only` dry-route mode. Validates ONLY these extension fields — the rest of the OpenAI body (model, messages, ...) passes through untouched (additionalProperties: true). No `version` field: this rides on the stock OpenAI request for maximum drop-in, so there is no document the client versions.",
   "type": "object",
   "properties": {
     "metadata": {
@@ -12,6 +12,10 @@
     },
     "route_trace": {
       "description": "Opt-in: when true, the response carries the full per-condition trace. Default omitted; minimal trace otherwise.",
+      "type": "boolean"
+    },
+    "route_only": {
+      "description": "Opt-in dry-route: when true, the server runs dispatch exactly as for a real request and returns the routing decision ({requested_model, selected_model, routed, decision}) instead of forwarding to a backend. The selected candidate is not loaded and no completion runs; `stream` is ignored. On a non-router model the response is the same shape with routed: false. Composes with `route_trace` (adds `decision.trace`).",
       "type": "boolean"
     }
   },

--- a/src/cpp/resources/schemas/request.schema.json
+++ b/src/cpp/resources/schemas/request.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://lemonade-sdk.github.io/schemas/request.schema.json",
   "title": "Lemonade routing request extension",
-  "description": "The lemonade-specific fields a client adds to a standard OpenAI chat-completions body when addressing a collection.router model: routing inputs on `metadata`, the optional `route_trace` opt-in, and the optional `route_only` dry-route mode. Validates ONLY these extension fields — the rest of the OpenAI body (model, messages, ...) passes through untouched (additionalProperties: true). No `version` field: this rides on the stock OpenAI request for maximum drop-in, so there is no document the client versions.",
+  "description": "The lemonade-specific fields a client adds to a standard OpenAI request body (chat/completions, completions, or responses) when addressing a collection.router model: routing inputs on `metadata`, the optional `route_trace` opt-in, and the optional `route_only` dry-route mode. Validates ONLY these extension fields — the rest of the OpenAI body (model, messages, ...) passes through untouched (additionalProperties: true). No `version` field: this rides on the stock OpenAI request for maximum drop-in, so there is no document the client versions.",
   "type": "object",
   "properties": {
     "metadata": {
@@ -15,7 +15,7 @@
       "type": "boolean"
     },
     "route_only": {
-      "description": "Opt-in dry-route: when true, the server runs dispatch exactly as for a real request and returns the routing decision ({requested_model, selected_model, routed, decision}) instead of forwarding to a backend. The selected candidate is not loaded and no completion runs; `stream` is ignored. On a non-router model the response is the same shape with routed: false. Composes with `route_trace` (adds `decision.trace`).",
+      "description": "Opt-in dry-route: when true, the server runs dispatch exactly as for a real request and returns the routing decision ({requested_model, selected_model, routed, decision}) instead of forwarding to a backend. The selected candidate is not loaded and no completion runs; `stream` is ignored. On a registered non-router model the response is the same shape with routed: false; unknown models and dispatch failures return the same error a real request would. A non-boolean value is rejected with 400 (fails closed — this flag means decision-without-inference).",
       "type": "boolean"
     }
   },

--- a/src/cpp/resources/schemas/schema-lock.json
+++ b/src/cpp/resources/schemas/schema-lock.json
@@ -8,7 +8,7 @@
     "released": false
   },
   "request.schema.json": {
-    "sha256": "a8b37f9c1577bfd84e9e1f01241df6a356573a84bc09efdc6a1392a55d4a0fca",
+    "sha256": "c2c9f9851a26ef1f2b8d9c2a57d0f925f614cde5caf68ccf97441cb1b852379f",
     "released": false
   }
 }

--- a/src/cpp/resources/schemas/schema-lock.json
+++ b/src/cpp/resources/schemas/schema-lock.json
@@ -8,7 +8,7 @@
     "released": false
   },
   "request.schema.json": {
-    "sha256": "c2c9f9851a26ef1f2b8d9c2a57d0f925f614cde5caf68ccf97441cb1b852379f",
+    "sha256": "37f69ee31d61fe5829cc218b45bedae76c0f73e688a144b7ec112c2286f7f3c5",
     "released": false
   }
 }

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -2960,6 +2960,46 @@ void Server::handle_routing_validate(const httplib::Request& req, httplib::Respo
     }
 }
 
+namespace {
+
+bool take_route_only_flag(nlohmann::json& request_json) {
+    if (!request_json.contains("route_only")) {
+        return false;
+    }
+    const bool enabled = request_json["route_only"].is_boolean() &&
+                         request_json["route_only"].get<bool>();
+    request_json.erase("route_only");
+    return enabled;
+}
+
+void set_route_only_response(const nlohmann::json& request_json,
+                             const std::optional<RouterDispatchResult>& dispatch,
+                             httplib::Response& res) {
+    nlohmann::json body;
+    if (dispatch) {
+        body = {
+            {"requested_model", dispatch->requested_model},
+            {"selected_model", dispatch->selected_model},
+            {"routed", true},
+            {"decision", route_decision_to_json(dispatch->decision)},
+        };
+        attach_route_header(res, dispatch->decision);
+    } else {
+        std::string model;
+        if (request_json.contains("model") && request_json["model"].is_string()) {
+            model = request_json["model"].get<std::string>();
+        }
+        body = {
+            {"requested_model", model},
+            {"selected_model", model},
+            {"routed", false},
+        };
+    }
+    res.set_content(body.dump(), "application/json");
+}
+
+} // namespace
+
 std::optional<RouterDispatchResult> Server::apply_router_collection_dispatch(
     nlohmann::json& request_json) {
     if (!request_json.contains("model") || !request_json["model"].is_string()) {
@@ -3021,6 +3061,8 @@ void Server::handle_chat_completions(const httplib::Request& req, httplib::Respo
         normalize_client_model_name(request_json);
         normalize_and_resolve_request_model(request_json);
 
+        const bool route_only = take_route_only_flag(request_json);
+
         // Debug: Check if tools are present
         if (request_json.contains("tools")) {
             LOG(DEBUG, "Server") << "Tools present in request: " << request_json["tools"].size() << " tool(s)" << std::endl;
@@ -3041,6 +3083,10 @@ void Server::handle_chat_completions(const httplib::Request& req, httplib::Respo
                 if (model_manager_->model_exists(requested_model)) {
                     ModelInfo info = model_manager_->get_model_info(requested_model);
                     if (is_omni_collection_recipe(info.recipe)) {
+                        if (route_only) {
+                            set_route_only_response(request_json, std::nullopt, res);
+                            return;
+                        }
                         handle_collection_chat_completions(request_json, info, res);
                         return;
                     }
@@ -3067,6 +3113,11 @@ void Server::handle_chat_completions(const httplib::Request& req, httplib::Respo
                 LOG(DEBUG, "Server") << "Collection check failed for '" << requested_model
                                      << "': " << e.what() << std::endl;
             }
+        }
+
+        if (route_only) {
+            set_route_only_response(request_json, route_dispatch, res);
+            return;
         }
 
         std::string requested_model;
@@ -3299,10 +3350,17 @@ void Server::handle_completions(const httplib::Request& req, httplib::Response& 
         normalize_client_model_name(request_json);
         normalize_and_resolve_request_model(request_json);
 
+        const bool route_only = take_route_only_flag(request_json);
+
         // A collection.router model flips this endpoint into engine mode: pick a
         // candidate and rewrite the model before the usual load/forward logic.
         std::optional<RouterDispatchResult> route_dispatch =
             apply_router_collection_dispatch(request_json);
+
+        if (route_only) {
+            set_route_only_response(request_json, route_dispatch, res);
+            return;
+        }
 
         std::string requested_model;
         if (request_json.contains("model") && request_json["model"].is_string()) {
@@ -4952,10 +5010,17 @@ void Server::handle_responses(const httplib::Request& req, httplib::Response& re
         normalize_client_model_name(request_json);
         normalize_and_resolve_request_model(request_json);
 
+        const bool route_only = take_route_only_flag(request_json);
+
         // A collection.router model flips this endpoint into engine mode: pick a
         // candidate and rewrite the model before the usual load/forward logic.
         std::optional<RouterDispatchResult> route_dispatch =
             apply_router_collection_dispatch(request_json);
+
+        if (route_only) {
+            set_route_only_response(request_json, route_dispatch, res);
+            return;
+        }
 
         // Handle model loading/switching using helper function
         if (request_json.contains("model")) {

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -2962,42 +2962,44 @@ void Server::handle_routing_validate(const httplib::Request& req, httplib::Respo
 
 namespace {
 
-// Returns false when the request was rejected (response already written).
-// route_only means "decision without inference", so an invalid value fails
-// closed with 400 rather than silently degrading into a real completion.
-bool take_route_only_flag(nlohmann::json& request_json, httplib::Response& res,
-                          bool& route_only) {
-    route_only = false;
+enum class RouteOnlyFlag { kAbsent, kEnabled, kInvalid };
+
+RouteOnlyFlag take_route_only_flag(nlohmann::json& request_json) {
     if (!request_json.contains("route_only")) {
-        return true;
+        return RouteOnlyFlag::kAbsent;
     }
     if (!request_json["route_only"].is_boolean()) {
-        res.status = 400;
-        res.set_content(
-            R"({"error": {"message": "'route_only' must be a boolean", "type": "invalid_request_error", "param": "route_only"}})",
-            "application/json");
-        return false;
+        return RouteOnlyFlag::kInvalid;
     }
-    route_only = request_json["route_only"].get<bool>();
+    const bool enabled = request_json["route_only"].get<bool>();
     request_json.erase("route_only");
-    return true;
+    return enabled ? RouteOnlyFlag::kEnabled : RouteOnlyFlag::kAbsent;
+}
+
+void set_json_error(httplib::Response& res, int status, const std::string& message,
+                    const std::string& type, const std::string& param = std::string()) {
+    nlohmann::json error = {{"message", message}, {"type", type}};
+    if (!param.empty()) {
+        error["param"] = param;
+    }
+    res.status = status;
+    res.set_content(nlohmann::json{{"error", std::move(error)}}.dump(), "application/json");
 }
 
 } // namespace
 
-void Server::respond_route_only(const nlohmann::json& request_json,
-                                const std::optional<RouterDispatchResult>& dispatch,
-                                httplib::Response& res) {
-    if (dispatch) {
-        nlohmann::json body = {
-            {"requested_model", dispatch->requested_model},
-            {"selected_model", dispatch->selected_model},
-            {"routed", true},
-            {"decision", route_decision_to_json(dispatch->decision)},
-        };
-        attach_route_header(res, dispatch->decision);
-        res.set_content(body.dump(), "application/json");
-        return;
+bool Server::try_respond_route_only(nlohmann::json& request_json, httplib::Response& res) {
+    switch (take_route_only_flag(request_json)) {
+        case RouteOnlyFlag::kAbsent:
+            return false;
+        case RouteOnlyFlag::kInvalid:
+            // route_only means "decision without inference" — an invalid value
+            // fails closed instead of degrading into a real completion.
+            set_json_error(res, 400, "'route_only' must be a boolean",
+                           "invalid_request_error", "route_only");
+            return true;
+        case RouteOnlyFlag::kEnabled:
+            break;
     }
 
     std::string model;
@@ -3005,11 +3007,9 @@ void Server::respond_route_only(const nlohmann::json& request_json,
         model = request_json["model"].get<std::string>();
     }
     if (model.empty()) {
-        res.status = 400;
-        res.set_content(
-            R"({"error": {"message": "route_only requires a 'model' field", "type": "invalid_request_error", "param": "model"}})",
-            "application/json");
-        return;
+        set_json_error(res, 400, "route_only requires a 'model' field",
+                       "invalid_request_error", "model");
+        return true;
     }
     // routed: false is reserved for "exists and is not a router". Lookup and
     // dispatch failures keep the same error behavior a real request would get.
@@ -3019,23 +3019,49 @@ void Server::respond_route_only(const nlohmann::json& request_json,
         res.status = get_http_status_from_error(
             error_response["error"]["code"].get<std::string>());
         res.set_content(error_response.dump(), "application/json");
-        return;
+        return true;
     }
-    if (is_router_collection_recipe(model_manager_->get_model_info(model).recipe)) {
-        res.status = 500;
-        nlohmann::json error = {{"error", {
-            {"message", "router dispatch failed for '" + model + "'"},
-            {"type", "server_error"}
-        }}};
-        res.set_content(error.dump(), "application/json");
-        return;
+
+    // Resolve once and reuse for both the recipe check and dispatch, so the
+    // decision reflects a single registry snapshot under concurrent updates.
+    const ModelInfo info = model_manager_->get_model_info(model);
+    if (!is_router_collection_recipe(info.recipe)) {
+        nlohmann::json body = {
+            {"requested_model", model},
+            {"selected_model", model},
+            {"routed", false},
+        };
+        res.set_content(body.dump(), "application/json");
+        return true;
     }
-    nlohmann::json body = {
-        {"requested_model", model},
-        {"selected_model", model},
-        {"routed", false},
-    };
-    res.set_content(body.dump(), "application/json");
+
+    try {
+        std::optional<RouterDispatchResult> dispatch =
+            route_collection_request(request_json, info);
+        if (dispatch) {
+            dispatch->requested_model = model;
+            nlohmann::json body = {
+                {"requested_model", model},
+                {"selected_model", dispatch->selected_model},
+                {"routed", true},
+                {"decision", route_decision_to_json(dispatch->decision)},
+            };
+            attach_route_header(res, dispatch->decision);
+            res.set_content(body.dump(), "application/json");
+            return true;
+        }
+        set_json_error(res, 500,
+                       "router dispatch failed for '" + model +
+                           "': no routing decision (no parsed policy)",
+                       "server_error");
+    } catch (const RouterResidencyConflictException& e) {
+        set_router_residency_conflict_response(e, res);
+    } catch (const std::exception& e) {
+        set_json_error(res, 500,
+                       "router dispatch failed for '" + model + "': " + e.what(),
+                       "server_error");
+    }
+    return true;
 }
 
 std::optional<RouterDispatchResult> Server::apply_router_collection_dispatch(
@@ -3099,8 +3125,7 @@ void Server::handle_chat_completions(const httplib::Request& req, httplib::Respo
         normalize_client_model_name(request_json);
         normalize_and_resolve_request_model(request_json);
 
-        bool route_only = false;
-        if (!take_route_only_flag(request_json, res, route_only)) {
+        if (try_respond_route_only(request_json, res)) {
             return;
         }
 
@@ -3124,10 +3149,6 @@ void Server::handle_chat_completions(const httplib::Request& req, httplib::Respo
                 if (model_manager_->model_exists(requested_model)) {
                     ModelInfo info = model_manager_->get_model_info(requested_model);
                     if (is_omni_collection_recipe(info.recipe)) {
-                        if (route_only) {
-                            respond_route_only(request_json, std::nullopt, res);
-                            return;
-                        }
                         handle_collection_chat_completions(request_json, info, res);
                         return;
                     }
@@ -3154,11 +3175,6 @@ void Server::handle_chat_completions(const httplib::Request& req, httplib::Respo
                 LOG(DEBUG, "Server") << "Collection check failed for '" << requested_model
                                      << "': " << e.what() << std::endl;
             }
-        }
-
-        if (route_only) {
-            respond_route_only(request_json, route_dispatch, res);
-            return;
         }
 
         std::string requested_model;
@@ -3391,8 +3407,7 @@ void Server::handle_completions(const httplib::Request& req, httplib::Response& 
         normalize_client_model_name(request_json);
         normalize_and_resolve_request_model(request_json);
 
-        bool route_only = false;
-        if (!take_route_only_flag(request_json, res, route_only)) {
+        if (try_respond_route_only(request_json, res)) {
             return;
         }
 
@@ -3400,11 +3415,6 @@ void Server::handle_completions(const httplib::Request& req, httplib::Response& 
         // candidate and rewrite the model before the usual load/forward logic.
         std::optional<RouterDispatchResult> route_dispatch =
             apply_router_collection_dispatch(request_json);
-
-        if (route_only) {
-            respond_route_only(request_json, route_dispatch, res);
-            return;
-        }
 
         std::string requested_model;
         if (request_json.contains("model") && request_json["model"].is_string()) {
@@ -5054,8 +5064,7 @@ void Server::handle_responses(const httplib::Request& req, httplib::Response& re
         normalize_client_model_name(request_json);
         normalize_and_resolve_request_model(request_json);
 
-        bool route_only = false;
-        if (!take_route_only_flag(request_json, res, route_only)) {
+        if (try_respond_route_only(request_json, res)) {
             return;
         }
 
@@ -5063,11 +5072,6 @@ void Server::handle_responses(const httplib::Request& req, httplib::Response& re
         // candidate and rewrite the model before the usual load/forward logic.
         std::optional<RouterDispatchResult> route_dispatch =
             apply_router_collection_dispatch(request_json);
-
-        if (route_only) {
-            respond_route_only(request_json, route_dispatch, res);
-            return;
-        }
 
         // Handle model loading/switching using helper function
         if (request_json.contains("model")) {

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -2962,43 +2962,81 @@ void Server::handle_routing_validate(const httplib::Request& req, httplib::Respo
 
 namespace {
 
-bool take_route_only_flag(nlohmann::json& request_json) {
+// Returns false when the request was rejected (response already written).
+// route_only means "decision without inference", so an invalid value fails
+// closed with 400 rather than silently degrading into a real completion.
+bool take_route_only_flag(nlohmann::json& request_json, httplib::Response& res,
+                          bool& route_only) {
+    route_only = false;
     if (!request_json.contains("route_only")) {
+        return true;
+    }
+    if (!request_json["route_only"].is_boolean()) {
+        res.status = 400;
+        res.set_content(
+            R"({"error": {"message": "'route_only' must be a boolean", "type": "invalid_request_error", "param": "route_only"}})",
+            "application/json");
         return false;
     }
-    const bool enabled = request_json["route_only"].is_boolean() &&
-                         request_json["route_only"].get<bool>();
+    route_only = request_json["route_only"].get<bool>();
     request_json.erase("route_only");
-    return enabled;
+    return true;
 }
 
-void set_route_only_response(const nlohmann::json& request_json,
-                             const std::optional<RouterDispatchResult>& dispatch,
-                             httplib::Response& res) {
-    nlohmann::json body;
+} // namespace
+
+void Server::respond_route_only(const nlohmann::json& request_json,
+                                const std::optional<RouterDispatchResult>& dispatch,
+                                httplib::Response& res) {
     if (dispatch) {
-        body = {
+        nlohmann::json body = {
             {"requested_model", dispatch->requested_model},
             {"selected_model", dispatch->selected_model},
             {"routed", true},
             {"decision", route_decision_to_json(dispatch->decision)},
         };
         attach_route_header(res, dispatch->decision);
-    } else {
-        std::string model;
-        if (request_json.contains("model") && request_json["model"].is_string()) {
-            model = request_json["model"].get<std::string>();
-        }
-        body = {
-            {"requested_model", model},
-            {"selected_model", model},
-            {"routed", false},
-        };
+        res.set_content(body.dump(), "application/json");
+        return;
     }
+
+    std::string model;
+    if (request_json.contains("model") && request_json["model"].is_string()) {
+        model = request_json["model"].get<std::string>();
+    }
+    if (model.empty()) {
+        res.status = 400;
+        res.set_content(
+            R"({"error": {"message": "route_only requires a 'model' field", "type": "invalid_request_error", "param": "model"}})",
+            "application/json");
+        return;
+    }
+    // routed: false is reserved for "exists and is not a router". Lookup and
+    // dispatch failures keep the same error behavior a real request would get.
+    if (!model_manager_->model_exists(model)) {
+        nlohmann::json error_response =
+            create_model_error(model, "Model not found: " + model);
+        res.status = get_http_status_from_error(
+            error_response["error"]["code"].get<std::string>());
+        res.set_content(error_response.dump(), "application/json");
+        return;
+    }
+    if (is_router_collection_recipe(model_manager_->get_model_info(model).recipe)) {
+        res.status = 500;
+        nlohmann::json error = {{"error", {
+            {"message", "router dispatch failed for '" + model + "'"},
+            {"type", "server_error"}
+        }}};
+        res.set_content(error.dump(), "application/json");
+        return;
+    }
+    nlohmann::json body = {
+        {"requested_model", model},
+        {"selected_model", model},
+        {"routed", false},
+    };
     res.set_content(body.dump(), "application/json");
 }
-
-} // namespace
 
 std::optional<RouterDispatchResult> Server::apply_router_collection_dispatch(
     nlohmann::json& request_json) {
@@ -3061,7 +3099,10 @@ void Server::handle_chat_completions(const httplib::Request& req, httplib::Respo
         normalize_client_model_name(request_json);
         normalize_and_resolve_request_model(request_json);
 
-        const bool route_only = take_route_only_flag(request_json);
+        bool route_only = false;
+        if (!take_route_only_flag(request_json, res, route_only)) {
+            return;
+        }
 
         // Debug: Check if tools are present
         if (request_json.contains("tools")) {
@@ -3084,7 +3125,7 @@ void Server::handle_chat_completions(const httplib::Request& req, httplib::Respo
                     ModelInfo info = model_manager_->get_model_info(requested_model);
                     if (is_omni_collection_recipe(info.recipe)) {
                         if (route_only) {
-                            set_route_only_response(request_json, std::nullopt, res);
+                            respond_route_only(request_json, std::nullopt, res);
                             return;
                         }
                         handle_collection_chat_completions(request_json, info, res);
@@ -3116,7 +3157,7 @@ void Server::handle_chat_completions(const httplib::Request& req, httplib::Respo
         }
 
         if (route_only) {
-            set_route_only_response(request_json, route_dispatch, res);
+            respond_route_only(request_json, route_dispatch, res);
             return;
         }
 
@@ -3350,7 +3391,10 @@ void Server::handle_completions(const httplib::Request& req, httplib::Response& 
         normalize_client_model_name(request_json);
         normalize_and_resolve_request_model(request_json);
 
-        const bool route_only = take_route_only_flag(request_json);
+        bool route_only = false;
+        if (!take_route_only_flag(request_json, res, route_only)) {
+            return;
+        }
 
         // A collection.router model flips this endpoint into engine mode: pick a
         // candidate and rewrite the model before the usual load/forward logic.
@@ -3358,7 +3402,7 @@ void Server::handle_completions(const httplib::Request& req, httplib::Response& 
             apply_router_collection_dispatch(request_json);
 
         if (route_only) {
-            set_route_only_response(request_json, route_dispatch, res);
+            respond_route_only(request_json, route_dispatch, res);
             return;
         }
 
@@ -5010,7 +5054,10 @@ void Server::handle_responses(const httplib::Request& req, httplib::Response& re
         normalize_client_model_name(request_json);
         normalize_and_resolve_request_model(request_json);
 
-        const bool route_only = take_route_only_flag(request_json);
+        bool route_only = false;
+        if (!take_route_only_flag(request_json, res, route_only)) {
+            return;
+        }
 
         // A collection.router model flips this endpoint into engine mode: pick a
         // candidate and rewrite the model before the usual load/forward logic.
@@ -5018,7 +5065,7 @@ void Server::handle_responses(const httplib::Request& req, httplib::Response& re
             apply_router_collection_dispatch(request_json);
 
         if (route_only) {
-            set_route_only_response(request_json, route_dispatch, res);
+            respond_route_only(request_json, route_dispatch, res);
             return;
         }
 

--- a/test/server_endpoints.py
+++ b/test/server_endpoints.py
@@ -3538,6 +3538,141 @@ class EndpointTests(ServerTestBase):
             except Exception:
                 pass
 
+    def test_021za_route_only_returns_decision_without_inference(self):
+        """route_only: true returns the routing decision without loading or
+        invoking the selected candidate (#3098). The decision must be the same
+        dispatch a real request would get, the candidate must stay unloaded,
+        trace stays opt-in via route_trace, and a non-router model answers
+        routed: false."""
+        suffix = uuid.uuid4().hex[:8]
+        canonical_name = f"user.RouterDry-{suffix}"
+        public_name = canonical_name[5:]
+        try:
+            pull_response = requests.post(
+                f"{self.base_url}/pull",
+                json={
+                    "model_name": canonical_name,
+                    "version": "1",
+                    "recipe": "collection.router",
+                    "components": [ENDPOINT_TEST_MODEL],
+                    "routing": {
+                        "candidates": [ENDPOINT_TEST_MODEL],
+                        "default_model": ENDPOINT_TEST_MODEL,
+                        "rules": [
+                            {
+                                "id": "code-to-test-model",
+                                "match": {"keywords_any": ["code", "def "]},
+                                "route_to": ENDPOINT_TEST_MODEL,
+                            }
+                        ],
+                    },
+                },
+                timeout=TIMEOUT_MODEL_OPERATION,
+            )
+            self.assertEqual(pull_response.status_code, 200, pull_response.text)
+
+            # Start from an empty router so we can prove route_only loads nothing.
+            requests.post(f"{self.base_url}/unload", json={}, timeout=TIMEOUT_DEFAULT)
+
+            response = requests.post(
+                f"{self.base_url}/chat/completions",
+                json={
+                    "model": public_name,
+                    "route_only": True,
+                    "messages": [
+                        {"role": "user", "content": "Please write code for me"}
+                    ],
+                },
+                timeout=TIMEOUT_DEFAULT,
+            )
+            self.assertEqual(response.status_code, 200, response.text)
+            body = response.json()
+            self.assertEqual(body.get("requested_model"), public_name)
+            self.assertEqual(body.get("selected_model"), ENDPOINT_TEST_MODEL)
+            self.assertEqual(body.get("routed"), True)
+            self.assertNotIn("choices", body, "route_only must not run a completion")
+            decision = body.get("decision")
+            self.assertIsInstance(decision, dict)
+            self.assertEqual(decision.get("route_to"), ENDPOINT_TEST_MODEL)
+            self.assertEqual(decision.get("matched_rule"), "code-to-test-model")
+            self.assertEqual(decision.get("default_used"), False)
+            self.assertNotIn("trace", decision, "trace must be opt-in via route_trace")
+            self.assertEqual(
+                response.headers.get("x-lemonade-route"), "code-to-test-model"
+            )
+
+            # The static keyword rule decided without touching any backend.
+            health = requests.get(
+                f"{self.base_url}/health", timeout=TIMEOUT_DEFAULT
+            ).json()
+            self.assertEqual(
+                health.get("all_models_loaded"),
+                [],
+                "route_only must not load the selected candidate",
+            )
+
+            # route_trace: true adds the per-condition trace to the decision.
+            traced = requests.post(
+                f"{self.base_url}/chat/completions",
+                json={
+                    "model": public_name,
+                    "route_only": True,
+                    "route_trace": True,
+                    "messages": [{"role": "user", "content": "Hello there"}],
+                },
+                timeout=TIMEOUT_DEFAULT,
+            )
+            self.assertEqual(traced.status_code, 200, traced.text)
+            traced_decision = traced.json().get("decision", {})
+            self.assertEqual(traced_decision.get("default_used"), True)
+            self.assertIn("trace", traced_decision)
+            self.assertEqual(traced.headers.get("x-lemonade-route"), "default")
+
+            # Same option on /completions and /responses.
+            for endpoint, payload in (
+                ("completions", {"prompt": "write code"}),
+                ("responses", {"input": "write code"}),
+            ):
+                sibling = requests.post(
+                    f"{self.base_url}/{endpoint}",
+                    json={"model": public_name, "route_only": True, **payload},
+                    timeout=TIMEOUT_DEFAULT,
+                )
+                self.assertEqual(sibling.status_code, 200, f"{endpoint}: {sibling.text}")
+                sibling_body = sibling.json()
+                self.assertEqual(sibling_body.get("routed"), True, endpoint)
+                self.assertEqual(
+                    sibling_body.get("selected_model"), ENDPOINT_TEST_MODEL, endpoint
+                )
+                self.assertNotIn("choices", sibling_body, endpoint)
+
+            # A non-router model answers uniformly with routed: false.
+            plain = requests.post(
+                f"{self.base_url}/chat/completions",
+                json={
+                    "model": ENDPOINT_TEST_MODEL,
+                    "route_only": True,
+                    "messages": [{"role": "user", "content": "hi"}],
+                },
+                timeout=TIMEOUT_DEFAULT,
+            )
+            self.assertEqual(plain.status_code, 200, plain.text)
+            plain_body = plain.json()
+            self.assertEqual(plain_body.get("routed"), False)
+            self.assertEqual(plain_body.get("selected_model"), ENDPOINT_TEST_MODEL)
+            self.assertNotIn("choices", plain_body)
+
+            print(f"[OK] route_only returned decisions for {public_name} without inference")
+        finally:
+            try:
+                requests.post(
+                    f"{self.base_url}/delete",
+                    json={"model_name": canonical_name},
+                    timeout=TIMEOUT_DEFAULT,
+                )
+            except Exception:
+                pass
+
     def test_021zh_router_collection_repull_overwrite(self):
         """Re-pulling an already-registered collection.router under the same
         name must succeed (#2703). On overwrite the registration data is

--- a/test/server_endpoints.py
+++ b/test/server_endpoints.py
@@ -3646,7 +3646,7 @@ class EndpointTests(ServerTestBase):
                 )
                 self.assertNotIn("choices", sibling_body, endpoint)
 
-            # A non-router model answers uniformly with routed: false.
+            # A registered non-router model answers uniformly with routed: false.
             plain = requests.post(
                 f"{self.base_url}/chat/completions",
                 json={
@@ -3661,6 +3661,39 @@ class EndpointTests(ServerTestBase):
             self.assertEqual(plain_body.get("routed"), False)
             self.assertEqual(plain_body.get("selected_model"), ENDPOINT_TEST_MODEL)
             self.assertNotIn("choices", plain_body)
+
+            # route_only fails closed: a non-boolean value must be rejected with
+            # 400, never silently dropped into a real completion.
+            for bad_value in ("true", 1, None):
+                bad = requests.post(
+                    f"{self.base_url}/chat/completions",
+                    json={
+                        "model": public_name,
+                        "route_only": bad_value,
+                        "messages": [{"role": "user", "content": "hi"}],
+                    },
+                    timeout=TIMEOUT_DEFAULT,
+                )
+                self.assertEqual(
+                    bad.status_code, 400, f"route_only={bad_value!r}: {bad.text}"
+                )
+                self.assertIn("error", bad.json())
+
+            # routed: false is reserved for registered non-routers: an unknown
+            # model keeps the normal not-found error, not a 200.
+            missing = requests.post(
+                f"{self.base_url}/chat/completions",
+                json={
+                    "model": f"NoSuchModel-{suffix}",
+                    "route_only": True,
+                    "messages": [{"role": "user", "content": "hi"}],
+                },
+                timeout=TIMEOUT_DEFAULT,
+            )
+            self.assertEqual(missing.status_code, 404, missing.text)
+            missing_body = missing.json()
+            self.assertIn("error", missing_body)
+            self.assertNotIn("routed", missing_body)
 
             print(f"[OK] route_only returned decisions for {public_name} without inference")
         finally:


### PR DESCRIPTION
Closes #3098.

Adds a `route_only: true` request option to `chat/completions`, `completions`, and `responses`: the server runs `collection.router` dispatch exactly as for a real request (rules, classifiers, LLM-as-router — classifier helpers load as usual), then returns the decision instead of forwarding to a backend. The selected candidate is not loaded and no completion runs.

- Response: `{requested_model, selected_model, routed, decision}` with `decision` in the existing `route_decision_to_json` shape; `x-lemonade-route` header set as usual; `decision.trace` appears with `route_trace: true`; non-router models answer `routed: false` uniformly.
- Complementary to `POST /routing/validate` (ad-hoc policy document + synthetic features): `route_only` answers what the server would do with a real request against a registered router. Documented in `docs/dev/router-policy.md`.
- Tests: new `test_021za` in `server_endpoints.py` covers rule match, trace opt-in, all three endpoints, `routed: false`, and asserts `all_models_loaded` stays empty (no load). Existing router dispatch tests and 13/13 C++ routing unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016yHZizzdKkiPz3WbPpUHu1
