### PR TITLE
feat(server): add model registration endpoint

### DIFF
--- a/docs/api/lemonade.md
+++ b/docs/api/lemonade.md
@@ -228,8 +228,8 @@ When `include_paths=true` is supplied, each file entry also includes `path`:
 
 Register or update a `user.*` model definition without downloading model files.
 Use this endpoint when registration and installation are separate actions.
-`POST /v1/pull` remains the install/download path and keeps its existing
-register-then-install behavior through the same internal registration path.
+`POST /v1/pull` remains the install/download path and performs the same internal
+registration step before downloading.
 
 The endpoint is available at:
 
@@ -250,11 +250,13 @@ The endpoint is available at:
 | `labels` | No | Additional model labels. |
 | `components` | No | Already-registered component model names for collection recipes. |
 
-The endpoint accepts the persisted user-model metadata understood by the current
-server build. It intentionally does not accept an embedded `models` array because
-that represents multiple definitions; register those component definitions first.
-A checkpoint is validated when supplied, but is not universally required by this
-endpoint because not every present or future recipe needs downloadable weights.
+A checkpoint is intentionally not universally required: registration is a model
+metadata operation and some present or future model types may not have local
+weights. `/pull` remains the operation that attempts installation/download.
+
+The endpoint accepts one model definition. An embedded `models` array represents
+multiple definitions and remains a collection-import concern; register those
+component definitions first when using this endpoint.
 
 Example request:
 
@@ -283,10 +285,9 @@ Example response:
 }
 ```
 
-`model_name` is the public ID exposed by `/v1/models` for the current alias
-winner; `canonical_model_name` is the stable `user.*` registration ID.
-Registration updates `user_models.json` and invalidates the server model cache,
-but does not start a model download.
+`model_name` is the public ID exposed by `/v1/models`; `canonical_model_name` is
+the stable `user.*` registration ID. Registration updates `user_models.json` and
+invalidates the model cache, but does not start a model download.
 
 ## `POST /v1/pull`
 <sub>![Status](https://img.shields.io/badge/status-fully_available-green)</sub>

--- a/docs/api/lemonade.md
+++ b/docs/api/lemonade.md
@@ -10,6 +10,7 @@ We have designed a set of Lemonade-specific endpoints to enable client applicati
 | Method | Endpoint | Description |
 |--------|----------|-------------|
 | `POST` | [`/v1/pull`](#post-v1pull) | Install a model |
+| `POST` | [`/v1/models/register`](#post-v1modelsregister) | Register or update a user model definition without downloading it |
 | `GET` | [`/v1/downloads`](#get-v1downloads) | List server-owned model download jobs |
 | `POST` | [`/v1/downloads/control`](#post-v1downloadscontrol) | Pause, cancel, or remove server-owned model download jobs |
 | `GET` | [`/v1/registry/search`](#get-v1registrysearch) | Search Hugging Face or ModelScope for model repositories |
@@ -221,6 +222,71 @@ When `include_paths=true` is supplied, each file entry also includes `path`:
 | `files[].role` | Checkpoint role, for example `main`, `mmproj`, or another recipe-specific role. |
 | `files[].size_bytes` | File size in bytes. Directories are summed recursively. Missing files report `0`. |
 | `files[].exists` | Whether the resolved path currently exists on disk. |
+
+## `POST /v1/models/register`
+<sub>![Status](https://img.shields.io/badge/status-fully_available-green)</sub>
+
+Register or update a `user.*` model definition without downloading model files.
+Use this endpoint when registration and installation are separate actions.
+`POST /v1/pull` remains the install/download path and keeps its existing
+register-then-install behavior through the same internal registration path.
+
+The endpoint is available at:
+
+- `/v1/models/register`
+- `/api/v1/models/register`
+- `/v0/models/register`
+- `/api/v0/models/register`
+
+### Parameters
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `model_name` | Yes | Non-empty namespaced model name under `user.*`. |
+| `recipe` | Yes | Lemonade recipe associated with the model definition. |
+| `checkpoint` | No | Main checkpoint, when the recipe uses one. |
+| `checkpoints` | No | Named checkpoints for multi-checkpoint models. |
+| `source` | No | Registry or local source. Remote values are `huggingface` or `modelscope`. |
+| `labels` | No | Additional model labels. |
+| `components` | No | Already-registered component model names for collection recipes. |
+
+The endpoint accepts the persisted user-model metadata understood by the current
+server build. It intentionally does not accept an embedded `models` array because
+that represents multiple definitions; register those component definitions first.
+A checkpoint is validated when supplied, but is not universally required by this
+endpoint because not every present or future recipe needs downloadable weights.
+
+Example request:
+
+```bash
+curl -X POST http://localhost:13305/v1/models/register \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "model_name": "user.Phi-4-Mini-GGUF",
+    "checkpoint": "unsloth/Phi-4-mini-instruct-GGUF:Q4_K_M",
+    "recipe": "llamacpp"
+  }'
+```
+
+Example response:
+
+```json
+{
+  "status": "success",
+  "model_name": "Phi-4-Mini-GGUF",
+  "canonical_model_name": "user.Phi-4-Mini-GGUF",
+  "model": {
+    "id": "Phi-4-Mini-GGUF",
+    "recipe": "llamacpp",
+    "downloaded": false
+  }
+}
+```
+
+`model_name` is the public ID exposed by `/v1/models` for the current alias
+winner; `canonical_model_name` is the stable `user.*` registration ID.
+Registration updates `user_models.json` and invalidates the server model cache,
+but does not start a model download.
 
 ## `POST /v1/pull`
 <sub>![Status](https://img.shields.io/badge/status-fully_available-green)</sub>

--- a/src/cpp/include/lemon/model_manager.h
+++ b/src/cpp/include/lemon/model_manager.h
@@ -210,6 +210,13 @@ public:
                             const json& model_data,
                             const std::string& source = "");
 
+    // Register or validate a model definition without downloading its files.
+    // Uses the same registration path as download_model.
+    void register_model(const std::string& model_name,
+                       const json& model_data,
+                       bool allow_missing_checkpoint = false,
+                       bool replace_existing = false);
+
     // Register (if needed) and download a model
     void download_model(const std::string& model_name,
                        const json& model_data,
@@ -315,7 +322,10 @@ private:
                        const json& model_data,
                        bool do_not_upgrade,
                        DownloadProgressCallback progress_callback,
-                       std::set<std::string>& visited);
+                       std::set<std::string>& visited,
+                       bool register_only,
+                       bool allow_missing_checkpoint,
+                       bool replace_existing);
 
     json load_server_models();
     json load_architecture_defaults();

--- a/src/cpp/include/lemon/server.h
+++ b/src/cpp/include/lemon/server.h
@@ -107,6 +107,17 @@ private:
     void handle_health(const httplib::Request& req, httplib::Response& res);
     void handle_live(const httplib::Request& req, httplib::Response& res);
     void handle_models(const httplib::Request& req, httplib::Response& res);
+    void handle_model_register(const httplib::Request& req, httplib::Response& res);
+    void validate_model_registration_name(const std::string& model_name,
+                                         bool require_user_namespace);
+    void normalize_model_registration_source(nlohmann::json& request_json,
+                                             bool local_import);
+    void validate_and_canonicalize_collection_registration(
+        const std::string& model_name,
+        nlohmann::json& request_json,
+        bool allow_embedded_models);
+    std::string register_model_definition_internal(const std::string& model_name,
+                                                   nlohmann::json& request_json);
     void handle_model_by_id(const httplib::Request& req, httplib::Response& res);
     void handle_model_update_check(const httplib::Request& req, httplib::Response& res);
     void handle_model_files(const httplib::Request& req, httplib::Response& res);

--- a/src/cpp/include/lemon/server.h
+++ b/src/cpp/include/lemon/server.h
@@ -116,8 +116,12 @@ private:
         const std::string& model_name,
         nlohmann::json& request_json,
         bool allow_embedded_models);
-    std::string register_model_definition_internal(const std::string& model_name,
-                                                   nlohmann::json& request_json);
+    std::string register_model_definition_internal(
+        const std::string& model_name,
+        nlohmann::json& request_json,
+        bool require_definition,
+        bool allow_embedded_models,
+        bool local_import);
     void handle_model_by_id(const httplib::Request& req, httplib::Response& res);
     void handle_model_update_check(const httplib::Request& req, httplib::Response& res);
     void handle_model_files(const httplib::Request& req, httplib::Response& res);

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -3371,19 +3371,32 @@ void ModelManager::populate_collection_components_from_cache_locked(ModelInfo& i
     }
 }
 
+void ModelManager::register_model(const std::string& model_name,
+                                 const json& model_data,
+                                 bool allow_missing_checkpoint,
+                                 bool replace_existing) {
+    std::set<std::string> visited;
+    download_model(model_name, model_data, true, nullptr, visited,
+                   true, allow_missing_checkpoint, replace_existing);
+}
+
 void ModelManager::download_model(const std::string& model_name,
                                  const json& model_data,
                                  bool do_not_upgrade,
                                  DownloadProgressCallback progress_callback) {
     std::set<std::string> visited;
-    download_model(model_name, model_data, do_not_upgrade, progress_callback, visited);
+    download_model(model_name, model_data, do_not_upgrade, progress_callback, visited,
+                   false, false, false);
 }
 
 void ModelManager::download_model(const std::string& model_name,
                                  const json& model_data,
                                  bool do_not_upgrade,
                                  DownloadProgressCallback progress_callback,
-                                 std::set<std::string>& visited) {
+                                 std::set<std::string>& visited,
+                                 bool register_only,
+                                 bool allow_missing_checkpoint,
+                                 bool replace_existing) {
     // Keep a mutable registration payload so legacy re-pulls that omit the
     // registry retain the source recorded on the existing model. The original
     // request remains untouched for validation and download semantics.
@@ -3446,8 +3459,13 @@ void ModelManager::download_model(const std::string& model_name,
             }
             LOG(INFO, "ModelManager") << "Registering new collection: " << model_name << std::endl;
         } else {
-            // Check that required arguments are provided
-            if (actual_checkpoint.empty() || actual_recipe.empty()) {
+            if (actual_recipe.empty()) {
+                throw std::runtime_error(
+                    "Model " + model_name + " is not registered with Lemonade Server. "
+                    "To register it, provide the `recipe` argument."
+                );
+            }
+            if (actual_checkpoint.empty() && !allow_missing_checkpoint) {
                 throw std::runtime_error(
                     "Model " + model_name + " is not registered with Lemonade Server. "
                     "To register and install it, provide the `checkpoint` and `recipe` "
@@ -3456,10 +3474,12 @@ void ModelManager::download_model(const std::string& model_name,
             }
 
             // Backend-specific checkpoint validation (llamacpp: GGUF needs :variant).
-            if (auto err = backends::ops_for(actual_recipe)->validate_registration_checkpoint(
-                    actual_checkpoint);
-                !err.empty()) {
-                throw std::runtime_error(err);
+            if (!actual_checkpoint.empty()) {
+                if (auto err = backends::ops_for(actual_recipe)->validate_registration_checkpoint(
+                        actual_checkpoint);
+                    !err.empty()) {
+                    throw std::runtime_error(err);
+                }
             }
 
             LOG(INFO, "ModelManager") << "Registering new user model: " << model_name << std::endl;
@@ -3477,34 +3497,49 @@ void ModelManager::download_model(const std::string& model_name,
             registration_data["source"] = effective_registry_source(info);
         }
 
-        bool is_collection_overwrite = is_model_collection_recipe(actual_recipe) &&
-                                        model_data.contains("components");
-        if (is_collection_overwrite) {
-            // Validate the original user-authored request, not registration_data:
-            // the latter is enriched with the persisted registry source, which is
-            // not part of the public routing-policy document the parser accepts.
-            if (auto err = validate_collection_request(model_name, model_data)) {
-                throw std::runtime_error(*err);
+        const bool explicit_definition =
+            !actual_recipe.empty() || !actual_checkpoint.empty() ||
+            model_data.contains("checkpoints") || model_data.contains("components");
+        if (register_only && replace_existing &&
+            is_user_model_name(model_name) && explicit_definition) {
+            if (is_model_collection_recipe(actual_recipe)) {
+                if (auto err = validate_collection_request(model_name, model_data)) {
+                    throw std::runtime_error(*err);
+                }
             }
             model_registered = false;
-            LOG(INFO, "ModelManager") << "Overwriting collection: "
+            LOG(INFO, "ModelManager") << "Replacing user model definition: "
                                       << model_name << std::endl;
-        } else if (actual_checkpoint.empty()) {
-            actual_checkpoint = info.checkpoint();
-            actual_recipe = info.recipe;
         } else {
-            std::string conflict = describe_registration_conflict(info, registration_data);
-            if (!conflict.empty()) {
-                throw std::runtime_error(
-                    "Model '" + model_name + "' is already registered with different "
-                    "model metadata: " + conflict + ". Choose a different model name "
-                    "for this registry checkpoint."
-                );
-            }
-            if (actual_recipe.empty()) {
+            bool is_collection_overwrite = is_model_collection_recipe(actual_recipe) &&
+                                            model_data.contains("components");
+            if (is_collection_overwrite) {
+                // Validate the original user-authored request, not registration_data:
+                // the latter is enriched with the persisted registry source, which is
+                // not part of the public routing-policy document the parser accepts.
+                if (auto err = validate_collection_request(model_name, model_data)) {
+                    throw std::runtime_error(*err);
+                }
+                model_registered = false;
+                LOG(INFO, "ModelManager") << "Overwriting collection: "
+                                          << model_name << std::endl;
+            } else if (actual_checkpoint.empty()) {
+                actual_checkpoint = info.checkpoint();
                 actual_recipe = info.recipe;
             } else {
-                model_registered = false;
+                std::string conflict = describe_registration_conflict(info, registration_data);
+                if (!conflict.empty()) {
+                    throw std::runtime_error(
+                        "Model '" + model_name + "' is already registered with different "
+                        "model metadata: " + conflict + ". Choose a different model name "
+                        "for this registry checkpoint."
+                    );
+                }
+                if (actual_recipe.empty()) {
+                    actual_recipe = info.recipe;
+                } else {
+                    model_registered = false;
+                }
             }
         }
     }
@@ -3527,6 +3562,10 @@ void ModelManager::download_model(const std::string& model_name,
         register_user_model(model_name, registration_data);
         model_registered = true;
         collection_registered_this_call = true;
+    }
+
+    if (register_only && is_model_collection_recipe(actual_recipe)) {
+        return;
     }
 
     // Collections don't have their own backend - download each component instead.
@@ -3635,7 +3674,7 @@ void ModelManager::download_model(const std::string& model_name,
             }
             LOG(INFO, "ModelManager") << "Downloading component: " << component << std::endl;
             json comp_data = json::object();
-            download_model(component, comp_data, do_not_upgrade, forward, visited);
+            download_model(component, comp_data, do_not_upgrade, forward, visited, false, false, false);
         }
 
         // A registry-backed collection's in-memory components were empty until the
@@ -3676,20 +3715,6 @@ void ModelManager::download_model(const std::string& model_name,
         );
     }
 
-    LOG(INFO, "ModelManager") << "Downloading model: " << repo_id;
-    if (!variant.empty()) {
-        LOG(INFO, "ModelManager") << " (variant: " << variant << ")";
-    }
-    LOG(INFO, "ModelManager") << std::endl;
-
-    // Check if offline mode
-    if (auto* cfg = RuntimeConfig::global()) {
-        if (cfg->offline()) {
-            LOG(INFO, "ModelManager") << "Offline mode enabled, skipping download" << std::endl;
-            return;
-        }
-    }
-
     // Persist registration and recipe options BEFORE the cache-first shortcut
     // below. A registration/import/overwrite that targets an already-downloaded
     // model must still update user_models.json and recipe_options.json. The
@@ -3714,6 +3739,24 @@ void ModelManager::download_model(const std::string& model_name,
         }
         model_info.recipe_options = RecipeOptions(model_info.recipe, merged);
         save_model_options(model_info);
+    }
+
+    if (register_only) {
+        return;
+    }
+
+    LOG(INFO, "ModelManager") << "Downloading model: " << repo_id;
+    if (!variant.empty()) {
+        LOG(INFO, "ModelManager") << " (variant: " << variant << ")";
+    }
+    LOG(INFO, "ModelManager") << std::endl;
+
+    // Check if offline mode
+    if (auto* cfg = RuntimeConfig::global()) {
+        if (cfg->offline()) {
+            LOG(INFO, "ModelManager") << "Offline mode enabled, skipping download" << std::endl;
+            return;
+        }
     }
 
     // CRITICAL: If do_not_upgrade=true AND model is already downloaded, skip the

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -2645,8 +2645,7 @@ void Server::validate_and_canonicalize_collection_registration(
         return;
     }
 
-    const bool has_embedded_models = request_json.contains("models");
-    if (has_embedded_models && !allow_embedded_models) {
+    if (request_json.contains("models") && !allow_embedded_models) {
         throw std::invalid_argument(
             "`models` embeds additional model definitions and is not accepted by "
             "the single-model registration endpoint; register components first");
@@ -2668,10 +2667,9 @@ void Server::validate_and_canonicalize_collection_registration(
         throw std::invalid_argument(*err);
     }
 
-    // An exported collection file carries inline component definitions in `models`.
-    // Those components may not exist yet; ModelManager::download_model owns their
-    // registration and rollback. A normal single-definition collection can safely
-    // canonicalize its already-registered component references here.
+    // Single-definition collections reference models already present in the
+    // registry. Exported bundles keep their raw component names because their
+    // embedded definitions are resolved by the collection import/download path.
     if (request_json.contains("components") && request_json["components"].is_array() &&
         (!request_json.contains("models") || !request_json["models"].is_array())) {
         for (auto& component : request_json["components"]) {
@@ -2682,26 +2680,20 @@ void Server::validate_and_canonicalize_collection_registration(
 
 std::string Server::register_model_definition_internal(
         const std::string& model_name,
-        nlohmann::json& request_json) {
+        nlohmann::json& request_json,
+        bool require_definition,
+        bool allow_embedded_models,
+        bool local_import) {
     if (!request_json.is_object()) {
         throw std::invalid_argument("Request body must be a JSON object");
     }
 
-    validate_model_registration_name(model_name, true);
-
-    if (!request_json.contains("recipe") || !request_json["recipe"].is_string() ||
-        request_json["recipe"].get<std::string>().empty()) {
-        throw std::invalid_argument("A non-empty string `recipe` is required");
+    if (request_json.contains("recipe") && !request_json["recipe"].is_string()) {
+        throw std::invalid_argument("`recipe` must be a string when provided");
     }
-    const std::string recipe = request_json["recipe"].get<std::string>();
-
-    // This method owns exactly one registry definition. Multi-definition exported
-    // collection files stay on /pull where download_model owns component registration
-    // and rollback.
-    if (request_json.contains("models")) {
-        throw std::invalid_argument(
-            "`models` embeds additional model definitions and is not accepted by "
-            "the single-model registration endpoint; register components first");
+    const std::string recipe = request_json.value("recipe", std::string());
+    if (require_definition && recipe.empty()) {
+        throw std::invalid_argument("A non-empty string `recipe` is required");
     }
 
     if (request_json.contains("checkpoint") && !request_json["checkpoint"].is_string()) {
@@ -2709,8 +2701,9 @@ std::string Server::register_model_definition_internal(
     }
     if (request_json.contains("checkpoints")) {
         const auto& checkpoints = request_json["checkpoints"];
-        if (!checkpoints.is_object()) {
-            throw std::invalid_argument("`checkpoints` must be an object when provided");
+        if (!checkpoints.is_object() || !checkpoints.contains("main")) {
+            throw std::invalid_argument(
+                "If present, `checkpoints` must be an object containing `main`");
         }
         for (const auto& [role, checkpoint] : checkpoints.items()) {
             if (!checkpoint.is_string()) {
@@ -2720,27 +2713,39 @@ std::string Server::register_model_definition_internal(
         }
     }
 
-    std::string primary_checkpoint;
-    if (request_json.contains("checkpoint")) {
-        primary_checkpoint = request_json["checkpoint"].get<std::string>();
-    } else if (request_json.contains("checkpoints")) {
-        primary_checkpoint = request_json["checkpoints"].value("main", std::string());
+    const bool has_definition =
+        require_definition || !recipe.empty() || request_json.contains("checkpoint") ||
+        request_json.contains("checkpoints") || request_json.contains("components") ||
+        request_json.contains("models");
+    validate_model_registration_name(model_name, has_definition);
+
+    if (request_json.contains("models") && !allow_embedded_models) {
+        throw std::invalid_argument(
+            "`models` embeds additional model definitions and is not accepted by "
+            "the single-model registration endpoint; register components first");
     }
 
-    // Registration itself does not universally require weights. When a checkpoint
-    // is supplied, still apply the backend's registration-level validation.
-    if (!is_model_collection_recipe(recipe) && !primary_checkpoint.empty()) {
-        const std::string validation_error =
-            backends::ops_for(recipe)->validate_registration_checkpoint(primary_checkpoint);
-        if (!validation_error.empty()) {
-            throw std::invalid_argument(validation_error);
-        }
+    normalize_model_registration_source(request_json, local_import);
+    validate_and_canonicalize_collection_registration(
+        model_name, request_json, allow_embedded_models);
+
+    if (local_import) {
+        std::string hf_cache = model_manager_->get_hf_cache_dir();
+        std::string model_name_clean = model_name.substr(5);
+        std::replace(model_name_clean.begin(), model_name_clean.end(), '/', '-');
+        std::string dest_path = hf_cache + "/models--" + model_name_clean;
+
+        LOG(INFO, "Server") << "Local import mode - resolving files in: "
+                            << dest_path << std::endl;
+        resolve_and_register_local_model(dest_path, model_name, request_json, hf_cache);
+    } else {
+        model_manager_->register_model(
+            model_name,
+            request_json,
+            /*allow_missing_checkpoint=*/require_definition,
+            /*replace_existing=*/require_definition);
     }
 
-    normalize_model_registration_source(request_json, false);
-    validate_and_canonicalize_collection_registration(model_name, request_json, false);
-
-    model_manager_->register_user_model(model_name, request_json);
     return model_manager_->get_public_model_name(model_name);
 }
 
@@ -2764,8 +2769,12 @@ void Server::handle_model_register(const httplib::Request& req, httplib::Respons
         }
 
         const std::string model_name = request_json["model_name"].get<std::string>();
-        const std::string public_name =
-            register_model_definition_internal(model_name, request_json);
+        const std::string public_name = register_model_definition_internal(
+            model_name,
+            request_json,
+            /*require_definition=*/true,
+            /*allow_embedded_models=*/false,
+            /*local_import=*/false);
 
         nlohmann::json response = {
             {"status", "success"},
@@ -5317,60 +5326,24 @@ void Server::handle_pull(const httplib::Request& req, httplib::Response& res) {
             LOG(INFO, "Server") << "   recipe: " << recipe << std::endl;
         }
 
-        // Registration and installation are separate API operations, but a new
-        // single model definition must go through exactly the same internal
-        // registration path as POST /models/register before /pull downloads it.
-        // Existing registrations keep the legacy download_model path so its
-        // conflict checks remain unchanged. Exported collection files with an
-        // embedded `models` array are multi-definition imports and also stay on
-        // download_model, which owns component registration and rollback.
-        bool registered_via_shared_definition = false;
+        // Both API operations always enter the same registration path.
+        // /pull continues with installation after this; /models/register returns.
         const bool collection_file_import =
             request_json.contains("models") && request_json["models"].is_array();
-        const bool already_registered = model_manager_->model_exists_unfiltered(model_name);
-        const bool explicit_registration = !checkpoint.empty() || !recipe.empty();
 
         try {
-            const bool can_register_before_pull =
-                !local_import &&
-                !collection_file_import &&
-                !already_registered &&
-                !recipe.empty() &&
-                (!checkpoint.empty() || request_json.contains("checkpoints") ||
-                 is_model_collection_recipe(recipe));
-
-            if (can_register_before_pull) {
-                register_model_definition_internal(model_name, request_json);
-                registered_via_shared_definition = true;
-            } else {
-                // These helpers are also used by register_model_definition_internal;
-                // keeping the fallback path composed from them prevents /pull and
-                // /models/register from growing separate validation implementations.
-                validate_model_registration_name(model_name, explicit_registration);
-                normalize_model_registration_source(request_json, local_import);
-                if (is_model_collection_recipe(recipe)) {
-                    validate_and_canonicalize_collection_registration(
-                        model_name, request_json, true);
-                }
-            }
+            register_model_definition_internal(
+                model_name,
+                request_json,
+                /*require_definition=*/false,
+                /*allow_embedded_models=*/true,
+                local_import);
         } catch (const std::invalid_argument& e) {
             bad_request(e.what());
             return;
         }
 
-        // Local import mode: CLI has already copied files to HF cache, just resolve and register
         if (local_import) {
-            std::string hf_cache = model_manager_->get_hf_cache_dir();
-            std::string model_name_clean = model_name.substr(5); // Remove "user." prefix
-            std::replace(model_name_clean.begin(), model_name_clean.end(), '/', '-');
-            std::string dest_path = hf_cache + "/models--" + model_name_clean;
-
-            LOG(INFO, "Server") << "Local import mode - resolving files in: " << dest_path << std::endl;
-
-            resolve_and_register_local_model(
-                dest_path, model_name, request_json, hf_cache
-            );
-
             nlohmann::json response = {
                 {"status", "success"},
                 {"model_name", model_name},
@@ -5387,9 +5360,9 @@ void Server::handle_pull(const httplib::Request& req, httplib::Response& res) {
             return;
         }
 
-        nlohmann::json download_request = registered_via_shared_definition
-            ? nlohmann::json::object()
-            : request_json;
+        nlohmann::json download_request = collection_file_import
+            ? request_json
+            : nlohmann::json::object();
 
         if (stream) {
             auto operation = [this, model_name, download_request, do_not_upgrade](DownloadProgressCallback progress_cb) {

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -1180,6 +1180,10 @@ void Server::setup_routes(httplib::Server &web_server) {
     });
 
     // Model management endpoints
+    register_post("models/register", [this](const httplib::Request& req, httplib::Response& res) {
+        handle_model_register(req, res);
+    });
+
     register_post("pull", [this](const httplib::Request& req, httplib::Response& res) {
         handle_pull(req, res);
     });
@@ -2566,6 +2570,225 @@ void Server::handle_models(const httplib::Request& req, httplib::Response& res) 
     }
 
     res.set_content(response.dump(), "application/json");
+}
+
+void Server::validate_model_registration_name(const std::string& model_name,
+                                             bool require_user_namespace) {
+    if (lemon::is_reserved_registration_name(model_name)) {
+        throw std::invalid_argument(
+            "Model names with 'extra.' / 'builtin.' prefixes are reserved, "
+            "including as bare-name parts of a 'user.' alias. Received: " + model_name);
+    }
+
+    if (require_user_namespace &&
+        (model_name.size() <= 5 || model_name.rfind("user.", 0) != 0)) {
+        throw std::invalid_argument(
+            "Registered model definitions must use a non-empty `user.*` name, "
+            "for example `user.Phi-4-Mini-GGUF`. Received: " + model_name);
+    }
+}
+
+void Server::normalize_model_registration_source(nlohmann::json& request_json,
+                                                 bool local_import) {
+    if (!request_json.contains("source") && !request_json.contains("registry_source")) {
+        return;
+    }
+
+    std::optional<std::string> normalized_registry;
+    if (request_json.contains("registry_source")) {
+        if (!request_json["registry_source"].is_string()) {
+            throw std::invalid_argument("`registry_source` must be a string when provided");
+        }
+        normalized_registry = remote_registry_source_name(
+            parse_remote_registry_source(
+                request_json["registry_source"].get<std::string>()));
+    }
+
+    if (request_json.contains("source")) {
+        if (!request_json["source"].is_string()) {
+            throw std::invalid_argument("`source` must be a string when provided");
+        }
+        const std::string public_source = request_json["source"].get<std::string>();
+        if (is_remote_registry_source(public_source)) {
+            const std::string normalized_public = remote_registry_source_name(
+                parse_remote_registry_source(public_source));
+            if (normalized_registry && *normalized_registry != normalized_public) {
+                throw std::invalid_argument(
+                    "`source` and `registry_source` must identify the same registry");
+            }
+            normalized_registry = normalized_public;
+            request_json["source"] = normalized_public;
+        } else if (!local_import && public_source != "local_upload" &&
+                   public_source != "local_path" &&
+                   public_source != "extra_models_dir") {
+            throw std::invalid_argument(
+                "Unsupported model source '" + public_source +
+                "' (expected 'huggingface', 'modelscope', or a local source)");
+        }
+    }
+
+    if (normalized_registry) {
+        if (!request_json.contains("source") ||
+            is_remote_registry_source(request_json["source"].get<std::string>())) {
+            request_json["source"] = *normalized_registry;
+        }
+        request_json["registry_source"] = *normalized_registry;
+    }
+}
+
+void Server::validate_and_canonicalize_collection_registration(
+        const std::string& model_name,
+        nlohmann::json& request_json,
+        bool allow_embedded_models) {
+    const std::string recipe = request_json.value("recipe", std::string());
+    if (!is_model_collection_recipe(recipe)) {
+        return;
+    }
+
+    const bool has_embedded_models = request_json.contains("models");
+    if (has_embedded_models && !allow_embedded_models) {
+        throw std::invalid_argument(
+            "`models` embeds additional model definitions and is not accepted by "
+            "the single-model registration endpoint; register components first");
+    }
+
+    if (request_json.contains("components")) {
+        if (!request_json["components"].is_array()) {
+            throw std::invalid_argument("`components` must be an array when provided");
+        }
+        for (const auto& component : request_json["components"]) {
+            if (!component.is_string()) {
+                throw std::invalid_argument(
+                    "Every collection component must be a string model name");
+            }
+        }
+    }
+
+    if (auto err = model_manager_->validate_collection_request(model_name, request_json)) {
+        throw std::invalid_argument(*err);
+    }
+
+    // An exported collection file carries inline component definitions in `models`.
+    // Those components may not exist yet; ModelManager::download_model owns their
+    // registration and rollback. A normal single-definition collection can safely
+    // canonicalize its already-registered component references here.
+    if (request_json.contains("components") && request_json["components"].is_array() &&
+        (!request_json.contains("models") || !request_json["models"].is_array())) {
+        for (auto& component : request_json["components"]) {
+            component = model_manager_->resolve_model_name(component.get<std::string>());
+        }
+    }
+}
+
+std::string Server::register_model_definition_internal(
+        const std::string& model_name,
+        nlohmann::json& request_json) {
+    if (!request_json.is_object()) {
+        throw std::invalid_argument("Request body must be a JSON object");
+    }
+
+    validate_model_registration_name(model_name, true);
+
+    if (!request_json.contains("recipe") || !request_json["recipe"].is_string() ||
+        request_json["recipe"].get<std::string>().empty()) {
+        throw std::invalid_argument("A non-empty string `recipe` is required");
+    }
+    const std::string recipe = request_json["recipe"].get<std::string>();
+
+    // This method owns exactly one registry definition. Multi-definition exported
+    // collection files stay on /pull where download_model owns component registration
+    // and rollback.
+    if (request_json.contains("models")) {
+        throw std::invalid_argument(
+            "`models` embeds additional model definitions and is not accepted by "
+            "the single-model registration endpoint; register components first");
+    }
+
+    if (request_json.contains("checkpoint") && !request_json["checkpoint"].is_string()) {
+        throw std::invalid_argument("`checkpoint` must be a string when provided");
+    }
+    if (request_json.contains("checkpoints")) {
+        const auto& checkpoints = request_json["checkpoints"];
+        if (!checkpoints.is_object()) {
+            throw std::invalid_argument("`checkpoints` must be an object when provided");
+        }
+        for (const auto& [role, checkpoint] : checkpoints.items()) {
+            if (!checkpoint.is_string()) {
+                throw std::invalid_argument(
+                    "Every `checkpoints` value must be a string; invalid role: " + role);
+            }
+        }
+    }
+
+    std::string primary_checkpoint;
+    if (request_json.contains("checkpoint")) {
+        primary_checkpoint = request_json["checkpoint"].get<std::string>();
+    } else if (request_json.contains("checkpoints")) {
+        primary_checkpoint = request_json["checkpoints"].value("main", std::string());
+    }
+
+    // Registration itself does not universally require weights. When a checkpoint
+    // is supplied, still apply the backend's registration-level validation.
+    if (!is_model_collection_recipe(recipe) && !primary_checkpoint.empty()) {
+        const std::string validation_error =
+            backends::ops_for(recipe)->validate_registration_checkpoint(primary_checkpoint);
+        if (!validation_error.empty()) {
+            throw std::invalid_argument(validation_error);
+        }
+    }
+
+    normalize_model_registration_source(request_json, false);
+    validate_and_canonicalize_collection_registration(model_name, request_json, false);
+
+    model_manager_->register_user_model(model_name, request_json);
+    return model_manager_->get_public_model_name(model_name);
+}
+
+void Server::handle_model_register(const httplib::Request& req, httplib::Response& res) {
+    auto bad_request = [&res](const std::string& message) {
+        res.status = 400;
+        res.set_content(nlohmann::json{{"error", message}}.dump(), "application/json");
+    };
+
+    nlohmann::json request_json;
+    if (!parse_required_json_body(req, res, request_json)) return;
+
+    try {
+        if (!request_json.is_object()) {
+            bad_request("Request body must be a JSON object");
+            return;
+        }
+        if (!request_json.contains("model_name") || !request_json["model_name"].is_string()) {
+            bad_request("A string `model_name` is required");
+            return;
+        }
+
+        const std::string model_name = request_json["model_name"].get<std::string>();
+        const std::string public_name =
+            register_model_definition_internal(model_name, request_json);
+
+        nlohmann::json response = {
+            {"status", "success"},
+            {"model_name", public_name},
+            {"canonical_model_name", model_name},
+        };
+
+        const auto models = model_manager_->get_supported_models();
+        auto model_it = models.find(public_name);
+        if (model_it != models.end()) {
+            response["model"] = model_info_to_json(public_name, model_it->second);
+        }
+
+        res.set_content(response.dump(), "application/json");
+    } catch (const std::invalid_argument& e) {
+        bad_request(e.what());
+    } catch (const nlohmann::json::exception& e) {
+        bad_request(e.what());
+    } catch (const std::exception& e) {
+        LOG(ERROR, "Server") << "ERROR in handle_model_register: " << e.what() << std::endl;
+        res.status = 500;
+        res.set_content(nlohmann::json{{"error", e.what()}}.dump(), "application/json");
+    }
 }
 
 // Maximum collection-component nesting depth embedded in "models" arrays.
@@ -5086,51 +5309,6 @@ void Server::handle_pull(const httplib::Request& req, httplib::Response& res) {
         // The helper may have rewritten a provider URL into an owner/repo id.
         checkpoint = request_json.value("checkpoint", "");
 
-        // Validate and canonicalize remote-registry provenance before anything is
-        // persisted. `source` remains backward-compatible with local origins, while
-        // remote registrations store a canonical huggingface/modelscope value.
-        if (request_json.contains("source") || request_json.contains("registry_source")) {
-            try {
-                std::optional<std::string> normalized_registry;
-                if (request_json.contains("registry_source")) {
-                    normalized_registry = remote_registry_source_name(
-                        parse_remote_registry_source(
-                            request_json["registry_source"].get<std::string>()));
-                }
-
-                if (request_json.contains("source")) {
-                    const std::string public_source = request_json["source"].get<std::string>();
-                    if (is_remote_registry_source(public_source)) {
-                        const std::string normalized_public = remote_registry_source_name(
-                            parse_remote_registry_source(public_source));
-                        if (normalized_registry && *normalized_registry != normalized_public) {
-                            bad_request("'source' and 'registry_source' must identify the same registry");
-                            return;
-                        }
-                        normalized_registry = normalized_public;
-                        request_json["source"] = normalized_public;
-                    } else if (!local_import && public_source != "local_upload" &&
-                               public_source != "local_path" &&
-                               public_source != "extra_models_dir") {
-                        bad_request("Unsupported model source '" + public_source +
-                                    "' (expected 'huggingface' or 'modelscope')");
-                        return;
-                    }
-                }
-
-                if (normalized_registry) {
-                    if (!request_json.contains("source") ||
-                        is_remote_registry_source(request_json["source"].get<std::string>())) {
-                        request_json["source"] = *normalized_registry;
-                    }
-                    request_json["registry_source"] = *normalized_registry;
-                }
-            } catch (const std::exception& e) {
-                bad_request(e.what());
-                return;
-            }
-        }
-
         LOG(INFO, "Server") << "Pulling model: " << model_name << std::endl;
         if (!checkpoint.empty()) {
             LOG(INFO, "Server") << "   checkpoint: " << checkpoint << std::endl;
@@ -5139,51 +5317,45 @@ void Server::handle_pull(const httplib::Request& req, httplib::Response& res) {
             LOG(INFO, "Server") << "   recipe: " << recipe << std::endl;
         }
 
-        // Reject reserved prefixes — extra.* / builtin.* cannot be created via
-        // /pull, and user.extra.* / user.builtin.* are also rejected because
-        // their bare-name part ("extra.X" / "builtin.X") would otherwise hijack
-        // the corresponding canonical alias slot. Then enforce the existing rule
-        // that explicit checkpoint/recipe requires the user.* prefix.
-        if (lemon::is_reserved_registration_name(model_name)) {
-            res.status = 400;
-            nlohmann::json error = {{"error",
-                "Model names with 'extra.' / 'builtin.' prefixes are reserved, "
-                "including as bare-name parts of a 'user.' alias. "
-                "Use 'user.<name>' for registration where <name> does not begin "
-                "with 'extra.' or 'builtin.'. Received: " + model_name}};
-            res.set_content(error.dump(), "application/json");
-            return;
-        }
-        if (!checkpoint.empty() || !recipe.empty()) {
-            if (model_name.substr(0, 5) != "user.") {
-                bad_request(
-                    "When providing 'checkpoint' or 'recipe', the model name must include the "
-                    "`user.` prefix, for example `user.Phi-4-Mini-GGUF`. Received: " + model_name);
-                return;
-            }
-        }
+        // Registration and installation are separate API operations, but a new
+        // single model definition must go through exactly the same internal
+        // registration path as POST /models/register before /pull downloads it.
+        // Existing registrations keep the legacy download_model path so its
+        // conflict checks remain unchanged. Exported collection files with an
+        // embedded `models` array are multi-definition imports and also stay on
+        // download_model, which owns component registration and rollback.
+        bool registered_via_shared_definition = false;
+        const bool collection_file_import =
+            request_json.contains("models") && request_json["models"].is_array();
+        const bool already_registered = model_manager_->model_exists_unfiltered(model_name);
+        const bool explicit_registration = !checkpoint.empty() || !recipe.empty();
 
-        if (is_model_collection_recipe(recipe)) {
-            if (auto err = model_manager_->validate_collection_request(model_name, request_json)) {
-                bad_request(*err);
-                return;
-            }
-            // A body carrying a `models` array is a collection file import: its
-            // components may not be registered yet (download_model registers them
-            // from the embedded definitions and canonicalizes the list itself).
-            // A pointer body (registry-backed collection) has no `components` at all —
-            // they come from the downloaded manifest. Only pre-canonicalize an
-            // inline `components` list whose entries must already exist.
-            if (request_json.contains("components") && request_json["components"].is_array() &&
-                (!request_json.contains("models") || !request_json["models"].is_array())) {
-                // Canonicalize components so downstream cache lookups
-                // (check_component_downloaded, update_model_in_cache) succeed
-                // even when the client passed a public alias (bare name) rather
-                // than the canonical `user.X` / `builtin.X` form.
-                for (auto& c : request_json["components"]) {
-                    c = model_manager_->resolve_model_name(c.get<std::string>());
+        try {
+            const bool can_register_before_pull =
+                !local_import &&
+                !collection_file_import &&
+                !already_registered &&
+                !recipe.empty() &&
+                (!checkpoint.empty() || request_json.contains("checkpoints") ||
+                 is_model_collection_recipe(recipe));
+
+            if (can_register_before_pull) {
+                register_model_definition_internal(model_name, request_json);
+                registered_via_shared_definition = true;
+            } else {
+                // These helpers are also used by register_model_definition_internal;
+                // keeping the fallback path composed from them prevents /pull and
+                // /models/register from growing separate validation implementations.
+                validate_model_registration_name(model_name, explicit_registration);
+                normalize_model_registration_source(request_json, local_import);
+                if (is_model_collection_recipe(recipe)) {
+                    validate_and_canonicalize_collection_registration(
+                        model_name, request_json, true);
                 }
             }
+        } catch (const std::invalid_argument& e) {
+            bad_request(e.what());
+            return;
         }
 
         // Local import mode: CLI has already copied files to HF cache, just resolve and register
@@ -5215,9 +5387,13 @@ void Server::handle_pull(const httplib::Request& req, httplib::Response& res) {
             return;
         }
 
+        nlohmann::json download_request = registered_via_shared_definition
+            ? nlohmann::json::object()
+            : request_json;
+
         if (stream) {
-            auto operation = [this, model_name, request_json, do_not_upgrade](DownloadProgressCallback progress_cb) {
-                model_manager_->download_model(model_name, request_json, do_not_upgrade, progress_cb);
+            auto operation = [this, model_name, download_request, do_not_upgrade](DownloadProgressCallback progress_cb) {
+                model_manager_->download_model(model_name, download_request, do_not_upgrade, progress_cb);
             };
 
             if (!subscribe) {
@@ -5241,7 +5417,7 @@ void Server::handle_pull(const httplib::Request& req, httplib::Response& res) {
             stream_download_operation(res, operation);
         } else {
             // Legacy synchronous mode - blocks until complete
-            model_manager_->download_model(model_name, request_json, do_not_upgrade);
+            model_manager_->download_model(model_name, download_request, do_not_upgrade);
 
             nlohmann::json response = {{"status", "success"}, {"model_name", model_name}};
             res.set_content(response.dump(), "application/json");

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -2729,6 +2729,11 @@ std::string Server::register_model_definition_internal(
     validate_and_canonicalize_collection_registration(
         model_name, request_json, allow_embedded_models);
 
+
+    if (!has_definition && !local_import) {
+        return model_name;
+    }
+
     if (local_import) {
         std::string hf_cache = model_manager_->get_hf_cache_dir();
         std::string model_name_clean = model_name.substr(5);

--- a/test/server_endpoints.py
+++ b/test/server_endpoints.py
@@ -206,7 +206,66 @@ class EndpointTests(ServerTestBase):
                     f"Endpoint {endpoint} is not registered on {version}",
                 )
 
+        # POST-only routes should be probed with their actual method. httplib does
+        # not synthesize HEAD responses for POST handlers.
+        for endpoint in ["models/register"]:
+            for version in ["v0", "v1"]:
+                url = f"http://localhost:{PORT}/api/{version}/{endpoint}"
+                response = session.post(url, json={}, timeout=TIMEOUT_DEFAULT)
+                self.assertNotEqual(
+                    response.status_code,
+                    404,
+                    f"POST endpoint {endpoint} is not registered on {version}",
+                )
+
         session.close()
+
+    def test_000a_register_model_definition_without_pull(self):
+        """Register a user model definition without downloading its checkpoint."""
+        canonical_name = f"user.RegisterEndpoint-{uuid.uuid4().hex[:8]}"
+        checkpoint = "example/register-endpoint-test:Q4_K_M"
+        try:
+            response = requests.post(
+                f"{self.base_url}/models/register",
+                json={
+                    "model_name": canonical_name,
+                    "recipe": "llamacpp",
+                    "checkpoint": checkpoint,
+                    "labels": ["test-register-endpoint"],
+                },
+                timeout=TIMEOUT_DEFAULT,
+            )
+            self.assertEqual(response.status_code, 200, response.text)
+
+            body = response.json()
+            self.assertEqual(body.get("status"), "success")
+            self.assertEqual(body.get("canonical_model_name"), canonical_name)
+            public_name = body.get("model_name")
+            self.assertIsInstance(public_name, str)
+            self.assertTrue(public_name)
+
+            models_response = requests.get(
+                f"{self.base_url}/models?show_all=true",
+                timeout=TIMEOUT_DEFAULT,
+            )
+            self.assertEqual(models_response.status_code, 200, models_response.text)
+            entry = next(
+                model
+                for model in models_response.json()["data"]
+                if model["id"] == public_name
+            )
+            self.assertEqual(entry.get("checkpoint"), checkpoint)
+            self.assertEqual(entry.get("recipe"), "llamacpp")
+            self.assertFalse(entry.get("downloaded"))
+        finally:
+            try:
+                requests.post(
+                    f"{self.base_url}/delete",
+                    json={"model_name": canonical_name},
+                    timeout=TIMEOUT_DEFAULT,
+                )
+            except Exception:
+                pass
 
     def test_001_live_endpoint(self):
         """Test the /live endpoint for load balancer health checks."""


### PR DESCRIPTION
Adds POST /v1/models/register for persisting user model definitions without downloading model files.

The endpoint reuses the existing server-side model registry and validation flow, updates the model cache, and returns the registered model name. /pull remains responsible for installation and downloads.

Includes endpoint tests and API documentation.