### PR TITLE
fix(alias): report the real reason for alias validation failures

### DIFF
--- a/docs/news/muse-glimmer.html
+++ b/docs/news/muse-glimmer.html
@@ -536,7 +536,7 @@
 
             <p class="mg-note"><strong>Note:</strong> Set the same key to <code>builtin</code> to return to the llama.cpp version Lemonade ships and tests, for example <code>lemonade config set llamacpp.vulkan_bin=builtin</code>.</p>
 
-            <p class="mg-note"><strong>Note:</strong> Muse Glimmer ships as a built-in model in the regular Wednesday Lemonade release on August 12, so this step becomes optional then.</p>
+            <p class="mg-note"><strong>Note:</strong> Muse Glimmer ships as a built-in model in Lemonade v11.6.0, so this step becomes optional once you update.</p>
           </div>
         </div>
 

--- a/src/cpp/cli/lemonade_client.cpp
+++ b/src/cpp/cli/lemonade_client.cpp
@@ -140,8 +140,15 @@ std::string extract_server_error_message(const HttpError& error) {
     if (!error.response_body().empty()) {
         try {
             auto parsed = json::parse(error.response_body());
-            if (parsed.contains("error") && parsed["error"].is_string()) {
-                return parsed["error"].get<std::string>();
+            if (parsed.contains("error")) {
+                const auto& err = parsed["error"];
+                if (err.is_string()) {
+                    return err.get<std::string>();
+                }
+                // OpenAI-style bodies nest the text under error.message.
+                if (err.is_object() && err.contains("message") && err["message"].is_string()) {
+                    return err["message"].get<std::string>();
+                }
             }
         } catch (const json::exception&) {
         }

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -5789,10 +5789,11 @@ void Server::handle_cleanup_cache(const httplib::Request& req, httplib::Response
 // message whenever the name is absent from the registry, which is always true for a
 // new alias, so routing these through it would report "model not found" instead of
 // the actual reason.
-static nlohmann::json create_alias_error(const std::string& message, const std::string& code) {
+static nlohmann::json create_alias_error(const std::string& message, const std::string& code,
+                                         const std::string& type = "invalid_request_error") {
     return nlohmann::json{{"error", {
         {"message", message},
-        {"type", "invalid_request_error"},
+        {"type", type},
         {"param", "alias"},
         {"code", code}
     }}};
@@ -5824,7 +5825,7 @@ void Server::handle_aliases_get(const httplib::Request& req, httplib::Response& 
         res.set_content(nlohmann::json{{"aliases", alias_list}}.dump(), "application/json");
     } catch (const std::exception& e) {
         res.status = 500;
-        res.set_content(create_alias_error(e.what(), "internal_error").dump(), "application/json");
+        res.set_content(create_alias_error(e.what(), "internal_error", "server_error").dump(), "application/json");
     }
 }
 
@@ -5863,7 +5864,7 @@ void Server::handle_aliases_add(const httplib::Request& req, httplib::Response& 
 
         if (!alias_manager_) {
             res.status = 500;
-            res.set_content(create_alias_error("AliasManager uninitialized", "internal_error").dump(), "application/json");
+            res.set_content(create_alias_error("AliasManager uninitialized", "internal_error", "server_error").dump(), "application/json");
             return;
         }
 
@@ -5901,7 +5902,7 @@ void Server::handle_aliases_remove(const httplib::Request& req, httplib::Respons
         res.set_content(response.dump(), "application/json");
     } catch (const std::exception& e) {
         res.status = 500;
-        res.set_content(create_alias_error(e.what(), "internal_error").dump(), "application/json");
+        res.set_content(create_alias_error(e.what(), "internal_error", "server_error").dump(), "application/json");
     }
 }
 

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -5785,6 +5785,19 @@ void Server::handle_cleanup_cache(const httplib::Request& req, httplib::Response
     }
 }
 
+// Alias failures are not model-lookup failures. create_model_error() rewrites its
+// message whenever the name is absent from the registry, which is always true for a
+// new alias, so routing these through it would report "model not found" instead of
+// the actual reason.
+static nlohmann::json create_alias_error(const std::string& message, const std::string& code) {
+    return nlohmann::json{{"error", {
+        {"message", message},
+        {"type", "invalid_request_error"},
+        {"param", "alias"},
+        {"code", code}
+    }}};
+}
+
 void Server::handle_aliases_get(const httplib::Request& req, httplib::Response& res) {
     try {
         nlohmann::json alias_list = nlohmann::json::array();
@@ -5811,7 +5824,7 @@ void Server::handle_aliases_get(const httplib::Request& req, httplib::Response& 
         res.set_content(nlohmann::json{{"aliases", alias_list}}.dump(), "application/json");
     } catch (const std::exception& e) {
         res.status = 500;
-        res.set_content(create_model_error("", e.what()).dump(), "application/json");
+        res.set_content(create_alias_error(e.what(), "internal_error").dump(), "application/json");
     }
 }
 
@@ -5823,19 +5836,19 @@ void Server::handle_aliases_add(const httplib::Request& req, httplib::Response& 
 
         if (alias.empty() || target.empty()) {
             res.status = 400;
-            res.set_content(create_model_error("", "Alias and target fields are required").dump(), "application/json");
+            res.set_content(create_alias_error("Alias and target fields are required", "invalid_request").dump(), "application/json");
             return;
         }
 
         if (alias == target) {
             res.status = 400;
-            res.set_content(create_model_error(alias, "Alias cannot point to itself").dump(), "application/json");
+            res.set_content(create_alias_error("Alias cannot point to itself", "invalid_alias").dump(), "application/json");
             return;
         }
 
         if (alias.rfind("user.", 0) == 0 || alias.rfind("extra.", 0) == 0 || alias.rfind("builtin.", 0) == 0) {
             res.status = 400;
-            res.set_content(create_model_error(alias, "Alias name cannot use reserved prefixes (user., extra., builtin.)").dump(), "application/json");
+            res.set_content(create_alias_error("Alias name cannot use reserved prefixes (user., extra., builtin.)", "invalid_alias").dump(), "application/json");
             return;
         }
 
@@ -5843,21 +5856,21 @@ void Server::handle_aliases_add(const httplib::Request& req, httplib::Response& 
             std::string canonical = model_manager_->resolve_model_name(alias);
             if (canonical == alias || canonical == "user." + alias || canonical == "builtin." + alias) {
                 res.status = 409;
-                res.set_content(create_model_error(alias, "Cannot create alias '" + alias + "': Name conflicts with an existing canonical model").dump(), "application/json");
+                res.set_content(create_alias_error("Cannot create alias '" + alias + "': Name conflicts with an existing canonical model", "alias_conflict").dump(), "application/json");
                 return;
             }
         }
 
         if (!alias_manager_) {
             res.status = 500;
-            res.set_content(create_model_error(alias, "AliasManager uninitialized").dump(), "application/json");
+            res.set_content(create_alias_error("AliasManager uninitialized", "internal_error").dump(), "application/json");
             return;
         }
 
         std::string err_msg;
         if (!alias_manager_->set_alias(alias, target, err_msg)) {
             res.status = 409;
-            res.set_content(create_model_error(alias, err_msg).dump(), "application/json");
+            res.set_content(create_alias_error(err_msg, "alias_conflict").dump(), "application/json");
             return;
         }
 
@@ -5869,7 +5882,7 @@ void Server::handle_aliases_add(const httplib::Request& req, httplib::Response& 
         res.set_content(response.dump(), "application/json");
     } catch (const std::exception& e) {
         res.status = 400;
-        res.set_content(create_model_error("", e.what()).dump(), "application/json");
+        res.set_content(create_alias_error(e.what(), "invalid_request").dump(), "application/json");
     }
 }
 
@@ -5878,7 +5891,7 @@ void Server::handle_aliases_remove(const httplib::Request& req, httplib::Respons
     try {
         if (!alias_manager_ || !alias_manager_->remove_alias(alias)) {
             res.status = 404;
-            res.set_content(create_model_error(alias, "Alias not found: " + alias).dump(), "application/json");
+            res.set_content(create_alias_error("Alias not found: " + alias, "alias_not_found").dump(), "application/json");
             return;
         }
         nlohmann::json response = {
@@ -5888,7 +5901,7 @@ void Server::handle_aliases_remove(const httplib::Request& req, httplib::Respons
         res.set_content(response.dump(), "application/json");
     } catch (const std::exception& e) {
         res.status = 500;
-        res.set_content(create_model_error(alias, e.what()).dump(), "application/json");
+        res.set_content(create_alias_error(e.what(), "internal_error").dump(), "application/json");
     }
 }
 


### PR DESCRIPTION
Three small fixes surfaced while verifying the v11.6.0 release checklist (#3107).

### 1. Alias validation errors reported the wrong reason

`handle_aliases_{get,add,remove}` routed failures through `create_model_error()`. That helper rewrites its message whenever `model_exists(requested_model)` is false (`server.cpp:2190`) — always true for a *new* alias name — so the real cause was discarded:

```
POST /internal/aliases {"alias":"foo","target":"foo"}
before: {"code":"model_not_found","message":"Model 'foo' was not found. Available models include: ..."}
after:  {"code":"invalid_alias","type":"invalid_request_error","param":"alias","message":"Alias cannot point to itself"}
```

Adds `create_alias_error()` and converts **10** call sites. HTTP status codes were already correct (400/404/409) and are unchanged, but this is **more than message quality**: the structured `code`, `type`, and `param` fields change too, so API consumers keying on `code` now get a meaningful value instead of `model_not_found` on every alias failure.

The three 500 paths (`handle_aliases_get` catch, `AliasManager uninitialized`, `handle_aliases_remove` catch) carry `type: server_error`; the seven 400/404/409 paths carry `invalid_request_error`.

New in v11.6.0 via #2818.

### 2. CLI discarded structured server errors

`extract_server_error_message()` only unwrapped `{"error": "<string>"}`. The server emits `error` as an object, so `is_string()` failed and the CLI fell back to `"Request failed: <code>"`. This affected every CLI command hitting a structured error — 31 `create_model_error` call sites feed it — not just aliases.

```
before: Request failed: 400
after:  Error creating alias: Alias cannot point to itself
```

Not a regression (the string-only check dates to `a2e6a8a45`, 2026-04-04), but fixing #1 without this leaves CLI users seeing nothing useful.

### 3. Muse Glimmer post promised a specific date

`docs/news/muse-glimmer.html:539` said the model ships built-in "in the regular **Wednesday** Lemonade release on **August 12**". Aug 12 is a Wednesday but Aug 13 is a Thursday, so a slipped tag makes the sentence self-contradictory rather than merely late. Now refers to v11.6.0 instead of a date, so it cannot go stale again. The substance was already true — the shipped `builtin` pin (b10375) covers Muse Glimmer.

Note `publish-website.yml` triggers on `push: tags: v*` and checks out the tag, so this fix only reaches the live site once it is on the tagged commit.

### Verification

Built clean and tested against a local server on this branch:
- self-referencing alias → `invalid_alias` / `invalid_request_error`
- delete nonexistent alias → `alias_not_found` / `invalid_request_error`
- `lemonade alias add foo foo` → `Error creating alias: Alias cannot point to itself`
- `lemonade alias remove nope` → `Error removing alias: Alias not found: nope`

### Follow-up

Automated coverage for `extract_server_error_message()` (string-shaped, object-shaped, malformed JSON, fallback) and the alias HTTP error envelopes is not included here — `lemonade_client.cpp` pulls in httplib/curl so it needs a new test target and `add_cpp_ci_test` wiring, which is not something to land on release night. Tracking as a follow-up alongside the other test gaps found during checklist verification.

Needs cherry-picking onto `release-v11.6.0` after merge — that branch was cut at `3e5325960`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)