### PR TITLE
fix(server): harden extra models directory handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2820,6 +2820,19 @@ if(BUILD_TESTING AND EXISTS "${_RUNTIME_CONFIG_BACKEND_VALIDATION_TEST_SRC}")
     )
 endif()
 
+set(_RUNTIME_CONFIG_DIRECTORY_VALIDATION_TEST_SRC
+    "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_runtime_config_directory_validation.cpp"
+)
+if(BUILD_TESTING AND EXISTS "${_RUNTIME_CONFIG_DIRECTORY_VALIDATION_TEST_SRC}")
+    add_executable(test_runtime_config_directory_validation
+        test/cpp/test_runtime_config_directory_validation.cpp
+    )
+    target_link_libraries(test_runtime_config_directory_validation PRIVATE lemonade-server-core)
+    add_cpp_ci_test(RuntimeConfigDirectoryValidationTest CI ON
+        COMMAND test_runtime_config_directory_validation
+    )
+endif()
+
 set(_CONFIG_DEFAULT_SOURCE_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_config_default_source.cpp")
 if(BUILD_TESTING AND EXISTS "${_CONFIG_DEFAULT_SOURCE_TEST_SRC}")
     add_executable(test_config_default_source test/cpp/test_config_default_source.cpp)

--- a/docs/embeddable/models.md
+++ b/docs/embeddable/models.md
@@ -160,6 +160,8 @@ extra.my_custom_model.gguf              Yes         llamacpp
 
 > Tip: `extra_models_dir` can be a relative path to any location within your app's package, or any absolute path on your user's system. It searches recursively and can import many GGUFs from a single directory tree.
 
+> Note: When an existing `extra_models_dir` is set at runtime, the path must be a readable directory for the `lemond` process. Permission or I/O failures are rejected instead of replacing the current model view. A path that does not exist yet is allowed and can be picked up later by the directory watcher.
+
 ## Customization
 
 ### Changing the Built-In Models List

--- a/docs/embeddable/runtime.md
+++ b/docs/embeddable/runtime.md
@@ -168,7 +168,10 @@ Accepts a JSON object with one or more keys to update atomically. Returns `{"sta
 | `log_level` | string (`trace`, `debug`, `info`, `warning`, `error`, `fatal`, `none`) | Reconfigures log filter |
 | `global_timeout` | int (positive) | Updates default HTTP client timeout |
 | `no_broadcast` | bool | Stops or starts UDP beacon |
-| `extra_models_dir` | string | Updates model manager search path |
+| `models_dir` | string (`"auto"` or path) | Updates the primary model cache location |
+| `extra_models_dir` | string | Validates access and updates the external GGUF search path |
+
+When `extra_models_dir` points to an existing path, `lemond` validates that it is a readable directory before applying the update. A path that does not exist yet is accepted so the directory watcher can pick it up if it is created later. Because `/internal/set` validates all supplied keys before applying any of them, a directory validation error rejects the whole request with `400`.
 
 **Deferred keys** (affect the next model load or eviction decision, no immediate side effect):
 

--- a/docs/guide/configuration/README.md
+++ b/docs/guide/configuration/README.md
@@ -179,8 +179,8 @@ Values set in the user's `config.json` always take precedence over these seeded 
 | `global_timeout` | int | 600 | Timeout in seconds for HTTP, inference, and readiness checks |
 | `max_loaded_models` | int | 1 | Max models per type slot. Use -1 for unlimited |
 | `no_broadcast` | bool | false | Disable UDP broadcasting for server discovery |
-| `extra_models_dir` | string | "" | Secondary directory to scan for GGUF model files |
-| `models_dir` | string | "auto" | Directory for cached model files. "auto" follows HF_HUB_CACHE / HF_HOME / platform default |
+| `extra_models_dir` | string | "" | Secondary directory recursively scanned for GGUF model files. Empty disables extra discovery; existing paths must be readable by `lemond` |
+| `models_dir` | string | "auto" | Directory for cached model files. `"auto"` follows `HF_HUB_CACHE` / `HF_HOME` / platform default |
 | `ctx_size` | int | -1 | Default context size for LLM models. Use `-1` for auto-resolution: the server computes the largest context that fits in available device memory using GGUF architecture metadata. Use a positive integer to set an explicit size. |
 | `default_model_source` | string | "huggingface" | Remote registry used to pull checkpoints when a request does not name one (`huggingface` or `modelscope`). Explicit `--source`, a `source`/`registry_source` field, or a provider URL always overrides it. |
 | `offline` | bool | false | Skip model downloads |
@@ -190,6 +190,8 @@ Values set in the user's `config.json` always take precedence over these seeded 
 | `inhibit_suspend` | bool | true | Prevent the OS from suspending while inference is active. Linux only (uses systemd-logind); no-op on Windows/macOS/non-systemd environments. |
 | `enable_dgpu_gtt` | bool | false | Include GTT for hardware-based model filtering |
 | `rocm_channel` | string | "stable" | ROCm backend channel: "stable" (default) or "nightly". See [llama.cpp Backend](./llamacpp.md) for details |
+
+Both `models_dir` and `extra_models_dir` can be changed at runtime through `POST /internal/set`. Existing `extra_models_dir` paths are preflighted as directories and must be enumerable by the `lemond` process. Nonexistent paths are accepted so the directory watcher can observe them if they are created later.
 
 ### Backend Configuration
 

--- a/src/cpp/Extra-Models-Dir-Spec.md
+++ b/src/cpp/Extra-Models-Dir-Spec.md
@@ -20,6 +20,12 @@ The `--extra-models-dir PATH` argument specifies a secondary directory to scan f
 2. Discovered models are added to the model list alongside registered models from `server_models.json` and `user_models.json`.
 3. HuggingFace cache remains the primary source for registered models.
 
+### Access and Failure Behavior
+
+When `extra_models_dir` is updated at runtime, an existing path must be a directory that the `lemond` process can enumerate. Permission and I/O failures reject the config update. A path that does not exist yet is accepted so the directory watcher can observe it if it is created later.
+
+During discovery, inaccessible nested directories are skipped. Extra-model discovery is optional: a filesystem failure must not remove or hide models from `server_models.json` or `user_models.json`.
+
 ### Naming Convention
 
 All discovered models are prefixed with `extra.` to prevent naming conflicts with registered models (similar to how user-added models are prefixed with `user.`):

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -1251,8 +1251,22 @@ std::map<std::string, ModelInfo> ModelManager::discover_extra_models() const {
         return discovered;
     }
 
-    if (!fs::exists(extra_models_dir_)) {
-        // Directory doesn't exist, return empty
+    const fs::path search_path = path_from_utf8(extra_models_dir_);
+    std::error_code status_ec;
+    const fs::file_status status = fs::status(search_path, status_ec);
+    if (status_ec) {
+        if (status_ec == std::errc::no_such_file_or_directory) {
+            return discovered;
+        }
+        LOG(ERROR, "ModelManager") << "Cannot inspect extra models directory "
+                                    << extra_models_dir_ << ": "
+                                    << status_ec.message() << std::endl;
+        return discovered;
+    }
+    if (!fs::exists(status) || !fs::is_directory(status)) {
+        // A missing path is allowed because the directory watcher may observe it
+        // later. A non-directory cannot contribute models, but must not affect
+        // the registered model cache either.
         return discovered;
     }
 
@@ -1266,8 +1280,10 @@ std::map<std::string, ModelInfo> ModelManager::discover_extra_models() const {
 
     // Recursively find all .gguf files
     try {
-        for (const auto& entry : fs::recursive_directory_iterator(search_dir)) {
-            if (!entry.is_regular_file()) continue;
+        for (const auto& entry : fs::recursive_directory_iterator(
+                 search_path, fs::directory_options::skip_permission_denied)) {
+            std::error_code entry_ec;
+            if (!entry.is_regular_file(entry_ec) || entry_ec) continue;
 
             std::string filename = entry.path().filename().string();
 
@@ -2116,7 +2132,15 @@ void ModelManager::build_cache() {
     // canonical IDs from any user. or builtin. records that may share a bare
     // name. Bare-name collisions are surfaced via the friendly-name layer in
     // rebuild_public_model_aliases_locked, not by dropping records here.
-    auto discovered_models = discover_extra_models();
+    std::map<std::string, ModelInfo> discovered_models;
+    try {
+        discovered_models = discover_extra_models();
+    } catch (const std::exception& e) {
+        // External discovery is additive. A filesystem failure in that optional
+        // source must never make built-in or user-registered models disappear.
+        LOG(ERROR, "ModelManager") << "Extra model discovery failed; keeping registered models: "
+                                    << e.what() << std::endl;
+    }
     for (const auto& [name, info] : discovered_models) {
         if (all_models.find(name) != all_models.end()) {
             LOG(INFO, "ModelManager") << "Warning: Discovered model '" << name

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -1259,23 +1259,21 @@ std::map<std::string, ModelInfo> ModelManager::discover_extra_models() const {
             return discovered;
         }
         LOG(ERROR, "ModelManager") << "Cannot inspect extra models directory "
-                                    << extra_models_dir_ << ": "
-                                    << status_ec.message() << std::endl;
+                                   << extra_models_dir_ << ": "
+                                   << status_ec.message() << std::endl;
         return discovered;
     }
-    if (!fs::exists(status) || !fs::is_directory(status)) {
+    if (!fs::is_directory(status)) {
         // A missing path is allowed because the directory watcher may observe it
         // later. A non-directory cannot contribute models, but must not affect
         // the registered model cache either.
         return discovered;
     }
 
-    std::string search_dir = extra_models_dir_;
-
-    LOG(INFO, "ModelManager") << "Scanning for GGUF models in: " << search_dir << std::endl;
+    LOG(INFO, "ModelManager") << "Scanning for GGUF models in: " << extra_models_dir_ << std::endl;
 
     // Track which directories we've processed (for multimodal/multi-shard detection)
-    std::map<std::string, std::vector<fs::path>> dirs_with_gguf;  // directory -> list of gguf files
+    std::map<fs::path, std::vector<fs::path>> dirs_with_gguf;  // directory -> list of gguf files
     std::vector<fs::path> standalone_files;  // GGUF files not in subdirectories
 
     // Recursively find all .gguf files
@@ -1283,7 +1281,7 @@ std::map<std::string, ModelInfo> ModelManager::discover_extra_models() const {
         for (const auto& entry : fs::recursive_directory_iterator(
                  search_path, fs::directory_options::skip_permission_denied)) {
             std::error_code entry_ec;
-            if (!entry.is_regular_file(entry_ec) || entry_ec) continue;
+            if (!entry.is_regular_file(entry_ec)) continue;
 
             std::string filename = entry.path().filename().string();
 
@@ -1292,16 +1290,16 @@ std::map<std::string, ModelInfo> ModelManager::discover_extra_models() const {
             fs::path parent_dir = entry.path().parent_path();
 
             // Check if this file is directly in the search directory or in a subdirectory
-            if (parent_dir == fs::path(search_dir)) {
+            if (parent_dir == search_path) {
                 // Standalone file in the root of search directory
                 standalone_files.push_back(entry.path());
             } else {
                 // File in a subdirectory - group by parent directory
-                dirs_with_gguf[parent_dir.string()].push_back(entry.path());
+                dirs_with_gguf[parent_dir].push_back(entry.path());
             }
         }
     } catch (const std::exception& e) {
-        LOG(ERROR, "ModelManager") << "Error scanning directory " << search_dir << ": " << e.what() << std::endl;
+        LOG(ERROR, "ModelManager") << "Error scanning directory " << extra_models_dir_ << ": " << e.what() << std::endl;
         return discovered;
     }
 
@@ -1332,7 +1330,7 @@ std::map<std::string, ModelInfo> ModelManager::discover_extra_models() const {
     // Process directories (multimodal and multi-shard models)
     for (const auto& [dir_path, gguf_files] : dirs_with_gguf) {
         if (gguf_files.empty()) continue;
-        discover_extra_models_in_directory(fs::path(dir_path), gguf_files, discovered);
+        discover_extra_models_in_directory(dir_path, gguf_files, discovered);
     }
 
     LOG(INFO, "ModelManager") << "Discovered " << discovered.size() << " models from extra directory" << std::endl;
@@ -2139,7 +2137,7 @@ void ModelManager::build_cache() {
         // External discovery is additive. A filesystem failure in that optional
         // source must never make built-in or user-registered models disappear.
         LOG(ERROR, "ModelManager") << "Extra model discovery failed; keeping registered models: "
-                                    << e.what() << std::endl;
+                                   << e.what() << std::endl;
     }
     for (const auto& [name, info] : discovered_models) {
         if (all_models.find(name) != all_models.end()) {

--- a/src/cpp/server/runtime_config.cpp
+++ b/src/cpp/server/runtime_config.cpp
@@ -86,8 +86,7 @@ static void validate_extra_models_dir_access(const std::string& raw_dir) {
     // enumerate the directory. Probe enumeration so the GUI can report a
     // permission error before RuntimeConfig::set applies either directory key.
     std::error_code read_ec;
-    fs::directory_iterator probe(dir, read_ec);
-    (void)probe;
+    fs::directory_iterator{dir, read_ec};
     if (read_ec) {
         throw std::invalid_argument(
             "'extra_models_dir' is not readable by the Lemonade server: " +

--- a/src/cpp/server/runtime_config.cpp
+++ b/src/cpp/server/runtime_config.cpp
@@ -53,6 +53,48 @@ static bool has_backend_selection(const std::string& config_section) {
     return false;
 }
 
+static void validate_extra_models_dir_access(const std::string& raw_dir) {
+    if (raw_dir.empty()) {
+        return;
+    }
+
+    const fs::path dir = utils::path_from_utf8(raw_dir);
+    std::error_code status_ec;
+    const fs::file_status status = fs::status(dir, status_ec);
+
+    // Keep the existing runtime semantics for paths that do not exist yet:
+    // DirectoryWatcher may observe the directory if it is created shortly after
+    // configuration. Permission and I/O failures, however, must not be accepted
+    // as a successful config update.
+    if (status_ec) {
+        if (status_ec == std::errc::no_such_file_or_directory) {
+            return;
+        }
+        throw std::invalid_argument(
+            "'extra_models_dir' is not accessible by the Lemonade server: " +
+            raw_dir + " (" + status_ec.message() + ")");
+    }
+    if (!fs::exists(status)) {
+        return;
+    }
+    if (!fs::is_directory(status)) {
+        throw std::invalid_argument(
+            "'extra_models_dir' must reference a directory: " + raw_dir);
+    }
+
+    // status() can succeed when the process can traverse the path but cannot
+    // enumerate the directory. Probe enumeration so the GUI can report a
+    // permission error before RuntimeConfig::set applies either directory key.
+    std::error_code read_ec;
+    fs::directory_iterator probe(dir, read_ec);
+    (void)probe;
+    if (read_ec) {
+        throw std::invalid_argument(
+            "'extra_models_dir' is not readable by the Lemonade server: " +
+            raw_dir + " (" + read_ec.message() + ")");
+    }
+}
+
 static std::pair<json, std::string> normalize_config_set_changes(const json& changes) {
     json normalized = changes;
     std::string message;
@@ -565,6 +607,9 @@ void RuntimeConfig::validate(const std::string& key, const json& value) const {
     } else if (key == "extra_models_dir" || key == "models_dir") {
         if (!value.is_string()) {
             throw std::invalid_argument("'" + key + "' must be a string");
+        }
+        if (key == "extra_models_dir") {
+            validate_extra_models_dir_access(value.get<std::string>());
         }
     } else if (key == "default_model_source") {
         if (!value.is_string()) {

--- a/test/cpp/test_runtime_config_directory_validation.cpp
+++ b/test/cpp/test_runtime_config_directory_validation.cpp
@@ -1,0 +1,95 @@
+#include <lemon/runtime_config.h>
+#include <lemon/utils/path_utils.h>
+
+#include <chrono>
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <stdexcept>
+#include <string>
+#include <system_error>
+
+namespace fs = std::filesystem;
+using lemon::RuntimeConfig;
+using lemon::json;
+using lemon::utils::path_to_utf8;
+
+namespace {
+
+class TempDirectory {
+public:
+    TempDirectory() {
+        const auto stamp = std::chrono::steady_clock::now().time_since_epoch().count();
+        path_ = fs::temp_directory_path() /
+                ("lemonade-runtime-config-dir-validation-" + std::to_string(stamp));
+        fs::create_directories(path_);
+    }
+
+    ~TempDirectory() {
+        std::error_code ec;
+        fs::remove_all(path_, ec);
+    }
+
+    const fs::path& path() const {
+        return path_;
+    }
+
+private:
+    fs::path path_;
+};
+
+bool accepts_directory_value(const fs::path& path, const char* label) {
+    RuntimeConfig config(json{{"extra_models_dir", ""}});
+    try {
+        config.set(json{{"extra_models_dir", path_to_utf8(path)}});
+        std::printf("[PASS] %s\n", label);
+        return true;
+    } catch (const std::exception& error) {
+        std::printf("[FAIL] %s: %s\n", label, error.what());
+        return false;
+    }
+}
+
+bool rejects_directory_value(const fs::path& path, const char* label) {
+    RuntimeConfig config(json{{"extra_models_dir", ""}});
+    try {
+        config.set(json{{"extra_models_dir", path_to_utf8(path)}});
+        std::printf("[FAIL] %s: value was unexpectedly accepted\n", label);
+        return false;
+    } catch (const std::invalid_argument&) {
+        std::printf("[PASS] %s\n", label);
+        return true;
+    } catch (const std::exception& error) {
+        std::printf("[FAIL] %s: unexpected exception: %s\n", label, error.what());
+        return false;
+    }
+}
+
+} // namespace
+
+int main() {
+    TempDirectory temp;
+    int failures = 0;
+
+    const fs::path readable_dir = temp.path() / "readable";
+    fs::create_directory(readable_dir);
+    if (!accepts_directory_value(readable_dir, "existing readable directory is accepted")) {
+        ++failures;
+    }
+
+    const fs::path missing_dir = temp.path() / "not-created";
+    if (!accepts_directory_value(missing_dir, "nonexistent directory is accepted")) {
+        ++failures;
+    }
+
+    const fs::path regular_file = temp.path() / "model.gguf";
+    {
+        std::ofstream output(regular_file);
+        output << "test";
+    }
+    if (!rejects_directory_value(regular_file, "existing regular file is rejected")) {
+        ++failures;
+    }
+
+    return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
Ports the server-side directory handling fix from #2998 to `main`.

* Validate `extra_models_dir` before applying runtime config changes
* Keep registered models available when extra-model discovery fails
* Document runtime directory validation behavior
