### PR TITLE
fix(server): preserve auxiliary checkpoints after interrupted updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2872,6 +2872,15 @@ if(BUILD_TESTING AND EXISTS "${_HF_VARIANTS_TEST_SRC}")
     add_cpp_ci_test(HfVariantsTest CI ON COMMAND test_hf_variants)
 endif()
 
+# Auxiliary checkpoint resolution must ignore snapshots that still carry the
+# downloader's live manifest, just like the GGUF resolver does.
+set(_BACKEND_OPS_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_backend_ops.cpp")
+if(BUILD_TESTING AND EXISTS "${_BACKEND_OPS_TEST_SRC}")
+    add_executable(test_backend_ops test/cpp/test_backend_ops.cpp)
+    target_link_libraries(test_backend_ops PRIVATE lemonade-server-core)
+    add_cpp_ci_test(BackendOpsTest CI ON COMMAND test_backend_ops)
+endif()
+
 # vLLM CDNA gating: the vllm descriptor support row + asset-family resolution for
 # AMD Instinct (gfx942), alongside the existing RDNA families.
 set(_VLLM_CDNA_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_vllm_cdna_gating.cpp")

--- a/src/cpp/server/backends/backend_ops.cpp
+++ b/src/cpp/server/backends/backend_ops.cpp
@@ -29,12 +29,29 @@ std::string BackendOps::resolve_checkpoint_path(const ModelInfo& info,
     fs::path model_cache_path_fs = path_from_utf8(ctx.model_cache_path);
 
     if (!ctx.variant.empty()) {
+        auto is_uncommitted_snapshot_file = [](const fs::path& candidate,
+                                               const fs::path& snapshots_path) {
+            const fs::path relative = candidate.lexically_relative(snapshots_path);
+            if (relative.empty()) {
+                return false;
+            }
+
+            auto first = relative.begin();
+            if (first == relative.end() || *first == "." || *first == "..") {
+                return false;
+            }
+
+            return hf_cache::exists(snapshots_path / *first / ".download_manifest.json");
+        };
+
         // Prefer refs/main for auxiliary checkpoints too (e.g. mmproj) so
         // companion files stay on the active snapshot as the main model.
+        const fs::path snapshots_path = model_cache_path_fs / "snapshots";
         fs::path active_snapshot = hf_cache::active_snapshot_path(model_cache_path_fs);
         if (!active_snapshot.empty()) {
             fs::path direct_variant_path = active_snapshot / path_from_utf8(ctx.variant);
-            if (hf_cache::exists(direct_variant_path)) {
+            if (hf_cache::exists(direct_variant_path) &&
+                !is_uncommitted_snapshot_file(direct_variant_path, snapshots_path)) {
                 return path_to_utf8(direct_variant_path);
             }
             std::error_code ec;
@@ -42,12 +59,14 @@ std::string BackendOps::resolve_checkpoint_path(const ModelInfo& info,
                  fs::recursive_directory_iterator(active_snapshot, hf_cache::dir_options(), ec)) {
                 if (ec) break;
                 if (entry.is_regular_file(ec)) {
-                    if (entry.path().filename().string() == ctx.variant) {
+                    if (entry.path().filename().string() == ctx.variant &&
+                        !is_uncommitted_snapshot_file(entry.path(), snapshots_path)) {
                         return path_to_utf8(entry.path());
                     }
                 } else if (entry.is_directory(ec)) {
                     fs::path variant_path = entry.path() / path_from_utf8(ctx.variant);
-                    if (hf_cache::exists(variant_path)) {
+                    if (hf_cache::exists(variant_path) &&
+                        !is_uncommitted_snapshot_file(variant_path, snapshots_path)) {
                         return path_to_utf8(variant_path);
                     }
                 }
@@ -60,12 +79,14 @@ std::string BackendOps::resolve_checkpoint_path(const ModelInfo& info,
             for (const auto& entry :
                  fs::recursive_directory_iterator(model_cache_path_fs, hf_cache::dir_options())) {
                 if (entry.is_regular_file()) {
-                    if (entry.path().filename().string() == ctx.variant) {
+                    if (entry.path().filename().string() == ctx.variant &&
+                        !is_uncommitted_snapshot_file(entry.path(), snapshots_path)) {
                         return path_to_utf8(entry.path());
                     }
                 } else if (entry.is_directory()) {
                     fs::path variant_path = entry.path() / path_from_utf8(ctx.variant);
-                    if (hf_cache::exists(variant_path)) {
+                    if (hf_cache::exists(variant_path) &&
+                        !is_uncommitted_snapshot_file(variant_path, snapshots_path)) {
                         return path_to_utf8(variant_path);
                     }
                 }
@@ -77,15 +98,18 @@ std::string BackendOps::resolve_checkpoint_path(const ModelInfo& info,
             std::string main_cache_path =
                 ctx.hf_cache + "/" + hf_cache::repo_id_to_cache_dir_name(ctx.main_repo_id, ctx.registry_source);
             fs::path main_cache_path_fs = path_from_utf8(main_cache_path);
+            const fs::path main_snapshots_path = main_cache_path_fs / "snapshots";
             if (fs::exists(main_cache_path_fs)) {
                 for (const auto& entry : fs::recursive_directory_iterator(main_cache_path_fs)) {
                     if (entry.is_regular_file()) {
-                        if (entry.path().filename().string() == ctx.variant) {
+                        if (entry.path().filename().string() == ctx.variant &&
+                            !is_uncommitted_snapshot_file(entry.path(), main_snapshots_path)) {
                             return path_to_utf8(entry.path());
                         }
                     } else if (entry.is_directory()) {
                         fs::path variant_path = entry.path() / path_from_utf8(ctx.variant);
-                        if (fs::exists(variant_path)) {
+                        if (fs::exists(variant_path) &&
+                            !is_uncommitted_snapshot_file(variant_path, main_snapshots_path)) {
                             return path_to_utf8(variant_path);
                         }
                     }

--- a/test/cpp/test_backend_ops.cpp
+++ b/test/cpp/test_backend_ops.cpp
@@ -1,0 +1,120 @@
+#include "lemon/backends/backend_ops.h"
+
+#include <chrono>
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+namespace fs = std::filesystem;
+
+namespace {
+
+int failures = 0;
+
+void check(const char* name, bool condition) {
+    std::printf("[%s] %s\n", condition ? "PASS" : "FAIL", name);
+    if (!condition) {
+        ++failures;
+    }
+}
+
+fs::path make_temp_dir() {
+    fs::path dir = fs::temp_directory_path();
+    dir /= "lemonade_backend_ops_" +
+           std::to_string(std::chrono::steady_clock::now().time_since_epoch().count());
+    fs::create_directories(dir);
+    return dir;
+}
+
+void write_text(const fs::path& path, const std::string& content) {
+    fs::create_directories(path.parent_path());
+    std::ofstream file(path);
+    file << content;
+}
+
+lemon::backends::CheckpointResolveContext make_context(const fs::path& cache) {
+    lemon::backends::CheckpointResolveContext ctx;
+    ctx.hf_cache = cache.parent_path().string();
+    ctx.model_cache_path = cache.string();
+    ctx.repo_id = "org/vision";
+    ctx.main_repo_id = "org/vision";
+    ctx.variant = "mmproj-F16.gguf";
+    ctx.type = "mmproj";
+    ctx.checkpoint = "org/vision:mmproj-F16.gguf";
+    ctx.registry_source = "huggingface";
+    return ctx;
+}
+
+void test_interrupted_active_snapshot_falls_back() {
+    const fs::path cache = make_temp_dir();
+    const fs::path old_snapshot = cache / "snapshots" / "old-complete";
+    const fs::path interrupted_snapshot = cache / "snapshots" / "new-interrupted";
+    const fs::path expected = old_snapshot / "mmproj-F16.gguf";
+    const fs::path misleading = interrupted_snapshot / "mmproj-F16.gguf";
+
+    write_text(expected, "complete auxiliary checkpoint");
+    write_text(interrupted_snapshot / ".download_manifest.json", "{}");
+    write_text(misleading, "part of an interrupted update");
+    write_text(cache / "refs" / "main", "new-interrupted\n");
+
+    lemon::ModelInfo info;
+    lemon::backends::BackendOps ops;
+    const std::string resolved = ops.resolve_checkpoint_path(info, make_context(cache));
+
+    check("auxiliary resolution skips the active snapshot with a live manifest",
+          resolved == expected.string());
+    check("auxiliary resolution never returns the interrupted snapshot",
+          resolved != misleading.string());
+
+    fs::remove_all(cache);
+}
+
+void test_completed_active_snapshot_remains_preferred() {
+    const fs::path cache = make_temp_dir();
+    const fs::path old_snapshot = cache / "snapshots" / "old-complete";
+    const fs::path active_snapshot = cache / "snapshots" / "active-complete";
+    const fs::path expected = active_snapshot / "mmproj-F16.gguf";
+
+    write_text(old_snapshot / "mmproj-F16.gguf", "older auxiliary checkpoint");
+    write_text(expected, "active auxiliary checkpoint");
+    write_text(cache / "refs" / "main", "active-complete\n");
+
+    lemon::ModelInfo info;
+    lemon::backends::BackendOps ops;
+    const std::string resolved = ops.resolve_checkpoint_path(info, make_context(cache));
+
+    check("a completed active snapshot remains preferred over older snapshots",
+          resolved == expected.string());
+
+    fs::remove_all(cache);
+}
+
+void test_only_interrupted_snapshot_is_not_resolved() {
+    const fs::path cache = make_temp_dir();
+    const fs::path interrupted_snapshot = cache / "snapshots" / "interrupted";
+
+    write_text(interrupted_snapshot / ".download_manifest.json", "{}");
+    write_text(interrupted_snapshot / "mmproj-F16.gguf", "incomplete update");
+    write_text(cache / "refs" / "main", "interrupted\n");
+
+    lemon::ModelInfo info;
+    lemon::backends::BackendOps ops;
+    const std::string resolved = ops.resolve_checkpoint_path(info, make_context(cache));
+
+    check("a cache containing only an interrupted snapshot resolves to no file",
+          resolved.empty());
+
+    fs::remove_all(cache);
+}
+
+}  // namespace
+
+int main() {
+    test_interrupted_active_snapshot_falls_back();
+    test_completed_active_snapshot_remains_preferred();
+    test_only_interrupted_snapshot_is_not_resolved();
+
+    std::printf("%d failed\n", failures);
+    return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

- Skip auxiliary checkpoint matches from snapshots with a live `.download_manifest.json`.
- Fall back to a completed snapshot so interrupted updates do not hide an otherwise usable model.
- Add a C++ regression test covering fallback, active-snapshot preference, and the interrupted-only case.

Fixes #3075

## Testing

- `ctest --test-dir build-ops -R 'BackendOpsTest|HfVariantsTest|ModelRegistryTest' --output-on-failure`
- Result: 3/3 tests passed (including 4 new BackendOps assertions, 16 HF variant assertions, and the model registry suite).
- `git diff --check`
- Tracked-content secret scan against `origin/main`: no new findings.
