### PR TITLE
lemonade import <file.json>: --dry-run policy validation, --alias; pull redirects file args to import

### DIFF
--- a/docs/dev/router-policy.md
+++ b/docs/dev/router-policy.md
@@ -157,8 +157,8 @@ and every entry's `model` must be one of `components`:
 Register the policy like any collection — from the CLI:
 
 ```bash
-lemonade pull ./my-router.json            # register (idempotent: re-pull to update)
-lemonade pull ./my-router.json --dry-run  # validate only; nothing is registered
+lemonade import ./my-router.json            # register (idempotent: re-import to update)
+lemonade import ./my-router.json --dry-run  # validate only; nothing is registered
 ```
 
 `--dry-run` runs the same structural checks as registration plus the

--- a/docs/dev/router-policy.md
+++ b/docs/dev/router-policy.md
@@ -154,7 +154,19 @@ and every entry's `model` must be one of `components`:
 
 ## Registering and invoking
 
-Register the policy like any collection — `POST /v1/pull` with the policy JSON:
+Register the policy like any collection — from the CLI:
+
+```bash
+lemonade pull ./my-router.json            # register (idempotent: re-pull to update)
+lemonade pull ./my-router.json --dry-run  # validate only; nothing is registered
+```
+
+`--dry-run` runs the same structural checks as registration plus the
+server-side policy parse (rule/candidate cross-checks, classifier references,
+`version`); component *existence* in the registry is only checked by a real
+registration.
+
+Or `POST /v1/pull` with the policy JSON directly:
 
 ```bash
 curl -X POST http://localhost:13305/api/v1/pull \

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -175,7 +175,7 @@ The `pull` command downloads and installs models. It can also register a custom 
 Common forms:
 
 ```bash
-lemonade pull MODEL_OR_CHECKPOINT_OR_FILE [--alias ALIAS] [--checkpoint TYPE CHECKPOINT] [--recipe RECIPE] [--label LABEL] [--components MODEL ...] [--dry-run]
+lemonade pull MODEL_OR_CHECKPOINT [--alias ALIAS] [--checkpoint TYPE CHECKPOINT] [--recipe RECIPE] [--label LABEL] [--components MODEL ...]
 ```
 
 ```bash
@@ -190,19 +190,17 @@ lemonade pull unsloth/Qwen3-8B-GGUF:Q4_K_M
 
 # Register and pull a custom model with an alias
 lemonade pull user.MyModel --checkpoint main org/model:Q4_0 --recipe llamacpp --alias my-alias
-
-# Register a model or router policy from a local JSON file (idempotent —
-# re-pull the file to update; --dry-run validates without registering)
-lemonade pull ./my-router.json
-lemonade pull ./my-router.json --dry-run
 ```
+
+To register a model or router policy from a local JSON file, use
+[`lemonade import`](#options-for-import) — a `.json` path passed to `pull`
+prints a hint pointing there.
 
 | Option | Description | Required |
 |--------|-------------|----------|
-| `MODEL_OR_CHECKPOINT_OR_FILE` | Registered model name, `owner/repo[:variant]` Hugging Face/ModelScope checkpoint, or path to a local `.json` model/policy file (e.g. a `collection.router` policy) | Yes |
+| `MODEL_OR_CHECKPOINT` | Registered model name, or `owner/repo[:variant]` Hugging Face/ModelScope checkpoint | Yes |
 | `--source` | Remote registry for checkpoint pulls: `huggingface` or `modelscope`; when omitted, the server's configured `default_model_source` applies. Direct hub URLs are auto-detected | No |
 | `--alias ALIAS` | Add an alias for the model being registered or pulled. | No |
-| `--dry-run` | With a `.json` file argument: validate without registering — structural checks plus the server-side policy parse for `collection.router` files. | No |
 | `--checkpoint TYPE CHECKPOINT` | Manual registration: add a checkpoint entry. Repeat for multi-component models such as `main` + `mmproj` or `main` + `vae`. | No |
 | `--recipe RECIPE` | Manual registration: recipe to associate with the new `user.*` model (`llamacpp`, `flm`, `ryzenai-llm`, `vllm`, `whispercpp`, `sd-cpp`, `kokoro`, `collection.omni`) | No |
 | `--label LABEL` | Manual registration: add a label to the new model. Repeatable. Valid: `coding`, `embeddings`, `hot`, `mtp`, `reasoning`, `reranking`, `tool-calling`, `vision` | No |
@@ -259,11 +257,23 @@ lemonade import [JSON_FILE] [options]
 
 | Option | Description | Required |
 |--------|-------------|----------|
-| `JSON_FILE` | Path to a JSON configuration file | No |
+| `JSON_FILE` | Path to a JSON model/policy file (e.g. a `collection.router` policy) | No |
+| `--dry-run` | Validate `JSON_FILE` without registering — structural checks, plus the server-side policy parse for `collection.router` files | No |
+| `--alias ALIAS` | Add an alias for the imported model | No |
 | `--directory DIR` | Remote recipes directory to query (e.g., `coding-agents`) | No |
 | `--recipe-file FILE` | Specific recipe JSON filename from the selected directory | No |
 | `--skip-prompt` | Run non-interactively (requires `--directory` and `--recipe-file` for remote import) | No |
 | `--yes` | Alias for `--skip-prompt` | No |
+
+Import is idempotent — re-import the file to update an existing registration.
+Router policies (`collection.router` files) register the same way; `--dry-run`
+additionally runs the server-side policy parse (rule/candidate cross-checks,
+classifier references, `version`) without registering anything:
+
+```bash
+lemonade import ./my-router.json            # register / update
+lemonade import ./my-router.json --dry-run  # validate only
+```
 
 **Remote import notes:**
 - Running `lemonade import` without `JSON_FILE` starts interactive recipe browsing from GitHub.

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -175,7 +175,7 @@ The `pull` command downloads and installs models. It can also register a custom 
 Common forms:
 
 ```bash
-lemonade pull MODEL_OR_CHECKPOINT [--alias ALIAS] [--checkpoint TYPE CHECKPOINT] [--recipe RECIPE] [--label LABEL] [--components MODEL ...]
+lemonade pull MODEL_OR_CHECKPOINT_OR_FILE [--alias ALIAS] [--checkpoint TYPE CHECKPOINT] [--recipe RECIPE] [--label LABEL] [--components MODEL ...] [--dry-run]
 ```
 
 ```bash
@@ -190,6 +190,11 @@ lemonade pull unsloth/Qwen3-8B-GGUF:Q4_K_M
 
 # Register and pull a custom model with an alias
 lemonade pull user.MyModel --checkpoint main org/model:Q4_0 --recipe llamacpp --alias my-alias
+
+# Register a model or router policy from a local JSON file (idempotent —
+# re-pull the file to update; --dry-run validates without registering)
+lemonade pull ./my-router.json
+lemonade pull ./my-router.json --dry-run
 ```
 
 | Option | Description | Required |

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -199,9 +199,10 @@ lemonade pull ./my-router.json --dry-run
 
 | Option | Description | Required |
 |--------|-------------|----------|
-| `MODEL_OR_CHECKPOINT` | Registered model name, or `owner/repo[:variant]` Hugging Face/ModelScope checkpoint | Yes |
+| `MODEL_OR_CHECKPOINT_OR_FILE` | Registered model name, `owner/repo[:variant]` Hugging Face/ModelScope checkpoint, or path to a local `.json` model/policy file (e.g. a `collection.router` policy) | Yes |
 | `--source` | Remote registry for checkpoint pulls: `huggingface` or `modelscope`; when omitted, the server's configured `default_model_source` applies. Direct hub URLs are auto-detected | No |
 | `--alias ALIAS` | Add an alias for the model being registered or pulled. | No |
+| `--dry-run` | With a `.json` file argument: validate without registering — structural checks plus the server-side policy parse for `collection.router` files. | No |
 | `--checkpoint TYPE CHECKPOINT` | Manual registration: add a checkpoint entry. Repeat for multi-component models such as `main` + `mmproj` or `main` + `vae`. | No |
 | `--recipe RECIPE` | Manual registration: recipe to associate with the new `user.*` model (`llamacpp`, `flm`, `ryzenai-llm`, `vllm`, `whispercpp`, `sd-cpp`, `kokoro`, `collection.omni`) | No |
 | `--label LABEL` | Manual registration: add a label to the new model. Repeatable. Valid: `coding`, `embeddings`, `hot`, `mtp`, `reasoning`, `reranking`, `tool-calling`, `vision` | No |

--- a/src/cpp/cli/main.cpp
+++ b/src/cpp/cli/main.cpp
@@ -19,7 +19,6 @@
 #include <CLI/CLI.hpp>
 #include <iostream>
 #include <string>
-#include <filesystem>
 #include <fstream>
 #include <nlohmann/json.hpp>
 #include <algorithm>
@@ -331,9 +330,22 @@ static bool handle_backend_operation(const std::string& spec, const std::string&
 
 static int handle_import_command(lemonade::LemonadeClient& client, const CliConfig& config) {
     if (!config.model.empty()) {
-        return lemon_cli::import_model_from_json_file(client, config.model);
+        if (config.dry_run) {
+            return lemon_cli::validate_model_json_file(client, config.model);
+        }
+        std::string imported_model;
+        const int res = lemon_cli::import_model_from_json_file(
+            client, config.model, &imported_model);
+        if (res == 0 && !config.alias_name.empty() && !imported_model.empty()) {
+            client.alias_add(config.alias_name, imported_model);
+        }
+        return res;
     }
 
+    if (config.dry_run || !config.alias_name.empty()) {
+        std::cerr << "Error: --dry-run and --alias require a JSON file argument." << std::endl;
+        return 1;
+    }
     return lemon_cli::import_remote_recipe(client, config.repo_dir, config.recipe_file,
                                            config.skip_prompt, config.yes, nullptr, true);
 }
@@ -403,30 +415,11 @@ static bool has_manual_pull_options(const CliConfig& config) {
 
 static int handle_pull_command(lemonade::LemonadeClient& client, const CliConfig& config) {
     if (lemon_cli::looks_like_json_file_argument(config.model)) {
-        if (has_manual_pull_options(config)) {
-            std::cerr << "Error: manual configuration options (--checkpoint, --recipe, "
-                         "--label, --components) cannot be combined with a JSON file argument."
-                      << std::endl;
-            return 1;
-        }
-        std::error_code ec;
-        if (!std::filesystem::is_regular_file(config.model, ec)) {
-            std::cerr << "Error: JSON file not found: '" << config.model << "'" << std::endl;
-            return 1;
-        }
-        if (config.dry_run) {
-            return lemon_cli::validate_model_json_file(client, config.model);
-        }
-        std::string imported_model;
-        const int res = lemon_cli::import_model_from_json_file(
-            client, config.model, &imported_model, /*upgrade=*/true);
-        if (res == 0 && !config.alias_name.empty() && !imported_model.empty()) {
-            client.alias_add(config.alias_name, imported_model);
-        }
-        return res;
-    }
-    if (config.dry_run) {
-        std::cerr << "Error: --dry-run requires a local .json file argument." << std::endl;
+        // Local files are import's job — redirect instead of silently falling
+        // through to a registry lookup that cannot succeed.
+        std::cerr << "Error: '" << config.model << "' looks like a local JSON file. "
+                     "Use: lemonade import " << config.model << " [--dry-run] [--alias ALIAS]"
+                  << std::endl;
         return 1;
     }
     if (has_manual_pull_options(config)) {
@@ -1361,13 +1354,10 @@ int main(int argc, char* argv[]) {
 
     // Pull options
     pull_cmd->add_option("model", config.model,
-        "Registered model name, registry checkpoint (owner/repo[:variant]), model URL, "
-        "or path to a local .json model/policy file (e.g. a collection.router policy)")
+        "Registered model name, registry checkpoint (owner/repo[:variant]), or model URL. "
+        "For a local .json model/policy file, use 'lemonade import'.")
         ->required()
-        ->type_name("MODEL_OR_CHECKPOINT_OR_FILE");
-    pull_cmd->add_flag("--dry-run", config.dry_run,
-        "With a .json file argument: validate without registering (structural checks, "
-        "plus the server-side policy parse for collection.router files)");
+        ->type_name("MODEL_OR_CHECKPOINT");
     CLI::Option* pull_source_opt =
         pull_cmd->add_option("--source", config.model_source,
             "Remote registry for checkpoint pulls: huggingface or modelscope "
@@ -1413,7 +1403,15 @@ int main(int argc, char* argv[]) {
     CLI::App* alias_list_cmd = alias_cmd->add_subcommand("list", "List registered model aliases")->group("Subcommands");
 
     // Import options
-    import_cmd->add_option("json_file", config.model, "Path to JSON file")->type_name("JSON_FILE");
+    import_cmd->add_option("json_file", config.model,
+        "Path to a JSON model/policy file (e.g. a collection.router policy)")
+        ->type_name("JSON_FILE");
+    import_cmd->add_flag("--dry-run", config.dry_run,
+        "Validate the JSON file without registering (structural checks, plus the "
+        "server-side policy parse for collection.router files)");
+    import_cmd->add_option("--alias", config.alias_name,
+        "Optional alias to register for the imported model")
+        ->type_name("ALIAS");
     import_cmd->add_option("--directory", config.repo_dir,
         "Remote recipe directory to query (e.g., coding-agents)")->type_name("DIR");
     import_cmd->add_option("--recipe-file", config.recipe_file,

--- a/src/cpp/cli/main.cpp
+++ b/src/cpp/cli/main.cpp
@@ -401,6 +401,22 @@ static bool has_manual_pull_options(const CliConfig& config) {
 }
 
 static int handle_pull_command(lemonade::LemonadeClient& client, const CliConfig& config) {
+    if (lemon_cli::is_local_json_file(config.model)) {
+        if (has_manual_pull_options(config)) {
+            std::cerr << "Error: manual configuration options (--checkpoint, --recipe, "
+                         "--label, --components) cannot be combined with a JSON file argument."
+                      << std::endl;
+            return 1;
+        }
+        if (config.dry_run) {
+            return lemon_cli::validate_model_json_file(client, config.model);
+        }
+        return lemon_cli::import_model_from_json_file(client, config.model);
+    }
+    if (config.dry_run) {
+        std::cerr << "Error: --dry-run requires a local .json file argument." << std::endl;
+        return 1;
+    }
     if (has_manual_pull_options(config)) {
         if (lemon::is_omni_collection_recipe(config.recipe)) {
             if (config.components.empty()) {
@@ -1333,9 +1349,13 @@ int main(int argc, char* argv[]) {
 
     // Pull options
     pull_cmd->add_option("model", config.model,
-        "Registered model name, registry checkpoint (owner/repo[:variant]), or model URL")
+        "Registered model name, registry checkpoint (owner/repo[:variant]), model URL, "
+        "or path to a local .json model/policy file (e.g. a collection.router policy)")
         ->required()
-        ->type_name("MODEL_OR_CHECKPOINT");
+        ->type_name("MODEL_OR_CHECKPOINT_OR_FILE");
+    pull_cmd->add_flag("--dry-run", config.dry_run,
+        "With a .json file argument: validate without registering (structural checks, "
+        "plus the server-side policy parse for collection.router files)");
     CLI::Option* pull_source_opt =
         pull_cmd->add_option("--source", config.model_source,
             "Remote registry for checkpoint pulls: huggingface or modelscope "

--- a/src/cpp/cli/main.cpp
+++ b/src/cpp/cli/main.cpp
@@ -19,6 +19,7 @@
 #include <CLI/CLI.hpp>
 #include <iostream>
 #include <string>
+#include <filesystem>
 #include <fstream>
 #include <nlohmann/json.hpp>
 #include <algorithm>
@@ -401,17 +402,28 @@ static bool has_manual_pull_options(const CliConfig& config) {
 }
 
 static int handle_pull_command(lemonade::LemonadeClient& client, const CliConfig& config) {
-    if (lemon_cli::is_local_json_file(config.model)) {
+    if (lemon_cli::looks_like_json_file_argument(config.model)) {
         if (has_manual_pull_options(config)) {
             std::cerr << "Error: manual configuration options (--checkpoint, --recipe, "
                          "--label, --components) cannot be combined with a JSON file argument."
                       << std::endl;
             return 1;
         }
+        std::error_code ec;
+        if (!std::filesystem::is_regular_file(config.model, ec)) {
+            std::cerr << "Error: JSON file not found: '" << config.model << "'" << std::endl;
+            return 1;
+        }
         if (config.dry_run) {
             return lemon_cli::validate_model_json_file(client, config.model);
         }
-        return lemon_cli::import_model_from_json_file(client, config.model);
+        std::string imported_model;
+        const int res = lemon_cli::import_model_from_json_file(
+            client, config.model, &imported_model, /*upgrade=*/true);
+        if (res == 0 && !config.alias_name.empty() && !imported_model.empty()) {
+            client.alias_add(config.alias_name, imported_model);
+        }
+        return res;
     }
     if (config.dry_run) {
         std::cerr << "Error: --dry-run requires a local .json file argument." << std::endl;

--- a/src/cpp/cli/recipe_import.cpp
+++ b/src/cpp/cli/recipe_import.cpp
@@ -321,7 +321,7 @@ bool validate_and_transform_model_json(nlohmann::json& model_data) {
     return true;
 }
 
-bool is_local_json_file(const std::string& path) {
+bool looks_like_json_file_argument(const std::string& path) {
     const std::string suffix = ".json";
     if (path.size() <= suffix.size()) {
         return false;
@@ -329,11 +329,7 @@ bool is_local_json_file(const std::string& path) {
     std::string lower = path;
     std::transform(lower.begin(), lower.end(), lower.begin(),
                    [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
-    if (lower.compare(lower.size() - suffix.size(), suffix.size(), suffix) != 0) {
-        return false;
-    }
-    std::error_code ec;
-    return std::filesystem::is_regular_file(path, ec);
+    return lower.compare(lower.size() - suffix.size(), suffix.size(), suffix) == 0;
 }
 
 int validate_model_json_file(lemonade::LemonadeClient& client,
@@ -371,9 +367,15 @@ int validate_model_json_file(lemonade::LemonadeClient& client,
         response = client.make_request("/api/v1/routing/validate", "POST",
                                        request.dump(), "application/json");
     } catch (const lemonade::HttpError& e) {
-        // A 400 is the validation verdict, not a transport failure.
-        std::cerr << "Invalid policy: " << lemonade::extract_server_error_message(e)
-                  << std::endl;
+        // Only a 400 is the validation verdict; anything else is a
+        // request/server failure and must not masquerade as one.
+        if (e.status_code() == 400) {
+            std::cerr << "Invalid policy: " << lemonade::extract_server_error_message(e)
+                      << std::endl;
+        } else {
+            std::cerr << "Error: routing/validate request failed (HTTP " << e.status_code()
+                      << "): " << lemonade::extract_server_error_message(e) << std::endl;
+        }
         return 1;
     } catch (const std::exception& e) {
         std::cerr << "Error: routing/validate request failed: " << e.what() << std::endl;
@@ -406,7 +408,8 @@ int validate_model_json_file(lemonade::LemonadeClient& client,
 
 int import_model_from_json_file(lemonade::LemonadeClient& client,
                                 const std::string& json_path,
-                                std::string* imported_model_out) {
+                                std::string* imported_model_out,
+                                bool upgrade) {
     nlohmann::json model_data;
 
     std::ifstream file(json_path);
@@ -431,7 +434,7 @@ int import_model_from_json_file(lemonade::LemonadeClient& client,
         return 1;
     }
 
-    return client.pull_model(model_data);
+    return client.pull_model(model_data, "", upgrade);
 }
 
 bool list_remote_recipe_files(const std::string& repo_dir,

--- a/src/cpp/cli/recipe_import.cpp
+++ b/src/cpp/cli/recipe_import.cpp
@@ -2,11 +2,13 @@
 
 #include "lemon/model_manager.h"
 #include "lemon/model_registry.h"
+#include "lemon/model_types.h"
 #include "lemon/utils/github_api.h"
 #include "lemon/utils/http_client.h"
 #include "lemon/utils/path_utils.h"
 
 #include <algorithm>
+#include <cctype>
 #include <chrono>
 #include <filesystem>
 #include <fstream>
@@ -317,6 +319,89 @@ bool validate_and_transform_model_json(nlohmann::json& model_data) {
     }
 
     return true;
+}
+
+bool is_local_json_file(const std::string& path) {
+    const std::string suffix = ".json";
+    if (path.size() <= suffix.size()) {
+        return false;
+    }
+    std::string lower = path;
+    std::transform(lower.begin(), lower.end(), lower.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+    if (lower.compare(lower.size() - suffix.size(), suffix.size(), suffix) != 0) {
+        return false;
+    }
+    std::error_code ec;
+    return std::filesystem::is_regular_file(path, ec);
+}
+
+int validate_model_json_file(lemonade::LemonadeClient& client,
+                             const std::string& json_path) {
+    nlohmann::json model_data;
+    std::ifstream file(json_path);
+    if (!file.good()) {
+        std::cerr << "Error: Failed to open JSON file '" << json_path << "'" << std::endl;
+        return 1;
+    }
+    try {
+        model_data = nlohmann::json::parse(file);
+    } catch (const nlohmann::json::exception& e) {
+        std::cerr << "Error: Failed to parse JSON file '" << json_path << "': " << e.what() << std::endl;
+        return 1;
+    }
+    if (!validate_and_transform_model_json(model_data)) {
+        return 1;
+    }
+
+    const std::string model_name = model_data["model_name"].get<std::string>();
+    const std::string recipe = model_data.value("recipe", std::string());
+    if (!lemon::is_router_collection_recipe(recipe)) {
+        std::cout << "Dry run OK (local checks): '" << model_name << "' (" << recipe
+                  << "). Nothing was registered." << std::endl;
+        return 0;
+    }
+
+    // Router policies additionally get the deep server-side parse the real
+    // registration would run (rule/candidate cross-checks, classifier refs,
+    // version) via the ad-hoc validation endpoint.
+    std::string response;
+    try {
+        nlohmann::json request = {{"policy", model_data}};
+        response = client.make_request("/api/v1/routing/validate", "POST",
+                                       request.dump(), "application/json");
+    } catch (const lemonade::HttpError& e) {
+        // A 400 is the validation verdict, not a transport failure.
+        std::cerr << "Invalid policy: " << lemonade::extract_server_error_message(e)
+                  << std::endl;
+        return 1;
+    } catch (const std::exception& e) {
+        std::cerr << "Error: routing/validate request failed: " << e.what() << std::endl;
+        return 1;
+    }
+    try {
+        nlohmann::json response_json = nlohmann::json::parse(response);
+        if (response_json.contains("error")) {
+            const auto& error = response_json["error"];
+            std::cerr << "Invalid policy: "
+                      << (error.is_string() ? error.get<std::string>() : error.dump())
+                      << std::endl;
+            return 1;
+        }
+        const nlohmann::json routing =
+            response_json.value("normalized_policy", nlohmann::json::object())
+                .value("routing", nlohmann::json::object());
+        std::cout << "Dry run OK: '" << model_name << "' (collection.router) — "
+                  << routing.value("candidates", nlohmann::json::array()).size()
+                  << " candidates, default '"
+                  << routing.value("default_model", std::string()) << "', "
+                  << routing.value("rules", nlohmann::json::array()).size()
+                  << " rules. Nothing was registered." << std::endl;
+        return 0;
+    } catch (const nlohmann::json::exception&) {
+        std::cerr << "Error: unexpected response from routing/validate: " << response << std::endl;
+        return 1;
+    }
 }
 
 int import_model_from_json_file(lemonade::LemonadeClient& client,

--- a/src/cpp/cli/recipe_import.cpp
+++ b/src/cpp/cli/recipe_import.cpp
@@ -408,8 +408,7 @@ int validate_model_json_file(lemonade::LemonadeClient& client,
 
 int import_model_from_json_file(lemonade::LemonadeClient& client,
                                 const std::string& json_path,
-                                std::string* imported_model_out,
-                                bool upgrade) {
+                                std::string* imported_model_out) {
     nlohmann::json model_data;
 
     std::ifstream file(json_path);
@@ -434,7 +433,7 @@ int import_model_from_json_file(lemonade::LemonadeClient& client,
         return 1;
     }
 
-    return client.pull_model(model_data, "", upgrade);
+    return client.pull_model(model_data);
 }
 
 bool list_remote_recipe_files(const std::string& repo_dir,

--- a/src/cpp/include/lemon_cli/recipe_import.h
+++ b/src/cpp/include/lemon_cli/recipe_import.h
@@ -9,9 +9,11 @@
 
 namespace lemon_cli {
 
-// True when `path` names an existing local .json file. `pull` uses this to
-// accept a model/policy document in place of a registry name.
-bool is_local_json_file(const std::string& path);
+// True when `path` is shaped like a local .json file argument (suffix check
+// only — existence is NOT verified). `pull` uses this to route the argument to
+// the file path, so a typo'd filename gets a clear file-not-found error
+// instead of falling through to the model/registry flow.
+bool looks_like_json_file_argument(const std::string& path);
 
 // Validate a model/policy JSON file without registering anything: the local
 // structural checks import runs, plus the server-side routing-policy parse
@@ -24,9 +26,12 @@ int validate_model_json_file(lemonade::LemonadeClient& client,
 bool validate_and_transform_model_json(nlohmann::json& model_data);
 
 // Import a local JSON recipe/model file.
+// `upgrade` mirrors pull_model's flag: explicit `pull <file>` opts into the
+// registry update check like any explicit pull; `import` keeps it off.
 int import_model_from_json_file(lemonade::LemonadeClient& client,
                                 const std::string& json_path,
-                                std::string* imported_model_out = nullptr);
+                                std::string* imported_model_out = nullptr,
+                                bool upgrade = false);
 
 // Import a remote recipe from lemonade-sdk/recipes on GitHub.
 int import_remote_recipe(lemonade::LemonadeClient& client,

--- a/src/cpp/include/lemon_cli/recipe_import.h
+++ b/src/cpp/include/lemon_cli/recipe_import.h
@@ -9,6 +9,17 @@
 
 namespace lemon_cli {
 
+// True when `path` names an existing local .json file. `pull` uses this to
+// accept a model/policy document in place of a registry name.
+bool is_local_json_file(const std::string& path);
+
+// Validate a model/policy JSON file without registering anything: the local
+// structural checks import runs, plus the server-side routing-policy parse
+// (POST /routing/validate) for collection.router documents. Returns 0 when
+// valid. Component existence is not checked — that happens at registration.
+int validate_model_json_file(lemonade::LemonadeClient& client,
+                             const std::string& json_path);
+
 // Validate and normalize imported model JSON payload.
 bool validate_and_transform_model_json(nlohmann::json& model_data);
 

--- a/src/cpp/include/lemon_cli/recipe_import.h
+++ b/src/cpp/include/lemon_cli/recipe_import.h
@@ -10,9 +10,9 @@
 namespace lemon_cli {
 
 // True when `path` is shaped like a local .json file argument (suffix check
-// only — existence is NOT verified). `pull` uses this to route the argument to
-// the file path, so a typo'd filename gets a clear file-not-found error
-// instead of falling through to the model/registry flow.
+// only — existence is NOT verified). `pull` uses this to redirect file
+// arguments to `import` with a clear hint instead of falling through to the
+// model/registry flow.
 bool looks_like_json_file_argument(const std::string& path);
 
 // Validate a model/policy JSON file without registering anything: the local
@@ -26,12 +26,9 @@ int validate_model_json_file(lemonade::LemonadeClient& client,
 bool validate_and_transform_model_json(nlohmann::json& model_data);
 
 // Import a local JSON recipe/model file.
-// `upgrade` mirrors pull_model's flag: explicit `pull <file>` opts into the
-// registry update check like any explicit pull; `import` keeps it off.
 int import_model_from_json_file(lemonade::LemonadeClient& client,
                                 const std::string& json_path,
-                                std::string* imported_model_out = nullptr,
-                                bool upgrade = false);
+                                std::string* imported_model_out = nullptr);
 
 // Import a remote recipe from lemonade-sdk/recipes on GitHub.
 int import_remote_recipe(lemonade::LemonadeClient& client,

--- a/test/server_cli2.py
+++ b/test/server_cli2.py
@@ -916,21 +916,20 @@ sys.exit(0)
                 ],
             },
         }
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".json", delete=False
-        ) as f:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
             json.dump(policy, f)
             return f.name
 
-    def test_057_pull_json_policy_file(self):
-        """`pull <policy.json>` registers a collection.router policy from a
-        local file (#3088), equivalent to POSTing the document to /pull."""
-        collection_name = f"user.CliPullFile-{uuid.uuid4().hex[:8]}"
-        alias_name = f"cli-pull-alias-{uuid.uuid4().hex[:8]}"
+    def test_057_import_json_policy_file(self):
+        """`import <policy.json>` registers a collection.router policy from a
+        local file (#3088); --alias binds to the normalized name from the
+        file."""
+        collection_name = f"user.CliImportFile-{uuid.uuid4().hex[:8]}"
+        alias_name = f"cli-import-alias-{uuid.uuid4().hex[:8]}"
         json_file = self._write_router_policy_file(collection_name)
         try:
             result = run_cli_command(
-                ["pull", json_file, "--alias", alias_name],
+                ["import", json_file, "--alias", alias_name],
                 timeout=TIMEOUT_MODEL_OPERATION,
             )
             self.assertEqual(
@@ -954,9 +953,8 @@ sys.exit(0)
             )
             self.assertEqual(entry.get("recipe"), "collection.router")
 
-            # --alias applies to the normalized name from the file. Alias
-            # lookups echo the alias as `id` but return the target's object —
-            # the recipe and components prove it resolved to our collection.
+            # Alias lookups echo the alias as `id` but return the target's
+            # object — the recipe and components prove it resolved.
             aliased = requests.get(
                 f"http://localhost:{PORT}/api/v1/models/{alias_name}",
                 headers=_auth_headers(),
@@ -966,18 +964,7 @@ sys.exit(0)
                 aliased.status_code, 200, f"alias should resolve: {aliased.text}"
             )
             self.assertEqual(aliased.json().get("recipe"), "collection.router")
-            self.assertEqual(
-                aliased.json().get("components"), [ENDPOINT_TEST_MODEL]
-            )
-
-            # A typo'd .json path is a clear file error, not a registry lookup.
-            missing = self.assertCommandFails(
-                ["pull", f"./no-such-{uuid.uuid4().hex[:8]}.json"],
-                timeout=TIMEOUT_DEFAULT,
-            )
-            self.assertIn(
-                "JSON file not found", missing.stdout + missing.stderr
-            )
+            self.assertEqual(aliased.json().get("components"), [ENDPOINT_TEST_MODEL])
         finally:
             os.unlink(json_file)
             try:
@@ -990,10 +977,11 @@ sys.exit(0)
             except Exception:
                 pass
 
-    def test_058_pull_json_dry_run(self):
-        """`pull <policy.json> --dry-run` validates without registering: a valid
-        policy reports OK and does not land in /models; a policy whose rule
-        routes to a non-candidate is rejected by the server-side parse."""
+    def test_058_import_json_dry_run(self):
+        """`import <policy.json> --dry-run` validates without registering: a
+        valid policy reports OK and does not land in /models; a policy whose
+        rule routes to a non-candidate is rejected by the server-side parse;
+        --dry-run without a file argument is rejected."""
         collection_name = f"user.CliDryRun-{uuid.uuid4().hex[:8]}"
         valid_file = self._write_router_policy_file(collection_name)
         invalid_file = self._write_router_policy_file(
@@ -1002,12 +990,10 @@ sys.exit(0)
         )
         try:
             result = run_cli_command(
-                ["pull", valid_file, "--dry-run"],
+                ["import", valid_file, "--dry-run"],
                 timeout=TIMEOUT_DEFAULT,
             )
-            self.assertEqual(
-                result.returncode, 0, f"dry-run failed: {result.stderr}"
-            )
+            self.assertEqual(result.returncode, 0, f"dry-run failed: {result.stderr}")
             self.assertIn("Nothing was registered", result.stdout)
 
             response = requests.get(
@@ -1021,36 +1007,36 @@ sys.exit(0)
             )
 
             bad = self.assertCommandFails(
-                ["pull", invalid_file, "--dry-run"],
+                ["import", invalid_file, "--dry-run"],
                 timeout=TIMEOUT_DEFAULT,
             )
             self.assertIn("Invalid policy", bad.stdout + bad.stderr)
 
             no_file = self.assertCommandFails(
-                ["pull", ENDPOINT_TEST_MODEL, "--dry-run"],
+                ["import", "--dry-run"],
                 timeout=TIMEOUT_DEFAULT,
             )
             self.assertIn(
-                "--dry-run requires", no_file.stdout + no_file.stderr
+                "require a JSON file argument", no_file.stdout + no_file.stderr
             )
         finally:
             os.unlink(valid_file)
             os.unlink(invalid_file)
 
-    def test_059_pull_json_conflicts_with_manual_options(self):
-        """A JSON file argument cannot be combined with manual configuration
-        flags — the file is the complete definition."""
+    def test_059_pull_json_file_redirects_to_import(self):
+        """A .json path passed to `pull` prints a hint pointing to `import`
+        instead of falling through to the registry flow — for existing and
+        typo'd paths alike."""
         json_file = self._write_router_policy_file(
-            f"user.CliConflict-{uuid.uuid4().hex[:8]}"
+            f"user.CliRedirect-{uuid.uuid4().hex[:8]}"
         )
         try:
-            result = self.assertCommandFails(
-                ["pull", json_file, "--recipe", "llamacpp"],
-                timeout=TIMEOUT_DEFAULT,
-            )
-            self.assertIn(
-                "cannot be combined", result.stdout + result.stderr
-            )
+            for arg in (json_file, f"./no-such-{uuid.uuid4().hex[:8]}.json"):
+                result = self.assertCommandFails(
+                    ["pull", arg],
+                    timeout=TIMEOUT_DEFAULT,
+                )
+                self.assertIn("lemonade import", result.stdout + result.stderr)
         finally:
             os.unlink(json_file)
 

--- a/test/server_cli2.py
+++ b/test/server_cli2.py
@@ -926,10 +926,11 @@ sys.exit(0)
         """`pull <policy.json>` registers a collection.router policy from a
         local file (#3088), equivalent to POSTing the document to /pull."""
         collection_name = f"user.CliPullFile-{uuid.uuid4().hex[:8]}"
+        alias_name = f"cli-pull-alias-{uuid.uuid4().hex[:8]}"
         json_file = self._write_router_policy_file(collection_name)
         try:
             result = run_cli_command(
-                ["pull", json_file],
+                ["pull", json_file, "--alias", alias_name],
                 timeout=TIMEOUT_MODEL_OPERATION,
             )
             self.assertEqual(
@@ -952,6 +953,31 @@ sys.exit(0)
                 entry, f"{collection_name} should be registered from the file"
             )
             self.assertEqual(entry.get("recipe"), "collection.router")
+
+            # --alias applies to the normalized name from the file. Alias
+            # lookups echo the alias as `id` but return the target's object —
+            # the recipe and components prove it resolved to our collection.
+            aliased = requests.get(
+                f"http://localhost:{PORT}/api/v1/models/{alias_name}",
+                headers=_auth_headers(),
+                timeout=TIMEOUT_DEFAULT,
+            )
+            self.assertEqual(
+                aliased.status_code, 200, f"alias should resolve: {aliased.text}"
+            )
+            self.assertEqual(aliased.json().get("recipe"), "collection.router")
+            self.assertEqual(
+                aliased.json().get("components"), [ENDPOINT_TEST_MODEL]
+            )
+
+            # A typo'd .json path is a clear file error, not a registry lookup.
+            missing = self.assertCommandFails(
+                ["pull", f"./no-such-{uuid.uuid4().hex[:8]}.json"],
+                timeout=TIMEOUT_DEFAULT,
+            )
+            self.assertIn(
+                "JSON file not found", missing.stdout + missing.stderr
+            )
         finally:
             os.unlink(json_file)
             try:

--- a/test/server_cli2.py
+++ b/test/server_cli2.py
@@ -897,6 +897,137 @@ sys.exit(0)
     # Import Tests
     # =============================================================================
 
+    def _write_router_policy_file(self, model_name, route_to=None):
+        """Write a minimal collection.router policy JSON to a temp file."""
+        policy = {
+            "model_name": model_name,
+            "version": "1",
+            "recipe": "collection.router",
+            "components": [ENDPOINT_TEST_MODEL],
+            "routing": {
+                "candidates": [ENDPOINT_TEST_MODEL],
+                "default_model": ENDPOINT_TEST_MODEL,
+                "rules": [
+                    {
+                        "id": "code-rule",
+                        "match": {"keywords_any": ["code"]},
+                        "route_to": route_to or ENDPOINT_TEST_MODEL,
+                    }
+                ],
+            },
+        }
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False
+        ) as f:
+            json.dump(policy, f)
+            return f.name
+
+    def test_057_pull_json_policy_file(self):
+        """`pull <policy.json>` registers a collection.router policy from a
+        local file (#3088), equivalent to POSTing the document to /pull."""
+        collection_name = f"user.CliPullFile-{uuid.uuid4().hex[:8]}"
+        json_file = self._write_router_policy_file(collection_name)
+        try:
+            result = run_cli_command(
+                ["pull", json_file],
+                timeout=TIMEOUT_MODEL_OPERATION,
+            )
+            self.assertEqual(
+                result.returncode,
+                0,
+                f"Command failed with exit code {result.returncode}: {result.stderr}",
+            )
+
+            response = requests.get(
+                f"http://localhost:{PORT}/api/v1/models?show_all=true",
+                headers=_auth_headers(),
+                timeout=TIMEOUT_DEFAULT,
+            )
+            self.assertEqual(response.status_code, 200)
+            entry = next(
+                (m for m in response.json()["data"] if m["id"] == collection_name),
+                None,
+            )
+            self.assertIsNotNone(
+                entry, f"{collection_name} should be registered from the file"
+            )
+            self.assertEqual(entry.get("recipe"), "collection.router")
+        finally:
+            os.unlink(json_file)
+            try:
+                requests.post(
+                    f"http://localhost:{PORT}/api/v1/delete",
+                    json={"model_name": collection_name},
+                    headers=_auth_headers(),
+                    timeout=TIMEOUT_DEFAULT,
+                )
+            except Exception:
+                pass
+
+    def test_058_pull_json_dry_run(self):
+        """`pull <policy.json> --dry-run` validates without registering: a valid
+        policy reports OK and does not land in /models; a policy whose rule
+        routes to a non-candidate is rejected by the server-side parse."""
+        collection_name = f"user.CliDryRun-{uuid.uuid4().hex[:8]}"
+        valid_file = self._write_router_policy_file(collection_name)
+        invalid_file = self._write_router_policy_file(
+            f"user.CliDryRunBad-{uuid.uuid4().hex[:8]}",
+            route_to="Not-A-Candidate",
+        )
+        try:
+            result = run_cli_command(
+                ["pull", valid_file, "--dry-run"],
+                timeout=TIMEOUT_DEFAULT,
+            )
+            self.assertEqual(
+                result.returncode, 0, f"dry-run failed: {result.stderr}"
+            )
+            self.assertIn("Nothing was registered", result.stdout)
+
+            response = requests.get(
+                f"http://localhost:{PORT}/api/v1/models?show_all=true",
+                headers=_auth_headers(),
+                timeout=TIMEOUT_DEFAULT,
+            )
+            ids = [m["id"] for m in response.json()["data"]]
+            self.assertNotIn(
+                collection_name, ids, "--dry-run must not register the policy"
+            )
+
+            bad = self.assertCommandFails(
+                ["pull", invalid_file, "--dry-run"],
+                timeout=TIMEOUT_DEFAULT,
+            )
+            self.assertIn("Invalid policy", bad.stdout + bad.stderr)
+
+            no_file = self.assertCommandFails(
+                ["pull", ENDPOINT_TEST_MODEL, "--dry-run"],
+                timeout=TIMEOUT_DEFAULT,
+            )
+            self.assertIn(
+                "--dry-run requires", no_file.stdout + no_file.stderr
+            )
+        finally:
+            os.unlink(valid_file)
+            os.unlink(invalid_file)
+
+    def test_059_pull_json_conflicts_with_manual_options(self):
+        """A JSON file argument cannot be combined with manual configuration
+        flags — the file is the complete definition."""
+        json_file = self._write_router_policy_file(
+            f"user.CliConflict-{uuid.uuid4().hex[:8]}"
+        )
+        try:
+            result = self.assertCommandFails(
+                ["pull", json_file, "--recipe", "llamacpp"],
+                timeout=TIMEOUT_DEFAULT,
+            )
+            self.assertIn(
+                "cannot be combined", result.stdout + result.stderr
+            )
+        finally:
+            os.unlink(json_file)
+
     def test_060_import_json_file(self):
         """Test import command with JSON configuration file."""
         json_data = {


### PR DESCRIPTION
Closes #3088.

Router policies (and any model definition) register from a local JSON file via `lemonade import`, which gains validation and aliasing; `pull` stays registry-only and redirects file arguments with a hint. (Originally implemented on `pull`; reworked onto `import` per review — one file-ingestion entry point, no `.json` heuristics on pull's positional.)

```bash
lemonade import ./my-router.json            # register (idempotent: re-import to update)
lemonade import ./my-router.json --dry-run  # validate only; nothing is registered
lemonade import ./my-router.json --alias my-router
lemonade pull ./my-router.json              # → hint: "Use: lemonade import ..."
```

- `--dry-run`: the local structural checks, plus the server-side policy parse via existing `POST /routing/validate` for `collection.router` documents (rule/candidate cross-checks, classifier refs, `version`). Only HTTP 400 reads as a validation verdict; other statuses report as request failures. Component *existence* is only checked by real registration — documented.
- `--alias`: binds to the normalized name returned by the import (so a bare-name file that gains the `user.` prefix aliases correctly). `--dry-run`/`--alias` without a file argument are rejected.
- `import`'s existing semantics are untouched: `upgrade` stays off, remote-recipe flow unchanged.
- Docs: `router-policy.md` registering section leads with the CLI form; `cli.md` import section documents the new flags, pull section points to import (edits outside generated regions).
- Tests (`server_cli2.py`): import-from-file + alias resolution, dry-run registers-nothing + bad-policy verdict + no-file-arg rejection, pull-redirect hint for existing and typo'd paths; neighboring pull/import tests pass as regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016yHZizzdKkiPz3WbPpUHu1