### PR TITLE
feat(gui): add thinking menu

### DIFF
--- a/src/app/src/components/ChatView.tsx
+++ b/src/app/src/components/ChatView.tsx
@@ -121,6 +121,8 @@ function getDownloadStoreModule(): Promise<typeof import('../features/downloadMa
 
 const CHAT_LOGS_WIDTH_KEY = 'chat_logs_panel_width';
 const CHAT_THINKING_MODE_KEY = 'chat_thinking_mode';
+const CHAT_COMPOSER_INPUT_MIN_HEIGHT = 40;
+const CHAT_COMPOSER_INPUT_MAX_HEIGHT = 200;
 const CHAT_LOGS_DEFAULT_WIDTH = 520;
 const CHAT_LOGS_MIN_WIDTH = 340;
 const CHAT_LOGS_MAX_WIDTH = 920;
@@ -189,6 +191,22 @@ function saveChatThinkingMode(mode: ChatThinkingMode): void {
   } catch {
     // Non-critical UI preference persistence.
   }
+}
+
+function resizeChatComposerInput(textarea: HTMLTextAreaElement | null): void {
+  if (!textarea) return;
+
+  // Measure from the content each time so the field can both grow and shrink.
+  // This JS path is intentional instead of field-sizing: content so WebKit/Safari
+  // gets the same behavior as Chromium.
+  textarea.style.height = 'auto';
+  const contentHeight = textarea.scrollHeight;
+  const height = Math.min(
+    CHAT_COMPOSER_INPUT_MAX_HEIGHT,
+    Math.max(CHAT_COMPOSER_INPUT_MIN_HEIGHT, contentHeight),
+  );
+  textarea.style.height = `${height}px`;
+  textarea.style.overflowY = contentHeight > CHAT_COMPOSER_INPUT_MAX_HEIGHT ? 'auto' : 'hidden';
 }
 
 function loadPersistencePreference(): boolean {
@@ -3090,6 +3108,49 @@ ${finalText}`
             : currentCapability === 'tts'
               ? (isOpenMossCloneMode ? 'Type text to speak, then attach a WAV voice sample…' : `Text to speak with ${currentModel}…`)
               : `Message ${currentModel}…`;
+
+  useEffect(() => {
+    resizeChatComposerInput(inputRef.current);
+  }, [composerPlaceholder, inputValue]);
+
+  useEffect(() => {
+    const textarea = inputRef.current;
+    if (!textarea) return;
+
+    let animationFrame = 0;
+    let lastObservedWidth = textarea.clientWidth;
+    const scheduleResize = () => {
+      if (animationFrame) cancelAnimationFrame(animationFrame);
+      animationFrame = requestAnimationFrame(() => resizeChatComposerInput(inputRef.current));
+    };
+
+    // Width changes can come from the viewport, side panels, or the controls
+    // beside the textarea. Observe the field itself and ignore height-only
+    // notifications to avoid a resize loop when auto-sizing it.
+    const resizeObserver = typeof ResizeObserver !== 'undefined'
+      ? new ResizeObserver(entries => {
+        const width = entries[0]?.contentRect.width ?? textarea.clientWidth;
+        if (Math.abs(width - lastObservedWidth) < 0.5) return;
+        lastObservedWidth = width;
+        scheduleResize();
+      })
+      : null;
+    resizeObserver?.observe(textarea);
+
+    // Window is the fallback for older WebViews. visualViewport catches iOS
+    // Safari viewport changes such as rotation and the on-screen keyboard.
+    window.addEventListener('resize', scheduleResize);
+    const visualViewport = window.visualViewport;
+    visualViewport?.addEventListener('resize', scheduleResize);
+
+    return () => {
+      if (animationFrame) cancelAnimationFrame(animationFrame);
+      resizeObserver?.disconnect();
+      window.removeEventListener('resize', scheduleResize);
+      visualViewport?.removeEventListener('resize', scheduleResize);
+    };
+  }, []);
+
   const hasComposerSettings = currentCapability === 'image'
     || currentCapability === 'audio-generation'
     || currentCapability === 'model3d'

--- a/src/app/src/components/ChatView.tsx
+++ b/src/app/src/components/ChatView.tsx
@@ -1882,6 +1882,20 @@ const ChatView: React.FC<ChatViewProps> = ({ currentModel: selectedModel, loaded
     if (isBusy) setThinkingMenuOpen(false);
   }, [isBusy]);
 
+  useEffect(() => {
+    const onThinkingShortcut = (event: KeyboardEvent) => {
+      if (event.key.toLowerCase() !== 'm' || !event.ctrlKey || !event.shiftKey || event.altKey || event.metaKey) return;
+      if (!modeSupportsChatCompletions || isBusy) return;
+      event.preventDefault();
+      setAddMenuOpen(false);
+      setMcpPickerOpen(false);
+      setThinkingMenuOpen(open => !open);
+      requestAnimationFrame(() => thinkingTriggerRef.current?.focus());
+    };
+    window.addEventListener('keydown', onThinkingShortcut);
+    return () => window.removeEventListener('keydown', onThinkingShortcut);
+  }, [isBusy, modeSupportsChatCompletions]);
+
   const streamingContent = currentStream?.content || '';
   const streamingThinking = currentStream?.thinking || '';
   const streamingToolStatus = currentStream?.toolStatus || '';
@@ -4134,18 +4148,24 @@ ${finalText}`
                   setThinkingMenuOpen(open => !open);
                 }}
                 disabled={isBusy}
-                title="Thinking"
-                aria-label={`Thinking: ${thinkingMode === 'off' ? 'Off' : 'Normal'}`}
+                aria-label={`Reasoning: ${thinkingMode === 'off' ? 'Off' : 'Thinking'}`}
                 aria-haspopup="menu"
                 aria-expanded={thinkingMenuOpen}
               >
-                <span>{thinkingMode === 'off' ? 'Off' : 'Normal'}</span>
+                <span>{thinkingMode === 'off' ? 'Off' : 'Thinking'}</span>
                 <Icon name="chevron-down" size={12} aria-hidden="true" />
               </button>
+              {!thinkingMenuOpen && (
+                <div className="composer__thinking-tooltip" role="tooltip" aria-hidden="true">
+                  <span>Reasoning</span>
+                  <kbd>Ctrl ⇧ M</kbd>
+                </div>
+              )}
               {thinkingMenuOpen && (
-                <div className="composer__thinking-menu" role="menu" aria-label="Thinking">
+                <div className="composer__thinking-menu" role="menu" aria-label="Reasoning">
                   {(['normal', 'off'] as const).map(mode => {
                     const selected = thinkingMode === mode;
+                    const enabled = mode !== 'off';
                     return (
                       <button
                         key={mode}
@@ -4155,7 +4175,12 @@ ${finalText}`
                         className={`composer__thinking-option${selected ? ' is-selected' : ''}`}
                         onClick={() => selectThinkingMode(mode)}
                       >
-                        <span>{mode === 'off' ? 'Off' : 'Normal'}</span>
+                        <span className="composer__thinking-option-copy">
+                          <span className="composer__thinking-option-label">{enabled ? 'Thinking' : 'Off'}</span>
+                          <span className="composer__thinking-option-description">
+                            {enabled ? 'Model thinks before answering' : 'Direct answer'}
+                          </span>
+                        </span>
                         {selected && <Icon name="check" size={13} aria-hidden="true" />}
                       </button>
                     );

--- a/src/app/src/components/ChatView.tsx
+++ b/src/app/src/components/ChatView.tsx
@@ -18,7 +18,7 @@ const MarkdownMessage: React.FC<React.ComponentProps<typeof LazyMarkdownMessage>
     <LazyMarkdownMessage {...props} />
   </Suspense>
 );
-import { useChatStreaming, ToolCallEntry, ChatToolRuntime, ToolArtifact } from '../hooks/useChatStreaming';
+import { useChatStreaming, ToolCallEntry, ChatToolRuntime, ToolArtifact, type ChatThinkingMode } from '../hooks/useChatStreaming';
 import { useAudioCapture } from '../hooks/useAudioCapture';
 import { useFocusTrap } from '../hooks/useFocusTrap';
 import {
@@ -120,6 +120,7 @@ function getDownloadStoreModule(): Promise<typeof import('../features/downloadMa
 }
 
 const CHAT_LOGS_WIDTH_KEY = 'chat_logs_panel_width';
+const CHAT_THINKING_MODE_KEY = 'chat_thinking_mode';
 const CHAT_LOGS_DEFAULT_WIDTH = 520;
 const CHAT_LOGS_MIN_WIDTH = 340;
 const CHAT_LOGS_MAX_WIDTH = 920;
@@ -169,6 +170,22 @@ function saveScopedStringArray(key: string, values: string[] | null): void {
   try {
     if (values === null) localStorage.removeItem(scopedKey(key));
     else localStorage.setItem(scopedKey(key), JSON.stringify([...new Set(values.filter(Boolean))]));
+  } catch {
+    // Non-critical UI preference persistence.
+  }
+}
+
+function loadChatThinkingMode(): ChatThinkingMode {
+  try {
+    return localStorage.getItem(scopedKey(CHAT_THINKING_MODE_KEY)) === 'off' ? 'off' : 'normal';
+  } catch {
+    return 'normal';
+  }
+}
+
+function saveChatThinkingMode(mode: ChatThinkingMode): void {
+  try {
+    localStorage.setItem(scopedKey(CHAT_THINKING_MODE_KEY), mode);
   } catch {
     // Non-critical UI preference persistence.
   }
@@ -812,6 +829,8 @@ const ChatView: React.FC<ChatViewProps> = ({ currentModel: selectedModel, loaded
   const [mcpPickerOpen, setMcpPickerOpen] = useState(false);
   const [mcpPickerTab, setMcpPickerTab] = useState<'lemonade' | 'external'>('lemonade');
   const [addMenuOpen, setAddMenuOpen] = useState(false);
+  const [thinkingMode, setThinkingMode] = useState<ChatThinkingMode>(() => loadChatThinkingMode());
+  const [thinkingMenuOpen, setThinkingMenuOpen] = useState(false);
   const [mcpOptions, setMcpOptions] = useState<McpServerToolOption[]>([]);
   const [mcpPickerLoading, setMcpPickerLoading] = useState(false);
   const [mcpPickerError, setMcpPickerError] = useState('');
@@ -834,6 +853,8 @@ const ChatView: React.FC<ChatViewProps> = ({ currentModel: selectedModel, loaded
   const fileInputRef = useRef<HTMLInputElement>(null);
   const modelPickerRef = useRef<HTMLDivElement>(null);
   const addMenuRef = useRef<HTMLDivElement>(null);
+  const thinkingMenuRef = useRef<HTMLDivElement>(null);
+  const thinkingTriggerRef = useRef<HTMLButtonElement>(null);
   const mcpReturnFocusEntryRef = useRef<'tools'>('tools');
   const mcpBackButtonRef = useRef<HTMLButtonElement | null>(null);
   const thinkingContentRef = useRef<HTMLDivElement>(null);
@@ -1452,6 +1473,24 @@ const ChatView: React.FC<ChatViewProps> = ({ currentModel: selectedModel, loaded
     return () => window.removeEventListener('pointerdown', onPointerDown);
   }, [addMenuOpen]);
 
+  useEffect(() => {
+    if (!thinkingMenuOpen) return;
+    const onPointerDown = (event: PointerEvent) => {
+      const root = thinkingMenuRef.current;
+      if (!root || root.contains(event.target as Node)) return;
+      setThinkingMenuOpen(false);
+    };
+    window.addEventListener('pointerdown', onPointerDown);
+    return () => window.removeEventListener('pointerdown', onPointerDown);
+  }, [thinkingMenuOpen]);
+
+  const selectThinkingMode = useCallback((mode: ChatThinkingMode) => {
+    setThinkingMode(mode);
+    saveChatThinkingMode(mode);
+    setThinkingMenuOpen(false);
+    requestAnimationFrame(() => thinkingTriggerRef.current?.focus());
+  }, []);
+
   const resetMcpSelection = useCallback(() => {
     const nextIds = DEFAULT_MCP_SERVER_IDS;
     persistMcpSelection(nextIds, null);
@@ -1838,6 +1877,11 @@ const ChatView: React.FC<ChatViewProps> = ({ currentModel: selectedModel, loaded
   const modelPreparation = activeId ? modelPreparations[activeId] || null : null;
   const capabilityBusy = activeId ? capabilityBusyConvoIds.has(activeId) : false;
   const isBusy = isStreaming || capabilityBusy || isLiveRecording || modelPreparation !== null;
+
+  useEffect(() => {
+    if (isBusy) setThinkingMenuOpen(false);
+  }, [isBusy]);
+
   const streamingContent = currentStream?.content || '';
   const streamingThinking = currentStream?.thinking || '';
   const streamingToolStatus = currentStream?.toolStatus || '';
@@ -2582,7 +2626,7 @@ ${finalText}`
     }
 
     streamModelsRef.current[convoId] = modelSnapshot;
-    await streaming.send(convoId, requestModelName, chatMessages, toolRuntime);
+    await streaming.send(convoId, requestModelName, chatMessages, toolRuntime, thinkingMode);
   }, [
     appendAssistantMessage,
     currentCapability,
@@ -2598,6 +2642,7 @@ ${finalText}`
     selectedMcpServerIds,
     selectedMcpToolNames,
     supportsChatImageInput,
+    thinkingMode,
     runCapabilityRequest,
     speakWithPinnedTts,
     streaming,
@@ -3863,6 +3908,7 @@ ${finalText}`
             <button
               className="composer__attach composer__add-trigger"
               onClick={() => {
+                setThinkingMenuOpen(false);
                 setAddMenuOpen(open => {
                   const next = !open;
                   if (!next) setMcpPickerOpen(false);
@@ -4055,18 +4101,6 @@ ${finalText}`
             style={{ display: 'none' }}
             onChange={handleFileSelect}
           />
-          {(supportsRealtimeAudio || isLiveRecording) && (
-            <button
-              className={`composer__mic${isLiveRecording ? ' composer__mic--recording' : ''}`}
-              onClick={isLiveRecording ? handleMicStop : handleMicStart}
-              disabled={!currentModel || (!supportsRealtimeAudio && !isLiveRecording) || ((isStreaming || capabilityBusy) && !isLiveRecording)}
-              title={isLiveRecording ? 'Stop live microphone transcription' : supportsRealtimeAudio ? 'Start live microphone transcription' : 'Live microphone needs HTTPS/localhost and a realtime-capable audio model'}
-              aria-label={isLiveRecording ? 'Stop live microphone transcription' : 'Start live microphone transcription'}
-              aria-pressed={isLiveRecording}
-            >
-              <Icon name="mic" size={16} />
-            </button>
-          )}
           <textarea
             ref={inputRef}
             className="composer__input"
@@ -4079,6 +4113,69 @@ ${finalText}`
             rows={1}
             aria-label="Message"
           />
+          {modeSupportsChatCompletions && (
+            <div
+              className="composer__thinking"
+              ref={thinkingMenuRef}
+              onKeyDown={event => {
+                if (event.key !== 'Escape' || !thinkingMenuOpen) return;
+                event.preventDefault();
+                setThinkingMenuOpen(false);
+                thinkingTriggerRef.current?.focus();
+              }}
+            >
+              <button
+                ref={thinkingTriggerRef}
+                type="button"
+                className="composer__thinking-trigger"
+                onClick={() => {
+                  setAddMenuOpen(false);
+                  setMcpPickerOpen(false);
+                  setThinkingMenuOpen(open => !open);
+                }}
+                disabled={isBusy}
+                title="Thinking"
+                aria-label={`Thinking: ${thinkingMode === 'off' ? 'Off' : 'Normal'}`}
+                aria-haspopup="menu"
+                aria-expanded={thinkingMenuOpen}
+              >
+                <span>{thinkingMode === 'off' ? 'Off' : 'Normal'}</span>
+                <Icon name="chevron-down" size={12} aria-hidden="true" />
+              </button>
+              {thinkingMenuOpen && (
+                <div className="composer__thinking-menu" role="menu" aria-label="Thinking">
+                  {(['normal', 'off'] as const).map(mode => {
+                    const selected = thinkingMode === mode;
+                    return (
+                      <button
+                        key={mode}
+                        type="button"
+                        role="menuitemradio"
+                        aria-checked={selected}
+                        className={`composer__thinking-option${selected ? ' is-selected' : ''}`}
+                        onClick={() => selectThinkingMode(mode)}
+                      >
+                        <span>{mode === 'off' ? 'Off' : 'Normal'}</span>
+                        {selected && <Icon name="check" size={13} aria-hidden="true" />}
+                      </button>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          )}
+          {(supportsRealtimeAudio || isLiveRecording) && (
+            <button
+              className={`composer__mic${isLiveRecording ? ' composer__mic--recording' : ''}`}
+              onClick={isLiveRecording ? handleMicStop : handleMicStart}
+              disabled={!currentModel || (!supportsRealtimeAudio && !isLiveRecording) || ((isStreaming || capabilityBusy) && !isLiveRecording)}
+              title={isLiveRecording ? 'Stop live microphone transcription' : supportsRealtimeAudio ? 'Start live microphone transcription' : 'Live microphone needs HTTPS/localhost and a realtime-capable audio model'}
+              aria-label={isLiveRecording ? 'Stop live microphone transcription' : 'Start live microphone transcription'}
+              aria-pressed={isLiveRecording}
+            >
+              <Icon name="mic" size={16} />
+            </button>
+          )}
           {isStreaming ? (
             <button className="composer__stop" onClick={handleStop} aria-label="Stop generating" title="Stop"><Icon name="stop" size={16} /></button>
           ) : (

--- a/src/app/src/hooks/useChatStreaming.ts
+++ b/src/app/src/hooks/useChatStreaming.ts
@@ -4,6 +4,13 @@ import type { ToolCall, ToolResult } from '../tools/lemonadeTools';
 
 export type { ToolCall } from '../tools/lemonadeTools';
 
+export type ChatThinkingMode = 'normal' | 'off';
+
+export function chatThinkingParams(mode: ChatThinkingMode): Record<string, unknown> {
+  return { enable_thinking: mode !== 'off' };
+}
+
+
 const MAX_TOOL_ROUNDS = 5;
 const TOOL_FOLLOWUP_PROMPT = [
   "Use the tool result to answer the user's last request with concrete, specific details.",
@@ -100,7 +107,13 @@ export interface ChatStreamingResult {
   streamingConvoIds: Set<string>;
   getStream: (convoId: string) => StreamState | undefined;
   getLiveStats: (convoId: string) => LiveStreamStats | undefined;
-  send: (convoId: string, model: string, messages: ChatMessage[], tools?: boolean | ChatToolRuntime | null) => Promise<void>;
+  send: (
+    convoId: string,
+    model: string,
+    messages: ChatMessage[],
+    tools?: boolean | ChatToolRuntime | null,
+    thinkingMode?: ChatThinkingMode,
+  ) => Promise<void>;
   stop: (convoId: string) => { content: string; thinking?: string } | null;
 }
 
@@ -154,7 +167,13 @@ export function useChatStreaming(
     [liveStats],
   );
 
-  const send = useCallback(async (convoId: string, model: string, messages: ChatMessage[], tools: boolean | ChatToolRuntime | null = false) => {
+  const send = useCallback(async (
+    convoId: string,
+    model: string,
+    messages: ChatMessage[],
+    tools: boolean | ChatToolRuntime | null = false,
+    thinkingMode: ChatThinkingMode = 'normal',
+  ) => {
     let runtime: ChatToolRuntime | null = tools && typeof tools === 'object' ? tools : null;
     if (tools === true) {
       const { LEMONADE_TOOLS, executeTool } = await import(
@@ -180,6 +199,7 @@ export function useChatStreaming(
       const { default: api } = await import(/* webpackChunkName: "api-client" */ '../api');
       return new Promise<void>((resolve, reject) => {
         api.chatCompletion(model, fullMessages, {
+          params: chatThinkingParams(thinkingMode),
           tools: runtime?.tools?.length ? runtime.tools : undefined,
           onReasoning: (_token, fullReasoning) => {
             const buf = tokenBufferRef.current;

--- a/src/app/src/styles/styles.css
+++ b/src/app/src/styles/styles.css
@@ -1693,6 +1693,93 @@ input[type="checkbox"]:disabled {
 
 .composer__input::placeholder { color: var(--text-tertiary); }
 
+.composer__thinking {
+  position: relative;
+  flex: 0 0 auto;
+}
+
+.composer__thinking-trigger {
+  height: 38px;
+  min-width: 0;
+  padding: 0 10px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  border: 0;
+  border-radius: var(--radius-lg);
+  background: transparent;
+  color: var(--text-secondary);
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  line-height: 1;
+  white-space: nowrap;
+  cursor: pointer;
+  transition:
+    color var(--duration-fast) var(--ease-out),
+    background var(--duration-fast) var(--ease-out),
+    opacity var(--duration-fast) var(--ease-out);
+}
+
+.composer__thinking-trigger .app-icon {
+  flex: 0 0 auto;
+}
+
+.composer__thinking-trigger:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.composer__thinking-menu {
+  position: absolute;
+  right: 0;
+  bottom: calc(100% + var(--space-2));
+  z-index: var(--z-dropdown);
+  width: 132px;
+  padding: var(--space-2);
+  display: grid;
+  gap: 2px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  background: var(--surface-raised);
+  box-shadow: var(--shadow-lg);
+}
+
+.composer__thinking-option {
+  width: 100%;
+  min-height: 34px;
+  padding: 6px 10px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  border: 0;
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--text-secondary);
+  font: inherit;
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  text-align: left;
+  cursor: pointer;
+}
+
+.composer__thinking-option:hover,
+.composer__thinking-option:focus-visible {
+  color: var(--text-primary);
+  background: color-mix(in srgb, var(--text-primary) 7%, transparent);
+}
+
+.composer__thinking-option.is-selected {
+  color: var(--text-primary);
+  background: var(--surface-2);
+}
+
+.composer__thinking-option.is-selected .app-icon {
+  color: var(--accent-fg);
+}
+
 .composer__send {
   width: 36px;
   height: 36px;
@@ -3554,6 +3641,10 @@ optgroup {
     flex-shrink: 0;
   }
 
+  .composer__thinking-trigger {
+    height: 44px;
+  }
+
   /* ── Composer toolbar: allow wrapping on very narrow screens ── */
 .composer__toolbar {
     flex-wrap: wrap;
@@ -4678,7 +4769,8 @@ optgroup {
   stroke-width: 2.25;
 }
 
-.composer__add-trigger:hover:not(:disabled) {
+.composer__add-trigger:hover:not(:disabled),
+.composer__thinking-trigger:hover:not(:disabled) {
   color: var(--text-primary);
   background: color-mix(
     in srgb,
@@ -4687,7 +4779,8 @@ optgroup {
   );
 }
 
-.composer__add-trigger:focus-visible {
+.composer__add-trigger:focus-visible,
+.composer__thinking-trigger:focus-visible {
   color: var(--text-primary);
   background: color-mix(
     in srgb,
@@ -4696,7 +4789,8 @@ optgroup {
   );
 }
 
-.composer__add-trigger[aria-expanded='true'] {
+.composer__add-trigger[aria-expanded='true'],
+.composer__thinking-trigger[aria-expanded='true'] {
   color: var(--text-primary);
   background: color-mix(
     in srgb,
@@ -5699,6 +5793,7 @@ optgroup {
 }
 
 .composer__attach,
+.composer__thinking,
 .composer__mic,
 .composer__send,
 .composer__stop {

--- a/src/app/src/styles/styles.css
+++ b/src/app/src/styles/styles.css
@@ -1666,8 +1666,11 @@ input[type="checkbox"]:disabled {
 }
 
 .composer__input {
-  flex: 1;
+  flex: 1 1 auto;
+  min-width: 0;
   resize: none;
+  overflow-y: hidden;
+  -webkit-overflow-scrolling: touch;
   font-size: var(--text-base);
   line-height: var(--leading-normal);
   padding: 8px var(--space-2);

--- a/src/app/src/styles/styles.css
+++ b/src/app/src/styles/styles.css
@@ -1731,12 +1731,63 @@ input[type="checkbox"]:disabled {
   cursor: not-allowed;
 }
 
+.composer__thinking-tooltip {
+  position: absolute;
+  right: 0;
+  bottom: calc(100% + var(--space-2));
+  z-index: var(--z-dropdown);
+  min-height: 32px;
+  padding: 4px 5px 4px 10px;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  background: var(--surface-raised);
+  box-shadow: var(--shadow-lg);
+  color: var(--text-primary);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-medium);
+  line-height: 1;
+  white-space: nowrap;
+  pointer-events: none;
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(3px);
+  transition:
+    opacity var(--duration-fast) var(--ease-out),
+    transform var(--duration-fast) var(--ease-out),
+    visibility var(--duration-fast) var(--ease-out);
+}
+
+.composer__thinking-tooltip kbd {
+  min-height: 22px;
+  padding: 0 6px;
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--surface-2);
+  color: var(--text-tertiary);
+  font-family: var(--font-sans);
+  font-size: 10px;
+  font-weight: var(--weight-medium);
+  letter-spacing: 0.01em;
+}
+
+.composer__thinking:hover .composer__thinking-tooltip,
+.composer__thinking:focus-within .composer__thinking-tooltip {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+}
+
 .composer__thinking-menu {
   position: absolute;
   right: 0;
   bottom: calc(100% + var(--space-2));
   z-index: var(--z-dropdown);
-  width: 132px;
+  width: 270px;
   padding: var(--space-2);
   display: grid;
   gap: 2px;
@@ -1748,21 +1799,43 @@ input[type="checkbox"]:disabled {
 
 .composer__thinking-option {
   width: 100%;
-  min-height: 34px;
-  padding: 6px 10px;
+  min-height: 54px;
+  padding: 7px 9px 7px 10px;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: var(--space-2);
+  gap: var(--space-3);
   border: 0;
   border-radius: var(--radius-md);
   background: transparent;
   color: var(--text-secondary);
   font: inherit;
-  font-size: var(--text-sm);
-  font-weight: var(--weight-medium);
   text-align: left;
   cursor: pointer;
+}
+
+.composer__thinking-option-copy {
+  min-width: 0;
+  display: grid;
+  gap: 2px;
+}
+
+.composer__thinking-option-label {
+  color: var(--text-primary);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  line-height: 1.2;
+}
+
+.composer__thinking-option-description {
+  color: var(--text-tertiary);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-normal);
+  line-height: 1.35;
+}
+
+.composer__thinking-option > .app-icon {
+  flex: 0 0 auto;
 }
 
 .composer__thinking-option:hover,


### PR DESCRIPTION
One remaining GUI2 regression - no option to disable thinking (which is rightfully an auto-on).
Cramping this into setting would be the wrong move I rather opted for this approach:
<img width="964" height="130" alt="image" src="https://github.com/user-attachments/assets/b22f0925-e045-4c34-b145-ae7b0b75f02c" />
<img width="280" height="169" alt="image" src="https://github.com/user-attachments/assets/f6914f95-731f-4350-acbe-e36125394458" />
<img width="238" height="171" alt="image" src="https://github.com/user-attachments/assets/718f4987-1178-422b-bb85-f45f43c3019d" />


This is the way like it's done in recent very well known chat client like chatGPT.

Using it that way actually enables to switch back and forth in chat between fast and more thought through answers - very helpful.

That it acutally works depends on #3132 

Also good ground laying work for future additions like Lemonade specific thinking modes or what we defently can't ignore more and more OSS model appearing with dedicated reasoning effort settings. 

Additionally move the mic of the audio mode also to the right where the user expects this action, also comparable with modern chat client websites.
<img width="958" height="146" alt="image" src="https://github.com/user-attachments/assets/9bb25138-62ce-4033-b122-88ebff230b9a" />
