### PR TITLE
fix(server): normalize thinking controls for llama.cpp

### DIFF
--- a/src/cpp/include/lemon/thinking_controls.h
+++ b/src/cpp/include/lemon/thinking_controls.h
@@ -1,8 +1,11 @@
 // Cross-backend "disable thinking" normalization for OpenAI-style chat
-// requests. Lemonade's convention: clients express intent via
-// `enable_thinking: false` (or the OpenAI-compat `thinking` field), and the
-// server normalizes that into a `/no_think` prefix on the last user message —
-// the mechanism every backend understands — then strips the handled fields.
+// requests. Lemonade's public convention is backend-neutral: clients express
+// intent via `enable_thinking: false` (or the OpenAI-compat `thinking` field).
+//
+// The server translates that intent into native OpenAI-compatible reasoning
+// controls before backend dispatch. A `/no_think` prefix is retained as a
+// compatibility fallback for backends/templates that do not consume those
+// controls yet. Client-facing thinking fields are stripped after translation.
 //
 // Shared by the HTTP request path (server.cpp) and by internal
 // classifier/router invocations (routing_classifier_services.cpp), so a
@@ -21,16 +24,19 @@ using json = nlohmann::json;
 // `thinking: false` / `thinking: {"type": "disabled"}` forms.
 bool should_disable_thinking(const json& request_json);
 
-// Prepend "/no_think\n" to the last string-content user message. Returns true
-// if a message was modified.
+// Prepend "/no_think\n" to the last string-content user message as a legacy
+// compatibility fallback. Returns true if a message was modified.
 bool prepend_no_think_to_last_user_message(json& request_json);
 
-// Remove the client-facing thinking fields once handled (backends don't
-// understand them). Returns true if anything was removed.
+// Remove the client-facing thinking fields once handled. Returns true if
+// anything was removed.
 bool strip_handled_thinking_fields(json& request_json);
 
-// The full normalization applied to every outgoing chat request: inject
-// /no_think when disabling was requested, then strip the handled fields.
+// Normalize Lemonade's backend-neutral thinking intent into request controls
+// understood by reasoning-capable OpenAI-compatible backends. When disabling,
+// this sets `reasoning_effort: "none"` and, when possible,
+// `chat_template_kwargs.enable_thinking: false`, while retaining `/no_think`
+// as a compatibility fallback. The client-facing fields are then stripped.
 // Returns true if the request was modified.
 bool normalize_thinking_controls(json& request_json);
 

--- a/src/cpp/server/thinking_controls.cpp
+++ b/src/cpp/server/thinking_controls.cpp
@@ -1,6 +1,41 @@
 #include "lemon/thinking_controls.h"
 
 namespace lemon {
+namespace {
+
+bool apply_native_disable_thinking_controls(json& request_json) {
+    bool modified = false;
+
+    // llama.cpp treats OpenAI-compatible reasoning_effort=none as a hard
+    // per-request disable. Other reasoning-capable backends can consume the
+    // same field without the client needing backend-specific knowledge.
+    if (!request_json.contains("reasoning_effort") ||
+        !request_json["reasoning_effort"].is_string() ||
+        request_json["reasoning_effort"].get<std::string>() != "none") {
+        request_json["reasoning_effort"] = "none";
+        modified = true;
+    }
+
+    auto kwargs = request_json.find("chat_template_kwargs");
+    if (kwargs == request_json.end()) {
+        request_json["chat_template_kwargs"] = {
+            {"enable_thinking", false},
+        };
+        modified = true;
+    } else if (kwargs->is_object()) {
+        auto enable_thinking = kwargs->find("enable_thinking");
+        if (enable_thinking == kwargs->end() ||
+            !enable_thinking->is_boolean() ||
+            enable_thinking->get<bool>() != false) {
+            (*kwargs)["enable_thinking"] = false;
+            modified = true;
+        }
+    }
+
+    return modified;
+}
+
+} // namespace
 
 bool should_disable_thinking(const json& request_json) {
     // enable_thinking takes precedence over thinking when both are present.
@@ -61,6 +96,7 @@ bool strip_handled_thinking_fields(json& request_json) {
 bool normalize_thinking_controls(json& request_json) {
     bool modified = false;
     if (should_disable_thinking(request_json)) {
+        modified = apply_native_disable_thinking_controls(request_json) || modified;
         modified = prepend_no_think_to_last_user_message(request_json) || modified;
     }
     modified = strip_handled_thinking_fields(request_json) || modified;


### PR DESCRIPTION
Tested and disabling thinking does not work.

Fixes server-side handling of enable_thinking for llama.cpp by mapping it to the native reasoning controls instead of relying on /no_think.

The legacy fallback is kept in place, so existing backends and clients continue to work unchanged.