### PR TITLE
feat(mcp): add Streamable HTTP client transport

### DIFF
--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -1915,6 +1915,7 @@ jobs:
         run: |
           .venv/bin/python -m test.utils.reset_server_state --best-effort --label "ubuntu endpoints"
           .venv/bin/python test/server_endpoints.py --cli-binary lemonade
+          .venv/bin/python test/server_mcp_client.py
           echo "Running WebSocket idle test..."
           .venv/bin/python test/test_websocket_idle.py
           echo "WebSocket idle test PASSED!"
@@ -2063,6 +2064,7 @@ jobs:
           elif [ "${{ matrix.test_type }}" = "endpoints" ]; then
             echo "Running endpoint tests..."
             $VENV_PYTHON test/server_endpoints.py --cli-binary "$CLI_BINARY"
+            $VENV_PYTHON test/server_mcp_client.py
             echo "Running WebSocket idle test..."
             $VENV_PYTHON test/test_websocket_idle.py
             echo "WebSocket idle test PASSED!"
@@ -2150,6 +2152,7 @@ jobs:
         run: |
           $VENV_PYTHON -m test.utils.reset_server_state --best-effort --label "windows-latest endpoints"
           $VENV_PYTHON test/server_endpoints.py --cli-binary "$CLI_BINARY"
+          $VENV_PYTHON test/server_mcp_client.py
           echo "Running WebSocket idle test..."
           $VENV_PYTHON test/test_websocket_idle.py
           echo "WebSocket idle test PASSED!"
@@ -2291,6 +2294,7 @@ jobs:
         run: |
           $VENV_PYTHON -m test.utils.reset_server_state --best-effort --label "macos-latest endpoints"
           $VENV_PYTHON test/server_endpoints.py --cli-binary "$CLI_BINARY"
+          $VENV_PYTHON test/server_mcp_client.py
           $VENV_PYTHON test/test_websocket_idle.py
           $VENV_PYTHON test/server_websocket_auth.py
           $VENV_PYTHON test/test_tray_https.py

--- a/docs/api/lemonade.md
+++ b/docs/api/lemonade.md
@@ -37,6 +37,103 @@ We have designed a set of Lemonade-specific endpoints to enable client applicati
 | `GET` | [`/internal/aliases`](#get-internalaliases) | List all active model aliases |
 | `POST` | [`/internal/aliases`](#post-internalaliases) | Create or update a model alias |
 | `DELETE` | [`/internal/aliases/{alias}`](#delete-internalaliasesalias) | Remove a model alias |
+| `GET` | [`/internal/mcp/servers`](#external-mcp-client-host) | List configured external MCP servers and their current state |
+| `GET` | [`/internal/mcp/tools`](#external-mcp-client-host) | List tools exposed by connected external MCP servers |
+| `POST` | [`/internal/mcp/servers`](#external-mcp-client-host) | Create or update an external MCP server configuration |
+| `POST` | [`/internal/mcp/servers/test`](#external-mcp-client-host) | Test a server configuration without persisting it |
+| `DELETE` | [`/internal/mcp/servers/{id}`](#external-mcp-client-host) | Remove an external MCP server configuration |
+| `POST` | [`/internal/mcp/servers/{id}/connect`](#external-mcp-client-host) | Connect to an external MCP server |
+| `POST` | [`/internal/mcp/servers/{id}/disconnect`](#external-mcp-client-host) | Disconnect from an external MCP server |
+| `POST` | [`/internal/mcp/servers/{id}/refresh-tools`](#external-mcp-client-host) | Refresh the server tool catalogue |
+| `POST` | [`/internal/mcp/servers/{id}/tools/call`](#external-mcp-client-host) | Call a tool on an external MCP server |
+
+## External MCP client host
+<sub>![Status](https://img.shields.io/badge/status-experimental-orange)</sub>
+
+Lemonade can also act as an **MCP client host** for external MCP servers. This is separate from the [`POST /mcp`](./mcp.md) gateway, where Lemonade itself acts as an MCP server.
+
+External servers are managed through the `/internal/mcp/*` administration API. The client host supports two transports:
+
+- **`streamable-http`** for remote or local MCP HTTP endpoints.
+- **`stdio`** for locally launched MCP processes. Existing configurations remain backward compatible because an omitted `transport` still defaults to `stdio`.
+
+### Streamable HTTP configuration
+
+A Streamable HTTP server configuration uses the following fields:
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `id` | no on create/test | Stable server identifier. When omitted for create/test, Lemonade derives one from the name or URL. |
+| `name` | no | Human-readable name. Defaults to the resolved id. |
+| `transport` | yes | Use `streamable-http`. `http` is accepted as an alias and normalized to `streamable-http`. |
+| `url` | yes | MCP endpoint URL. HTTP and HTTPS are supported. |
+| `bearer_token` | no | Bearer credential as a `${VARIABLE}` environment reference. Raw tokens are rejected and are never persisted. |
+| `allow_insecure_http` | no | Allow plain HTTP to a non-loopback host. Plain HTTP to localhost/loopback is allowed without this flag. Defaults to `false`. |
+| `enabled` | no | Whether the configured server may be connected. Defaults to `true`. |
+| `timeout_ms` | no | Request timeout in milliseconds, from 1000 to 300000. Defaults to 30000. |
+
+Streamable HTTP configurations must not include stdio-only fields such as `command`, `args`, `env`, or `working_dir`.
+
+Example:
+
+```json
+{
+  "server": {
+    "id": "example-mcp",
+    "name": "Example MCP",
+    "transport": "streamable-http",
+    "url": "https://example.com/mcp",
+    "bearer_token": "${EXAMPLE_MCP_TOKEN}",
+    "timeout_ms": 30000,
+    "enabled": true
+  }
+}
+```
+
+### Local stdio configuration
+
+The existing stdio transport remains available for MCP servers that Lemonade should launch and supervise locally:
+
+```json
+{
+  "server": {
+    "id": "local-mcp",
+    "name": "Local MCP",
+    "transport": "stdio",
+    "command": "python",
+    "args": ["/absolute/path/server.py"],
+    "env": {
+      "SERVICE_TOKEN": "${SERVICE_TOKEN}"
+    },
+    "timeout_ms": 30000,
+    "enabled": true
+  }
+}
+```
+
+Values in `env` must also be `${VARIABLE}` references. HTTP-only fields such as `url`, `bearer_token`, and `allow_insecure_http` are rejected for stdio configurations.
+
+### Administration endpoints
+
+| Method | Endpoint | Purpose |
+|--------|----------|---------|
+| `GET` | `/internal/mcp/servers` | List configured servers and current connection state. |
+| `GET` | `/internal/mcp/tools` | List tools exposed by connected external servers. |
+| `POST` | `/internal/mcp/servers` | Create or update a persisted server configuration. |
+| `POST` | `/internal/mcp/servers/test` | Connect, initialize, discover tools, disconnect, and return the result without persisting the draft. |
+| `DELETE` | `/internal/mcp/servers/{id}` | Remove a persisted configuration. |
+| `POST` | `/internal/mcp/servers/{id}/connect` | Connect and perform the MCP initialization handshake. |
+| `POST` | `/internal/mcp/servers/{id}/disconnect` | Disconnect and clear local connection state. |
+| `POST` | `/internal/mcp/servers/{id}/refresh-tools` | Refresh `tools/list`. |
+| `POST` | `/internal/mcp/servers/{id}/tools/call` | Call a remote tool. The body requires `name` and may include an `arguments` object. |
+
+These are internal administrative routes and follow Lemonade's existing authentication rules for `/internal/*` endpoints.
+
+### Streamable HTTP behavior
+
+For Streamable HTTP connections, Lemonade performs the MCP initialization flow, negotiates a supported protocol version, and then sends `notifications/initialized`. It supports both JSON responses and `text/event-stream` responses, carries the negotiated `MCP-Protocol-Version` header, tracks `Mcp-Session-Id`, and performs best-effort session cleanup with HTTP `DELETE` on disconnect.
+
+If an HTTP session expires and the server returns `404`, Lemonade invalidates the local session so a later operation can establish a fresh connection. Incoming server requests are handled while waiting for a response; `ping` is answered directly and unsupported methods receive a JSON-RPC method-not-found response.
 
 ## `POST /v1/classify`
 <sub>![Status](https://img.shields.io/badge/status-experimental-orange)</sub>

--- a/docs/api/mcp.md
+++ b/docs/api/mcp.md
@@ -2,6 +2,8 @@
 
 Lemonade exposes its inference capabilities as a Model Context Protocol (MCP) server, so any MCP-compatible client (GitHub Copilot, Claude Desktop, MCP Inspector, Cursor, the `mcp` Python client, etc.) can call your locally running models as tools.
 
+> **Server vs. client host:** This page documents Lemonade acting as an MCP **server** at `/mcp`. Lemonade can also act as an MCP **client** for external Streamable HTTP or stdio servers through its internal administration API. See [External MCP client host](./lemonade.md#external-mcp-client-host).
+
 The gateway implements the **MCP "Streamable HTTP" transport** (spec version `2025-06-18`) with the `tools` capability only. All traffic flows through a single endpoint:
 
 | Endpoint | Status | Notes |

--- a/src/cpp/include/lemon/mcp_client.h
+++ b/src/cpp/include/lemon/mcp_client.h
@@ -15,13 +15,23 @@ using json = nlohmann::json;
 
 // Server-side MCP client host for external MCP servers.
 //
-// This foundation intentionally provides only stdio transport, persistent server
+// Supports Streamable HTTP endpoints and local stdio processes, with persistent
 // configuration, explicit connect/disconnect, tool discovery, and raw tool calls.
-// Chat-loop orchestration and GUI selection remain separate follow-up work.
+// Chat-loop orchestration and GUI selection remain separate.
 struct McpServerConfig {
     std::string id;
     std::string name;
+    // Existing configs remain stdio by default. New UI-created configs default
+    // to streamable-http explicitly.
     std::string transport = "stdio";
+
+    // Streamable HTTP configuration. `bearer_token` is persisted only as a
+    // ${VARIABLE} reference and resolved from the lemond environment at use time.
+    std::string url;
+    std::string bearer_token;
+    bool allow_insecure_http = false;
+
+    // Local stdio process configuration.
     std::string command;
     std::vector<std::string> args;
     // Values must be environment references in the form ${VARIABLE}. Raw values
@@ -53,6 +63,7 @@ public:
     json list_servers_json() const;
     json list_tools_json() const;
     json upsert_server_json(const json& body);
+    json test_server_json(const json& body);
     json remove_server_json(const std::string& id);
     json connect_server_json(const std::string& id);
     json disconnect_server_json(const std::string& id);

--- a/src/cpp/server/mcp_client.cpp
+++ b/src/cpp/server/mcp_client.cpp
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <cwchar>
+#include <exception>
 #include <filesystem>
 #include <fstream>
 #include <functional>
@@ -53,6 +54,8 @@ constexpr const char* kProtocolVersion20250618 = "2025-06-18";
 constexpr const char* kProtocolVersion20250326 = "2025-03-26";
 constexpr const char* kProtocolVersion20241105 = "2024-11-05";
 constexpr const char* kConfigFileName = "mcp_servers.json";
+constexpr const char* kStdioTransport = "stdio";
+constexpr const char* kStreamableHttpTransport = "streamable-http";
 constexpr int kDefaultTimeoutMs = 30000;
 constexpr int kMinTimeoutMs = 1000;
 constexpr int kMaxTimeoutMs = 300000;
@@ -135,6 +138,137 @@ std::string trim(std::string value) {
     return value;
 }
 
+std::string lower_ascii(std::string value) {
+    std::transform(value.begin(), value.end(), value.begin(),
+                   [](unsigned char c) { return ascii_to_lower(c); });
+    return value;
+}
+
+struct ParsedHttpEndpoint {
+    std::string scheme;
+    std::string host;
+    std::string base_url;
+    std::string path;
+    bool loopback = false;
+};
+
+bool is_loopback_host(const std::string& host) {
+    const std::string lowered = lower_ascii(host);
+    return lowered == "localhost" || lowered == "127.0.0.1" ||
+           lowered == "::1" || lowered == "[::1]";
+}
+
+void validate_http_port(const std::string& port) {
+    if (port.empty() ||
+        !std::all_of(port.begin(), port.end(), ascii_is_digit)) {
+        throw std::runtime_error("MCP URL contains an invalid port");
+    }
+    try {
+        const unsigned long value = std::stoul(port);
+        if (value == 0 || value > 65535) {
+            throw std::runtime_error("MCP URL port must be between 1 and 65535");
+        }
+    } catch (const std::invalid_argument&) {
+        throw std::runtime_error("MCP URL contains an invalid port");
+    } catch (const std::out_of_range&) {
+        throw std::runtime_error("MCP URL port must be between 1 and 65535");
+    }
+}
+
+ParsedHttpEndpoint parse_http_endpoint(const std::string& raw_url,
+                                       bool allow_insecure_http) {
+    const std::string url = trim(raw_url);
+    if (url.empty()) {
+        throw std::runtime_error("MCP Streamable HTTP config requires url");
+    }
+    if (has_control_char(url) || url.find('\0') != std::string::npos) {
+        throw std::runtime_error("MCP URL must not contain control characters");
+    }
+    if (url.find('#') != std::string::npos) {
+        throw std::runtime_error("MCP URL must not contain a fragment");
+    }
+
+    const std::size_t scheme_end = url.find("://");
+    if (scheme_end == std::string::npos) {
+        throw std::runtime_error("MCP URL must start with http:// or https://");
+    }
+    const std::string scheme = lower_ascii(url.substr(0, scheme_end));
+    if (scheme != "http" && scheme != "https") {
+        throw std::runtime_error("MCP URL must use http or https");
+    }
+
+    const std::size_t authority_begin = scheme_end + 3;
+    const std::size_t authority_end = url.find_first_of("/?", authority_begin);
+    const std::string authority = url.substr(
+        authority_begin,
+        authority_end == std::string::npos ? std::string::npos
+                                            : authority_end - authority_begin);
+    if (authority.empty() || authority.find('@') != std::string::npos) {
+        throw std::runtime_error(
+            "MCP URL must contain a host and must not embed credentials");
+    }
+    if (std::any_of(authority.begin(), authority.end(), [](unsigned char c) {
+            return std::isspace(c) || c == '\\';
+        })) {
+        throw std::runtime_error("MCP URL contains an invalid host");
+    }
+
+    std::string host;
+    if (authority.front() == '[') {
+        const std::size_t close = authority.find(']');
+        if (close == std::string::npos) {
+            throw std::runtime_error("MCP URL contains an invalid IPv6 host");
+        }
+        host = authority.substr(1, close - 1);
+        if (close + 1 < authority.size()) {
+            if (authority[close + 1] != ':' || close + 2 >= authority.size()) {
+                throw std::runtime_error("MCP URL contains an invalid port");
+            }
+            const std::string port = authority.substr(close + 2);
+            validate_http_port(port);
+        }
+    } else {
+        const std::size_t colon = authority.rfind(':');
+        if (colon != std::string::npos) {
+            if (authority.find(':') != colon) {
+                throw std::runtime_error(
+                    "IPv6 MCP URLs must wrap the host in brackets");
+            }
+            host = authority.substr(0, colon);
+            const std::string port = authority.substr(colon + 1);
+            if (host.empty()) {
+                throw std::runtime_error("MCP URL must contain a host");
+            }
+            validate_http_port(port);
+        } else {
+            host = authority;
+        }
+    }
+    if (host.empty()) {
+        throw std::runtime_error("MCP URL must contain a host");
+    }
+
+    const bool loopback = is_loopback_host(host);
+    if (scheme == "http" && !loopback && !allow_insecure_http) {
+        throw std::runtime_error(
+            "Plain HTTP is allowed only for localhost. Use HTTPS or explicitly "
+            "enable insecure HTTP for this endpoint");
+    }
+
+    ParsedHttpEndpoint endpoint;
+    endpoint.scheme = scheme;
+    endpoint.host = host;
+    endpoint.base_url = scheme + "://" + authority;
+    endpoint.path = authority_end == std::string::npos
+                        ? "/"
+                        : (url[authority_end] == '?'
+                               ? "/" + url.substr(authority_end)
+                               : url.substr(authority_end));
+    if (endpoint.path.empty()) endpoint.path = "/";
+    endpoint.loopback = loopback;
+    return endpoint;
+}
+
 bool valid_id(const std::string& id) {
     if (id.empty() || id.size() > 96) return false;
     return std::all_of(id.begin(), id.end(), [](unsigned char c) {
@@ -197,6 +331,12 @@ void validate_env_references(const McpServerConfig& config) {
                 "}; raw values are not persisted");
         }
     }
+    if (!config.bearer_token.empty() &&
+        !env_reference_name(config.bearer_token)) {
+        throw std::runtime_error(
+            "MCP bearer_token must be a ${VARIABLE} reference; raw tokens are "
+            "never persisted");
+    }
 }
 
 McpServerConfig resolve_env_references(McpServerConfig config) {
@@ -213,6 +353,20 @@ McpServerConfig resolve_env_references(McpServerConfig config) {
                 "Required MCP environment variable is not set: " + *ref);
         }
         value = env_value;
+    }
+    if (!config.bearer_token.empty()) {
+        const auto ref = env_reference_name(config.bearer_token);
+        if (!ref) {
+            throw std::runtime_error(
+                "MCP bearer_token is not a valid ${VARIABLE} reference");
+        }
+        const char* token = std::getenv(ref->c_str());
+        if (!token || !*token) {
+            throw std::runtime_error(
+                "Required MCP bearer token environment variable is not set: " +
+                *ref);
+        }
+        config.bearer_token = token;
     }
     return config;
 }
@@ -272,6 +426,355 @@ std::string json_rpc_error_message(const json& response) {
     if (err.is_object()) return err.value("message", err.dump());
     if (err.is_string()) return err.get<std::string>();
     return err.dump();
+}
+
+
+struct HttpMcpReply {
+    json message;
+    std::string session_id;
+};
+
+class McpHttpStatusError : public std::runtime_error {
+public:
+    McpHttpStatusError(int status_code, std::string message)
+        : std::runtime_error(std::move(message)),
+          status_code_(status_code) {}
+
+    int status_code() const noexcept { return status_code_; }
+
+private:
+    int status_code_;
+};
+
+class SseJsonDecoder {
+public:
+    std::vector<json> feed(const char* bytes, std::size_t size,
+                           bool finish = false) {
+        if (bytes && size > 0) pending_line_.append(bytes, size);
+
+        std::vector<json> messages;
+        std::size_t newline = 0;
+        while ((newline = pending_line_.find('\n')) != std::string::npos) {
+            std::string line = pending_line_.substr(0, newline);
+            pending_line_.erase(0, newline + 1);
+            if (!line.empty() && line.back() == '\r') line.pop_back();
+            consume_line(line, messages);
+        }
+
+        if (finish) {
+            if (!pending_line_.empty()) {
+                std::string line = std::move(pending_line_);
+                pending_line_.clear();
+                if (!line.empty() && line.back() == '\r') line.pop_back();
+                consume_line(line, messages);
+            }
+            flush(messages);
+        }
+        return messages;
+    }
+
+private:
+    void consume_line(const std::string& line,
+                      std::vector<json>& messages) {
+        if (line.empty()) {
+            flush(messages);
+            return;
+        }
+        if (line.front() == ':') return;
+        if (line.rfind("data:", 0) != 0) return;
+
+        std::string chunk = line.substr(5);
+        if (!chunk.empty() && chunk.front() == ' ') chunk.erase(chunk.begin());
+        data_ += chunk;
+        data_.push_back('\n');
+    }
+
+    void flush(std::vector<json>& messages) {
+        if (data_.empty()) return;
+        if (data_.back() == '\n') data_.pop_back();
+        const std::string payload = trim(std::move(data_));
+        data_.clear();
+        if (payload.empty() || payload == "[DONE]") return;
+
+        json parsed = json::parse(payload);
+        if (parsed.is_array()) {
+            for (auto& item : parsed) messages.push_back(std::move(item));
+        } else {
+            messages.push_back(std::move(parsed));
+        }
+    }
+
+    std::string pending_line_;
+    std::string data_;
+};
+
+std::vector<json> parse_http_mcp_messages(const std::string& content_type,
+                                          const std::string& body) {
+    if (trim(body).empty()) return {};
+    if (content_type.find("text/event-stream") != std::string::npos ||
+        body.rfind("data:", 0) == 0 || body.rfind("event:", 0) == 0) {
+        SseJsonDecoder decoder;
+        return decoder.feed(body.data(), body.size(), true);
+    }
+
+    json parsed = json::parse(body);
+    std::vector<json> messages;
+    if (parsed.is_array()) {
+        for (auto& item : parsed) messages.push_back(std::move(item));
+    } else {
+        messages.push_back(std::move(parsed));
+    }
+    return messages;
+}
+
+bool json_rpc_is_response(const json& value) {
+    return value.is_object() && value.contains("id") &&
+           !value.contains("method") &&
+           (value.contains("result") || value.contains("error"));
+}
+
+bool json_rpc_is_request(const json& value) {
+    return value.is_object() && value.contains("id") &&
+           value.contains("method") && value["method"].is_string() &&
+           !value.contains("result") && !value.contains("error");
+}
+
+json json_rpc_client_response(const json& request) {
+    const std::string method = request["method"].get<std::string>();
+    if (method == "ping") {
+        return json{{"jsonrpc", "2.0"},
+                    {"id", request["id"]},
+                    {"result", json::object()}};
+    }
+    return json_rpc_method_not_found(request["id"], method);
+}
+
+bool json_rpc_id_matches(const json& value, std::int64_t expected) {
+    if (!json_rpc_is_response(value)) return false;
+    const json& id = value["id"];
+    if (id.is_number_integer()) return id.get<std::int64_t>() == expected;
+    if (id.is_number_unsigned()) {
+        const auto unsigned_id = id.get<std::uint64_t>();
+        return unsigned_id <=
+                   static_cast<std::uint64_t>(
+                       std::numeric_limits<std::int64_t>::max()) &&
+               static_cast<std::int64_t>(unsigned_id) == expected;
+    }
+    if (id.is_string()) return id.get<std::string>() == std::to_string(expected);
+    return false;
+}
+
+void configure_http_client(httplib::Client& client, int timeout_ms) {
+    const int clamped = clamp_timeout_ms(timeout_ms);
+    const time_t seconds = clamped / 1000;
+    const time_t microseconds = (clamped % 1000) * 1000;
+    client.set_connection_timeout(seconds, microseconds);
+    client.set_read_timeout(seconds, microseconds);
+    client.set_write_timeout(seconds, microseconds);
+    client.set_follow_location(false);
+    client.set_keep_alive(false);
+}
+
+httplib::Headers make_http_mcp_headers(const McpServerConfig& raw_config,
+                                       const std::string& session_id,
+                                       const std::string& protocol_version) {
+    const McpServerConfig resolved = resolve_env_references(raw_config);
+    httplib::Headers headers{{"Accept", "application/json, text/event-stream"}};
+    if (!protocol_version.empty()) {
+        headers.emplace("MCP-Protocol-Version", protocol_version);
+    }
+    if (!session_id.empty()) {
+        headers.emplace("Mcp-Session-Id", session_id);
+    }
+    if (!resolved.bearer_token.empty()) {
+        headers.emplace("Authorization", "Bearer " + resolved.bearer_token);
+    }
+    return headers;
+}
+
+HttpMcpReply http_mcp_post(const McpServerConfig& config,
+                           const std::string& session_id,
+                           const std::string& protocol_version,
+                           const json& message, int timeout_ms,
+                           std::optional<std::int64_t> expected_id) {
+    const ParsedHttpEndpoint endpoint =
+        parse_http_endpoint(config.url, config.allow_insecure_http);
+    httplib::Client client(endpoint.base_url);
+    configure_http_client(client, timeout_ms);
+    if (endpoint.scheme == "https") {
+        client.enable_server_certificate_verification(true);
+    }
+
+    HttpMcpReply reply;
+    int status = 0;
+    std::string content_type;
+    std::string body;
+    std::size_t received = 0;
+    bool notification_complete = false;
+    bool matching_response_received = false;
+    bool size_limit_exceeded = false;
+    std::exception_ptr receiver_error;
+    SseJsonDecoder sse_decoder;
+
+    auto handle_incoming_message = [&](const json& candidate) {
+        if (json_rpc_is_request(candidate)) {
+            const std::string active_session_id =
+                reply.session_id.empty() ? session_id : reply.session_id;
+            HttpMcpReply server_request_reply = http_mcp_post(
+                config, active_session_id, protocol_version,
+                json_rpc_client_response(candidate), timeout_ms,
+                std::nullopt);
+            if (!server_request_reply.session_id.empty()) {
+                reply.session_id =
+                    std::move(server_request_reply.session_id);
+            }
+            return false;
+        }
+        if (expected_id &&
+            json_rpc_id_matches(candidate, *expected_id)) {
+            reply.message = candidate;
+            matching_response_received = true;
+            return true;
+        }
+        return false;
+    };
+
+    httplib::Request request;
+    request.method = "POST";
+    request.path = endpoint.path;
+    request.headers =
+        make_http_mcp_headers(config, session_id, protocol_version);
+    request.headers.emplace("Content-Type", "application/json");
+    request.body = message.dump();
+
+    request.response_handler = [&](const httplib::Response& response) {
+        status = response.status;
+        content_type =
+            lower_ascii(response.get_header_value("Content-Type"));
+        reply.session_id = response.get_header_value("Mcp-Session-Id");
+
+        // Notifications normally return 202 without a body. Some servers keep
+        // an SSE response open for unrelated messages, so stop after receiving
+        // a successful response header rather than waiting for that stream.
+        if (!expected_id && status >= 200 && status < 300) {
+            notification_complete = true;
+            return false;
+        }
+        return true;
+    };
+
+    request.content_receiver =
+        [&](const char* data, std::size_t size, std::size_t,
+            std::size_t) {
+            if (size > kMaxMessageBytes - received) {
+                size_limit_exceeded = true;
+                return false;
+            }
+            received += size;
+
+            try {
+                if (expected_id &&
+                    content_type.find("text/event-stream") !=
+                        std::string::npos) {
+                    for (const auto& candidate :
+                         sse_decoder.feed(data, size)) {
+                        if (handle_incoming_message(candidate)) return false;
+                    }
+                } else {
+                    body.append(data, size);
+                }
+            } catch (...) {
+                receiver_error = std::current_exception();
+                return false;
+            }
+            return true;
+        };
+
+    auto response = client.send(request);
+
+    if (receiver_error) std::rethrow_exception(receiver_error);
+    if (size_limit_exceeded) {
+        throw std::runtime_error("MCP HTTP response exceeded the size limit");
+    }
+
+    if (status == 0 && response) {
+        status = response->status;
+        content_type =
+            lower_ascii(response->get_header_value("Content-Type"));
+        reply.session_id = response->get_header_value("Mcp-Session-Id");
+    }
+
+    const bool intentional_cancel =
+        notification_complete || matching_response_received;
+    if (!response && !intentional_cancel) {
+        throw std::runtime_error(
+            "Could not reach MCP endpoint " + config.url + " (" +
+            httplib::to_string(response.error()) + ")");
+    }
+    if (response.error() != httplib::Error::Success &&
+        response.error() != httplib::Error::Canceled) {
+        throw std::runtime_error(
+            "Could not read MCP HTTP response (" +
+            httplib::to_string(response.error()) + ")");
+    }
+    if (response.error() == httplib::Error::Canceled &&
+        !intentional_cancel) {
+        throw std::runtime_error(
+            "MCP HTTP response was cancelled before completion");
+    }
+
+    if (status == 401) {
+        throw std::runtime_error(
+            "MCP endpoint rejected authentication (HTTP 401)");
+    }
+    if (status == 403) {
+        throw std::runtime_error("MCP endpoint denied access (HTTP 403)");
+    }
+    if (status < 200 || status >= 300) {
+        std::string detail = trim(body);
+        if (detail.size() > 512) detail.resize(512);
+        throw McpHttpStatusError(
+            status,
+            "MCP endpoint returned HTTP " + std::to_string(status) +
+                (detail.empty() ? std::string() : ": " + detail));
+    }
+
+    if (!expected_id || matching_response_received) return reply;
+
+    if (content_type.find("text/event-stream") != std::string::npos) {
+        for (const auto& candidate : sse_decoder.feed(nullptr, 0, true)) {
+            if (handle_incoming_message(candidate)) return reply;
+        }
+    } else {
+        for (const auto& candidate :
+             parse_http_mcp_messages(content_type, body)) {
+            if (handle_incoming_message(candidate)) return reply;
+        }
+    }
+
+    throw std::runtime_error(
+        "MCP HTTP response did not contain the matching JSON-RPC response");
+}
+
+void http_mcp_delete_session(const McpServerConfig& config,
+                             const std::string& session_id,
+                             const std::string& protocol_version) {
+    if (session_id.empty()) return;
+    try {
+        const ParsedHttpEndpoint endpoint =
+            parse_http_endpoint(config.url, config.allow_insecure_http);
+        httplib::Client client(endpoint.base_url);
+        configure_http_client(client, std::min(config.timeout_ms, 2000));
+        if (endpoint.scheme == "https") {
+            client.enable_server_certificate_verification(true);
+        }
+        const httplib::Headers headers =
+            make_http_mcp_headers(config, session_id, protocol_version);
+        (void)client.Delete(endpoint.path, headers);
+    } catch (...) {
+        // Session termination is best-effort. The local connection state is
+        // already cleared and the remote server may not implement DELETE.
+    }
 }
 
 #ifdef _WIN32
@@ -1284,12 +1787,19 @@ struct McpClientManager::Runtime {
     std::string negotiated_protocol_version;
     json tools = json::array();
     std::shared_ptr<StdioProcess> process;
+    std::string http_session_id;
+    std::mutex http_mutex;
 
     std::atomic<std::int64_t> next_request_id{1};
     std::mutex waiters_mutex;
     std::map<std::int64_t, std::shared_ptr<Waiter>> waiters;
 
     void connect(const McpServerConfig& new_config) {
+        if (new_config.transport == kStreamableHttpTransport) {
+            connect_http(new_config);
+            return;
+        }
+
         // Capture the generation before waiting for the connect serializer. A
         // disconnect that happens while this call is queued therefore cancels
         // it instead of allowing it to reconnect after disconnect returns.
@@ -1345,6 +1855,7 @@ struct McpClientManager::Runtime {
                     server_capabilities = json::object();
                     negotiated_protocol_version.clear();
                     tools = json::array();
+                    http_session_id.clear();
                     process = candidate;
                 }
 
@@ -1444,12 +1955,18 @@ struct McpClientManager::Runtime {
 
     void disconnect() {
         std::shared_ptr<StdioProcess> old_process;
+        McpServerConfig old_config;
+        std::string old_http_session;
+        std::string old_protocol_version;
         {
             std::lock_guard<std::mutex> lifecycle_lock(lifecycle_mutex);
             ++lifecycle_generation;
             {
                 std::lock_guard<std::mutex> state_lock(state_mutex);
                 old_process = std::move(process);
+                old_config = config;
+                old_http_session = std::move(http_session_id);
+                old_protocol_version = negotiated_protocol_version;
                 connected = false;
                 last_error.clear();
                 server_info = json::object();
@@ -1462,64 +1979,153 @@ struct McpClientManager::Runtime {
             }
         }
         if (old_process) old_process->stop();
+        if (old_config.transport == kStreamableHttpTransport &&
+            !old_http_session.empty()) {
+            http_mcp_delete_session(old_config, old_http_session,
+                                    old_protocol_version);
+        }
     }
 
     void refresh_tools() {
+        McpServerConfig active_config;
+        std::string session_id;
+        std::string protocol_version;
+        std::uint64_t generation = 0;
         std::shared_ptr<StdioProcess> source;
-        int timeout_ms = kDefaultTimeoutMs;
+        bool http = false;
         {
+            std::lock_guard<std::mutex> lifecycle_lock(lifecycle_mutex);
+            generation = lifecycle_generation;
             std::lock_guard<std::mutex> state_lock(state_mutex);
-            if (!connected || !process) {
+            if (!connected) {
                 throw std::runtime_error("MCP server is not connected");
             }
+            active_config = config;
+            http = active_config.transport == kStreamableHttpTransport;
             source = process;
-            timeout_ms = config.timeout_ms;
+            session_id = http_session_id;
+            protocol_version = negotiated_protocol_version;
             if (!server_capabilities.contains("tools")) {
                 tools = json::array();
                 return;
             }
+            if (!http && !source) {
+                throw std::runtime_error("MCP server is not connected");
+            }
         }
 
-        json discovered = fetch_tools(source, timeout_ms);
+        json discovered;
+        if (http) {
+            std::lock_guard<std::mutex> request_lock(http_mutex);
+            ensure_http_request_current(generation, session_id);
+            try {
+                discovered = fetch_tools_http(
+                    active_config, session_id, protocol_version,
+                    active_config.timeout_ms);
+            } catch (const McpHttpStatusError& error) {
+                if (error.status_code() == 404 && !session_id.empty()) {
+                    invalidate_expired_http_session(
+                        generation, session_id,
+                        "MCP HTTP session expired (HTTP 404); the next "
+                        "request will establish a new session");
+                }
+                throw;
+            }
+            update_http_session_after_request(generation, session_id);
+        } else {
+            discovered = fetch_tools(source, active_config.timeout_ms);
+        }
+
         {
+            std::lock_guard<std::mutex> lifecycle_lock(lifecycle_mutex);
             std::lock_guard<std::mutex> state_lock(state_mutex);
-            if (!connected || process != source) {
+            if (lifecycle_generation != generation || !connected ||
+                config.transport != active_config.transport ||
+                (!http && process != source)) {
                 throw std::runtime_error(
                     "MCP server disconnected while refreshing tools");
             }
+            if (http) http_session_id = std::move(session_id);
             tools = std::move(discovered);
+            last_error.clear();
         }
     }
 
     json call_tool(const std::string& name, const json& arguments,
                    int timeout_ms) {
+        McpServerConfig active_config;
+        std::string session_id;
+        std::string protocol_version;
+        std::uint64_t generation = 0;
         std::shared_ptr<StdioProcess> source;
-        int configured_timeout = kDefaultTimeoutMs;
+        bool http = false;
         {
+            std::lock_guard<std::mutex> lifecycle_lock(lifecycle_mutex);
+            generation = lifecycle_generation;
             std::lock_guard<std::mutex> state_lock(state_mutex);
-            if (!connected || !process) {
+            if (!connected) {
                 throw std::runtime_error("MCP server is not connected");
             }
+            active_config = config;
+            http = active_config.transport == kStreamableHttpTransport;
             source = process;
-            configured_timeout = config.timeout_ms;
+            session_id = http_session_id;
+            protocol_version = negotiated_protocol_version;
             if (!server_capabilities.contains("tools")) {
                 throw std::runtime_error(
                     "MCP server did not advertise the tools capability");
+            }
+            if (!http && !source) {
+                throw std::runtime_error("MCP server is not connected");
             }
         }
 
         json params{{"name", name},
                     {"arguments",
                      arguments.is_object() ? arguments : json::object()}};
-        const json response = request(
-            source, "tools/call", std::move(params),
-            timeout_ms > 0 ? timeout_ms : configured_timeout);
+        json response;
+        const int effective_timeout =
+            timeout_ms > 0 ? timeout_ms : active_config.timeout_ms;
+        if (http) {
+            std::lock_guard<std::mutex> request_lock(http_mutex);
+            ensure_http_request_current(generation, session_id);
+            try {
+                response = request_http(
+                    active_config, session_id, protocol_version,
+                    "tools/call", std::move(params), effective_timeout);
+            } catch (const McpHttpStatusError& error) {
+                if (error.status_code() == 404 && !session_id.empty()) {
+                    invalidate_expired_http_session(
+                        generation, session_id,
+                        "MCP HTTP session expired (HTTP 404); the next "
+                        "request will establish a new session");
+                }
+                throw;
+            }
+            update_http_session_after_request(generation, session_id);
+        } else {
+            response = request(source, "tools/call", std::move(params),
+                               effective_timeout);
+        }
+
         if (response.contains("error")) {
             throw std::runtime_error(json_rpc_error_message(response));
         }
         if (!response.contains("result")) {
             throw std::runtime_error(
                 "MCP tools/call response is missing result");
+        }
+
+        if (http) {
+            std::lock_guard<std::mutex> lifecycle_lock(lifecycle_mutex);
+            std::lock_guard<std::mutex> state_lock(state_mutex);
+            if (lifecycle_generation != generation || !connected ||
+                config.transport != kStreamableHttpTransport) {
+                throw std::runtime_error(
+                    "MCP server disconnected while calling a tool");
+            }
+            http_session_id = std::move(session_id);
+            last_error.clear();
         }
         return response["result"];
     }
@@ -1539,6 +2145,266 @@ struct McpClientManager::Runtime {
     }
 
 private:
+    void ensure_http_request_current(
+        std::uint64_t generation,
+        const std::string& expected_session_id) {
+        std::lock_guard<std::mutex> lifecycle_lock(lifecycle_mutex);
+        if (lifecycle_generation != generation) {
+            throw std::runtime_error(
+                "MCP HTTP connection changed before the request was sent");
+        }
+        std::lock_guard<std::mutex> state_lock(state_mutex);
+        if (!connected ||
+            config.transport != kStreamableHttpTransport ||
+            http_session_id != expected_session_id) {
+            throw std::runtime_error(
+                "MCP HTTP connection changed before the request was sent");
+        }
+    }
+
+    void update_http_session_after_request(
+        std::uint64_t generation,
+        const std::string& session_id) {
+        std::lock_guard<std::mutex> lifecycle_lock(lifecycle_mutex);
+        if (lifecycle_generation != generation) {
+            throw std::runtime_error(
+                "MCP HTTP connection changed while the request was running");
+        }
+        std::lock_guard<std::mutex> state_lock(state_mutex);
+        if (!connected ||
+            config.transport != kStreamableHttpTransport) {
+            throw std::runtime_error(
+                "MCP HTTP connection changed while the request was running");
+        }
+        http_session_id = session_id;
+    }
+
+    void invalidate_expired_http_session(
+        std::uint64_t generation,
+        const std::string& expired_session_id,
+        const std::string& message) {
+        std::lock_guard<std::mutex> lifecycle_lock(lifecycle_mutex);
+        if (lifecycle_generation != generation) return;
+        std::lock_guard<std::mutex> state_lock(state_mutex);
+        if (!connected ||
+            config.transport != kStreamableHttpTransport ||
+            http_session_id != expired_session_id) {
+            return;
+        }
+
+        ++lifecycle_generation;
+        connected = false;
+        http_session_id.clear();
+        negotiated_protocol_version.clear();
+        server_info = json::object();
+        server_capabilities = json::object();
+        tools = json::array();
+        last_error = message;
+    }
+
+    void connect_http(const McpServerConfig& new_config) {
+        std::uint64_t connect_generation = 0;
+        {
+            std::lock_guard<std::mutex> lifecycle_lock(lifecycle_mutex);
+            connect_generation = lifecycle_generation;
+        }
+
+        std::lock_guard<std::mutex> connect_lock(connect_mutex);
+        {
+            std::lock_guard<std::mutex> lifecycle_lock(lifecycle_mutex);
+            if (lifecycle_generation != connect_generation) {
+                throw std::runtime_error(
+                    "MCP connection was cancelled before initialization");
+            }
+            std::lock_guard<std::mutex> state_lock(state_mutex);
+            if (connected) return;
+            config = new_config;
+            process.reset();
+            http_session_id.clear();
+            connected = false;
+            last_error.clear();
+            server_info = json::object();
+            server_capabilities = json::object();
+            negotiated_protocol_version.clear();
+            tools = json::array();
+        }
+
+        std::string session_id;
+        std::string negotiated_version;
+        try {
+            std::lock_guard<std::mutex> request_lock(http_mutex);
+            const json init = request_http(
+                new_config, session_id, std::string(), "initialize",
+                json{{"protocolVersion", kProtocolVersion},
+                     {"capabilities", json::object()},
+                     {"clientInfo",
+                      json{{"name", "lemonade-mcp-client"},
+                           {"title", "Lemonade MCP Client Host"},
+                           {"version", "1"}}}},
+                new_config.timeout_ms);
+            if (init.contains("error")) {
+                throw std::runtime_error(
+                    "initialize failed: " + json_rpc_error_message(init));
+            }
+            if (!init.contains("result") || !init["result"].is_object()) {
+                throw std::runtime_error(
+                    "MCP initialize response is missing an object result");
+            }
+
+            const json result = init["result"];
+            if (!result.contains("protocolVersion") ||
+                !result["protocolVersion"].is_string()) {
+                throw std::runtime_error(
+                    "MCP initialize result is missing protocolVersion");
+            }
+            const std::string protocol_version =
+                result["protocolVersion"].get<std::string>();
+            negotiated_version = protocol_version;
+            if (!supported_protocol_version(protocol_version)) {
+                throw std::runtime_error(
+                    "MCP server negotiated unsupported protocol version: " +
+                    protocol_version);
+            }
+
+            const json info = result.value("serverInfo", json::object());
+            const json capabilities =
+                result.value("capabilities", json::object());
+            if (!info.is_object() || !capabilities.is_object()) {
+                throw std::runtime_error(
+                    "MCP initialize result contains invalid server metadata");
+            }
+
+            notify_http(new_config, session_id, protocol_version,
+                        "notifications/initialized", json::object(),
+                        new_config.timeout_ms);
+
+            json discovered_tools = json::array();
+            if (capabilities.contains("tools")) {
+                if (!capabilities["tools"].is_object()) {
+                    throw std::runtime_error(
+                        "MCP tools capability must be an object");
+                }
+                discovered_tools = fetch_tools_http(
+                    new_config, session_id, protocol_version,
+                    new_config.timeout_ms);
+            }
+
+            {
+                std::lock_guard<std::mutex> lifecycle_lock(lifecycle_mutex);
+                if (lifecycle_generation != connect_generation) {
+                    throw std::runtime_error(
+                        "MCP connection was cancelled during initialization");
+                }
+                std::lock_guard<std::mutex> state_lock(state_mutex);
+                config = new_config;
+                http_session_id = std::move(session_id);
+                negotiated_protocol_version = protocol_version;
+                server_info = info;
+                server_capabilities = capabilities;
+                tools = std::move(discovered_tools);
+                connected = true;
+                last_error.clear();
+            }
+        } catch (const std::exception& error) {
+            if (!session_id.empty()) {
+                http_mcp_delete_session(new_config, session_id,
+                                        negotiated_version);
+            }
+            std::lock_guard<std::mutex> lifecycle_lock(lifecycle_mutex);
+            if (lifecycle_generation == connect_generation) {
+                std::lock_guard<std::mutex> state_lock(state_mutex);
+                connected = false;
+                http_session_id.clear();
+                negotiated_protocol_version.clear();
+                server_info = json::object();
+                server_capabilities = json::object();
+                tools = json::array();
+                last_error = error.what();
+            }
+            throw;
+        }
+    }
+
+    json request_http(const McpServerConfig& active_config,
+                      std::string& session_id,
+                      const std::string& protocol_version,
+                      const std::string& method, json params,
+                      int timeout_ms) {
+        const std::int64_t id = allocate_request_id();
+        HttpMcpReply reply = http_mcp_post(
+            active_config, session_id, protocol_version,
+            json_rpc_request(id, method, std::move(params)), timeout_ms, id);
+        if (!reply.session_id.empty()) session_id = std::move(reply.session_id);
+        return std::move(reply.message);
+    }
+
+    void notify_http(const McpServerConfig& active_config,
+                     std::string& session_id,
+                     const std::string& protocol_version,
+                     const std::string& method, json params,
+                     int timeout_ms) {
+        HttpMcpReply reply = http_mcp_post(
+            active_config, session_id, protocol_version,
+            json_rpc_notification(method, std::move(params)), timeout_ms,
+            std::nullopt);
+        if (!reply.session_id.empty()) session_id = std::move(reply.session_id);
+    }
+
+    json fetch_tools_http(const McpServerConfig& active_config,
+                          std::string& session_id,
+                          const std::string& protocol_version,
+                          int timeout_ms) {
+        json collected = json::array();
+        std::string cursor;
+        for (int page = 0; page < kMaxToolListPages; ++page) {
+            json params = json::object();
+            if (!cursor.empty()) params["cursor"] = cursor;
+            const json response = request_http(
+                active_config, session_id, protocol_version, "tools/list",
+                std::move(params), timeout_ms);
+            if (response.contains("error")) {
+                throw std::runtime_error(
+                    "tools/list failed: " +
+                    json_rpc_error_message(response));
+            }
+            if (!response.contains("result") ||
+                !response["result"].is_object()) {
+                throw std::runtime_error(
+                    "MCP tools/list response is missing an object result");
+            }
+
+            const json& result = response["result"];
+            if (result.contains("tools")) {
+                if (!result["tools"].is_array()) {
+                    throw std::runtime_error(
+                        "MCP tools/list result.tools must be an array");
+                }
+                for (const auto& tool : result["tools"]) {
+                    if (!tool.is_object() || !tool.contains("name") ||
+                        !tool["name"].is_string() ||
+                        tool["name"].get<std::string>().empty()) {
+                        throw std::runtime_error(
+                            "MCP tools/list returned an invalid tool entry");
+                    }
+                    collected.push_back(tool);
+                }
+            }
+
+            cursor.clear();
+            if (result.contains("nextCursor") &&
+                !result["nextCursor"].is_null()) {
+                if (!result["nextCursor"].is_string()) {
+                    throw std::runtime_error(
+                        "MCP tools/list nextCursor must be a string");
+                }
+                cursor = result["nextCursor"].get<std::string>();
+            }
+            if (cursor.empty()) return collected;
+        }
+        throw std::runtime_error(
+            "MCP tools/list exceeded the 32-page safety limit");
+    }
+
     bool is_current_process(
         const std::shared_ptr<StdioProcess>& source) const {
         std::lock_guard<std::mutex> state_lock(state_mutex);
@@ -1792,10 +2658,7 @@ private:
 
         if (message.contains("method") && message["method"].is_string() &&
             message.contains("id")) {
-            const std::string method =
-                message["method"].get<std::string>();
-            source->write_line(
-                json_rpc_method_not_found(message["id"], method).dump());
+            source->write_line(json_rpc_client_response(message).dump());
             return;
         }
 
@@ -1896,6 +2759,18 @@ void McpClientManager::register_routes(httplib::Server& server) {
                     }
                 });
 
+    server.Post("/internal/mcp/servers/test",
+                [self](const httplib::Request& req,
+                       httplib::Response& res) {
+                    json body;
+                    if (!parse_json_body(req, res, body)) return;
+                    try {
+                        set_json(res, self->test_server_json(body));
+                    } catch (const std::exception& e) {
+                        set_error(res, e.what(), 502);
+                    }
+                });
+
     server.Delete(
         R"(/internal/mcp/servers/([A-Za-z0-9_.-]+))",
         [self](const httplib::Request& req, httplib::Response& res) {
@@ -1984,7 +2859,18 @@ McpServerConfig McpClientManager::parse_server_config_json(
     McpServerConfig config;
     config.id = trim(read_string("id"));
     config.name = trim(read_string("name"));
-    config.transport = trim(read_string("transport", "stdio"));
+    config.transport = lower_ascii(trim(read_string("transport", "stdio")));
+    if (config.transport == "http") {
+        config.transport = kStreamableHttpTransport;
+    }
+    config.url = trim(read_string("url"));
+    if (value.contains("bearer_token") && value.contains("bearerToken")) {
+        throw std::runtime_error(
+            "Use only one of bearer_token or bearerToken");
+    }
+    config.bearer_token = trim(
+        value.contains("bearer_token") ? read_string("bearer_token")
+                                       : read_string("bearerToken"));
     config.command = trim(read_string("command"));
 
     if (value.contains("working_dir") && value.contains("workingDir")) {
@@ -2000,6 +2886,23 @@ McpServerConfig McpClientManager::parse_server_config_json(
             throw std::runtime_error("MCP enabled must be a boolean");
         }
         config.enabled = value["enabled"].get<bool>();
+    }
+
+    if (value.contains("allow_insecure_http") &&
+        value.contains("allowInsecureHttp")) {
+        throw std::runtime_error(
+            "Use only one of allow_insecure_http or allowInsecureHttp");
+    }
+    const char* insecure_field = value.contains("allow_insecure_http")
+                                     ? "allow_insecure_http"
+                                     : "allowInsecureHttp";
+    if (value.contains(insecure_field)) {
+        if (!value[insecure_field].is_boolean()) {
+            throw std::runtime_error(
+                "MCP allow_insecure_http must be a boolean");
+        }
+        config.allow_insecure_http =
+            value[insecure_field].get<bool>();
     }
 
     if (value.contains("timeout_ms") && value.contains("timeoutMs")) {
@@ -2064,9 +2967,12 @@ McpServerConfig McpClientManager::parse_server_config_json(
     }
 
     if (allow_missing_id && config.id.empty()) {
-        config.id = sanitize_id_seed(
-            !config.name.empty() ? config.name
-                                 : basename_like(config.command));
+        const std::string seed = !config.name.empty()
+                                     ? config.name
+                                     : config.transport == kStreamableHttpTransport
+                                           ? config.url
+                                           : basename_like(config.command);
+        config.id = sanitize_id_seed(seed);
     }
     if (!valid_id(config.id)) {
         throw std::runtime_error(
@@ -2077,23 +2983,38 @@ McpServerConfig McpClientManager::parse_server_config_json(
         throw std::runtime_error(
             "MCP server name must not contain control characters");
     }
-    if (config.transport != "stdio") {
+
+    if (config.transport == kStreamableHttpTransport) {
+        (void)parse_http_endpoint(config.url, config.allow_insecure_http);
+        if (!config.command.empty() || !config.args.empty() ||
+            !config.env.empty() || !config.working_dir.empty()) {
+            throw std::runtime_error(
+                "MCP Streamable HTTP configs must not include command, args, "
+                "env, or working_dir");
+        }
+    } else if (config.transport == kStdioTransport) {
+        if (config.command.empty()) {
+            throw std::runtime_error(
+                "MCP stdio server config requires command");
+        }
+        if (!config.url.empty() || !config.bearer_token.empty() ||
+            config.allow_insecure_http) {
+            throw std::runtime_error(
+                "MCP stdio configs must not include HTTP endpoint fields");
+        }
+        if (config.command.find('\0') != std::string::npos ||
+            has_control_char(config.command)) {
+            throw std::runtime_error(
+                "MCP command must not contain control characters");
+        }
+        if (config.working_dir.find('\0') != std::string::npos ||
+            has_control_char(config.working_dir)) {
+            throw std::runtime_error(
+                "MCP working_dir must not contain control characters");
+        }
+    } else {
         throw std::runtime_error(
-            "This MCP client host supports only stdio transport");
-    }
-    if (config.command.empty()) {
-        throw std::runtime_error(
-            "MCP stdio server config requires command");
-    }
-    if (config.command.find('\0') != std::string::npos ||
-        has_control_char(config.command)) {
-        throw std::runtime_error(
-            "MCP command must not contain control characters");
-    }
-    if (config.working_dir.find('\0') != std::string::npos ||
-        has_control_char(config.working_dir)) {
-        throw std::runtime_error(
-            "MCP working_dir must not contain control characters");
+            "MCP transport must be streamable-http or stdio");
     }
 
     validate_env_references(config);
@@ -2110,15 +3031,27 @@ json McpClientManager::config_to_json(const McpServerConfig& config,
                        ? value
                        : "***";
     }
-    return json{{"id", config.id},
-                {"name", config.name},
-                {"transport", config.transport},
-                {"command", config.command},
-                {"args", config.args},
-                {"env", env},
-                {"working_dir", config.working_dir},
-                {"enabled", config.enabled},
-                {"timeout_ms", config.timeout_ms}};
+    json out{{"id", config.id},
+             {"name", config.name},
+             {"transport", config.transport},
+             {"enabled", config.enabled},
+             {"timeout_ms", config.timeout_ms}};
+    if (config.transport == kStreamableHttpTransport) {
+        out["url"] = config.url;
+        out["bearer_token"] =
+            config.bearer_token.empty()
+                ? std::string()
+                : (include_env_values || env_reference_name(config.bearer_token)
+                       ? config.bearer_token
+                       : "***");
+        out["allow_insecure_http"] = config.allow_insecure_http;
+    } else {
+        out["command"] = config.command;
+        out["args"] = config.args;
+        out["env"] = std::move(env);
+        out["working_dir"] = config.working_dir;
+    }
+    return out;
 }
 
 std::string McpClientManager::make_chat_tool_name(
@@ -2265,6 +3198,17 @@ json McpClientManager::upsert_server_json(const json& body) {
     }
     if (old_runtime) old_runtime->disconnect();
     return json{{"server", config_to_json(config, false)}};
+}
+
+json McpClientManager::test_server_json(const json& body) {
+    const json& raw = body.contains("server") ? body["server"] : body;
+    McpServerConfig config = parse_server_config_json(raw, true);
+    auto runtime = std::make_shared<Runtime>(config);
+    runtime->connect(config);
+    json state = runtime->snapshot(false);
+    runtime->disconnect();
+    state["test_only"] = true;
+    return json{{"server", std::move(state)}};
 }
 
 json McpClientManager::remove_server_json(const std::string& id) {

--- a/test/server_mcp_client.py
+++ b/test/server_mcp_client.py
@@ -1,0 +1,727 @@
+#!/usr/bin/env python3
+"""End-to-end tests for Lemonade's external MCP client administration API.
+
+The suite starts its own isolated lemond instance with an admin key and an
+in-process loopback MCP Streamable HTTP server. No external network access,
+model download, or local MCP process launch is required.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import unittest
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+
+import requests
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from utils.test_models import get_default_lemond_binary
+
+ADMIN_KEY = "mcp-admin-test-key"
+BEARER_ENV = "LEMONADE_MCP_TEST_BEARER"
+BEARER_SECRET = "mcp-bearer-secret-value"
+REQUEST_TIMEOUT = 8
+
+
+def find_free_port() -> int:
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+    finally:
+        sock.close()
+
+
+class MockMcpState:
+    def __init__(self) -> None:
+        self.lock = threading.Lock()
+        self.session_counter = 0
+        self.tools_list_count: dict[str, int] = {}
+        self.authorizations: list[str] = []
+        self.ping_replies: list[dict[str, Any]] = []
+        self.deleted_sessions: list[str] = []
+
+    def new_session(self) -> str:
+        with self.lock:
+            self.session_counter += 1
+            return f"mock-session-{self.session_counter}"
+
+    def record_authorization(self, value: str) -> None:
+        with self.lock:
+            self.authorizations.append(value)
+
+    def increment_tools_list(self, session_id: str) -> int:
+        with self.lock:
+            count = self.tools_list_count.get(session_id, 0) + 1
+            self.tools_list_count[session_id] = count
+            return count
+
+    def record_ping_reply(self, message: dict[str, Any]) -> None:
+        with self.lock:
+            self.ping_replies.append(message)
+
+    def record_delete(self, session_id: str) -> None:
+        with self.lock:
+            self.deleted_sessions.append(session_id)
+
+    def delete_count(self) -> int:
+        with self.lock:
+            return len(self.deleted_sessions)
+
+    def saw_bearer_secret(self) -> bool:
+        expected = f"Bearer {BEARER_SECRET}"
+        with self.lock:
+            return expected in self.authorizations
+
+    def saw_successful_ping_reply(self) -> bool:
+        with self.lock:
+            return any(
+                item.get("id") == "server-ping-1"
+                and isinstance(item.get("result"), dict)
+                and not item["result"]
+                for item in self.ping_replies
+            )
+
+
+class MockMcpHandler(BaseHTTPRequestHandler):
+    server_version = "LemonadeMockMCP/1.0"
+
+    @property
+    def state(self) -> MockMcpState:
+        return self.server.state  # type: ignore[attr-defined]
+
+    def log_message(self, _format: str, *_args: object) -> None:
+        return
+
+    def _read_json(self) -> dict[str, Any]:
+        raw_length = self.headers.get("Content-Length", "0")
+        length = int(raw_length) if raw_length.isdigit() else 0
+        raw = self.rfile.read(length) if length else b"{}"
+        value = json.loads(raw.decode("utf-8"))
+        if not isinstance(value, dict):
+            raise ValueError("MCP request body must be a JSON object")
+        return value
+
+    def _write_empty(self, status: int) -> None:
+        self.send_response(status)
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+    def _write_json(
+        self,
+        status: int,
+        payload: dict[str, Any],
+        *,
+        session_id: str | None = None,
+    ) -> None:
+        data = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(data)))
+        if session_id:
+            self.send_header("Mcp-Session-Id", session_id)
+        self.end_headers()
+        self.wfile.write(data)
+
+    def _write_sse(
+        self,
+        messages: list[dict[str, Any]],
+        *,
+        session_id: str | None = None,
+    ) -> None:
+        body = "".join(
+            f"data: {json.dumps(message, separators=(',', ':'))}\n\n"
+            for message in messages
+        ).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Cache-Control", "no-cache")
+        self.send_header("Content-Length", str(len(body)))
+        if session_id:
+            self.send_header("Mcp-Session-Id", session_id)
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_POST(self) -> None:  # noqa: N802 - stdlib handler API
+        path = self.path.split("?", 1)[0]
+        if path not in {"/mcp-json", "/mcp-sse", "/mcp-ping", "/mcp-expire"}:
+            self._write_empty(404)
+            return
+
+        try:
+            message = self._read_json()
+        except Exception as exc:
+            self._write_json(
+                400,
+                {
+                    "jsonrpc": "2.0",
+                    "id": None,
+                    "error": {"code": -32700, "message": str(exc)},
+                },
+            )
+            return
+
+        self.state.record_authorization(self.headers.get("Authorization", ""))
+
+        # Client replies to server-initiated requests are ordinary JSON-RPC
+        # responses sent as a second POST on the same MCP endpoint.
+        if (
+            "method" not in message
+            and "id" in message
+            and ("result" in message or "error" in message)
+        ):
+            if str(message.get("id", "")).startswith("server-ping"):
+                self.state.record_ping_reply(message)
+            self._write_empty(202)
+            return
+
+        method = message.get("method")
+        request_id = message.get("id")
+
+        if method == "initialize":
+            session_id = self.state.new_session()
+            response = {
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "result": {
+                    "protocolVersion": "2025-11-25",
+                    "capabilities": {"tools": {"listChanged": True}},
+                    "serverInfo": {"name": "lemonade-test-mcp", "version": "1.0"},
+                },
+            }
+            if path == "/mcp-sse":
+                self._write_sse([response], session_id=session_id)
+            else:
+                self._write_json(200, response, session_id=session_id)
+            return
+
+        if method == "notifications/initialized":
+            self._write_empty(202)
+            return
+
+        session_id = self.headers.get("Mcp-Session-Id", "")
+        if not session_id:
+            self._write_empty(400)
+            return
+
+        if method == "tools/list":
+            list_count = self.state.increment_tools_list(session_id)
+            if path == "/mcp-expire" and list_count == 2:
+                # The first tools/list is part of connect. The second is a
+                # refresh request and simulates an expired server session.
+                self._write_empty(404)
+                return
+
+            response = {
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "result": {
+                    "tools": [
+                        {
+                            "name": "echo",
+                            "description": "Echo a message for integration tests",
+                            "inputSchema": {
+                                "type": "object",
+                                "properties": {"message": {"type": "string"}},
+                            },
+                        }
+                    ]
+                },
+            }
+            if path == "/mcp-ping":
+                self._write_sse(
+                    [
+                        {
+                            "jsonrpc": "2.0",
+                            "id": "server-ping-1",
+                            "method": "ping",
+                        },
+                        response,
+                    ]
+                )
+            elif path == "/mcp-sse":
+                self._write_sse([response])
+            else:
+                self._write_json(200, response)
+            return
+
+        if method == "tools/call":
+            params = message.get("params")
+            if not isinstance(params, dict):
+                params = {}
+            arguments = params.get("arguments")
+            if not isinstance(arguments, dict):
+                arguments = {}
+            text = str(arguments.get("message", ""))
+            self._write_json(
+                200,
+                {
+                    "jsonrpc": "2.0",
+                    "id": request_id,
+                    "result": {
+                        "content": [{"type": "text", "text": text}],
+                        "structuredContent": {"echo": text},
+                    },
+                },
+            )
+            return
+
+        self._write_json(
+            200,
+            {
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "error": {"code": -32601, "message": "Method not found"},
+            },
+        )
+
+    def do_DELETE(self) -> None:  # noqa: N802 - stdlib handler API
+        path = self.path.split("?", 1)[0]
+        if path not in {"/mcp-json", "/mcp-sse", "/mcp-ping", "/mcp-expire"}:
+            self._write_empty(404)
+            return
+        self.state.record_delete(self.headers.get("Mcp-Session-Id", ""))
+        self._write_empty(204)
+
+
+class MockMcpServer:
+    def __init__(self) -> None:
+        self.state = MockMcpState()
+        self.server = ThreadingHTTPServer(("127.0.0.1", 0), MockMcpHandler)
+        self.server.daemon_threads = True
+        self.server.state = self.state  # type: ignore[attr-defined]
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+
+    @property
+    def port(self) -> int:
+        return int(self.server.server_address[1])
+
+    def start(self) -> None:
+        self.thread.start()
+
+    def stop(self) -> None:
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(timeout=3)
+
+
+class McpClientEndpointTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        super().setUpClass()
+        cls.lemond_bin = get_default_lemond_binary()
+        if not cls.lemond_bin or not os.path.exists(cls.lemond_bin):
+            raise unittest.SkipTest(
+                f"lemond binary not found at {cls.lemond_bin!r}; "
+                "source/install build required"
+            )
+
+        cls.mock = MockMcpServer()
+        cls.mock.start()
+        cls.temp_dir = tempfile.mkdtemp(prefix="lemond_mcp_http_")
+        cls.port = find_free_port()
+        cls.log_path = os.path.join(cls.temp_dir, "lemond.log")
+        cls.log_file = open(cls.log_path, "w", encoding="utf-8")
+
+        env = os.environ.copy()
+        env.pop("LEMONADE_API_KEY", None)
+        env["LEMONADE_ADMIN_API_KEY"] = ADMIN_KEY
+        env[BEARER_ENV] = BEARER_SECRET
+        env["LEMONADE_DISABLE_SYSTEMD_JOURNAL"] = "1"
+
+        cls.proc = subprocess.Popen(
+            [cls.lemond_bin, cls.temp_dir, "--port", str(cls.port)],
+            stdout=cls.log_file,
+            stderr=cls.log_file,
+            env=env,
+        )
+        cls.root_url = f"http://127.0.0.1:{cls.port}"
+        cls.mcp_url = f"{cls.root_url}/internal/mcp"
+        cls.admin_headers = {"Authorization": f"Bearer {ADMIN_KEY}"}
+
+        try:
+            cls._wait_for_server()
+        except Exception:
+            cls._stop_lemond()
+            cls.mock.stop()
+            cls._close_log()
+            shutil.rmtree(cls.temp_dir, ignore_errors=True)
+            raise
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls._stop_lemond()
+        mock = getattr(cls, "mock", None)
+        if mock:
+            mock.stop()
+        cls._close_log()
+        temp_dir = getattr(cls, "temp_dir", None)
+        if temp_dir:
+            shutil.rmtree(temp_dir, ignore_errors=True)
+        super().tearDownClass()
+
+    @classmethod
+    def _close_log(cls) -> None:
+        log_file = getattr(cls, "log_file", None)
+        if log_file and not log_file.closed:
+            log_file.close()
+
+    @classmethod
+    def _stop_lemond(cls) -> None:
+        proc = getattr(cls, "proc", None)
+        if proc and proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait(timeout=5)
+
+    @classmethod
+    def _log_tail(cls) -> str:
+        log_file = getattr(cls, "log_file", None)
+        if log_file and not log_file.closed:
+            log_file.flush()
+        path = Path(getattr(cls, "log_path", ""))
+        if not path.exists():
+            return "<no lemond log>"
+        text = path.read_text(encoding="utf-8", errors="replace")
+        return text[-5000:]
+
+    @classmethod
+    def _wait_for_server(cls) -> None:
+        deadline = time.monotonic() + 15
+        last_error: Exception | None = None
+        while time.monotonic() < deadline:
+            if cls.proc.poll() is not None:
+                raise RuntimeError(
+                    f"lemond exited with code {cls.proc.returncode}\n{cls._log_tail()}"
+                )
+            try:
+                response = requests.get(f"{cls.root_url}/live", timeout=0.5)
+                if response.status_code == 200:
+                    return
+            except requests.RequestException as exc:
+                last_error = exc
+            time.sleep(0.05)
+        raise RuntimeError(
+            f"lemond did not become ready: {last_error}\n{cls._log_tail()}"
+        )
+
+    def setUp(self) -> None:
+        self._delete_all_servers_best_effort()
+
+    def tearDown(self) -> None:
+        self._delete_all_servers_best_effort()
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        payload: dict[str, Any] | None = None,
+        auth: bool = True,
+        expected: int | tuple[int, ...] = 200,
+    ) -> requests.Response:
+        headers = self.admin_headers if auth else {}
+        response = requests.request(
+            method,
+            f"{self.mcp_url}{path}",
+            headers=headers,
+            json=payload,
+            timeout=REQUEST_TIMEOUT,
+        )
+        expected_codes = (expected,) if isinstance(expected, int) else expected
+        self.assertIn(
+            response.status_code,
+            expected_codes,
+            f"{method} {path}: expected {expected_codes}, got {response.status_code}; "
+            f"body={response.text[:2000]!r}\nlemond log:\n{self._log_tail()}",
+        )
+        return response
+
+    def _list_servers(self) -> list[dict[str, Any]]:
+        payload = self._request("GET", "/servers").json()
+        servers = payload.get("servers", [])
+        self.assertIsInstance(servers, list)
+        return servers
+
+    def _delete_all_servers_best_effort(self) -> None:
+        try:
+            response = requests.get(
+                f"{self.mcp_url}/servers",
+                headers=self.admin_headers,
+                timeout=2,
+            )
+            if response.status_code != 200:
+                return
+            servers = response.json().get("servers", [])
+            for item in servers:
+                server_id = item.get("id") if isinstance(item, dict) else None
+                if server_id:
+                    requests.delete(
+                        f"{self.mcp_url}/servers/{server_id}",
+                        headers=self.admin_headers,
+                        timeout=2,
+                    )
+        except Exception:
+            pass
+
+    def _config(
+        self,
+        server_id: str,
+        path: str = "/mcp-json",
+        *,
+        bearer: bool = False,
+    ) -> dict[str, Any]:
+        config: dict[str, Any] = {
+            "id": server_id,
+            "name": f"Test {server_id}",
+            "transport": "streamable-http",
+            "url": f"http://127.0.0.1:{self.mock.port}{path}",
+            "timeout_ms": 5000,
+            "enabled": True,
+        }
+        if bearer:
+            config["bearer_token"] = f"${{{BEARER_ENV}}}"
+        return config
+
+    def test_001_admin_gate_is_fail_closed(self) -> None:
+        public_health = requests.get(
+            f"{self.root_url}/api/v1/health", timeout=REQUEST_TIMEOUT
+        )
+        self.assertEqual(public_health.status_code, 200)
+
+        unauthorized = self._request("GET", "/servers", auth=False, expected=(401, 403))
+        self.assertNotEqual(unauthorized.status_code, 200)
+
+        authorized = self._request("GET", "/servers")
+        self.assertEqual(authorized.status_code, 200)
+
+        keyless_dir = tempfile.mkdtemp(prefix="lemond_mcp_keyless_")
+        keyless_port = find_free_port()
+        keyless_env = os.environ.copy()
+        keyless_env.pop("LEMONADE_API_KEY", None)
+        keyless_env.pop("LEMONADE_ADMIN_API_KEY", None)
+        keyless_proc = subprocess.Popen(
+            [self.lemond_bin, keyless_dir, "--port", str(keyless_port)],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            env=keyless_env,
+        )
+        try:
+            keyless_root = f"http://127.0.0.1:{keyless_port}"
+            deadline = time.monotonic() + 10
+            while time.monotonic() < deadline:
+                try:
+                    if (
+                        requests.get(f"{keyless_root}/live", timeout=0.5).status_code
+                        == 200
+                    ):
+                        break
+                except requests.RequestException:
+                    pass
+                time.sleep(0.05)
+            else:
+                self.fail("keyless lemond did not become ready")
+
+            health = requests.get(
+                f"{keyless_root}/api/v1/health", timeout=REQUEST_TIMEOUT
+            )
+            self.assertEqual(health.status_code, 200)
+            for method in ("GET", "OPTIONS"):
+                response = requests.request(
+                    method,
+                    f"{keyless_root}/internal/mcp/servers",
+                    timeout=REQUEST_TIMEOUT,
+                )
+                self.assertEqual(response.status_code, 403)
+        finally:
+            if keyless_proc.poll() is None:
+                keyless_proc.terminate()
+                try:
+                    keyless_proc.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    keyless_proc.kill()
+                    keyless_proc.wait(timeout=5)
+            shutil.rmtree(keyless_dir, ignore_errors=True)
+
+    def test_010_http_config_validation_and_secret_persistence(self) -> None:
+        created = self._request(
+            "POST",
+            "/servers",
+            payload={"server": self._config("valid-http", bearer=True)},
+        ).json()
+        self.assertIn("server", created)
+
+        persisted_path = Path(self.temp_dir) / "mcp_servers.json"
+        persisted = persisted_path.read_text(encoding="utf-8")
+        self.assertNotIn(BEARER_SECRET, persisted)
+        self.assertIn(f"${{{BEARER_ENV}}}", persisted)
+
+        bad_configs = [
+            {
+                "id": "bad-port",
+                "transport": "streamable-http",
+                "url": "http://127.0.0.1:70000/mcp",
+            },
+            {
+                "id": "plain-remote",
+                "transport": "streamable-http",
+                "url": "http://example.invalid/mcp",
+            },
+            {
+                "id": "raw-bearer",
+                "transport": "streamable-http",
+                "url": f"http://127.0.0.1:{self.mock.port}/mcp-json",
+                "bearer_token": "plaintext-secret",
+            },
+            {
+                "id": "http-with-command",
+                "transport": "streamable-http",
+                "url": f"http://127.0.0.1:{self.mock.port}/mcp-json",
+                "command": "python",
+            },
+            {
+                "id": "stdio-with-url",
+                "transport": "stdio",
+                "command": "python",
+                "url": f"http://127.0.0.1:{self.mock.port}/mcp-json",
+            },
+        ]
+        for config in bad_configs:
+            with self.subTest(server_id=config["id"]):
+                self._request(
+                    "POST", "/servers", payload={"server": config}, expected=400
+                )
+
+        insecure_opt_in = {
+            "id": "plain-remote-opt-in",
+            "transport": "streamable-http",
+            "url": "http://example.invalid/mcp",
+            "allow_insecure_http": True,
+        }
+        response = self._request(
+            "POST", "/servers", payload={"server": insecure_opt_in}
+        )
+        self.assertEqual(
+            response.json().get("server", {}).get("allow_insecure_http"), True
+        )
+
+    def test_020_test_endpoint_is_non_persistent_and_supports_json_and_sse(
+        self,
+    ) -> None:
+        before = {item.get("id") for item in self._list_servers()}
+
+        for suffix, path in (("json", "/mcp-json"), ("sse", "/mcp-sse")):
+            with self.subTest(transport_response=suffix):
+                response = self._request(
+                    "POST",
+                    "/servers/test",
+                    payload={
+                        "server": self._config(
+                            f"probe-{suffix}", path, bearer=(suffix == "json")
+                        )
+                    },
+                )
+                self.assertIsInstance(response.json(), dict)
+
+        after = {item.get("id") for item in self._list_servers()}
+        self.assertEqual(before, after)
+        self.assertTrue(
+            self.mock.state.saw_bearer_secret(),
+            "mock MCP server never received the resolved bearer credential",
+        )
+
+    def test_030_all_lifecycle_endpoints_and_tool_call(self) -> None:
+        server_id = "lifecycle"
+        self._request(
+            "POST",
+            "/servers",
+            payload={"server": self._config(server_id, bearer=True)},
+        )
+        self._request("POST", f"/servers/{server_id}/connect")
+
+        listed = self._list_servers()
+        lifecycle = next(item for item in listed if item.get("id") == server_id)
+        self.assertTrue(lifecycle.get("connected"))
+
+        tools_payload = self._request("GET", "/tools").json()
+        tools = tools_payload.get("tools", [])
+        self.assertTrue(
+            any(
+                isinstance(tool, dict)
+                and tool.get("server_id") == server_id
+                and tool.get("name") == "echo"
+                for tool in tools
+            )
+        )
+
+        call = self._request(
+            "POST",
+            f"/servers/{server_id}/tools/call",
+            payload={"name": "echo", "arguments": {"message": "hello-mcp"}},
+        ).json()
+        self.assertEqual(
+            call.get("result", {}).get("content", [{}])[0].get("text"),
+            "hello-mcp",
+        )
+
+        refreshed = self._request("POST", f"/servers/{server_id}/refresh-tools").json()
+        self.assertIn("server", refreshed)
+
+        deletes_before = self.mock.state.delete_count()
+        self._request("POST", f"/servers/{server_id}/disconnect")
+        self.assertGreater(
+            self.mock.state.delete_count(),
+            deletes_before,
+            "disconnect did not issue best-effort MCP session DELETE",
+        )
+
+        self._request("DELETE", f"/servers/{server_id}")
+        self.assertNotIn(server_id, {item.get("id") for item in self._list_servers()})
+
+    def test_040_server_initiated_ping_is_answered(self) -> None:
+        self._request(
+            "POST",
+            "/servers/test",
+            payload={"server": self._config("ping-probe", "/mcp-ping")},
+        )
+        self.assertTrue(
+            self.mock.state.saw_successful_ping_reply(),
+            "client host did not answer the server-initiated MCP ping request",
+        )
+
+    def test_050_expired_http_session_is_invalidated_and_can_reconnect(self) -> None:
+        server_id = "session-expiry"
+        self._request(
+            "POST",
+            "/servers",
+            payload={"server": self._config(server_id, "/mcp-expire")},
+        )
+        self._request("POST", f"/servers/{server_id}/connect")
+
+        # The mock expires the session on the second tools/list. The HTTP route
+        # reports the upstream failure, and the client should clear its local
+        # session so a later connect can initialize a new one.
+        self._request("POST", f"/servers/{server_id}/refresh-tools", expected=502)
+        self._request("POST", f"/servers/{server_id}/connect")
+
+        listed = self._list_servers()
+        reconnected = next(item for item in listed if item.get("id") == server_id)
+        self.assertTrue(reconnected.get("connected"))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Adds Streamable HTTP support to the server-side MCP client host while keeping the existing stdio transport.

This allows Lemonade to connect directly to external MCP HTTP endpoints instead of requiring every external server to run as a local process.

## Changes

- add `streamable-http` as an MCP client transport
- keep existing `stdio` configs backwards compatible
- support MCP initialization and protocol negotiation over HTTP
- handle JSON and SSE responses
- track and clean up `Mcp-Session-Id` sessions
- support tool discovery and tool calls over HTTP
- respond to server-initiated MCP requests such as `ping`
- add URL and port validation
- require HTTPS for non-local endpoints unless insecure HTTP is explicitly enabled
- support bearer authentication through `${VARIABLE}` environment references
- add `POST /internal/mcp/servers/test` for testing a configuration without persisting it
- handle expired HTTP sessions and disconnect cleanup
