### PR TITLE
test(gui): detect em dash regression, fix UI test

### DIFF
--- a/src/app/scripts/run-playwright-tests.mjs
+++ b/src/app/scripts/run-playwright-tests.mjs
@@ -10,6 +10,7 @@ const hasProject = args.some(arg => arg.startsWith('--project') || arg === '-p')
 const hasHelp = args.some(arg => arg === '--help' || arg === '-h' || arg === 'help');
 
 const npxCommand = process.platform === 'win32' ? 'npx.cmd' : 'npx';
+const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm';
 
 if (hasProject || hasHelp) {
   const result = spawnSync(npxCommand, ['playwright', 'test', ...args], {
@@ -23,30 +24,63 @@ if (hasProject || hasHelp) {
   process.exit(result.status ?? 1);
 }
 
-console.log('Running accessibility (a11y) tests...');
-const a11yResult = spawnSync(npxCommand, ['playwright', 'test', '--project=a11y', ...args], {
+let failed = false;
+
+console.log('Running UI regression tests...');
+const regressionResult = spawnSync(npmCommand, ['run', 'test:ui-regressions'], {
   stdio: 'inherit',
   shell: false,
 });
+
+if (regressionResult.error || regressionResult.status !== 0) {
+  if (regressionResult.error) {
+    console.error(
+      'Failed to start UI regression tests:',
+      regressionResult.error.message || regressionResult.error,
+    );
+  }
+
+  failed = true;
+}
+
+console.log('Running accessibility (a11y) tests...');
+const a11yResult = spawnSync(
+  npxCommand,
+  ['playwright', 'test', '--project=a11y', ...args],
+  {
+    stdio: 'inherit',
+    shell: false,
+  },
+);
 
 if (a11yResult.error || a11yResult.status !== 0) {
   if (a11yResult.error) {
-    console.error('Failed to start accessibility tests:', a11yResult.error.message || a11yResult.error);
+    console.error(
+      'Failed to start accessibility tests:',
+      a11yResult.error.message || a11yResult.error,
+    );
   }
-  process.exit(a11yResult.status ?? 1);
+  failed = true;
 }
 
 console.log('Running functional tests...');
-const functionalResult = spawnSync(npxCommand, ['playwright', 'test', '--project=functional', ...args], {
-  stdio: 'inherit',
-  shell: false,
-});
+const functionalResult = spawnSync(
+  npxCommand,
+  ['playwright', 'test', '--project=functional', ...args],
+  {
+    stdio: 'inherit',
+    shell: false,
+  },
+);
 
 if (functionalResult.error || functionalResult.status !== 0) {
   if (functionalResult.error) {
-    console.error('Failed to start functional tests:', functionalResult.error.message || functionalResult.error);
+    console.error(
+      'Failed to start functional tests:',
+      functionalResult.error.message || functionalResult.error,
+    );
   }
-  process.exit(functionalResult.status ?? 1);
+  failed = true;
 }
 
-process.exit(0);
+process.exit(failed ? 1 : 0);

--- a/src/app/tests/ui-regression-contracts.runtime.cjs
+++ b/src/app/tests/ui-regression-contracts.runtime.cjs
@@ -37,21 +37,117 @@ for (const [key, filename] of Object.entries(files)) {
 // JSX text and JSX attribute strings are not JavaScript string literals: a `\uXXXX`
 // sequence there reaches the user verbatim instead of the character it names.
 const jsxEscape = /\\(?:u\{[0-9a-fA-F]+\}|u[0-9a-fA-F]{4}|x[0-9a-fA-F]{2})/;
+
+// Em dashes used as prose punctuation in UI copy are disallowed. A standalone
+// em dash remains valid as an unavailable-value placeholder.
+const proseEmDash = /[\p{L}\p{N}]\s*—\s*[\p{L}\p{N}]/u;
+
+assert.match(
+  'Model tuning details are unavailable — for this model.',
+  proseEmDash,
+  'proseEmDash must detect sentence-style em dashes',
+);
+assert.doesNotMatch(
+  '—',
+  proseEmDash,
+  'proseEmDash must allow standalone unavailable-value placeholders',
+);
+
 const collectTsx = dir => fs.readdirSync(dir, { withFileTypes: true }).flatMap(entry => {
   const full = path.join(dir, entry.name);
   if (entry.isDirectory()) return collectTsx(full);
   return entry.isFile() && full.endsWith('.tsx') ? [full] : [];
 });
 
+const isFunctionBoundary = node => (
+  ts.isArrowFunction(node)
+  || ts.isFunctionExpression(node)
+  || ts.isFunctionDeclaration(node)
+  || ts.isMethodDeclaration(node)
+  || ts.isGetAccessorDeclaration(node)
+  || ts.isSetAccessorDeclaration(node)
+);
+
 for (const filename of collectTsx(path.join(root, 'src'))) {
-  const sourceFile = ts.createSourceFile(filename, fs.readFileSync(filename, 'utf8'), ts.ScriptTarget.ES2022, true, ts.ScriptKind.TSX);
-  const visit = node => {
-    if (ts.isJsxText(node) || (ts.isStringLiteral(node) && node.parent && ts.isJsxAttribute(node.parent))) {
-      const found = node.getText(sourceFile).match(jsxEscape);
-      if (found) {
-        const { line } = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
-        assert.fail(`${path.relative(root, filename)}:${line + 1} renders "${found[0]}" literally; write the character itself`);
+  const sourceFile = ts.createSourceFile(
+    filename,
+    fs.readFileSync(filename, 'utf8'),
+    ts.ScriptTarget.ES2022,
+    true,
+    ts.ScriptKind.TSX,
+  );
+
+  const failAtNode = (node, message) => {
+    const { line } = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
+    assert.fail(`${path.relative(root, filename)}:${line + 1} ${message}`);
+  };
+
+  const checkUiCopy = (node, text) => {
+    if (proseEmDash.test(text)) {
+      failAtNode(node, 'contains an em dash used as UI prose punctuation; use normal punctuation instead');
+    }
+  };
+
+  // Only consider strings/templates that are syntactically part of a JSX
+  // expression. Stop at function boundaries so implementation strings in
+  // helpers, callbacks, prompts, logs, and request payloads are not treated as
+  // rendered UI copy.
+  const isDirectlyRenderedJsxExpression = node => {
+    let current = node.parent;
+
+    while (current) {
+      if (ts.isJsxExpression(current)) {
+        return true;
       }
+      if (isFunctionBoundary(current)) {
+        return false;
+      }
+      current = current.parent;
+    }
+    return false;
+  };
+
+  const visit = node => {
+    if (ts.isJsxText(node)) {
+      const text = node.getText(sourceFile);
+      const found = text.match(jsxEscape);
+
+      if (found) {
+        failAtNode(node, `renders "${found[0]}" literally; write the character itself`);
+      }
+      checkUiCopy(node, text);
+    }
+    if (ts.isStringLiteral(node)) {
+      const isJsxAttribute = node.parent && ts.isJsxAttribute(node.parent);
+
+      if (isJsxAttribute) {
+        const found = node.getText(sourceFile).match(jsxEscape);
+
+        if (found) {
+          failAtNode(node, `renders "${found[0]}" literally; write the character itself`);
+        }
+        checkUiCopy(node, node.text);
+      } else if (isDirectlyRenderedJsxExpression(node)) {
+        checkUiCopy(node, node.text);
+      }
+    }
+    if (
+      ts.isNoSubstitutionTemplateLiteral(node)
+      && isDirectlyRenderedJsxExpression(node)
+    ) {
+      checkUiCopy(node, node.text);
+    }
+    if (
+      ts.isTemplateExpression(node)
+      && isDirectlyRenderedJsxExpression(node)
+    ) {
+      // Expressions are represented by a letter so prose punctuation around
+      // interpolated values is still detected, e.g. `${name} — unavailable`.
+      const text = [
+        node.head.text,
+        ...node.templateSpans.flatMap(span => ['x', span.literal.text]),
+      ].join('');
+      checkUiCopy(node, text);
     }
     ts.forEachChild(node, visit);
   };


### PR DESCRIPTION
Adds a regression check for em dashes used as punctuation in rendered UI copy. Check it catches correctly. 

While keeping standalone `—` placeholders valid (e.g. used in the monitor tab). Internal non-UI strings are ignored.

Also fixed:
wires the existing UI regression suite into the default npm test flow without preventing the remaining Playwright suites from running after a failure.

Did not found any other critical em dashes but without a regression test we would need to maintain this very carefully.

Closes #3066 