### PR TITLE
GUI3 fix(chat): handle active request cancellation correctly

### DIFF
--- a/src/app/src/api.ts
+++ b/src/app/src/api.ts
@@ -1055,6 +1055,9 @@ class LemonadeAPI {
     try {
       resp = await fetch(url, { ...processedOpts, headers } as RequestInit);
     } catch (cause) {
+      if (processedOpts.signal?.aborted) {
+        throw cause;
+      }
       if (includeSessionHeaders && this.sessionHeadersEnabled) {
         this.sessionHeadersEnabled = false;
         this.onSessionHeadersFailed?.();

--- a/src/app/src/components/ChatView.tsx
+++ b/src/app/src/components/ChatView.tsx
@@ -1958,10 +1958,11 @@ const ChatView: React.FC<ChatViewProps> = ({ currentModel: selectedModel, loaded
   }, []);
 
   const handleDeleteConversation = useCallback((id: string) => {
+    streaming.stop(id);
+    delete streamModelsRef.current[id];
     setConversations(prev => prev.filter(c => c.id !== id));
     if (activeId === id) setActiveId(null);
-  }, [activeId]);
-
+  }, [activeId, streaming.stop]);
 
 
   const handleRailToggle = useCallback(() => {


### PR DESCRIPTION
Fixes two related cancellation issues in the chat UI:

1. Deleting a conversation now stops any active request before removing the chat. Before that an (also UX breaking extreme long computing) request could not be stopped anymore by the GUI.
2. 
3. User-initiated request aborts, such as pressing Stop during prefill, are no longer shown as connection errors.

This keeps cancellation behavior consistent and prevents requests from continuing after their conversation has been deleted.