### PR TITLE
refactor(gui3): persist custom models in lemond

### DIFF
--- a/src/app/src/App.tsx
+++ b/src/app/src/App.tsx
@@ -381,11 +381,11 @@ const App: React.FC = () => {
   const serverModelState = useServerModelState();
   const status = serverModelState.status;
   const serverModels = serverModelState.models?.data ?? EMPTY_MODELS;
+  const customModelInfos = useMemo(() => serverModels.filter(model => (model as any).custom === true), [serverModels]);
   const rawLoadedModels = serverModelState.health?.all_models_loaded ?? EMPTY_LOADED_MODELS;
   const [currentModel, setCurrentModel] = useState<string | null>(null);
   const [theme, setTheme] = useState<Theme>(loadTheme);
   const [clientDataResetNonce, setClientDataResetNonce] = useState(0);
-  const [customModelInfos, setCustomModelInfos] = useState<ModelInfo[]>(EMPTY_MODELS);
   const [modelHelpers, setModelHelpers] = useState<ModelHelpers | null>(null);
   const [downloadManagerOpen, setDownloadManagerOpen] = useState(false);
   const downloadManagerMountedRef = useRef(false);
@@ -657,24 +657,9 @@ const App: React.FC = () => {
     return () => { cancelled = true; };
   }, [customModelInfos.length, modelHelpers, rawLoadedModels.length, serverModels.length]);
 
-  useEffect(() => {
-    let cancelled = false;
-    const cancelSchedule = scheduleIdleWork(() => {
-      void import(/* webpackChunkName: "custom-model-store" */ './features/customModels/customModelStore')
-        .then(({ loadCustomModels, customModelToModelInfo }) => {
-          if (!cancelled) setCustomModelInfos(loadCustomModels().map(customModelToModelInfo));
-        })
-        .catch(error => console.warn('Failed to hydrate custom models:', error));
-    }, 700);
-    return () => {
-      cancelled = true;
-      cancelSchedule();
-    };
-  }, [clientDataResetNonce]);
-
   const loadedModelViewState = useMemo(() => {
     const customInfos = customModelInfos;
-    const knownInfos = [...customInfos, ...serverModels];
+    const knownInfos = serverModels;
     if (!modelHelpers) return { models: rawLoadedModels, customInfos, knownInfos };
     const models = modelHelpers.withVirtualLoadedCollections(rawLoadedModels, knownInfos).map(model => {
       const info = modelHelpers.findModelInfoByName(knownInfos, model.model_name);

--- a/src/app/src/api.ts
+++ b/src/app/src/api.ts
@@ -2189,34 +2189,17 @@ class LemonadeAPI {
   // ── Model registration / pull ───────────────────────────────────
 
   /**
-   * Persist a user model or collection definition before returning. Unlike the
-   * streaming pull path, this mirrors GUI2's registration flow and guarantees
-   * that a successful save is immediately visible through /api/v1/models and
-   * survives a lemond/UI restart.
+   * Persist a user model or collection definition without downloading weights.
    */
   async registerModelDefinition(modelName: string, opts?: Record<string, unknown>): Promise<Record<string, unknown>> {
-    const resp = await this._fetch('/api/v1/pull', {
+    const result = await this._json<Record<string, unknown>>('/api/v1/models/register', {
       method: 'POST',
       body: {
         ...(opts || {}),
         model_name: modelName,
-        stream: false,
-        subscribe: false,
-        do_not_upgrade: true,
       },
       cache: 'no-store',
     });
-    const text = await resp.text();
-    let result: Record<string, unknown> = {};
-    if (text.trim()) {
-      try {
-        const parsed = JSON.parse(text);
-        if (isObject(parsed)) result = parsed;
-      } catch {
-        // Some lemond builds return an empty/plain acknowledgement for a
-        // non-streaming registration. HTTP success is sufficient here.
-      }
-    }
     this._notifyModelsChanged();
     return result;
   }

--- a/src/app/src/components/ChatView.tsx
+++ b/src/app/src/components/ChatView.tsx
@@ -1084,21 +1084,10 @@ const ChatView: React.FC<ChatViewProps> = ({ currentModel: selectedModel, loaded
     }
   }, [chatContainerWidth, chatLogsWidth, railExpanded]);
 
-  const [customModelInfos, setCustomModelInfos] = useState<ModelInfo[]>([]);
-  useEffect(() => {
-    let cancelled = false;
-    const cancelSchedule = scheduleIdleWork(() => {
-      void import(/* webpackChunkName: "custom-model-store" */ '../features/customModels/customModelStore')
-        .then(({ loadCustomModels, customModelToModelInfo }) => {
-          if (!cancelled) setCustomModelInfos(loadCustomModels().map(customModelToModelInfo));
-        })
-        .catch(error => console.warn('Failed to hydrate chat custom models:', error));
-    }, 650);
-    return () => {
-      cancelled = true;
-      cancelSchedule();
-    };
-  }, []);
+  const customModelInfos = useMemo(
+    () => serverModels.filter(model => (model as any).custom === true),
+    [serverModels],
+  );
   const knownModelInfos = useMemo(
     () => {
       const seen = new Set<string>();

--- a/src/app/src/components/ModelManager.tsx
+++ b/src/app/src/components/ModelManager.tsx
@@ -4,7 +4,7 @@ import { copyTextToClipboard } from '../clipboard';
 import { capabilityFromModelInfo, modelCapabilityTags, modelSupportsChatImageInput } from '../modelCapabilities';
 import { Icon } from './Icon';
 import { storageKey } from '../storage';
-import { CUSTOM_CAPABILITIES, CustomModelCapability, generatedLabelsFor, CustomOmniToolDefinition, customLoadOptions, customModelToModelInfo, customRegistrationOptions, deleteCustomModel, exportCustomModelsPayload, importCustomModels, loadCustomModels, upsertCustomModel, type CustomModelRecord, type CustomOmniToolTargetType } from '../features/customModels/customModelStore';
+import { CUSTOM_CAPABILITIES, CustomModelCapability, generatedLabelsFor, buildCustomModelRecord, CustomOmniToolDefinition, customLoadOptions, customModelToModelInfo, customRegistrationOptions, exportCustomModelsPayload, parseCustomModelsImport, type CustomOmniToolTargetType } from '../features/customModels/customModelStore';
 import { getCollectionComponents, isCollectionModel, isCollectionFullyDownloaded, withVirtualLoadedCollections } from '../features/collections/collectionModels';
 import {
   detectHuggingFaceBackend,
@@ -63,6 +63,11 @@ function canonicalCustomModelName(m: ModelInfo | null | undefined): string {
   const name = modelName(m);
   if (!name || !m || !modelIsCustom(m) || name.toLowerCase().startsWith('user.')) return name;
   return `user.${name}`;
+}
+
+function customModelNameKey(name: string): string {
+  const normalized = name.trim().toLowerCase();
+  return normalized.startsWith('user.') ? normalized.slice('user.'.length) : normalized;
 }
 
 function objectRecord(value: unknown): Record<string, unknown> {
@@ -1109,7 +1114,6 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
   const [remoteVariantsLoading, setRemoteVariantsLoading] = useState<Record<string, boolean>>({});
   const [hfDetectedRecipes, setHfDetectedRecipes] = useState<Record<string, string | null>>({});
 
-  const [customModels, setCustomModels] = useState<ModelInfo[]>(() => loadCustomModels().map(customModelToModelInfo));
   const [routerModels, setRouterModels] = useState<ModelInfo[]>(() => loadRouterRecords().map(routerRecordToModelInfo));
   const [showRouterEditor, setShowRouterEditor] = useState(false);
   const [routerEditorModel, setRouterEditorModel] = useState<ModelInfo | null>(null);
@@ -1156,12 +1160,6 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
   useEffect(() => {
     if (fullModelStateReady && fastLocalModels.length > 0) setFastLocalModels(EMPTY_MODELS);
   }, [fastLocalModels.length, fullModelStateReady]);
-
-  const reloadCustomModels = useCallback(() => {
-    setCustomModels(loadCustomModels().map(customModelToModelInfo));
-  }, []);
-
-  useEffect(() => { reloadCustomModels(); }, [reloadCustomModels]);
 
   const reloadRouterModels = useCallback(() => {
     setRouterModels(loadRouterRecords().map(routerRecordToModelInfo));
@@ -1464,21 +1462,13 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
   const findCurrentModel = (name: string): ModelInfo | null => {
     const target = name.trim().toLowerCase();
     if (!target) return null;
-    const targetBare = target.startsWith('user.') ? target.slice('user.'.length) : target;
+    const targetCustomKey = customModelNameKey(target);
     const matchesName = (candidateName: string, custom: boolean): boolean => {
       const candidate = candidateName.toLowerCase();
       if (candidate === target) return true;
-      if (!custom) return false;
-      const candidateBare = candidate.startsWith('user.') ? candidate.slice('user.'.length) : candidate;
-      return candidateBare === targetBare;
+      return custom && customModelNameKey(candidate) === targetCustomKey;
     };
-    const current = allModels.find(mi => matchesName(modelName(mi), modelIsCustom(mi)));
-    if (current) return current;
-
-    // Legacy custom records may still carry a bare name in localStorage even
-    // though lemond requires user.* for any definition with checkpoint/recipe.
-    const local = loadCustomModels().find(record => matchesName(record.name, true));
-    return local ? customModelToModelInfo(local) : null;
+    return allModels.find(mi => matchesName(modelName(mi), modelIsCustom(mi))) || null;
   };
 
   const canonicalComponentName = (name: string): string => {
@@ -1564,25 +1554,10 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
     return null;
   };
 
-  const ensureCustomRegistration = async (model: ModelInfo | null) => {
-    if (!model || !(model as any).custom) return;
-    await api.pullModel(modelName(model), {}, customRegistrationOptions(model));
-  };
-
-  const ensureCustomCollectionComponentsRegistered = async (model: ModelInfo) => {
-    if (!isCollectionModel(model)) return;
-    for (const componentName of getCollectionComponents(model)) {
-      const componentInfo = findCurrentModel(componentName);
-      if (componentInfo && (componentInfo as any).custom) {
-        await ensureCustomRegistration(componentInfo);
-      }
-    }
-  };
 
   const loadModelRuntime = async (
     target: ModelInfo | string,
     visited = new Set<string>(),
-    registered = new Set<string>(),
     overrideOptions?: Record<string, unknown>,
   ) => {
     const name = typeof target === 'string' ? target : modelName(target);
@@ -1598,22 +1573,14 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
       // Mirror Lemonade main: collection models are registered as collection.omni
       // entries, but loading them means loading their concrete component models.
       // The collection itself stays the selected virtual model in the UI.
-      if (!registered.has(key)) {
-        await ensureCustomRegistration(info);
-        registered.add(key);
-      }
       for (const componentName of components) {
         const componentInfo = findCurrentModel(componentName);
-        await loadModelRuntime(componentInfo || componentName, visited, registered);
+        await loadModelRuntime(componentInfo || componentName, visited);
       }
       visited.delete(key);
       return;
     }
 
-    if (!registered.has(key)) {
-      await ensureCustomRegistration(info);
-      registered.add(key);
-    }
     // overrideOptions (direct configuration) wins over stored custom options for ordinary models.
     await api.loadModel(name, overrideOptions ?? (info ? customLoadOptions(info) : undefined), info);
     visited.delete(key);
@@ -1627,7 +1594,7 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
       pinnedNames: pinnedModels,
       settings: globalModelSettings,
       unload: name => api.unloadModel(name),
-      load: () => loadModelRuntime(model, new Set<string>(), new Set<string>(), overrideOptions),
+      load: () => loadModelRuntime(model, new Set<string>(), overrideOptions),
     });
   };
 
@@ -1736,9 +1703,8 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
         : `Delete custom model "${displayName}"? This removes the model definition and downloaded model files, if present.`;
       if (!confirm(message)) return;
       try {
-        if (api.isConnected) await api.deleteModel(name);
-        deleteCustomModel(String((model as any).id || name));
-        reloadCustomModels();
+        if (!api.isConnected) throw new Error('Connect to the Lemonade server before deleting a custom model.');
+        await api.deleteModel(name);
         await refresh();
       } catch (err) {
         console.error('Custom model delete failed:', err);
@@ -1764,8 +1730,6 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
     setPulling(p => ({ ...p, [name]: 0 }));
     downloadStore.markLocal(name, 'downloading', 'model');
 
-    await ensureCustomCollectionComponentsRegistered(model);
-
     const callbacks: PullCallbacks = {
       onProgress: (data) => {
         const item = downloadStore.upsertFromPull(name, data, 'model');
@@ -1786,7 +1750,7 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
     };
 
     try {
-      await api.pullModel(name, callbacks, customRegistrationOptions(model));
+      await api.pullModel(name, callbacks);
     } finally {
       delete pullAbortRef.current[name];
       setPulling(p => {
@@ -1814,8 +1778,6 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
     setPulling(p => ({ ...p, [name]: 0 }));
     downloadStore.markLocal(name, 'downloading', 'model');
 
-    await ensureCustomCollectionComponentsRegistered(model);
-
     const callbacks: PullCallbacks = {
       onProgress: (data) => {
         const item = downloadStore.upsertFromPull(name, data, 'model');
@@ -1828,7 +1790,7 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
         await refresh();
         setLoadingModel(name);
         try {
-          await loadModelRuntime(model, new Set<string>(), new Set<string>([name.toLowerCase()]));
+          await loadModelRuntime(model, new Set<string>());
           await refresh();
           onModelSelect(name);
         } catch (err) {
@@ -1848,7 +1810,7 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
     };
 
     try {
-      await api.pullModel(name, callbacks, customRegistrationOptions(model));
+      await api.pullModel(name, callbacks);
     } finally {
       delete pullAbortRef.current[name];
       setPulling(p => {
@@ -2071,7 +2033,10 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
   };
 
   const handleExportCustomModels = () => {
-    exportJsonFile('lemonade-custom-models', exportCustomModelsPayload());
+    const customServerModels = visibleServerModels.filter(model =>
+      modelIsCustom(model) && String((model as any).recipe || '').toLowerCase() !== ROUTER_RECIPE
+    );
+    exportJsonFile('lemonade-custom-models', exportCustomModelsPayload(customServerModels));
     setCustomJsonNotice('Exported custom model JSON.');
     window.setTimeout(() => setCustomJsonNotice(null), 2200);
   };
@@ -2080,11 +2045,27 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
     if (!file) return;
     setCustomError(null);
     try {
+      if (!api.isConnected) throw new Error('Connect to the Lemonade server before importing custom models.');
       const payload = JSON.parse(await file.text());
-      const result = importCustomModels(payload);
-      reloadCustomModels();
-      setCustomJsonNotice(`Imported ${result.imported} custom model${result.imported === 1 ? '' : 's'}${result.skipped ? `, skipped ${result.skipped}` : ''}.`);
-      if (result.errors.length) setCustomError(result.errors.slice(0, 3).join(' '));
+      const parsed = parseCustomModelsImport(payload);
+      const records = parsed.drafts.map(draft => buildCustomModelRecord(draft));
+      records.sort((a, b) => Number(Boolean(a.components?.length)) - Number(Boolean(b.components?.length)));
+
+      let imported = 0;
+      const errors = [...parsed.errors];
+      for (const record of records) {
+        try {
+          const info = customModelToModelInfo(record);
+          await api.registerModelDefinition(record.name, customRegistrationOptions(info));
+          imported += 1;
+        } catch (err) {
+          errors.push(`${record.name}: ${err instanceof Error ? err.message : String(err)}`);
+        }
+      }
+      await refresh();
+      const skipped = parsed.skipped + (records.length - imported);
+      setCustomJsonNotice(`Imported ${imported} custom model${imported === 1 ? '' : 's'}${skipped ? `, skipped ${skipped}` : ''}.`);
+      if (errors.length) setCustomError(errors.slice(0, 3).join(' '));
       window.setTimeout(() => setCustomJsonNotice(null), 3200);
     } catch (err) {
       setCustomError(`Could not import JSON: ${err instanceof Error ? err.message : String(err)}`);
@@ -2114,7 +2095,6 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
   const handleSaveCustomModel = async (e: React.FormEvent) => {
     e.preventDefault();
     setCustomError(null);
-    let pendingCollectionSave: { saved: ReturnType<typeof upsertCustomModel>; previous: CustomModelRecord | null } | null = null;
     try {
       if (!customDraft.displayName.trim()) {
         throw new Error('Enter a model name.');
@@ -2197,10 +2177,7 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
         ? { main: checkpoint, ...extraCheckpoints }
         : undefined;
       const saveName = editingCustomModelName || implicitCustomModelName(customDraft.displayName, customDraft.checkpoint, customDraft.capability === 'omni' ? 'omni-model' : 'custom-model');
-      const previousCustomModel = isOmniCollection
-        ? loadCustomModels().find(record => record.name.toLowerCase() === saveName.toLowerCase()) || null
-        : null;
-      const saved = upsertCustomModel({
+      const saved = buildCustomModelRecord({
         name: saveName,
         displayName: customDraft.displayName,
         checkpoint,
@@ -2218,75 +2195,36 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
         componentRoles,
         customTools,
       });
-      if (isOmniCollection) {
-        pendingCollectionSave = { saved, previous: previousCustomModel };
-      } else {
-        reloadCustomModels();
-      }
+      if (!api.isConnected) throw new Error('Connect to the Lemonade server before saving a custom model.');
+      const savedInfo = customModelToModelInfo(saved);
 
-      // A custom collection is a server model definition, not merely UI state.
-      // Register custom component definitions first, then synchronously persist
-      // the collection itself so /models exposes it immediately and restart does
-      // not depend on this WebView's localStorage.
+      // Custom model persistence is server-owned. Collections register custom
+      // component definitions first, then every custom model is synchronously
+      // persisted through lemond before the editor reports success.
       if (isOmniCollection) {
-        const savedInfo = customModelToModelInfo(saved);
         for (const componentName of getCollectionComponents(savedInfo)) {
           const componentInfo = findCurrentModel(componentName);
           if (componentInfo && modelIsCustom(componentInfo)) {
             await api.registerModelDefinition(canonicalCustomModelName(componentInfo), customRegistrationOptions(componentInfo));
           }
         }
-        await api.registerModelDefinition(saved.name, customRegistrationOptions(savedInfo));
-        const persistedModels = await api.models(true);
-        const persisted = persistedModels.data.some(model => modelName(model).toLowerCase() === saved.name.toLowerCase());
-        if (!persisted) {
-          throw new Error(`Lemond acknowledged the collection but did not expose ${saved.name} through /api/v1/models.`);
-        }
-        // Only expose the local collection after lemond confirms persistence.
-        // Until this point a failed /pull is rolled back below and never becomes
-        // a ghost entry in the model list.
-        pendingCollectionSave = null;
-        reloadCustomModels();
-        await refresh();
       }
+      const registration = await api.registerModelDefinition(saved.name, customRegistrationOptions(savedInfo));
+      const persistedName = typeof registration.model_name === 'string' && registration.model_name.trim()
+        ? registration.model_name.trim()
+        : saved.name;
+      await refresh();
 
       setShowCustomForm(false);
       setEditingCustomModelName(null);
       setPrimaryFilter('my-models');
       setSearchQuery('');
-      setSelectedDetailModelId(saved.name);
+      setSelectedDetailModelId(persistedName);
       setMobileDetailOpen(true);
       setCustomDraft(createEmptyCustomDraft());
+      setCustomJsonNotice(`Saved ${persistedName} to lemond.`);
+      window.setTimeout(() => setCustomJsonNotice(null), 2600);
     } catch (err) {
-      if (pendingCollectionSave) {
-        const { saved, previous } = pendingCollectionSave;
-        try {
-          if (previous) {
-            upsertCustomModel({
-              name: previous.name,
-              displayName: previous.display_name,
-              checkpoint: previous.checkpoint,
-              checkpoints: previous.checkpoints,
-              mmproj: previous.mmproj,
-              recipe: previous.recipe,
-              capability: previous.type,
-              maxContextWindow: previous.max_context_window,
-              labels: previous.labels,
-              components: previous.components,
-              componentRoles: previous.component_roles,
-              recipeOptions: previous.recipe_options,
-              system_prompt: previous.system_prompt,
-              customTools: previous.custom_tools,
-            });
-          } else {
-            deleteCustomModel(saved.id || saved.name);
-          }
-          reloadCustomModels();
-          if (selectedDetailModelId === saved.name) setSelectedDetailModelId(null);
-        } catch (rollbackError) {
-          console.error('Failed to roll back local custom collection after server registration failed:', rollbackError);
-        }
-      }
       setCustomError(err instanceof Error ? err.message : 'Could not save custom model.');
     }
   };
@@ -2302,12 +2240,6 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
       seen.add(name);
       merged.push(m);
     }
-    for (const m of customModels) {
-      const name = modelName(m).toLowerCase();
-      if (!name || seen.has(name)) continue;
-      seen.add(name);
-      merged.push(m);
-    }
     const loadedNames = new Set(loadedModels.map(lm => lm.model_name.toLowerCase()));
     for (const m of visibleServerModels) {
       const name = modelName(m).toLowerCase();
@@ -2318,7 +2250,7 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
       merged.push(m);
     }
     return merged;
-  }, [routerModels, customModels, visibleServerModels, loadedModels]);
+  }, [routerModels, visibleServerModels, loadedModels]);
 
   const omniComponentOptions = useMemo(() => {
     const roles: Record<OmniComponentRole, OmniComponentOption[]> = {
@@ -2777,6 +2709,7 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
       style={panelResize.style}
     >
       {mobileRail.isOpen && <div className="workspace-mobile-rail-backdrop" onClick={mobileRail.close} aria-hidden="true" />}
+      {customJsonNotice && <div className="manager__toast" role="status" aria-live="polite">{customJsonNotice}</div>}
       <WorkspaceMobileMenuButton
         menuLabel="Open model filters"
         panelId="model-nav-rail"
@@ -3197,7 +3130,6 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
             accept="application/json,.json"
             onChange={e => { void handleImportCustomModels(e.target.files?.[0]); }}
           />
-          {customJsonNotice && <div className="manager__inline-notice">{customJsonNotice}</div>}
           </WorkspaceDetailPanel>
         </div>
       ) : (!selectedDetailModel && !selectedRemoteModel) ? (

--- a/src/app/src/features/customModels/customModelStore.ts
+++ b/src/app/src/features/customModels/customModelStore.ts
@@ -1,7 +1,6 @@
 import type { ModelInfo } from '../../api';
 import type { ModelCapability } from '../../modelCapabilities';
 import { DEPLOYMENT_LABEL_KIND, IMAGE_INPUT_LABELS, deploymentKindFromLabels } from '../../modelCapabilities';
-import { storageKey } from '../../storage';
 import { COLLECTION_OMNI_RECIPE } from '../collections/collectionModels';
 import { routerRegistrationOptions } from '../router/routerStore';
 
@@ -79,7 +78,6 @@ export interface CustomModelDraft {
   customTools?: CustomOmniToolDefinition[];
 }
 
-const CUSTOM_MODELS_KEY = 'custom_models';
 
 function normalizeModelName(name: string): string {
   const cleaned = name.trim().replace(/\s+/g, '-').replace(/[^a-zA-Z0-9._\-/]/g, '-').replace(/-+/g, '-');
@@ -189,32 +187,7 @@ export function recordLabels(record: CustomModelRecord): string[] {
   return labelsFor(record.type, stored);
 }
 
-function isRecord(value: unknown): value is CustomModelRecord {
-  if (!value || typeof value !== 'object') return false;
-  const obj = value as Record<string, unknown>;
-  return typeof obj.id === 'string'
-    && typeof obj.name === 'string'
-    && typeof obj.checkpoint === 'string'
-    && typeof obj.recipe === 'string'
-    && typeof obj.type === 'string'
-    && obj.custom === true;
-}
-
-export function loadCustomModels(): CustomModelRecord[] {
-  try {
-    const raw = localStorage.getItem(storageKey(CUSTOM_MODELS_KEY));
-    if (!raw) return [];
-    const parsed = JSON.parse(raw);
-    const items = Array.isArray(parsed?.models) ? parsed.models : [];
-    return items.filter(isRecord);
-  } catch { return []; }
-}
-
-function saveCustomModels(models: CustomModelRecord[]): void {
-  localStorage.setItem(storageKey(CUSTOM_MODELS_KEY), JSON.stringify({ version: 2, models }));
-}
-
-export function upsertCustomModel(draft: CustomModelDraft): CustomModelRecord {
+export function buildCustomModelRecord(draft: CustomModelDraft, existing?: CustomModelRecord | null): CustomModelRecord {
   const now = Date.now();
   const customTools = normalizeCustomTools(draft.customTools);
   const normalizedComponents = Array.from(new Set((draft.components || []).map(normalizeComponentName).filter(Boolean)));
@@ -242,8 +215,6 @@ export function upsertCustomModel(draft: CustomModelDraft): CustomModelRecord {
   const isCollectionOmni = capability === 'omni' && components.length > 0;
   if (!hasCheckpoint && !isCollectionOmni) throw new Error('Checkpoint, repo id, or local model path is required. Omni collections can instead reference existing component model names.');
 
-  const current = loadCustomModels();
-  const existing = current.find(m => m.name.toLowerCase() === name.toLowerCase());
   const record: CustomModelRecord = {
     id: existing?.id || `custom.${now.toString(36)}.${Math.random().toString(36).slice(2, 8)}`,
     name,
@@ -271,13 +242,7 @@ export function upsertCustomModel(draft: CustomModelDraft): CustomModelRecord {
     record.recipe = COLLECTION_OMNI_RECIPE;
     record.checkpoint = '';
   }
-  saveCustomModels([record, ...current.filter(m => m.id !== record.id && m.name.toLowerCase() !== name.toLowerCase())]);
   return record;
-}
-
-export function deleteCustomModel(idOrName: string): void {
-  const current = loadCustomModels();
-  saveCustomModels(current.filter(m => m.id !== idOrName && m.name !== idOrName));
 }
 
 export function customModelToModelInfo(record: CustomModelRecord): ModelInfo {
@@ -333,20 +298,26 @@ export function customRegistrationOptions(model: ModelInfo): Record<string, unkn
   if (displayName) opts.display_name = displayName;
   if (serverLabels.length) opts.labels = serverLabels;
   const checkpoints = isPlainObject((model as any).checkpoints) ? (model as any).checkpoints as Record<string, unknown> : null;
-  if (checkpoints && Object.keys(checkpoints).length > 0) {
-    opts.checkpoints = Object.fromEntries(Object.entries(checkpoints).filter(([, value]) => typeof value === 'string' && value.trim()).map(([key, value]) => [key, String(value).trim()]));
+  const normalizedCheckpoints: Record<string, string> = checkpoints
+    ? Object.fromEntries(Object.entries(checkpoints)
+      .filter(([, value]) => typeof value === 'string' && value.trim())
+      .map(([key, value]) => [key, String(value).trim()]))
+    : {};
+  if (Object.keys(normalizedCheckpoints).length > 0) {
+    if (!normalizedCheckpoints.main && checkpoint) normalizedCheckpoints.main = checkpoint;
+    if (normalizedCheckpoints.main) opts.checkpoints = normalizedCheckpoints;
   } else if (checkpoint) {
     opts.checkpoint = checkpoint;
   }
   if (recipe) opts.recipe = recipe;
   if (isPlainObject((model as any).recipe_options)) opts.recipe_options = { ...(model as any).recipe_options };
-  // Current /v1/pull registration uses capability booleans rather than a generic type/labels payload.
+  // The registration API accepts the legacy capability booleans used by model definitions.
   if (labels.includes('reasoning')) opts.reasoning = true;
   if (labels.some(label => ['vision', 'omni', 'multimodal', 'vision-language', 'image-input'].includes(label))) opts.vision = true;
   if (type === 'embedding' || labels.some(label => label === 'embedding' || label === 'embeddings')) opts.embedding = true;
   if (type === 'reranking' || labels.some(label => label === 'reranking' || label === 'reranker')) opts.reranking = true;
   const mmproj = String((model as any).mmproj || '').trim();
-  if (mmproj && !(checkpoints && Object.prototype.hasOwnProperty.call(checkpoints, 'mmproj'))) opts.mmproj = mmproj;
+  if (mmproj && !Object.prototype.hasOwnProperty.call(normalizedCheckpoints, 'mmproj')) opts.mmproj = mmproj;
   if (type !== 'omni' && (model as any).max_context_window) opts.ctx_size = (model as any).max_context_window;
   return opts;
 }
@@ -372,8 +343,8 @@ export const CUSTOM_CAPABILITIES: Array<{ value: CustomModelCapability; label: s
   { value: 'reranking', label: 'Reranking', hint: 'Utility model; not selectable in composer' },
 ];
 
-export interface CustomModelImportResult {
-  imported: number;
+export interface CustomModelImportParseResult {
+  drafts: CustomModelDraft[];
   skipped: number;
   errors: string[];
 }
@@ -457,7 +428,8 @@ function normalizeImportedRecord(raw: unknown, index: number): CustomModelDraft 
     ? Object.fromEntries(Object.entries(rawCheckpoints).filter(([, value]) => typeof value === 'string' && value.trim()).map(([key, value]) => [key, String(value).trim()]))
     : undefined;
   const checkpoint = valueString(source, ['checkpoint', 'path', 'repo', 'model_path', 'modelPath'])
-    || (checkpoints?.main ?? Object.values(checkpoints || {})[0] ?? '');
+    || checkpoints?.main
+    || '';
   const mmproj = valueString(source, ['mmproj']) || checkpoints?.mmproj;
   const name = valueString(source, ['name', 'model_name', 'id']) || displayName;
   const recipe = valueString(source, ['recipe', 'backend']) || defaultRecipe(capability, components);
@@ -483,14 +455,6 @@ function normalizeImportedRecord(raw: unknown, index: number): CustomModelDraft 
   };
 }
 
-export function exportCustomModelsPayload(): Record<string, unknown> {
-  return {
-    version: 2,
-    exportedAt: new Date().toISOString(),
-    models: loadCustomModels(),
-  };
-}
-
 function looksLikeModelPayload(value: unknown): boolean {
   if (!isPlainObject(value)) return false;
   return ['model_name', 'name', 'id', 'display_name', 'checkpoint', 'checkpoints', 'components', 'recipe'].some(key => key in value);
@@ -503,9 +467,26 @@ function importItemsFromPayload(payload: unknown): unknown[] {
   return looksLikeModelPayload(payload) ? [payload, ...embedded] : embedded;
 }
 
-export function importCustomModels(payload: unknown): CustomModelImportResult {
+export function exportCustomModelsPayload(models: ModelInfo[]): Record<string, unknown> {
+  const records = models.flatMap((model, index) => {
+    const draft = normalizeImportedRecord(model, index);
+    if (!draft) return [];
+    try {
+      return [buildCustomModelRecord(draft)];
+    } catch {
+      return [];
+    }
+  });
+  return {
+    version: 2,
+    exportedAt: new Date().toISOString(),
+    models: records,
+  };
+}
+
+export function parseCustomModelsImport(payload: unknown): CustomModelImportParseResult {
   const rawItems = importItemsFromPayload(payload);
-  const result: CustomModelImportResult = { imported: 0, skipped: 0, errors: [] };
+  const result: CustomModelImportParseResult = { drafts: [], skipped: 0, errors: [] };
   rawItems.forEach((item, index) => {
     const draft = normalizeImportedRecord(item, index);
     if (!draft) {
@@ -514,8 +495,9 @@ export function importCustomModels(payload: unknown): CustomModelImportResult {
       return;
     }
     try {
-      upsertCustomModel(draft);
-      result.imported += 1;
+      // Validate and normalize without persisting anything in the browser.
+      buildCustomModelRecord(draft);
+      result.drafts.push(draft);
     } catch (err) {
       result.skipped += 1;
       result.errors.push(`Entry ${index + 1}: ${err instanceof Error ? err.message : String(err)}`);

--- a/src/app/src/styles/styles.css
+++ b/src/app/src/styles/styles.css
@@ -3268,7 +3268,8 @@ optgroup {
   cursor: pointer;
 }
 
-.backends__toast {
+.backends__toast,
+.manager__toast {
   position: fixed;
   bottom: var(--space-6);
   left: 50%;

--- a/src/app/tests/model-provider-search.runtime.cjs
+++ b/src/app/tests/model-provider-search.runtime.cjs
@@ -12,6 +12,7 @@ const remoteCapabilitiesSource = fs.readFileSync(path.join(root, 'src/remoteMode
 const listPanelSource = fs.readFileSync(path.join(root, 'src/components/ModelListPanel.tsx'), 'utf8');
 const detailPanelSource = fs.readFileSync(path.join(root, 'src/components/ModelDetailPanel.tsx'), 'utf8');
 const styles = fs.readFileSync(path.join(root, 'src/styles/styles.css'), 'utf8');
+const customModelStoreSource = fs.readFileSync(path.join(root, 'src/features/customModels/customModelStore.ts'), 'utf8');
 const huggingFaceSearchPath = path.join(root, 'src/features/models/huggingFaceSearch.ts');
 
 function loadTypeScriptModule(filename) {
@@ -49,16 +50,44 @@ assert.match(api, /filterHuggingFaceSearchResults\(data\)/);
 // localStorage entries. This keeps them visible through /models after restart.
 assert.match(api, /async registerModelDefinition\(modelName: string/,
   'API client must expose synchronous model-definition registration');
-assert.match(api, /stream: false[\s\S]*subscribe: false[\s\S]*do_not_upgrade: true/,
-  'definition registration must use the non-streaming persistent /pull path');
+assert.match(api, /\/api\/v1\/models\/register/,
+  'definition registration must use the dedicated lemond registration endpoint');
+assert.doesNotMatch(api, /register_only: true/,
+  'definition registration must not tunnel through /pull');
 assert.match(api, /name\.startsWith\('user\.'\)[\s\S]*labels\.includes\('custom'\)/,
   'server-returned user models must be normalized as custom models');
 assert.match(manager, /await api\.registerModelDefinition\(saved\.name/,
   'saved Omni collections must be registered with lemond');
-assert.match(manager, /persistedModels\.data\.some/,
-  'collection save must verify that /models exposes the registered definition');
+assert.match(manager, /const registration = await api\.registerModelDefinition\(saved\.name/,
+  'custom-model save must use the registration response directly');
+assert.match(manager, /registration\.model_name/,
+  'custom-model save must use lemond\'s public model name from the registration response');
+assert.match(manager, /setCustomJsonNotice\(`Saved \${persistedName} to lemond\.`\)/,
+  'successful custom-model saves must surface a confirmation notice');
 assert.match(listPanelSource, /name\.startsWith\('user\.'\)[\s\S]*labels\.includes\('custom'\)/,
   'My Models must include custom definitions restored from lemond');
+assert.match(customModelStoreSource, /if \(!normalizedCheckpoints\.main && checkpoint\) normalizedCheckpoints\.main = checkpoint/,
+  'legacy secondary checkpoint maps must promote the primary checkpoint to checkpoints.main');
+assert.match(customModelStoreSource, /if \(normalizedCheckpoints\.main\) opts\.checkpoints = normalizedCheckpoints/,
+  'the GUI must only send a checkpoints object when main is present');
+assert.doesNotMatch(customModelStoreSource, /Object\.values\(checkpoints \|\| \{\}\)\[0\]/,
+  'import must not reinterpret an arbitrary secondary checkpoint as the main checkpoint');
+assert.doesNotMatch(manager, /loadLegacyCustomModels|clearLegacyCustomModels|legacyCustomMigrationStartedRef/,
+  'GUI3 must not migrate custom-model definitions from browser storage');
+assert.doesNotMatch(customModelStoreSource, /localStorage|CUSTOM_MODELS_KEY|loadLegacyCustomModels|clearLegacyCustomModels/,
+  'customModelStore must contain no browser persistence compatibility layer');
+
+// Registered custom models are pulled by name only. Their persisted definition
+// must not be resent through /pull, because the server then treats a public
+// bare name as a new model definition and rejects it.
+assert.doesNotMatch(manager, /api\.pullModel\(name,\s*callbacks,\s*customRegistrationOptions\(model\)\)/,
+  'registered custom model downloads must not resend their definition through /pull');
+assert.ok((manager.match(/await api\.pullModel\(name, callbacks\);/g) || []).length >= 2,
+  'download and download+load must pull registered models by name only');
+assert.doesNotMatch(manager, /ensureCustomRegistration|ensureCustomCollectionComponentsRegistered/,
+  'server-owned models must not be re-registered during load or download');
+assert.match(manager, /api\.pullModel\(targetModelName, callbacks, \{[\s\S]*?checkpoint,[\s\S]*?recipe,[\s\S]*?source: provider/,
+  'remote registry downloads must retain their explicit register+download payload');
 
 // Server selection remains the prototype's existing contract; ModelScope uses
 // Lemonade's registry endpoint without a browser-side fallback.

--- a/src/app/tests/model-state-deduplication.runtime.cjs
+++ b/src/app/tests/model-state-deduplication.runtime.cjs
@@ -84,7 +84,7 @@ const originalFetch = global.fetch;
 let healthRequests = 0;
 let modelRequests = 0;
 let deleteRequests = 0;
-let pullRequests = 0;
+let registerRequests = 0;
 let modelRows = [
   { id: 'test-model', model_name: 'test-model', downloaded: true },
 ];
@@ -119,7 +119,7 @@ global.fetch = async (url, init = {}) => {
     }), { status: 200, headers: { 'content-type': 'application/json' } });
   }
 
-  if (target.includes('/api/v1/models')) {
+  if (target.includes('/api/v1/models') && method === 'GET') {
     modelRequests += 1;
     const snapshot = modelRows.map(model => ({ ...model }));
     const gate = nextModelReadGate;
@@ -136,9 +136,9 @@ global.fetch = async (url, init = {}) => {
     });
   }
 
-  if (target.endsWith('/api/v1/pull') && method === 'POST') {
+  if (target.endsWith('/api/v1/models/register') && method === 'POST') {
     await new Promise(resolve => setTimeout(resolve, 15));
-    pullRequests += 1;
+    registerRequests += 1;
     const body = typeof init.body === 'string'
       ? JSON.parse(init.body)
       : (init.body || {});
@@ -149,7 +149,12 @@ global.fetch = async (url, init = {}) => {
         { id: name, model_name: name, custom: true },
       ];
     }
-    return new Response(JSON.stringify({ ok: true }), {
+    const publicName = name.startsWith('user.') ? name.slice('user.'.length) : name;
+    return new Response(JSON.stringify({
+      status: 'success',
+      model_name: publicName,
+      canonical_model_name: name,
+    }), {
       status: 200,
       headers: { 'content-type': 'application/json' },
     });
@@ -227,7 +232,7 @@ async function waitFor(predicate, timeoutMs = 1500) {
     await staleReadGate.started;
 
     await api.registerModelDefinition('user.collection', { recipe: 'omni' });
-    assert.equal(pullRequests, 1, 'the collection registration must complete before verification');
+    assert.equal(registerRequests, 1, 'the collection registration must complete before verification');
 
     const verifiedModels = await Promise.race([
       api.models(true),


### PR DESCRIPTION
Moves GUI3 custom model persistence from browser storage to lemond.

Custom models are now saved through /v1/models/register and read back from the server model registry. Import, delete, and selection follow the same server-owned model state.

Uses the new server registration endpoint from #3118 