### PR TITLE
feat(server,cli): add discovery and broadcast controls with config decoupling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2872,11 +2872,18 @@ if(BUILD_TESTING AND EXISTS "${_CONFIG_MIGRATION_TEST_SRC}")
     add_cpp_ci_test(ConfigMigrationTest CI OFF COMMAND test_config_migration)
 endif()
 
+set(_CONFIG_DISCOVERY_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_config_discovery.cpp")
+if(BUILD_TESTING AND EXISTS "${_CONFIG_DISCOVERY_TEST_SRC}")
+    add_executable(test_config_discovery test/cpp/test_config_discovery.cpp)
+    target_link_libraries(test_config_discovery PRIVATE lemonade-server-core)
+    add_cpp_ci_test(ConfigDiscoveryTest CI ON COMMAND test_config_discovery)
+endif()
+
 set(_CONFIG_TELEMETRY_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_config_telemetry.cpp")
 if(BUILD_TESTING AND EXISTS "${_CONFIG_TELEMETRY_TEST_SRC}")
     add_executable(test_config_telemetry test/cpp/test_config_telemetry.cpp)
     target_link_libraries(test_config_telemetry PRIVATE lemonade-server-core)
-    add_cpp_ci_test(ConfigTelemetryTest CI OFF COMMAND test_config_telemetry)
+    add_cpp_ci_test(ConfigTelemetryTest CI ON COMMAND test_config_telemetry)
 endif()
 
 set(_RUNTIME_CONFIG_BACKEND_VALIDATION_TEST_SRC

--- a/docs/dev/getting-started.md
+++ b/docs/dev/getting-started.md
@@ -641,7 +641,7 @@ Accepts a JSON object with one or more keys to update atomically. Returns `{"sta
 | `host` | string | HTTP rebind |
 | `log_level` | string (`trace`, `debug`, `info`, `warning`, `error`, `fatal`, `none`) | Reconfigures log filter |
 | `global_timeout` | int (positive) | Updates default HTTP client timeout |
-| `no_broadcast` | bool | Stops or starts UDP beacon |
+| `broadcast` | bool | Starts or stops UDP beacon |
 | `extra_models_dir` | string | Updates model manager search path |
 
 **Deferred keys** (affect the next model load or eviction decision, no immediate side effect):

--- a/docs/embeddable/runtime.md
+++ b/docs/embeddable/runtime.md
@@ -167,7 +167,7 @@ Accepts a JSON object with one or more keys to update atomically. Returns `{"sta
 | `host` | string | HTTP rebind |
 | `log_level` | string (`trace`, `debug`, `info`, `warning`, `error`, `fatal`, `none`) | Reconfigures log filter |
 | `global_timeout` | int (positive) | Updates default HTTP client timeout |
-| `no_broadcast` | bool | Stops or starts UDP beacon |
+| `broadcast` | bool | Starts or stops UDP beacon |
 | `models_dir` | string (`"auto"` or path) | Updates the primary model cache location |
 | `extra_models_dir` | string | Validates access and updates the external GGUF search path |
 

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -82,6 +82,7 @@ The following options are available for all commands:
 | `--host HOST` | Server host address | `127.0.0.1` |
 | `--port PORT` | Server port number | `13305` |
 | `--api-key KEY` | API key for authentication | None |
+| `--discovery` / `--no-discovery` | Enable or disable auto-discovery of local server via UDP beacon | Enabled |
 
 These options can also be set via environment variables:
 - `LEMONADE_HOST` for `--host`

--- a/docs/guide/configuration/README.md
+++ b/docs/guide/configuration/README.md
@@ -80,7 +80,6 @@ Values set in the user's `config.json` always take precedence over these seeded 
     "cpu_args": "",
     "cpu_bin": "builtin"
   },
-  "no_broadcast": false,
   "no_fetch_executables": false,
   "offline": false,
   "onnxruntime": {

--- a/docs/guide/configuration/README.md
+++ b/docs/guide/configuration/README.md
@@ -42,6 +42,7 @@ Values set in the user's `config.json` always take precedence over these seeded 
     "vulkan_bin": "builtin"
   },
   "auto_check_model_updates": true,
+  "broadcast": true,
   "cloud_providers": [],
   "config_version": 2,
   "ctx_size": -1,
@@ -178,7 +179,7 @@ Values set in the user's `config.json` always take precedence over these seeded 
 | `log_level` | string | "info" | Logging level (trace, debug, info, warning, error, fatal, none) |
 | `global_timeout` | int | 600 | Timeout in seconds for HTTP, inference, and readiness checks |
 | `max_loaded_models` | int | 1 | Max models per type slot. Use -1 for unlimited |
-| `no_broadcast` | bool | false | Disable UDP broadcasting for server discovery |
+| `broadcast` | bool | true | Enable or disable UDP broadcasting for server discovery |
 | `extra_models_dir` | string | "" | Secondary directory recursively scanned for GGUF model files. Empty disables extra discovery; existing paths must be readable by `lemond` |
 | `models_dir` | string | "auto" | Directory for cached model files. `"auto"` follows `HF_HUB_CACHE` / `HF_HOME` / platform default |
 | `ctx_size` | int | -1 | Default context size for LLM models. Use `-1` for auto-resolution: the server computes the largest context that fits in available device memory using GGUF architecture metadata. Use a positive integer to set an explicit size. |
@@ -414,12 +415,13 @@ sudo systemctl restart lemond
 ## lemond CLI
 
 ```
-lemond [cache_dir] [--port PORT] [--host HOST]
+lemond [cache_dir] [--port PORT] [--host HOST] [--broadcast] [--no-broadcast]
 ```
 
 - **cache_dir** — Path to the lemonade cache directory containing config.json and model data. Optional; defaults to platform-specific location.
 - **--port** — Port to serve on (overrides config.json, persisted). Use as a fallback if the server cannot start.
 - **--host** — Address to bind (overrides config.json, persisted). Use as a fallback if the server cannot start.
+- **--broadcast** / **--no-broadcast** — Enable or disable UDP broadcasting for server discovery (non-persistent override).
 
 ## API Key and Security
 

--- a/docs/tools/gen_backend_boilerplate.py
+++ b/docs/tools/gen_backend_boilerplate.py
@@ -28,6 +28,7 @@ are rewritten; surrounding prose is left untouched.
 
 import argparse
 import json
+import os
 import re
 import socket
 import subprocess
@@ -103,7 +104,14 @@ class Lemond:
 
     def _get(self, path: str, timeout: float = 5):
         url = f"http://127.0.0.1:{self.port}{path}"
-        with urllib.request.urlopen(url, timeout=timeout) as r:
+        req = urllib.request.Request(url)
+        api_key = os.environ.get("LEMONADE_ADMIN_API_KEY") or os.environ.get(
+            "LEMONADE_API_KEY"
+        )
+        if api_key:
+            req.add_header("Authorization", f"Bearer {api_key}")
+        opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+        with opener.open(req, timeout=timeout) as r:
             return r.read()
 
     def system_info(self) -> dict:

--- a/src/cpp/cli/main.cpp
+++ b/src/cpp/cli/main.cpp
@@ -148,6 +148,7 @@ struct CliConfig {
     std::string host = "127.0.0.1";
     int port = 13305;
     bool is_ssl = false;
+    bool no_discovery = false;
     std::string api_key;
     std::string model;
     std::string list_filter;
@@ -1243,6 +1244,7 @@ int main(int argc, char* argv[]) {
         ->default_val(config.api_key)
         ->type_name("KEY")
         ->envname("LEMONADE_API_KEY");
+    app.add_flag("!--discovery,--no-discovery", config.no_discovery, "Enable or disable auto-discovery of local server via UDP beacon");
 
     // Subcommands
     // Quick start commands
@@ -1510,10 +1512,10 @@ int main(int argc, char* argv[]) {
     config.codex_use_user_config = (codex_provider_opt != nullptr && codex_provider_opt->count() > 0);
 
     // Auto-discover local server via UDP beacon if the default connection fails
-    // Skip when: no command given, scan command, or user explicitly set --host/--port
+    // Skip when: no command given, scan command, or user explicitly set --host/--port, or --no-discovery is set
     bool has_command = !app.get_subcommands().empty();
     bool explicit_target = (host_opt->count() > 0 || port_opt->count() > 0);
-    if (has_command && scan_cmd->count() == 0 && !explicit_target) {
+    if (has_command && scan_cmd->count() == 0 && !explicit_target && !config.no_discovery) {
         // Localhost responds in <10ms; use short timeout. Remote hosts need more.
         bool is_local = (config.host.empty() || config.host == "127.0.0.1" ||
                          config.host == "localhost" || config.host == "0.0.0.0");

--- a/src/cpp/include/lemon/cli_parser.h
+++ b/src/cpp/include/lemon/cli_parser.h
@@ -1,14 +1,16 @@
 #pragma once
 
 #include <CLI/CLI.hpp>
+#include <optional>
 #include <string>
 
 namespace lemon {
 
 struct ServerConfig {
-    std::string cache_dir;     // Positional arg: lemonade cache dir (optional, platform default)
-    int port = -1;             // -1 = not specified on CLI, use config.json value
-    std::string host;          // Empty = not specified on CLI, use config.json value
+    std::string cache_dir;                // Positional arg: lemonade cache dir (optional, platform default)
+    int port = -1;                        // -1 = not specified on CLI, use config.json value
+    std::string host;                     // Empty = not specified on CLI, use config.json value
+    std::optional<bool> broadcast;        // std::nullopt = not specified on CLI, use config.json value
 };
 
 class CLIParser {

--- a/src/cpp/include/lemon/runtime_config.h
+++ b/src/cpp/include/lemon/runtime_config.h
@@ -1,8 +1,11 @@
 #pragma once
 
 #include <string>
-#include <shared_mutex>
 #include <functional>
+#include <map>
+#include <optional>
+#include <shared_mutex>
+#include <string>
 #include <vector>
 #include <nlohmann/json.hpp>
 
@@ -27,7 +30,8 @@ public:
     int websocket_port() const;
     std::string log_level() const;
     std::string extra_models_dir() const;
-    bool no_broadcast() const;
+    bool broadcast() const;
+    void set_broadcast_override(std::optional<bool> override_val);
     long global_timeout() const;
     int max_loaded_models() const;
     std::string models_dir() const;
@@ -145,6 +149,9 @@ private:
 
     // Config stored as nested JSON matching config.json structure.
     json config_;
+
+    // Transient CLI overrides (not persisted to disk)
+    std::optional<bool> broadcast_override_;
 
     // Valid log levels
     static const std::vector<std::string> valid_log_levels_;

--- a/src/cpp/resources/defaults.json
+++ b/src/cpp/resources/defaults.json
@@ -7,6 +7,7 @@
     "vulkan_bin": "builtin"
   },
   "auto_check_model_updates": true,
+  "broadcast": true,
   "cloud_providers": [],
   "config_version": 2,
   "ctx_size": -1,
@@ -44,7 +45,6 @@
     "cpu_args": "",
     "cpu_bin": "builtin"
   },
-  "no_broadcast": false,
   "no_fetch_executables": false,
   "offline": false,
   "onnxruntime": {

--- a/src/cpp/server/cli_parser.cpp
+++ b/src/cpp/server/cli_parser.cpp
@@ -24,6 +24,8 @@ CLIParser::CLIParser()
 
     app_.add_option("--host", config_.host, "Address to bind for connections (overrides config.json)")
         ->type_name("HOST");
+
+    app_.add_flag("--broadcast,!--no-broadcast", config_.broadcast, "Enable or disable UDP broadcasting for server discovery");
 }
 
 int CLIParser::parse(int argc, char** argv) {

--- a/src/cpp/server/config_file.cpp
+++ b/src/cpp/server/config_file.cpp
@@ -28,6 +28,23 @@ static json load_json_file(const fs::path& path) {
     }
 }
 
+static json normalize_legacy_keys(json obj) {
+    if (!obj.is_object()) return obj;
+    if (obj.contains("no_broadcast")) {
+        if (!obj["no_broadcast"].is_boolean()) {
+            throw std::invalid_argument("'no_broadcast' must be a boolean");
+        }
+        if (!obj.contains("broadcast")) {
+            obj["broadcast"] = !obj["no_broadcast"].get<bool>();
+        }
+        obj.erase("no_broadcast");
+    }
+    if (obj.contains("broadcast") && !obj["broadcast"].is_boolean()) {
+        throw std::invalid_argument("'broadcast' must be a boolean");
+    }
+    return obj;
+}
+
 json ConfigFile::base_defaults() {
     json defaults = load_json_file(utils::path_from_utf8(
         utils::get_resource_path("resources/defaults.json")));
@@ -51,14 +68,16 @@ json ConfigFile::get_defaults() {
 #ifndef _WIN32
     fs::path distro_defaults = "/usr/share/lemonade/defaults.json";
     if (fs::exists(distro_defaults)) {
-        defaults = utils::JsonUtils::merge(defaults, load_json_file(distro_defaults));
+        json distro = normalize_legacy_keys(load_json_file(distro_defaults));
+        defaults = utils::JsonUtils::merge(defaults, distro);
     }
 #endif
 
     // Packagers on non-FHS distros (Nix, Guix) can't write the /usr/share
     // file above; this seeds the same defaults from any path.
     if (const char* env = std::getenv("LEMONADE_DEFAULTS_PATH"); env && *env && fs::exists(env)) {
-        defaults = utils::JsonUtils::merge(defaults, load_json_file(env));
+        json env_defaults = normalize_legacy_keys(load_json_file(env));
+        defaults = utils::JsonUtils::merge(defaults, env_defaults);
     }
 
     return defaults;
@@ -124,25 +143,23 @@ json ConfigFile::load(const std::string& cache_dir) {
         return defaults;
     }
 
-    // Deep-merge: user values override defaults, missing fields filled from defaults.
-    json merged = utils::JsonUtils::merge(defaults, loaded);
-
     // Capture the original config version BEFORE merge, so that migration
     // can see past the defaults-injected version number.
     int original_version = config_get_version(loaded);
+
+    bool had_legacy_no_broadcast = loaded.contains("no_broadcast");
+    json normalized_loaded = normalize_legacy_keys(loaded);
+
+    // Deep-merge: user values override defaults, missing fields filled from defaults.
+    json merged = utils::JsonUtils::merge(defaults, normalized_loaded);
 
     // Apply migrations if the config is older than the current version.
     // The inline config_migrate() handles version bumping and field removal.
     bool migrated = config_migrate(merged, defaults, original_version);
 
-    // Handle legacy no_broadcast key migration
-    if (loaded.contains("no_broadcast")) {
-        if (!loaded.contains("broadcast") && loaded["no_broadcast"].is_boolean()) {
-            merged["broadcast"] = !loaded["no_broadcast"].get<bool>();
-            LOG(INFO) << "Migrating config: no_broadcast=" << loaded["no_broadcast"]
-                      << " -> broadcast=" << merged["broadcast"] << std::endl;
-        }
-        merged.erase("no_broadcast");
+    if (had_legacy_no_broadcast) {
+        LOG(INFO) << "Migrating config: no_broadcast=" << loaded["no_broadcast"]
+                  << " -> broadcast=" << merged["broadcast"] << std::endl;
         migrated = true;
     }
 

--- a/src/cpp/server/config_file.cpp
+++ b/src/cpp/server/config_file.cpp
@@ -134,6 +134,18 @@ json ConfigFile::load(const std::string& cache_dir) {
     // Apply migrations if the config is older than the current version.
     // The inline config_migrate() handles version bumping and field removal.
     bool migrated = config_migrate(merged, defaults, original_version);
+
+    // Handle legacy no_broadcast key migration
+    if (loaded.contains("no_broadcast")) {
+        if (!loaded.contains("broadcast") && loaded["no_broadcast"].is_boolean()) {
+            merged["broadcast"] = !loaded["no_broadcast"].get<bool>();
+            LOG(INFO) << "Migrating config: no_broadcast=" << loaded["no_broadcast"]
+                      << " -> broadcast=" << merged["broadcast"] << std::endl;
+        }
+        merged.erase("no_broadcast");
+        migrated = true;
+    }
+
     if (migrated) {
         // Log migration details for user visibility.
         if (original_version < config_get_version(defaults)) {

--- a/src/cpp/server/main.cpp
+++ b/src/cpp/server/main.cpp
@@ -88,14 +88,21 @@ int main(int argc, char** argv) {
             config_json["host"] = cli_config.host;
             cli_overrides = true;
         }
+
+        if (cli_overrides) {
+            ConfigFile::save(cli_config.cache_dir, config_json);
+        }
+
         auto config = std::make_shared<RuntimeConfig>(config_json);
+        if (cli_config.broadcast.has_value()) {
+            config->set_broadcast_override(cli_config.broadcast);
+        }
         RuntimeConfig::set_global(config.get());
 
         // Initialize logging with the configured level — console + file + log hub
         configure_application_logging(config->log_level(), LoggingMode::direct_server);
 
         if (cli_overrides) {
-            ConfigFile::save(cli_config.cache_dir, config_json);
             if (cli_config.port != -1) {
                 LOG(INFO) << "Persisted port=" << cli_config.port << " to config.json" << std::endl;
             }

--- a/src/cpp/server/runtime_config.cpp
+++ b/src/cpp/server/runtime_config.cpp
@@ -114,14 +114,21 @@ static std::pair<json, std::string> normalize_config_set_changes(const json& cha
         LOG(WARNING) << message << std::endl;
     }
 
+    // Reject conflicting broadcast options
+    if (normalized.contains("broadcast") && normalized.contains("no_broadcast")) {
+        throw std::invalid_argument("Cannot specify both 'broadcast' and 'no_broadcast'");
+    }
+
+    if (normalized.contains("broadcast") && !normalized["broadcast"].is_boolean()) {
+        throw std::invalid_argument("'broadcast' must be a boolean");
+    }
+
     // Migrate legacy no_broadcast to broadcast
     if (normalized.contains("no_broadcast")) {
         if (!normalized["no_broadcast"].is_boolean()) {
             throw std::invalid_argument("'no_broadcast' must be a boolean");
         }
-        if (!normalized.contains("broadcast")) {
-            normalized["broadcast"] = !normalized["no_broadcast"].get<bool>();
-        }
+        normalized["broadcast"] = !normalized["no_broadcast"].get<bool>();
         normalized.erase("no_broadcast");
     }
 
@@ -252,9 +259,15 @@ void RuntimeConfig::validate_bin_path(const std::string& config_section,
 
 RuntimeConfig::RuntimeConfig(const json& config)
     : config_(config) {
+    if (config_.contains("broadcast") && !config_["broadcast"].is_boolean()) {
+        throw std::invalid_argument("'broadcast' must be a boolean");
+    }
     // Migrate legacy no_broadcast if present
     if (config_.contains("no_broadcast")) {
-        if (!config_.contains("broadcast") && config_["no_broadcast"].is_boolean()) {
+        if (!config_["no_broadcast"].is_boolean()) {
+            throw std::invalid_argument("'no_broadcast' must be a boolean");
+        }
+        if (!config_.contains("broadcast")) {
             config_["broadcast"] = !config_["no_broadcast"].get<bool>();
         }
         config_.erase("no_broadcast");
@@ -950,17 +963,24 @@ void RuntimeConfig::apply_changes(const json& changes, json& applied_diff) {
             }
         } else if (key == "no_broadcast") {
             bool bcast = !value.get<bool>();
-            if (!config_.contains("broadcast") || config_["broadcast"] != bcast) {
-                config_["broadcast"] = bcast;
+            bool prev_effective_bcast = (broadcast_override_.has_value())
+                ? *broadcast_override_
+                : (config_.contains("broadcast") && config_["broadcast"].is_boolean() ? config_["broadcast"].get<bool>() : true);
+            config_["broadcast"] = bcast;
+            broadcast_override_ = std::nullopt;
+            if (prev_effective_bcast != bcast) {
                 applied_diff["broadcast"] = bcast;
             }
-            broadcast_override_ = std::nullopt;
         } else if (key == "broadcast") {
-            if (!config_.contains("broadcast") || config_["broadcast"] != value) {
-                config_["broadcast"] = value;
-                applied_diff["broadcast"] = value;
-            }
+            bool bcast = value.get<bool>();
+            bool prev_effective_bcast = (broadcast_override_.has_value())
+                ? *broadcast_override_
+                : (config_.contains("broadcast") && config_["broadcast"].is_boolean() ? config_["broadcast"].get<bool>() : true);
+            config_["broadcast"] = bcast;
             broadcast_override_ = std::nullopt;
+            if (prev_effective_bcast != bcast) {
+                applied_diff["broadcast"] = bcast;
+            }
         } else {
             if (!config_.contains(key) || config_[key] != value) {
                 config_[key] = value;

--- a/src/cpp/server/runtime_config.cpp
+++ b/src/cpp/server/runtime_config.cpp
@@ -114,6 +114,17 @@ static std::pair<json, std::string> normalize_config_set_changes(const json& cha
         LOG(WARNING) << message << std::endl;
     }
 
+    // Migrate legacy no_broadcast to broadcast
+    if (normalized.contains("no_broadcast")) {
+        if (!normalized["no_broadcast"].is_boolean()) {
+            throw std::invalid_argument("'no_broadcast' must be a boolean");
+        }
+        if (!normalized.contains("broadcast")) {
+            normalized["broadcast"] = !normalized["no_broadcast"].get<bool>();
+        }
+        normalized.erase("no_broadcast");
+    }
+
     // Promote flat backend keys (e.g. "vllm_args", "llamacpp_backend") into
     // their nested form ("vllm": {"args": ...}). Backend CLI flags and docs use
     // the flat underscore form, but config.json stores backend options nested.
@@ -241,7 +252,13 @@ void RuntimeConfig::validate_bin_path(const std::string& config_section,
 
 RuntimeConfig::RuntimeConfig(const json& config)
     : config_(config) {
-    // Config is expected to already have defaults merged in (by ConfigFile::load).
+    // Migrate legacy no_broadcast if present
+    if (config_.contains("no_broadcast")) {
+        if (!config_.contains("broadcast") && config_["no_broadcast"].is_boolean()) {
+            config_["broadcast"] = !config_["no_broadcast"].get<bool>();
+        }
+        config_.erase("no_broadcast");
+    }
 
     // In CI mode, override log level to debug for easier diagnostics
     const char* ci_mode = std::getenv("LEMONADE_CI_MODE");

--- a/src/cpp/server/runtime_config.cpp
+++ b/src/cpp/server/runtime_config.cpp
@@ -280,9 +280,23 @@ std::string RuntimeConfig::extra_models_dir() const {
     return config_["extra_models_dir"].get<std::string>();
 }
 
-bool RuntimeConfig::no_broadcast() const {
+bool RuntimeConfig::broadcast() const {
     std::shared_lock lock(mutex_);
-    return config_["no_broadcast"].get<bool>();
+    if (broadcast_override_.has_value()) {
+        return *broadcast_override_;
+    }
+    if (config_.contains("broadcast") && config_["broadcast"].is_boolean()) {
+        return config_["broadcast"].get<bool>();
+    }
+    if (config_.contains("no_broadcast") && config_["no_broadcast"].is_boolean()) {
+        return !config_["no_broadcast"].get<bool>();
+    }
+    return true;
+}
+
+void RuntimeConfig::set_broadcast_override(std::optional<bool> override_val) {
+    std::unique_lock lock(mutex_);
+    broadcast_override_ = override_val;
 }
 
 long RuntimeConfig::global_timeout() const {
@@ -619,7 +633,7 @@ void RuntimeConfig::validate(const std::string& key, const json& value) const {
             throw std::invalid_argument(
                 "'default_model_source' must be either 'huggingface', or 'modelscope'");
         }
-    } else if (key == "no_broadcast" || key == "offline" ||
+    } else if (key == "broadcast" || key == "no_broadcast" || key == "offline" ||
                key == "auto_check_model_updates" ||
                key == "no_fetch_executables" ||
                key == "disable_model_filtering" || key == "enable_dgpu_gtt") {
@@ -917,6 +931,19 @@ void RuntimeConfig::apply_changes(const json& changes, json& applied_diff) {
                     }
                 }
             }
+        } else if (key == "no_broadcast") {
+            bool bcast = !value.get<bool>();
+            if (!config_.contains("broadcast") || config_["broadcast"] != bcast) {
+                config_["broadcast"] = bcast;
+                applied_diff["broadcast"] = bcast;
+            }
+            broadcast_override_ = std::nullopt;
+        } else if (key == "broadcast") {
+            if (!config_.contains("broadcast") || config_["broadcast"] != value) {
+                config_["broadcast"] = value;
+                applied_diff["broadcast"] = value;
+            }
+            broadcast_override_ = std::nullopt;
         } else {
             if (!config_.contains(key) || config_[key] != value) {
                 config_[key] = value;

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -2043,8 +2043,8 @@ void Server::run() {
         // Enumerate all RFC1918 interfaces to determine if we can broadcast.
         // The beacon will send per-interface with the correct IP in the payload.
         auto rfc1918Interfaces = udp_beacon_.getLocalRFC1918Interfaces();
-        bool no_bcast = config_->no_broadcast();
-        if (!rfc1918Interfaces.empty() && !no_bcast) {
+        bool bcast = config_->broadcast();
+        if (!rfc1918Interfaces.empty() && bcast) {
             std::cout << "[Server] [Net Broadcast] Broadcasting on " << rfc1918Interfaces.size()
                       << " RFC1918 interface(s):";
             for (const auto& iface : rfc1918Interfaces) {
@@ -2056,8 +2056,8 @@ void Server::run() {
                 port_,
                 2
             );
-        } else if (!rfc1918Interfaces.empty() && no_bcast) {
-            LOG(INFO, "Server") << "Broadcasting disabled by --no-broadcast option" << std::endl;
+        } else if (!rfc1918Interfaces.empty() && !bcast) {
+            LOG(INFO, "Server") << "Broadcasting disabled by configuration or CLI option" << std::endl;
         } else {
             LOG(INFO, "Server") << "Unable to broadcast my existance please use a RFC1918 IPv4," << std::endl
                         << "or hostname that resolves to RFC1918 IPv4." << std::endl;
@@ -7004,10 +7004,10 @@ void Server::apply_config_side_effects(const json& applied_changes) {
             long timeout = config_->global_timeout();
             LOG(INFO, "Server") << "Global timeout changed to: " << timeout << "s" << std::endl;
             utils::HttpClient::set_default_timeout(timeout);
-        } else if (key == "no_broadcast") {
-            bool nb = config_->no_broadcast();
-            LOG(INFO, "Server") << "Broadcast " << (nb ? "disabled" : "enabled") << std::endl;
-            if (nb) {
+        } else if (key == "broadcast" || key == "no_broadcast") {
+            bool bcast = config_->broadcast();
+            LOG(INFO, "Server") << "Broadcast " << (bcast ? "enabled" : "disabled") << std::endl;
+            if (!bcast) {
                 udp_beacon_.stopBroadcasting();
             } else {
                 auto rfc1918Interfaces = udp_beacon_.getLocalRFC1918Interfaces();

--- a/test/cpp/test_config_discovery.cpp
+++ b/test/cpp/test_config_discovery.cpp
@@ -34,11 +34,16 @@ int main() {
     config.set({{"broadcast", true}});
     check(config.broadcast() == true, "broadcast updated to true");
 
-    // 2. Test legacy no_broadcast alias mapping
+    // 2. Test legacy no_broadcast alias mapping via set()
     config.set({{"no_broadcast", true}});
     check(config.broadcast() == false, "legacy no_broadcast: true sets broadcast to false");
+    check(config.snapshot()["broadcast"] == false, "snapshot contains broadcast: false");
+    check(!config.snapshot().contains("no_broadcast"), "snapshot does not contain legacy no_broadcast");
+
     config.set({{"no_broadcast", false}});
     check(config.broadcast() == true, "legacy no_broadcast: false sets broadcast to true");
+    check(config.snapshot()["broadcast"] == true, "snapshot contains broadcast: true");
+    check(!config.snapshot().contains("no_broadcast"), "snapshot does not contain legacy no_broadcast");
 
     // 3. Validation: rejects non-boolean values
     bool threw_invalid_broadcast = false;
@@ -94,6 +99,29 @@ int main() {
     check(server_parser_3.parse(1, const_cast<char**>(argv3)) == 0, "CLIParser parses default invocation");
     check(!server_parser_3.get_config().broadcast.has_value(),
           "default invocation leaves broadcast unset (nullopt)");
+
+    // 8. Test legacy constructor JSON migration
+    json legacy_cfg_true = {
+        {"config_version", 2},
+        {"port", 13305},
+        {"host", "localhost"},
+        {"no_broadcast", true}
+    };
+    RuntimeConfig config_legacy_true(legacy_cfg_true);
+    check(config_legacy_true.broadcast() == false, "legacy no_broadcast: true migrates to broadcast: false in ctor");
+    check(config_legacy_true.snapshot()["broadcast"] == false, "snapshot has broadcast: false");
+    check(!config_legacy_true.snapshot().contains("no_broadcast"), "legacy no_broadcast removed from snapshot");
+
+    json legacy_cfg_false = {
+        {"config_version", 2},
+        {"port", 13305},
+        {"host", "localhost"},
+        {"no_broadcast", false}
+    };
+    RuntimeConfig config_legacy_false(legacy_cfg_false);
+    check(config_legacy_false.broadcast() == true, "legacy no_broadcast: false migrates to broadcast: true in ctor");
+    check(config_legacy_false.snapshot()["broadcast"] == true, "snapshot has broadcast: true");
+    check(!config_legacy_false.snapshot().contains("no_broadcast"), "legacy no_broadcast removed from snapshot");
 
     return test_helpers::report_results("C++ config/discovery");
 }

--- a/test/cpp/test_config_discovery.cpp
+++ b/test/cpp/test_config_discovery.cpp
@@ -181,5 +181,64 @@ int main() {
     }
     fs::remove_all(temp_test_dir);
 
+    // 9. Test deployment defaults (LEMONADE_DEFAULTS_PATH) with legacy no_broadcast: true
+    fs::path temp_defaults_dir = fs::temp_directory_path() / ("lemonade_test_defaults_" + std::to_string(std::time(nullptr)));
+    fs::create_directories(temp_defaults_dir);
+
+    try {
+        fs::path defaults_file = temp_defaults_dir / "custom_defaults.json";
+        {
+            std::ofstream out(defaults_file);
+            out << "{\"no_broadcast\": true}\n";
+        }
+
+#ifdef _WIN32
+        _putenv_s("LEMONADE_DEFAULTS_PATH", defaults_file.string().c_str());
+#else
+        setenv("LEMONADE_DEFAULTS_PATH", defaults_file.string().c_str(), 1);
+#endif
+
+        json defaults = ConfigFile::get_defaults();
+        check(defaults["broadcast"] == false, "LEMONADE_DEFAULTS_PATH legacy no_broadcast: true overrides broadcast to false");
+        check(!defaults.contains("no_broadcast"), "LEMONADE_DEFAULTS_PATH removes legacy no_broadcast from defaults object");
+
+        // When user creates a fresh config under these defaults, broadcast is false
+        fs::path fresh_cache_dir = temp_defaults_dir / "cache";
+        json fresh_loaded = ConfigFile::load(fresh_cache_dir.string());
+        check(fresh_loaded["broadcast"] == false, "fresh config inherited broadcast=false from deployment defaults");
+
+#ifdef _WIN32
+        _putenv_s("LEMONADE_DEFAULTS_PATH", "");
+#else
+        unsetenv("LEMONADE_DEFAULTS_PATH");
+#endif
+    } catch (const std::exception& e) {
+        check(false, (std::string("LEMONADE_DEFAULTS_PATH test failed: ") + e.what()).c_str());
+    }
+    fs::remove_all(temp_defaults_dir);
+
+    // 10. Test that malformed legacy values in config.json are rejected
+    fs::path malformed_dir = fs::temp_directory_path() / ("lemonade_test_malformed_" + std::to_string(std::time(nullptr)));
+    fs::create_directories(malformed_dir);
+
+    try {
+        fs::path cfg_file = malformed_dir / "config.json";
+        {
+            std::ofstream out(cfg_file);
+            out << "{\"config_version\": 2, \"port\": 13305, \"no_broadcast\": \"true\"}\n";
+        }
+
+        bool threw_malformed = false;
+        try {
+            ConfigFile::load(malformed_dir.string());
+        } catch (const std::invalid_argument&) {
+            threw_malformed = true;
+        }
+        check(threw_malformed, "ConfigFile::load rejects malformed non-boolean no_broadcast string");
+    } catch (const std::exception& e) {
+        check(false, (std::string("malformed test failed: ") + e.what()).c_str());
+    }
+    fs::remove_all(malformed_dir);
+
     return test_helpers::report_results("C++ config/discovery");
 }

--- a/test/cpp/test_config_discovery.cpp
+++ b/test/cpp/test_config_discovery.cpp
@@ -1,4 +1,6 @@
 #include <cstdio>
+#include <filesystem>
+#include <fstream>
 #include <iostream>
 #include <stdexcept>
 #include <string>
@@ -6,14 +8,16 @@
 
 #include <nlohmann/json.hpp>
 #include <lemon/cli_parser.h>
+#include <lemon/config_file.h>
 #include <lemon/runtime_config.h>
 
 #include "test_config_helpers.h"
 
+namespace fs = std::filesystem;
 using json = nlohmann::json;
+using lemon::ConfigFile;
 using lemon::RuntimeConfig;
 using test_helpers::check;
-using test_helpers::parse_cli_args;
 
 int main() {
     std::puts("=== RUNNING RUNTIME CONFIG DISCOVERY TESTS ===");
@@ -45,7 +49,7 @@ int main() {
     check(config.snapshot()["broadcast"] == true, "snapshot contains broadcast: true");
     check(!config.snapshot().contains("no_broadcast"), "snapshot does not contain legacy no_broadcast");
 
-    // 3. Validation: rejects non-boolean values
+    // 3. Validation: rejects non-boolean values and conflicting keys
     bool threw_invalid_broadcast = false;
     try {
         config.set({{"broadcast", "not-a-bool"}});
@@ -62,26 +66,54 @@ int main() {
     }
     check(threw_invalid_no_broadcast, "rejects non-boolean no_broadcast");
 
+    bool threw_conflicting = false;
+    try {
+        config.set({{"broadcast", true}, {"no_broadcast", false}});
+    } catch (const std::invalid_argument& e) {
+        threw_conflicting = true;
+    }
+    check(threw_conflicting, "rejects conflicting broadcast and no_broadcast in set()");
+
     // 4. Test transient override does NOT leak into snapshot()
     config.set({{"broadcast", true}});
     config.set_broadcast_override(false);
     check(config.broadcast() == false, "broadcast_override(false) takes effect at runtime");
     check(config.snapshot()["broadcast"] == true, "broadcast_override does NOT mutate snapshot()");
 
-    // 5. Explicit set() clears transient override
+    // 5. Override -> config set transition and side-effect callback firing
+    // Case A: Persisted broadcast=false, startup override=true, user sets broadcast=false
+    config.set({{"broadcast", false}});
+    config.set_broadcast_override(true);
+    check(config.broadcast() == true, "effective broadcast is true due to override");
+
+    bool side_effect_fired_a = false;
+    json side_effect_diff_a = json::object();
+    config.set({{"broadcast", false}}, [&](const json& diff) {
+        side_effect_fired_a = true;
+        side_effect_diff_a = diff;
+    });
+    check(config.broadcast() == false, "broadcast becomes false after set()");
+    check(side_effect_fired_a, "side-effect callback fires when effective broadcast changes (override cleared)");
+    check(side_effect_diff_a.contains("broadcast") && side_effect_diff_a["broadcast"] == false,
+          "applied_diff reflects broadcast change from override true -> false");
+
+    // Case B: Persisted broadcast=true, startup override=false, user sets broadcast=true
     config.set({{"broadcast", true}});
-    check(config.broadcast() == true, "explicit set() clears override and applies new value");
+    config.set_broadcast_override(false);
+    check(config.broadcast() == false, "effective broadcast is false due to override");
 
-    // 6. Test CLI parsing of broadcast and no-broadcast
-    std::vector<std::string> cli_args = {
-        "broadcast=false",
-        "no-broadcast=true"
-    };
-    json cli_updates = parse_cli_args(cli_args);
-    check(cli_updates["broadcast"] == false, "CLI parses broadcast=false");
-    check(cli_updates["no_broadcast"] == true, "CLI parses and normalizes no-broadcast to no_broadcast");
+    bool side_effect_fired_b = false;
+    json side_effect_diff_b = json::object();
+    config.set({{"broadcast", true}}, [&](const json& diff) {
+        side_effect_fired_b = true;
+        side_effect_diff_b = diff;
+    });
+    check(config.broadcast() == true, "broadcast becomes true after set()");
+    check(side_effect_fired_b, "side-effect callback fires when effective broadcast changes (override cleared)");
+    check(side_effect_diff_b.contains("broadcast") && side_effect_diff_b["broadcast"] == true,
+          "applied_diff reflects broadcast change from override false -> true");
 
-    // 7. Test Server CLI parser flags
+    // 6. Test Server CLI parser flags
     lemon::CLIParser server_parser_1;
     const char* argv1[] = {"lemond", "--no-broadcast"};
     check(server_parser_1.parse(2, const_cast<char**>(argv1)) == 0, "CLIParser parses --no-broadcast");
@@ -100,7 +132,7 @@ int main() {
     check(!server_parser_3.get_config().broadcast.has_value(),
           "default invocation leaves broadcast unset (nullopt)");
 
-    // 8. Test legacy constructor JSON migration
+    // 7. Test legacy constructor JSON migration
     json legacy_cfg_true = {
         {"config_version", 2},
         {"port", 13305},
@@ -122,6 +154,32 @@ int main() {
     check(config_legacy_false.broadcast() == true, "legacy no_broadcast: false migrates to broadcast: true in ctor");
     check(config_legacy_false.snapshot()["broadcast"] == true, "snapshot has broadcast: true");
     check(!config_legacy_false.snapshot().contains("no_broadcast"), "legacy no_broadcast removed from snapshot");
+
+    // 8. Test real ConfigFile::load() and save() migration on disk
+    fs::path temp_test_dir = fs::temp_directory_path() / ("lemonade_test_discovery_" + std::to_string(std::time(nullptr)));
+    fs::create_directories(temp_test_dir);
+
+    try {
+        // Write initial config with legacy no_broadcast: true
+        fs::path cfg_file = temp_test_dir / "config.json";
+        {
+            std::ofstream out(cfg_file);
+            out << "{\"config_version\": 2, \"port\": 13305, \"host\": \"localhost\", \"no_broadcast\": true}\n";
+        }
+
+        json loaded = ConfigFile::load(temp_test_dir.string());
+        check(loaded["broadcast"] == false, "ConfigFile::load migrates legacy no_broadcast: true to broadcast: false");
+        check(!loaded.contains("no_broadcast"), "ConfigFile::load removes legacy no_broadcast from in-memory object");
+
+        // Verify disk file was saved with migrated keys
+        std::ifstream saved_in(cfg_file);
+        json saved_disk = json::parse(saved_in);
+        check(saved_disk["broadcast"] == false, "saved disk config.json contains broadcast: false");
+        check(!saved_disk.contains("no_broadcast"), "saved disk config.json does not contain no_broadcast");
+    } catch (const std::exception& e) {
+        check(false, (std::string("ConfigFile::load disk migration failed: ") + e.what()).c_str());
+    }
+    fs::remove_all(temp_test_dir);
 
     return test_helpers::report_results("C++ config/discovery");
 }

--- a/test/cpp/test_config_discovery.cpp
+++ b/test/cpp/test_config_discovery.cpp
@@ -1,0 +1,99 @@
+#include <cstdio>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+#include <lemon/cli_parser.h>
+#include <lemon/runtime_config.h>
+
+#include "test_config_helpers.h"
+
+using json = nlohmann::json;
+using lemon::RuntimeConfig;
+using test_helpers::check;
+using test_helpers::parse_cli_args;
+
+int main() {
+    std::puts("=== RUNNING RUNTIME CONFIG DISCOVERY TESTS ===");
+
+    json base_cfg = {
+        {"config_version", 2},
+        {"port", 13305},
+        {"host", "localhost"},
+        {"broadcast", true}
+    };
+
+    RuntimeConfig config(base_cfg);
+
+    // 1. Test broadcast initial value and updates
+    check(config.broadcast() == true, "initial broadcast is true");
+    config.set({{"broadcast", false}});
+    check(config.broadcast() == false, "broadcast updated to false");
+    config.set({{"broadcast", true}});
+    check(config.broadcast() == true, "broadcast updated to true");
+
+    // 2. Test legacy no_broadcast alias mapping
+    config.set({{"no_broadcast", true}});
+    check(config.broadcast() == false, "legacy no_broadcast: true sets broadcast to false");
+    config.set({{"no_broadcast", false}});
+    check(config.broadcast() == true, "legacy no_broadcast: false sets broadcast to true");
+
+    // 3. Validation: rejects non-boolean values
+    bool threw_invalid_broadcast = false;
+    try {
+        config.set({{"broadcast", "not-a-bool"}});
+    } catch (const std::invalid_argument& e) {
+        threw_invalid_broadcast = true;
+    }
+    check(threw_invalid_broadcast, "rejects non-boolean broadcast");
+
+    bool threw_invalid_no_broadcast = false;
+    try {
+        config.set({{"no_broadcast", 123}});
+    } catch (const std::invalid_argument& e) {
+        threw_invalid_no_broadcast = true;
+    }
+    check(threw_invalid_no_broadcast, "rejects non-boolean no_broadcast");
+
+    // 4. Test transient override does NOT leak into snapshot()
+    config.set({{"broadcast", true}});
+    config.set_broadcast_override(false);
+    check(config.broadcast() == false, "broadcast_override(false) takes effect at runtime");
+    check(config.snapshot()["broadcast"] == true, "broadcast_override does NOT mutate snapshot()");
+
+    // 5. Explicit set() clears transient override
+    config.set({{"broadcast", true}});
+    check(config.broadcast() == true, "explicit set() clears override and applies new value");
+
+    // 6. Test CLI parsing of broadcast and no-broadcast
+    std::vector<std::string> cli_args = {
+        "broadcast=false",
+        "no-broadcast=true"
+    };
+    json cli_updates = parse_cli_args(cli_args);
+    check(cli_updates["broadcast"] == false, "CLI parses broadcast=false");
+    check(cli_updates["no_broadcast"] == true, "CLI parses and normalizes no-broadcast to no_broadcast");
+
+    // 7. Test Server CLI parser flags
+    lemon::CLIParser server_parser_1;
+    const char* argv1[] = {"lemond", "--no-broadcast"};
+    check(server_parser_1.parse(2, const_cast<char**>(argv1)) == 0, "CLIParser parses --no-broadcast");
+    check(server_parser_1.get_config().broadcast.has_value() && *server_parser_1.get_config().broadcast == false,
+          "--no-broadcast sets broadcast to false");
+
+    lemon::CLIParser server_parser_2;
+    const char* argv2[] = {"lemond", "--broadcast"};
+    check(server_parser_2.parse(2, const_cast<char**>(argv2)) == 0, "CLIParser parses --broadcast");
+    check(server_parser_2.get_config().broadcast.has_value() && *server_parser_2.get_config().broadcast == true,
+          "--broadcast sets broadcast to true");
+
+    lemon::CLIParser server_parser_3;
+    const char* argv3[] = {"lemond"};
+    check(server_parser_3.parse(1, const_cast<char**>(argv3)) == 0, "CLIParser parses default invocation");
+    check(!server_parser_3.get_config().broadcast.has_value(),
+          "default invocation leaves broadcast unset (nullopt)");
+
+    return test_helpers::report_results("C++ config/discovery");
+}

--- a/test/cpp/test_config_helpers.h
+++ b/test/cpp/test_config_helpers.h
@@ -1,0 +1,112 @@
+#pragma once
+
+#include <algorithm>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+
+namespace test_helpers {
+
+inline int passed = 0;
+inline int failures = 0;
+
+inline void check(bool cond, const char* desc) {
+    if (cond) {
+        std::printf("[PASS] %s\n", desc);
+        ++passed;
+    } else {
+        std::printf("[FAIL] %s\n", desc);
+        ++failures;
+    }
+}
+
+inline void reset_counts() {
+    passed = 0;
+    failures = 0;
+}
+
+inline int report_results(const char* suite_name) {
+    std::printf("================================================\n");
+    if (failures > 0) {
+        std::printf("Tests finished: %d FAILURE(S)\n", failures);
+        return 1;
+    } else {
+        std::printf("All %s tests PASSED (%d passed).\n", suite_name, passed);
+        return 0;
+    }
+}
+
+// Replicate CLI parser logic to test it unit-wise
+inline nlohmann::json parse_cli_args(const std::vector<std::string>& args) {
+    auto normalize_key = [](std::string s) {
+        std::replace(s.begin(), s.end(), '-', '_');
+        return s;
+    };
+    auto parse_typed_value = [](const std::string& val) -> nlohmann::json {
+        if (!val.empty() && (val.front() == '[' || val.front() == '{')) {
+            auto parsed = nlohmann::json::parse(val, nullptr, false);
+            if (!parsed.is_discarded()) {
+                return parsed;
+            }
+        }
+        if (val == "true") return true;
+        if (val == "false") return false;
+        try {
+            size_t idx;
+            int i = std::stoi(val, &idx);
+            if (idx == val.size()) return i;
+        } catch (...) {}
+        try {
+            size_t idx;
+            double d = std::stod(val, &idx);
+            if (idx == val.size()) return d;
+        } catch (...) {}
+        return val;
+    };
+
+    nlohmann::json updates = nlohmann::json::object();
+    for (const auto& arg : args) {
+        size_t eq_pos = arg.find('=');
+        if (eq_pos == std::string::npos || eq_pos == 0) continue;
+        std::string key = arg.substr(0, eq_pos);
+        std::string value = arg.substr(eq_pos + 1);
+
+        std::vector<std::string> path;
+        size_t last_pos = 0;
+        while (true) {
+            size_t next_dot = key.find('.', last_pos);
+            if (next_dot == std::string::npos) {
+                std::string part = key.substr(last_pos);
+                if (!part.empty()) {
+                    path.push_back(normalize_key(part));
+                }
+                break;
+            }
+            std::string part = key.substr(last_pos, next_dot - last_pos);
+            if (!part.empty()) {
+                path.push_back(normalize_key(part));
+            }
+            last_pos = next_dot + 1;
+        }
+
+        if (path.empty()) continue;
+
+        nlohmann::json* current = &updates;
+        for (size_t i = 0; i < path.size(); ++i) {
+            const std::string& k = path[i];
+            if (i == path.size() - 1) {
+                (*current)[k] = parse_typed_value(value);
+            } else {
+                if (!current->contains(k) || !(*current)[k].is_object()) {
+                    (*current)[k] = nlohmann::json::object();
+                }
+                current = &((*current)[k]);
+            }
+        }
+    }
+    return updates;
+}
+
+} // namespace test_helpers

--- a/test/cpp/test_config_telemetry.cpp
+++ b/test/cpp/test_config_telemetry.cpp
@@ -1,105 +1,22 @@
-#include <cassert>
 #include <cstdio>
 #include <iostream>
 #include <stdexcept>
-#include <unordered_set>
-#include <vector>
 #include <string>
-#include <algorithm>
+#include <vector>
+
 #include <nlohmann/json.hpp>
 #include <lemon/runtime_config.h>
 
+#include "test_config_helpers.h"
+
 using json = nlohmann::json;
 using lemon::RuntimeConfig;
-
-static int passed = 0;
-static int failures = 0;
-
-static void check(bool cond, const char* desc) {
-    if (cond) {
-        std::printf("[PASS] %s\n", desc);
-        ++passed;
-    } else {
-        std::printf("[FAIL] %s\n", desc);
-        ++failures;
-    }
-}
-
-// Replicate CLI parser logic to test it unit-wise
-static json parse_cli_args(const std::vector<std::string>& args) {
-    auto normalize_key = [](std::string s) {
-        std::replace(s.begin(), s.end(), '-', '_');
-        return s;
-    };
-    auto parse_typed_value = [](const std::string& val) -> json {
-        if (!val.empty() && (val.front() == '[' || val.front() == '{')) {
-            auto parsed = json::parse(val, nullptr, false);
-            if (!parsed.is_discarded()) {
-                return parsed;
-            }
-        }
-        if (val == "true") return true;
-        if (val == "false") return false;
-        try {
-            size_t idx;
-            int i = std::stoi(val, &idx);
-            if (idx == val.size()) return i;
-        } catch (...) {}
-        try {
-            size_t idx;
-            double d = std::stod(val, &idx);
-            if (idx == val.size()) return d;
-        } catch (...) {}
-        return val;
-    };
-
-    json updates = json::object();
-    for (const auto& arg : args) {
-        size_t eq_pos = arg.find('=');
-        if (eq_pos == std::string::npos || eq_pos == 0) continue;
-        std::string key = arg.substr(0, eq_pos);
-        std::string value = arg.substr(eq_pos + 1);
-
-        std::vector<std::string> path;
-        size_t last_pos = 0;
-        while (true) {
-            size_t next_dot = key.find('.', last_pos);
-            if (next_dot == std::string::npos) {
-                std::string part = key.substr(last_pos);
-                if (!part.empty()) {
-                    path.push_back(normalize_key(part));
-                }
-                break;
-            }
-            std::string part = key.substr(last_pos, next_dot - last_pos);
-            if (!part.empty()) {
-                path.push_back(normalize_key(part));
-            }
-            last_pos = next_dot + 1;
-        }
-
-        if (path.empty()) continue;
-
-        json* current = &updates;
-        for (size_t i = 0; i < path.size(); ++i) {
-            const std::string& k = path[i];
-            if (i == path.size() - 1) {
-                (*current)[k] = parse_typed_value(value);
-            } else {
-                if (!current->contains(k) || !(*current)[k].is_object()) {
-                    (*current)[k] = json::object();
-                }
-                current = &((*current)[k]);
-            }
-        }
-    }
-    return updates;
-}
+using test_helpers::check;
+using test_helpers::parse_cli_args;
 
 int main() {
     std::puts("=== RUNNING RUNTIME CONFIG & TELEMETRY TESTS ===");
 
-    // 1. Initial base config matching defaults
     json base_cfg = {
         {"config_version", 2},
         {"port", 13305},
@@ -125,7 +42,7 @@ int main() {
 
     RuntimeConfig config(base_cfg);
 
-    // 2. Test recursive merge: toggling telemetry should preserve existing otlp.* settings
+    // 1. Test recursive merge: toggling telemetry should preserve existing otlp.* settings
     json toggle_off = {
         {"telemetry", {
             {"enabled", false}
@@ -148,7 +65,7 @@ int main() {
     check(snapshot["telemetry"]["otlp"]["endpoint"] == "http://localhost:4318/v1/traces", "otlp.endpoint preserved on toggle on");
     check(snapshot["telemetry"]["otlp"]["semantics"] == json::array({"openinference", "otel_genai"}), "otlp.semantics preserved on toggle on");
 
-    // 3. Test validation: rejecting unknown telemetry / OTLP subkeys
+    // 2. Test validation: rejecting unknown telemetry / OTLP subkeys
     bool threw_unknown_telemetry = false;
     try {
         json invalid_telemetry = {
@@ -179,6 +96,7 @@ int main() {
     }
     check(threw_unknown_otlp, "rejects unknown telemetry.otlp subkey");
 
+    // 3. Test CLI dotted key config path parsing logic
     std::vector<std::string> cli_args = {
         "telemetry.otlp.endpoint=http://127.0.0.1:5555/v1/traces",
         "telemetry.otlp.protocol=http/json",
@@ -195,12 +113,5 @@ int main() {
     check(cli_updates["telemetry"]["otlp"]["headers"].is_object(), "CLI parses JSON object for headers");
     check(cli_updates["telemetry"]["otlp"]["headers"]["Authorization"] == "Bearer test-key", "CLI parsed object field matches");
 
-    std::printf("================================================\n");
-    if (failures > 0) {
-        std::printf("Tests finished: %d FAILURE(S)\n", failures);
-        return 1;
-    } else {
-        std::printf("All C++ config/telemetry tests PASSED (%d passed).\n", passed);
-        return 0;
-    }
+    return test_helpers::report_results("C++ config/telemetry");
 }

--- a/test/server_cli2.py
+++ b/test/server_cli2.py
@@ -702,6 +702,61 @@ sys.exit(0)
         self.assertEqual(telemetry.get("otlp", {}).get("protocol"), "http/json")
         self.assertEqual(telemetry.get("otlp", {}).get("semantics"), ["openinference"])
 
+    def test_045_config_set_broadcast(self):
+        """Verify that CLI config set can modify broadcast setting, and client CLI works with --discovery / --no-discovery."""
+        try:
+            # 1. Set broadcast to false using the CLI config set
+            result = self.assertCommandSucceeds(
+                [
+                    "config",
+                    "set",
+                    "broadcast=false",
+                ]
+            )
+            print(f"Config set broadcast=false output: {result.stdout}")
+
+            # Verify it is set to false on the server
+            response = requests.get(
+                f"http://localhost:{PORT}/api/v1/params",
+                headers=_auth_headers(),
+                timeout=10,
+            )
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.json().get("broadcast"), False)
+
+            # 2. Set broadcast back to true
+            result = self.assertCommandSucceeds(
+                [
+                    "config",
+                    "set",
+                    "broadcast=true",
+                ]
+            )
+            response = requests.get(
+                f"http://localhost:{PORT}/api/v1/params",
+                headers=_auth_headers(),
+                timeout=10,
+            )
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.json().get("broadcast"), True)
+
+            # 3. Test that the client works with --no-discovery and --discovery flags
+            self.assertCommandSucceeds(
+                [
+                    "--no-discovery",
+                    "status",
+                ]
+            )
+            self.assertCommandSucceeds(
+                [
+                    "--discovery",
+                    "status",
+                ]
+            )
+        finally:
+            # Restore default
+            run_cli_command(["config", "set", "broadcast=true"])
+
     # =============================================================================
     # Pull Tests
     # =============================================================================

--- a/test/server_cli2.py
+++ b/test/server_cli2.py
@@ -708,6 +708,8 @@ sys.exit(0)
             # 1. Set broadcast to false using the CLI config set
             result = self.assertCommandSucceeds(
                 [
+                    "--port",
+                    str(PORT),
                     "config",
                     "set",
                     "broadcast=false",
@@ -727,6 +729,8 @@ sys.exit(0)
             # 2. Set broadcast back to true
             result = self.assertCommandSucceeds(
                 [
+                    "--port",
+                    str(PORT),
                     "config",
                     "set",
                     "broadcast=true",
@@ -743,19 +747,23 @@ sys.exit(0)
             # 3. Test that the client works with --no-discovery and --discovery flags
             self.assertCommandSucceeds(
                 [
+                    "--port",
+                    str(PORT),
                     "--no-discovery",
                     "status",
                 ]
             )
             self.assertCommandSucceeds(
                 [
+                    "--port",
+                    str(PORT),
                     "--discovery",
                     "status",
                 ]
             )
         finally:
             # Restore default
-            run_cli_command(["config", "set", "broadcast=true"])
+            run_cli_command(["--port", str(PORT), "config", "set", "broadcast=true"])
 
     # =============================================================================
     # Pull Tests


### PR DESCRIPTION
Add configuration and CLI controls to enable or disable server UDP beacon broadcasting (`lemond --broadcast` / `--no-broadcast`) and client auto-discovery (`lemonade --discovery` / `--no-discovery`). Broadcast state is configured via a new `broadcast` boolean key (defaulting to `true`) with backward-compatible normalization for `no_broadcast`. Transient CLI startup overrides are isolated in process memory to prevent leaking into persistent `config.json` on dynamic configuration updates.

- **Server CLI (`lemond`)**: Add `--broadcast,!--no-broadcast` with tristate `std::optional<bool>` override semantics.
- **Client CLI (`lemonade`)**: Add `!--discovery,--no-discovery` flags for auto-discovery control.
- **Configuration & Migration**: Add `broadcast: true` to `defaults.json` and `RuntimeConfig`, with automatic on-disk migration of legacy `no_broadcast` in `ConfigFile::load`, dynamic side-effects for runtime beacon start/stop, and backward-compatible input normalization.
- **Persistence Isolation**: Decouple CLI startup overrides from `config.json` persistence via `RuntimeConfig::broadcast_override_`, ensuring `snapshot()` only serializes persistent settings.
- **Tests**: Add unit test suite `test_config_discovery` (`CI ON`), clean up telemetry test boilerplate into shared helper `test_config_helpers.h`, and add integration test `test_045_config_set_broadcast`.