### PR TITLE
fix: stop request during prefill now possible

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2918,6 +2918,13 @@ if(BUILD_TESTING AND EXISTS "${_HTTP_CLIENT_SECURITY_TEST_SRC}")
     add_cpp_ci_test(HttpClientSecurityTest CI OFF COMMAND test_http_client_security)
 endif()
 
+set(_STREAMING_PROXY_CANCEL_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_streaming_proxy_cancel.cpp")
+if(BUILD_TESTING AND EXISTS "${_STREAMING_PROXY_CANCEL_TEST_SRC}")
+    add_executable(test_streaming_proxy_cancel test/cpp/test_streaming_proxy_cancel.cpp)
+    target_link_libraries(test_streaming_proxy_cancel PRIVATE lemonade-server-core)
+    add_cpp_ci_test(StreamingProxyCancelTest CI OFF COMMAND test_streaming_proxy_cancel)
+endif()
+
 set(_CLOUD_DISCOVERY_POLICY_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_cloud_discovery_policy.cpp")
 if(BUILD_TESTING AND EXISTS "${_CLOUD_DISCOVERY_POLICY_TEST_SRC}")
     add_executable(test_cloud_discovery_policy test/cpp/test_cloud_discovery_policy.cpp)

--- a/src/cpp/include/lemon/utils/http_client.h
+++ b/src/cpp/include/lemon/utils/http_client.h
@@ -135,7 +135,8 @@ public:
         const std::map<std::string, std::string>& headers = {},
         long timeout_seconds = 300,
         std::function<void(int status_code)> on_status = nullptr,
-        HttpSecurityPolicy policy = HttpSecurityPolicy::ExternalHttpsOnly);
+        HttpSecurityPolicy policy = HttpSecurityPolicy::ExternalHttpsOnly,
+        std::function<bool()> should_cancel = nullptr);
 
     // Download file to disk with automatic retry and resume support
     static DownloadResult download_file(const std::string& url,

--- a/src/cpp/server/streaming_proxy.cpp
+++ b/src/cpp/server/streaming_proxy.cpp
@@ -144,14 +144,20 @@ void StreamingProxy::forward_sse_stream(
         {},
         timeout_seconds,
         [&backend_status](int status) { backend_status = status; },
-        utils::HttpSecurityPolicy::TrustedLoopback
+        utils::HttpSecurityPolicy::TrustedLoopback,
+        [&sink]() {
+            return sink.is_writable && !sink.is_writable();
+        }
     );
 
+    const bool client_disconnected =
+        result.curl_code == CURLE_WRITE_ERROR ||
+        result.curl_code == CURLE_ABORTED_BY_CALLBACK;
     const bool transport_interrupted =
         result.curl_code == CURLE_PARTIAL_FILE || result.curl_code == CURLE_RECV_ERROR;
 
     if (result.curl_code != CURLE_OK) {
-        if (result.curl_code == CURLE_WRITE_ERROR) {
+        if (client_disconnected) {
             stream_error = true;
             LOG(WARNING, "StreamingProxy") << "Client disconnected during SSE stream (CURL error: " << result.curl_error << ")" << std::endl;
             telemetry.error_message = "Client disconnected during stream";
@@ -172,7 +178,8 @@ void StreamingProxy::forward_sse_stream(
         }
     }
 
-    if (result.status_code != 200 || backend_status != 200) {
+    if (!client_disconnected &&
+        (result.status_code != 200 || backend_status != 200)) {
         stream_error = true;
         const int status = backend_status != 200 ? backend_status : result.status_code;
         LOG(ERROR, "StreamingProxy") << "Backend returned error: " << status

--- a/src/cpp/server/utils/http_client.cpp
+++ b/src/cpp/server/utils/http_client.cpp
@@ -260,6 +260,22 @@ static int cancel_xferinfo_callback(void* clientp, curl_off_t, curl_off_t, curl_
     return (flag && flag->load()) ? 1 : 0;
 }
 
+static int stream_cancel_xferinfo_callback(void* clientp, curl_off_t, curl_off_t,
+                                           curl_off_t, curl_off_t) {
+    auto* should_cancel = static_cast<std::function<bool()>*>(clientp);
+    if (!should_cancel || !*should_cancel) {
+        return 0;
+    }
+
+    try {
+        return (*should_cancel)() ? 1 : 0;
+    } catch (...) {
+        // Never allow a C++ exception to cross libcurl's C callback boundary.
+        // Failing closed is safer than leaving an orphaned upstream request.
+        return 1;
+    }
+}
+
 struct ProgressData {
     ProgressCallback callback;
     bool cancelled = false;
@@ -658,7 +674,8 @@ HttpResponse HttpClient::post_stream(const std::string& url,
                                      const std::map<std::string, std::string>& headers,
                                      long timeout_seconds,
                                      std::function<void(int)> on_status,
-                                     HttpSecurityPolicy policy) {
+                                     HttpSecurityPolicy policy,
+                                     std::function<bool()> should_cancel) {
     CURL* curl = curl_easy_init();
     if (!curl) {
         throw std::runtime_error("Failed to initialize CURL");
@@ -684,6 +701,12 @@ HttpResponse HttpClient::post_stream(const std::string& url,
     }
     curl_easy_setopt(curl, CURLOPT_TIMEOUT, timeout_seconds);
     curl_easy_setopt(curl, CURLOPT_USERAGENT, "lemon.cpp/1.0");
+
+    if (should_cancel) {
+        curl_easy_setopt(curl, CURLOPT_XFERINFOFUNCTION, stream_cancel_xferinfo_callback);
+        curl_easy_setopt(curl, CURLOPT_XFERINFODATA, &should_cancel);
+        curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 0L);
+    }
 
     // Add custom headers
     bool has_content_type = false;
@@ -715,12 +738,14 @@ HttpResponse HttpClient::post_stream(const std::string& url,
     response.curl_code = static_cast<int>(res);
     response.curl_error = (res == CURLE_OK) ? std::string() : std::string(curl_easy_strerror(res));
 
-    // For streaming, libcurl can report CURLE_PARTIAL_FILE or CURLE_RECV_ERROR
-    // after a backend closes the connection. Do not throw here because the SSE
-    // layer knows whether it saw the protocol-level [DONE] marker. It will treat
-    // the same transport code as success after [DONE] and as backend failure
-    // before [DONE]. Other CURL errors are still exceptional.
-    if (res != CURLE_OK && res != CURLE_PARTIAL_FILE && res != CURLE_RECV_ERROR && res != CURLE_WRITE_ERROR) {
+    // For streaming, preserve transport codes that the stream layer needs
+    // to classify. CURLE_ABORTED_BY_CALLBACK is the expected result when the
+    // downstream cancellation predicate fires before the backend emits data.
+    if (res != CURLE_OK &&
+        res != CURLE_PARTIAL_FILE &&
+        res != CURLE_RECV_ERROR &&
+        res != CURLE_WRITE_ERROR &&
+        res != CURLE_ABORTED_BY_CALLBACK) {
         std::string error = "CURL error: " + response.curl_error;
         LOG(ERROR, "HttpClient") << "" << error << std::endl;
         curl_slist_free_all(header_list);

--- a/test/cpp/test_streaming_proxy_cancel.cpp
+++ b/test/cpp/test_streaming_proxy_cancel.cpp
@@ -1,0 +1,128 @@
+// Regression test for cancelling a proxied SSE request before the first body byte.
+//
+// The backend accepts the request but intentionally emits no SSE data. The
+// downstream client then becomes unwritable. StreamingProxy must notice that via
+// HttpClient's libcurl progress callback and return promptly instead of waiting
+// for the backend's first chunk.
+
+#include <atomic>
+#include <chrono>
+#include <cstdio>
+#include <string>
+#include <thread>
+
+#include <httplib.h>
+
+#include <lemon/streaming_proxy.h>
+
+using namespace std::chrono_literals;
+
+int main() {
+    int failures = 0;
+    auto check = [&failures](bool condition, const char* name) {
+        if (condition) {
+            std::printf("[PASS] %s\\n", name);
+        } else {
+            std::printf("[FAIL] %s\\n", name);
+            ++failures;
+        }
+    };
+
+    httplib::Server backend;
+    std::atomic<bool> backend_started{false};
+    std::atomic<bool> release_backend{false};
+
+    backend.Post("/v1/chat/completions",
+        [&](const httplib::Request&, httplib::Response& res) {
+            backend_started.store(true, std::memory_order_release);
+
+            res.set_chunked_content_provider(
+                "text/event-stream",
+                [&](size_t, httplib::DataSink&) {
+                    // Simulate a long prefill/TTFT period: keep the connection
+                    // open without sending a single response body byte.
+                    while (!release_backend.load(std::memory_order_acquire)) {
+                        std::this_thread::sleep_for(10ms);
+                    }
+                    return false;
+                });
+        });
+
+    const int port = backend.bind_to_any_port("127.0.0.1");
+    if (port <= 0) {
+        std::printf("[FAIL] failed to bind mock backend\\n");
+        return 1;
+    }
+
+    std::thread backend_thread([&backend]() {
+        backend.listen_after_bind();
+    });
+    backend.wait_until_ready();
+
+    std::atomic<bool> downstream_writable{true};
+    int downstream_write_calls = 0;
+
+    httplib::DataSink downstream;
+    downstream.write = [&](const char*, size_t) {
+        ++downstream_write_calls;
+        return downstream_writable.load(std::memory_order_acquire);
+    };
+    downstream.done = []() {};
+    downstream.done_with_trailer = [](const httplib::Headers&) {};
+    downstream.is_writable = [&downstream_writable]() {
+        return downstream_writable.load(std::memory_order_acquire);
+    };
+
+    std::string telemetry_error;
+
+    std::thread disconnect_thread([&]() {
+        const auto wait_deadline = std::chrono::steady_clock::now() + 2s;
+        while (!backend_started.load(std::memory_order_acquire) &&
+               std::chrono::steady_clock::now() < wait_deadline) {
+            std::this_thread::sleep_for(5ms);
+        }
+
+        // Give the backend enough time to establish the HTTP response while
+        // still remaining before any SSE body bytes.
+        std::this_thread::sleep_for(100ms);
+        downstream_writable.store(false, std::memory_order_release);
+    });
+
+    const auto started = std::chrono::steady_clock::now();
+
+    lemon::StreamingProxy::forward_sse_stream(
+        "http://127.0.0.1:" + std::to_string(port) + "/v1/chat/completions",
+        R"({"model":"test-model","stream":true})",
+        downstream,
+        [&](const lemon::StreamingProxy::TelemetryData& telemetry) {
+            telemetry_error = telemetry.error_message;
+        },
+        10);
+
+    const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::steady_clock::now() - started);
+
+    disconnect_thread.join();
+    release_backend.store(true, std::memory_order_release);
+    backend.stop();
+    backend_thread.join();
+
+    check(
+        backend_started.load(std::memory_order_acquire),
+        "mock backend received the streaming request");
+    check(
+        elapsed < 3000ms,
+        "client disconnect cancels upstream before first stream byte");
+    check(
+        telemetry_error == "Client disconnected during stream",
+        "early cancellation is classified as a client disconnect");
+    check(
+        downstream_write_calls == 0,
+        "no payload is written after a pre-first-byte disconnect");
+
+    std::printf(
+        "StreamingProxy pre-first-byte cancellation completed in %lld ms\\n",
+        static_cast<long long>(elapsed.count()));
+
+    return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
Propagate streaming client disconnects to the backend while waiting for the first response bytes.

Previously, disconnects were only detected when the backend produced another chunk. During a long prefill, this could leave the backend request running even after the client had stopped the request, blocking hardware etc.

post_stream() now polls the downstream connection through libcurl's transfer callback and aborts the upstream request when the client disconnects.

This does not change model unload behavior. 