### PR TITLE
fix(gui): chat log position and overlay behavior

### DIFF
--- a/src/app/src/components/ChatView.tsx
+++ b/src/app/src/components/ChatView.tsx
@@ -119,15 +119,24 @@ function getDownloadStoreModule(): Promise<typeof import('../features/downloadMa
   return downloadStoreModulePromise;
 }
 
-const CHAT_LOGS_WIDTH_KEY = 'chat_logs_panel_width';
-const CHAT_LOGS_DEFAULT_WIDTH = 520;
+const CHAT_LOGS_WIDTH_KEY = 'chat_logs_overlay_width_v2';
+const CHAT_LOGS_DEFAULT_WIDTH = 640;
+const CHAT_LOGS_DEFAULT_VIEWPORT_RATIO = 0.60;
 const CHAT_LOGS_MIN_WIDTH = 340;
 const CHAT_LOGS_MAX_WIDTH = 920;
+const CHAT_LOGS_MIN_REVEALED_CHAT_WIDTH = 160;
+const CHAT_RAIL_COLLAPSED_WIDTH = 56;
+const CHAT_RAIL_EXPANDED_WIDTH = 248;
+
+function chatRailWidth(railExpanded = true): number {
+  if (typeof window !== 'undefined' && window.innerWidth <= 768) return 0;
+  return railExpanded ? CHAT_RAIL_EXPANDED_WIDTH : CHAT_RAIL_COLLAPSED_WIDTH;
+}
 
 function maxChatLogsWidthForViewport(railExpanded = true): number {
   if (typeof window === 'undefined') return CHAT_LOGS_MAX_WIDTH;
-  const railWidth = railExpanded ? 280 : 56;
-  const viewportMax = window.innerWidth - railWidth - 380;
+  const availableChatWidth = Math.max(0, window.innerWidth - chatRailWidth(railExpanded));
+  const viewportMax = availableChatWidth - CHAT_LOGS_MIN_REVEALED_CHAT_WIDTH;
   return Math.max(CHAT_LOGS_MIN_WIDTH, Math.min(CHAT_LOGS_MAX_WIDTH, viewportMax));
 }
 
@@ -135,14 +144,31 @@ function clampChatLogsWidth(width: number, railExpanded = true): number {
   return Math.max(CHAT_LOGS_MIN_WIDTH, Math.min(maxChatLogsWidthForViewport(railExpanded), Math.round(width)));
 }
 
+function defaultChatLogsWidth(railExpanded = true): number {
+  if (typeof window === 'undefined') return CHAT_LOGS_DEFAULT_WIDTH;
+  const availableChatWidth = Math.max(0, window.innerWidth - chatRailWidth(railExpanded));
+  const viewportTarget = Math.round(availableChatWidth * CHAT_LOGS_DEFAULT_VIEWPORT_RATIO);
+  return clampChatLogsWidth(Math.max(CHAT_LOGS_DEFAULT_WIDTH, viewportTarget), railExpanded);
+}
+
 function loadChatLogsWidth(): number {
   if (typeof window === 'undefined') return CHAT_LOGS_DEFAULT_WIDTH;
   try {
-    const stored = Number(window.localStorage.getItem(scopedKey(CHAT_LOGS_WIDTH_KEY)));
-    const width = Number.isFinite(stored) ? stored : CHAT_LOGS_DEFAULT_WIDTH;
-    return clampChatLogsWidth(width, true);
+    const raw = window.localStorage.getItem(scopedKey(CHAT_LOGS_WIDTH_KEY));
+    const stored = raw === null ? Number.NaN : Number(raw);
+    return Number.isFinite(stored)
+      ? Math.max(CHAT_LOGS_MIN_WIDTH, Math.min(CHAT_LOGS_MAX_WIDTH, Math.round(stored)))
+      : defaultChatLogsWidth(true);
   } catch {
-    return clampChatLogsWidth(CHAT_LOGS_DEFAULT_WIDTH, true);
+    return defaultChatLogsWidth(true);
+  }
+}
+
+function persistChatLogsWidth(width: number): void {
+  try {
+    window.localStorage.setItem(scopedKey(CHAT_LOGS_WIDTH_KEY), String(Math.round(width)));
+  } catch {
+    // Non-critical: log overlay width persistence is best-effort only.
   }
 }
 
@@ -901,32 +927,26 @@ const ChatView: React.FC<ChatViewProps> = ({ currentModel: selectedModel, loaded
     return () => { cancelled = true; };
   }, [connectionStatus]);
 
-  useEffect(() => {
-    try {
-      window.localStorage.setItem(scopedKey(CHAT_LOGS_WIDTH_KEY), String(chatLogsWidth));
-    } catch {
-      // Non-critical: inline log width persistence is best-effort only.
-    }
-  }, [chatLogsWidth]);
-
+  const effectiveChatLogsWidth = clampChatLogsWidth(chatLogsWidth, railExpanded);
   const chatLayoutStyle = useMemo(() => ({
-    '--chat-logs-width': `${chatLogsWidth}px`,
-  } as React.CSSProperties), [chatLogsWidth]);
+    '--chat-logs-width': `${effectiveChatLogsWidth}px`,
+  } as React.CSSProperties), [effectiveChatLogsWidth]);
 
   const handleChatLogsResizeStart = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
     if (window.innerWidth <= 980) return;
     event.preventDefault();
 
     const startX = event.clientX;
-    const startWidth = chatLogsWidth;
+    const startWidth = clampChatLogsWidth(chatLogsWidth, railExpanded);
+    let latestWidth = startWidth;
     const handle = event.currentTarget;
     try { handle.setPointerCapture(event.pointerId); } catch { /* ignore */ }
 
     const handlePointerMove = (moveEvent: PointerEvent) => {
       // The handle sits on the left edge of the logs panel: dragging left makes
       // the panel wider, dragging right makes it narrower.
-      const nextWidth = clampChatLogsWidth(startWidth - (moveEvent.clientX - startX), railExpanded);
-      setChatLogsWidth(nextWidth);
+      latestWidth = clampChatLogsWidth(startWidth - (moveEvent.clientX - startX), railExpanded);
+      setChatLogsWidth(latestWidth);
     };
 
     const stopResize = () => {
@@ -934,6 +954,7 @@ const ChatView: React.FC<ChatViewProps> = ({ currentModel: selectedModel, loaded
       window.removeEventListener('pointerup', stopResize);
       window.removeEventListener('pointercancel', stopResize);
       document.body.classList.remove('is-resizing-chat-logs');
+      persistChatLogsWidth(latestWidth);
       try { handle.releasePointerCapture(event.pointerId); } catch { /* ignore */ }
     };
 
@@ -945,20 +966,27 @@ const ChatView: React.FC<ChatViewProps> = ({ currentModel: selectedModel, loaded
 
   const handleChatLogsResizeKeyDown = useCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
     const step = event.shiftKey ? 48 : 20;
+    const currentWidth = clampChatLogsWidth(chatLogsWidth, railExpanded);
+    let nextWidth: number | null = null;
     if (event.key === 'ArrowLeft') {
       event.preventDefault();
-      setChatLogsWidth(width => clampChatLogsWidth(width + step, railExpanded));
+      nextWidth = clampChatLogsWidth(currentWidth + step, railExpanded);
     } else if (event.key === 'ArrowRight') {
       event.preventDefault();
-      setChatLogsWidth(width => clampChatLogsWidth(width - step, railExpanded));
+      nextWidth = clampChatLogsWidth(currentWidth - step, railExpanded);
     } else if (event.key === 'Home') {
       event.preventDefault();
-      setChatLogsWidth(CHAT_LOGS_MIN_WIDTH);
+      nextWidth = CHAT_LOGS_MIN_WIDTH;
     } else if (event.key === 'End') {
       event.preventDefault();
-      setChatLogsWidth(clampChatLogsWidth(CHAT_LOGS_MAX_WIDTH, railExpanded));
+      nextWidth = maxChatLogsWidthForViewport(railExpanded);
     }
-  }, [railExpanded]);
+
+    if (nextWidth !== null) {
+      setChatLogsWidth(nextWidth);
+      persistChatLogsWidth(nextWidth);
+    }
+  }, [chatLogsWidth, railExpanded]);
 
   const [customModelInfos, setCustomModelInfos] = useState<ModelInfo[]>([]);
   useEffect(() => {
@@ -3334,19 +3362,28 @@ ${finalText}`
       </div>
 
       {showInlineLogs && (
-        <aside className="chat__logs" aria-label="Lemonade logs next to chat">
+        <aside className="chat__logs" aria-label="Lemonade logs">
           <div
             className="chat__logs-resizer"
             role="separator"
             aria-orientation="vertical"
             aria-label="Resize logs panel"
             aria-valuemin={CHAT_LOGS_MIN_WIDTH}
-            aria-valuemax={CHAT_LOGS_MAX_WIDTH}
-            aria-valuenow={chatLogsWidth}
+            aria-valuemax={maxChatLogsWidthForViewport(railExpanded)}
+            aria-valuenow={effectiveChatLogsWidth}
             tabIndex={0}
             onPointerDown={handleChatLogsResizeStart}
             onKeyDown={handleChatLogsResizeKeyDown}
           />
+          <button
+            type="button"
+            className="chat__logs-close"
+            onClick={() => setShowInlineLogs(false)}
+            aria-label="Close logs"
+            title="Close logs"
+          >
+            <Icon name="x" size={14} aria-hidden="true" />
+          </button>
           <Suspense fallback={<div className="view-loading view-loading--compact"><span className="spinner" aria-hidden="true" /></div>}>
             <LogViewer />
           </Suspense>
@@ -3493,7 +3530,7 @@ ${finalText}`
             className={`composer__tools-toggle ${showInlineLogs ? 'composer__tools-toggle--active' : ''}`}
             onClick={() => setShowInlineLogs(v => !v)}
             aria-pressed={showInlineLogs}
-            title="Show logs next to the chat"
+            title="Show logs"
           >
             <Icon name="logs" size={13} /> Logs
           </button>

--- a/src/app/src/components/ChatView.tsx
+++ b/src/app/src/components/ChatView.tsx
@@ -119,48 +119,74 @@ function getDownloadStoreModule(): Promise<typeof import('../features/downloadMa
   return downloadStoreModulePromise;
 }
 
-const CHAT_LOGS_WIDTH_KEY = 'chat_logs_overlay_width_v2';
-const CHAT_LOGS_DEFAULT_WIDTH = 640;
-const CHAT_LOGS_DEFAULT_VIEWPORT_RATIO = 0.60;
+
+const CHAT_LOGS_WIDTH_KEY = 'chat_logs_split_width';
+const CHAT_LOGS_DEFAULT_WIDTH = 520;
+const CHAT_LOGS_DEFAULT_EDGE_RATIO = 0.60;
+const CHAT_LOGS_MAX_EDGE_RATIO = 0.70;
 const CHAT_LOGS_MIN_WIDTH = 340;
-const CHAT_LOGS_MAX_WIDTH = 920;
-const CHAT_LOGS_MIN_REVEALED_CHAT_WIDTH = 160;
+const CHAT_LOGS_MAX_WIDTH = 1280;
+const CHAT_LOGS_MIN_REVEALED_CHAT_WIDTH = 360;
+const CHAT_LOGS_RESIZER_WIDTH = 12;
 const CHAT_RAIL_COLLAPSED_WIDTH = 56;
 const CHAT_RAIL_EXPANDED_WIDTH = 248;
+const CHAT_MOBILE_BREAKPOINT = 768;
 
 function chatRailWidth(railExpanded = true): number {
-  if (typeof window !== 'undefined' && window.innerWidth <= 768) return 0;
+  if (typeof window !== 'undefined' && window.innerWidth <= CHAT_MOBILE_BREAKPOINT) return 0;
   return railExpanded ? CHAT_RAIL_EXPANDED_WIDTH : CHAT_RAIL_COLLAPSED_WIDTH;
 }
 
-function maxChatLogsWidthForViewport(railExpanded = true): number {
-  if (typeof window === 'undefined') return CHAT_LOGS_MAX_WIDTH;
-  const availableChatWidth = Math.max(0, window.innerWidth - chatRailWidth(railExpanded));
-  const viewportMax = availableChatWidth - CHAT_LOGS_MIN_REVEALED_CHAT_WIDTH;
-  return Math.max(CHAT_LOGS_MIN_WIDTH, Math.min(CHAT_LOGS_MAX_WIDTH, viewportMax));
+function chatLogsResizerWidth(): number {
+  if (typeof window !== 'undefined' && window.innerWidth <= CHAT_MOBILE_BREAKPOINT) return 0;
+  return CHAT_LOGS_RESIZER_WIDTH;
 }
 
-function clampChatLogsWidth(width: number, railExpanded = true): number {
-  return Math.max(CHAT_LOGS_MIN_WIDTH, Math.min(maxChatLogsWidthForViewport(railExpanded), Math.round(width)));
+function maxChatLogsWidthForLayout(containerWidth: number, railExpanded = true): number {
+  const railWidth = chatRailWidth(railExpanded);
+  const resizerWidth = chatLogsResizerWidth();
+  const availableWidth = Math.max(0, containerWidth - railWidth - resizerWidth);
+  const chatWidthMax = availableWidth - CHAT_LOGS_MIN_REVEALED_CHAT_WIDTH;
+  const edgeMax = Math.round(containerWidth * CHAT_LOGS_MAX_EDGE_RATIO) - railWidth - resizerWidth;
+  const layoutMax = Math.min(chatWidthMax, edgeMax);
+  return Math.max(CHAT_LOGS_MIN_WIDTH, Math.min(CHAT_LOGS_MAX_WIDTH, layoutMax));
 }
 
-function defaultChatLogsWidth(railExpanded = true): number {
-  if (typeof window === 'undefined') return CHAT_LOGS_DEFAULT_WIDTH;
-  const availableChatWidth = Math.max(0, window.innerWidth - chatRailWidth(railExpanded));
-  const viewportTarget = Math.round(availableChatWidth * CHAT_LOGS_DEFAULT_VIEWPORT_RATIO);
-  return clampChatLogsWidth(Math.max(CHAT_LOGS_DEFAULT_WIDTH, viewportTarget), railExpanded);
+function clampChatLogsWidth(width: number, containerWidth: number, railExpanded = true): number {
+  return Math.max(
+    CHAT_LOGS_MIN_WIDTH,
+    Math.min(maxChatLogsWidthForLayout(containerWidth, railExpanded), Math.round(width)),
+  );
+}
+
+function defaultChatLogsWidth(containerWidth: number, railExpanded = false): number {
+  const railWidth = chatRailWidth(railExpanded);
+  const resizerWidth = chatLogsResizerWidth();
+  const edgeTarget = Math.round(containerWidth * CHAT_LOGS_DEFAULT_EDGE_RATIO);
+  const layoutTarget = edgeTarget - railWidth - resizerWidth;
+  return clampChatLogsWidth(
+    Math.max(CHAT_LOGS_DEFAULT_WIDTH, layoutTarget),
+    containerWidth,
+    railExpanded,
+  );
+}
+
+function initialChatLayoutWidth(): number {
+  if (typeof window === 'undefined') return 1280;
+  return Math.max(0, Math.round(window.innerWidth));
 }
 
 function loadChatLogsWidth(): number {
-  if (typeof window === 'undefined') return CHAT_LOGS_DEFAULT_WIDTH;
+  const initialWidth = initialChatLayoutWidth();
+  if (typeof window === 'undefined') return defaultChatLogsWidth(initialWidth, false);
   try {
     const raw = window.localStorage.getItem(scopedKey(CHAT_LOGS_WIDTH_KEY));
     const stored = raw === null ? Number.NaN : Number(raw);
     return Number.isFinite(stored)
       ? Math.max(CHAT_LOGS_MIN_WIDTH, Math.min(CHAT_LOGS_MAX_WIDTH, Math.round(stored)))
-      : defaultChatLogsWidth(true);
+      : defaultChatLogsWidth(initialWidth, false);
   } catch {
-    return defaultChatLogsWidth(true);
+    return defaultChatLogsWidth(initialWidth, false);
   }
 }
 
@@ -168,7 +194,7 @@ function persistChatLogsWidth(width: number): void {
   try {
     window.localStorage.setItem(scopedKey(CHAT_LOGS_WIDTH_KEY), String(Math.round(width)));
   } catch {
-    // Non-critical: log overlay width persistence is best-effort only.
+    // Non-critical: split-pane width persistence is best-effort only.
   }
 }
 
@@ -820,6 +846,7 @@ const ChatView: React.FC<ChatViewProps> = ({ currentModel: selectedModel, loaded
   const [ttsPlaybackSettings, setTtsPlaybackSettings] = useState(() => loadTtsPlaybackSettings());
   const [globalModelSettings, setGlobalModelSettings] = useState(() => loadGlobalModelSettings());
   const [railExpanded, setRailExpanded] = useState(true);
+  const autoCollapsedRailForLogsRef = useRef(false);
   const [mobileSheetOpen, setMobileSheetOpen] = useState(false);
   const sheetHandleRef = useRef<HTMLDivElement>(null);
   const sheetTriggerRef = useRef<HTMLButtonElement>(null);
@@ -843,6 +870,7 @@ const ChatView: React.FC<ChatViewProps> = ({ currentModel: selectedModel, loaded
   const [mcpPickerError, setMcpPickerError] = useState('');
   const [showInlineLogs, setShowInlineLogs] = useState(false);
   const [chatLogsWidth, setChatLogsWidth] = useState(() => loadChatLogsWidth());
+  const [chatContainerWidth, setChatContainerWidth] = useState(() => initialChatLayoutWidth());
   const [modelPickerOpen, setModelPickerOpen] = useState(false);
   const [modelPickerQuery, setModelPickerQuery] = useState('');
   const modelPickerListRef = useRef<HTMLUListElement>(null);
@@ -855,6 +883,7 @@ const ChatView: React.FC<ChatViewProps> = ({ currentModel: selectedModel, loaded
   const [effectiveSettingsOpen, setEffectiveSettingsOpen] = useState(false);
   const [serverDefaultCtxSize, setServerDefaultCtxSize] = useState(DEFAULT_CONTEXT_SIZE);
   const [currentModelTuning, setCurrentModelTuning] = useState<ModelTuning | null>(null);
+  const chatRootRef = useRef<HTMLDivElement>(null);
   const threadRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -927,25 +956,53 @@ const ChatView: React.FC<ChatViewProps> = ({ currentModel: selectedModel, loaded
     return () => { cancelled = true; };
   }, [connectionStatus]);
 
-  const effectiveChatLogsWidth = clampChatLogsWidth(chatLogsWidth, railExpanded);
+  useEffect(() => {
+    const root = chatRootRef.current;
+    if (!root) return;
+
+    const updateWidth = () => {
+      const nextWidth = Math.max(0, Math.round(root.getBoundingClientRect().width));
+      if (nextWidth > 0) setChatContainerWidth(current => current === nextWidth ? current : nextWidth);
+    };
+
+    updateWidth();
+    if (typeof ResizeObserver === 'undefined') {
+      window.addEventListener('resize', updateWidth);
+      return () => window.removeEventListener('resize', updateWidth);
+    }
+
+    const observer = new ResizeObserver(updateWidth);
+    observer.observe(root);
+    return () => observer.disconnect();
+  }, []);
+
+  // chatLogsWidth is the user's preferred split size. effectiveChatLogsWidth
+  // may be smaller while History is expanded or the window is narrow, but that
+  // temporary constraint is deliberately not written back to localStorage.
+  const effectiveChatLogsWidth = clampChatLogsWidth(chatLogsWidth, chatContainerWidth, railExpanded);
   const chatLayoutStyle = useMemo(() => ({
     '--chat-logs-width': `${effectiveChatLogsWidth}px`,
+    '--chat-logs-resizer-width': `${CHAT_LOGS_RESIZER_WIDTH}px`,
   } as React.CSSProperties), [effectiveChatLogsWidth]);
 
   const handleChatLogsResizeStart = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
-    if (window.innerWidth <= 980) return;
+    if (window.innerWidth <= CHAT_MOBILE_BREAKPOINT) return;
     event.preventDefault();
 
     const startX = event.clientX;
-    const startWidth = clampChatLogsWidth(chatLogsWidth, railExpanded);
+    const startWidth = clampChatLogsWidth(chatLogsWidth, chatContainerWidth, railExpanded);
     let latestWidth = startWidth;
     const handle = event.currentTarget;
     try { handle.setPointerCapture(event.pointerId); } catch { /* ignore */ }
 
     const handlePointerMove = (moveEvent: PointerEvent) => {
-      // The handle sits on the left edge of the logs panel: dragging left makes
-      // the panel wider, dragging right makes it narrower.
-      latestWidth = clampChatLogsWidth(startWidth - (moveEvent.clientX - startX), railExpanded);
+      // Logs sit to the left of chat, so moving their right separator to the
+      // right grows the logs pane and moving it left shrinks the pane.
+      latestWidth = clampChatLogsWidth(
+        startWidth + (moveEvent.clientX - startX),
+        chatContainerWidth,
+        railExpanded,
+      );
       setChatLogsWidth(latestWidth);
     };
 
@@ -962,31 +1019,31 @@ const ChatView: React.FC<ChatViewProps> = ({ currentModel: selectedModel, loaded
     window.addEventListener('pointermove', handlePointerMove);
     window.addEventListener('pointerup', stopResize, { once: true });
     window.addEventListener('pointercancel', stopResize, { once: true });
-  }, [chatLogsWidth, railExpanded]);
+  }, [chatContainerWidth, chatLogsWidth, railExpanded]);
 
   const handleChatLogsResizeKeyDown = useCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
     const step = event.shiftKey ? 48 : 20;
-    const currentWidth = clampChatLogsWidth(chatLogsWidth, railExpanded);
+    const currentWidth = clampChatLogsWidth(chatLogsWidth, chatContainerWidth, railExpanded);
     let nextWidth: number | null = null;
     if (event.key === 'ArrowLeft') {
       event.preventDefault();
-      nextWidth = clampChatLogsWidth(currentWidth + step, railExpanded);
+      nextWidth = clampChatLogsWidth(currentWidth - step, chatContainerWidth, railExpanded);
     } else if (event.key === 'ArrowRight') {
       event.preventDefault();
-      nextWidth = clampChatLogsWidth(currentWidth - step, railExpanded);
+      nextWidth = clampChatLogsWidth(currentWidth + step, chatContainerWidth, railExpanded);
     } else if (event.key === 'Home') {
       event.preventDefault();
       nextWidth = CHAT_LOGS_MIN_WIDTH;
     } else if (event.key === 'End') {
       event.preventDefault();
-      nextWidth = maxChatLogsWidthForViewport(railExpanded);
+      nextWidth = maxChatLogsWidthForLayout(chatContainerWidth, railExpanded);
     }
 
     if (nextWidth !== null) {
       setChatLogsWidth(nextWidth);
       persistChatLogsWidth(nextWidth);
     }
-  }, [chatLogsWidth, railExpanded]);
+  }, [chatContainerWidth, chatLogsWidth, railExpanded]);
 
   const [customModelInfos, setCustomModelInfos] = useState<ModelInfo[]>([]);
   useEffect(() => {
@@ -2003,9 +2060,31 @@ const ChatView: React.FC<ChatViewProps> = ({ currentModel: selectedModel, loaded
     if (window.innerWidth <= 480) {
       setMobileSheetOpen(prev => !prev);
     } else {
+      // Once the user touches History while logs are open, their choice wins;
+      // closing logs must not undo it as an automatic layout adjustment.
+      if (showInlineLogs) autoCollapsedRailForLogsRef.current = false;
       setRailExpanded(prev => !prev);
     }
-  }, []);
+  }, [showInlineLogs]);
+
+  const handleToggleInlineLogs = useCallback(() => {
+    if (showInlineLogs) {
+      setShowInlineLogs(false);
+      if (autoCollapsedRailForLogsRef.current) {
+        autoCollapsedRailForLogsRef.current = false;
+        setRailExpanded(true);
+      }
+      return;
+    }
+
+    // Give logs a real pane instead of covering chat. Reclaim the expanded
+    // History width on open, while still letting the user immediately expand
+    // History again if that is their preferred layout.
+    const canShowDesktopRail = window.innerWidth > CHAT_MOBILE_BREAKPOINT;
+    autoCollapsedRailForLogsRef.current = canShowDesktopRail && railExpanded;
+    if (autoCollapsedRailForLogsRef.current) setRailExpanded(false);
+    setShowInlineLogs(true);
+  }, [railExpanded, showInlineLogs]);
 
   const closeMobileSheet = useCallback(() => {
     setMobileSheetOpen(false);
@@ -3146,6 +3225,7 @@ ${finalText}`
   return (
     <>
       <div
+        ref={chatRootRef}
         className={`chat ${railExpanded ? 'rail-expanded' : ''}${showInlineLogs ? ' chat--with-logs' : ''}`}
         style={showInlineLogs ? chatLayoutStyle : undefined}
         data-startup-ready="chat"
@@ -3362,32 +3442,25 @@ ${finalText}`
       </div>
 
       {showInlineLogs && (
-        <aside className="chat__logs" aria-label="Lemonade logs">
+        <>
+          <aside className="chat__logs" aria-label="Lemonade logs">
+            <Suspense fallback={<div className="view-loading view-loading--compact"><span className="spinner" aria-hidden="true" /></div>}>
+              <LogViewer />
+            </Suspense>
+          </aside>
           <div
             className="chat__logs-resizer"
             role="separator"
             aria-orientation="vertical"
             aria-label="Resize logs panel"
             aria-valuemin={CHAT_LOGS_MIN_WIDTH}
-            aria-valuemax={maxChatLogsWidthForViewport(railExpanded)}
+            aria-valuemax={maxChatLogsWidthForLayout(chatContainerWidth, railExpanded)}
             aria-valuenow={effectiveChatLogsWidth}
             tabIndex={0}
             onPointerDown={handleChatLogsResizeStart}
             onKeyDown={handleChatLogsResizeKeyDown}
           />
-          <button
-            type="button"
-            className="chat__logs-close"
-            onClick={() => setShowInlineLogs(false)}
-            aria-label="Close logs"
-            title="Close logs"
-          >
-            <Icon name="x" size={14} aria-hidden="true" />
-          </button>
-          <Suspense fallback={<div className="view-loading view-loading--compact"><span className="spinner" aria-hidden="true" /></div>}>
-            <LogViewer />
-          </Suspense>
-        </aside>
+        </>
       )}
 
       {/* Composer */}
@@ -3528,9 +3601,9 @@ ${finalText}`
           )}
           <button
             className={`composer__tools-toggle ${showInlineLogs ? 'composer__tools-toggle--active' : ''}`}
-            onClick={() => setShowInlineLogs(v => !v)}
+            onClick={handleToggleInlineLogs}
             aria-pressed={showInlineLogs}
-            title="Show logs"
+            title={showInlineLogs ? 'Hide logs' : 'Show logs'}
           >
             <Icon name="logs" size={13} /> Logs
           </button>

--- a/src/app/src/styles/styles.css
+++ b/src/app/src/styles/styles.css
@@ -553,7 +553,6 @@ input[type="checkbox"]:disabled {
   grid-template-areas:
     "rail main"
     "rail composer";
-  position: relative;
   height: 100%;
   transition: grid-template-columns var(--duration-base) var(--ease-out);
 }
@@ -1621,6 +1620,8 @@ input[type="checkbox"]:disabled {
 .composer__entry--with-settings {
   max-width: var(--max-content-width);
   margin: 0 auto;
+  container-type: inline-size;
+  container-name: composer-settings;
   background: var(--surface-1);
   border: 1px solid var(--border-subtle);
   border-radius: var(--radius-xl);
@@ -5293,6 +5294,33 @@ optgroup {
   }
 }
 
+/* Split-pane chat can be narrow even on a wide desktop viewport. Reflow image
+   controls from the width of the composer shell itself, not window width. */
+@container composer-settings (max-width: 700px) {
+  .composer__image-settings {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: var(--space-1-5);
+    padding: var(--space-2);
+  }
+}
+
+@container composer-settings (max-width: 460px) {
+  .composer__image-settings {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .composer__image-setting input,
+  .composer__image-setting select {
+    padding-left: var(--space-2);
+    padding-right: var(--space-2);
+  }
+
+  .composer__image-setting select {
+    padding-right: 24px;
+    background-position: right 8px center;
+  }
+}
+
 /* Live realtime transcription in audio mode */
 .composer__mic {
   width: 36px;
@@ -5456,63 +5484,67 @@ optgroup {
 }
 
 .chat--with-logs {
-  /* Keep logs out of the grid so changing panel width cannot move either
-     the conversation or the composer. */
-  grid-template-columns: var(--rail-collapsed) minmax(0, 1fr);
+  /* Logs are a real split pane between History and chat. The separator owns
+     its grid column so LogViewer content cannot cover or clip the drag target. */
+  grid-template-columns: var(--rail-collapsed) var(--chat-logs-width, 640px) var(--chat-logs-resizer-width, 12px) minmax(0, 1fr);
   grid-template-areas:
-    "rail main"
-    "rail composer";
+    "rail logs logs-resizer main"
+    "rail logs logs-resizer composer";
 }
 
 .chat--with-logs.rail-expanded {
-  grid-template-columns: var(--rail-expanded) minmax(0, 1fr);
+  grid-template-columns: var(--rail-expanded) var(--chat-logs-width, 640px) var(--chat-logs-resizer-width, 12px) minmax(0, 1fr);
+}
+
+/* Reclaim a little horizontal room while logs are open. The content remains
+   aligned, but the narrower chat pane does not spend 48 px on outer gutters. */
+.chat--with-logs .chat__inner {
+  padding-left: var(--space-4);
+  padding-right: var(--space-4);
+}
+
+.chat--with-logs .composer {
+  padding-left: var(--space-4);
+  padding-right: var(--space-4);
 }
 
 .chat__logs {
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  width: var(--chat-logs-width, 640px);
-  max-width: max(340px, calc(100% - var(--rail-collapsed) - 160px));
+  grid-area: logs;
+  position: relative;
   min-width: 0;
-  z-index: 60;
-  border-left: 1px solid var(--border-strong);
-  background: var(--surface-base);
-  box-shadow: var(--shadow-lg);
+  min-height: 0;
+  background: color-mix(in srgb, var(--surface-1) 90%, transparent);
   overflow: hidden;
 }
 
-.chat.rail-expanded .chat__logs {
-  max-width: max(340px, calc(100% - var(--rail-expanded) - 160px));
-}
-
 .chat__logs-resizer {
-  position: absolute;
-  left: -5px;
-  top: 0;
-  bottom: 0;
-  width: 10px;
+  grid-area: logs-resizer;
+  position: relative;
+  align-self: stretch;
+  min-width: var(--chat-logs-resizer-width, 12px);
   cursor: col-resize;
-  z-index: 3;
+  z-index: 5;
   touch-action: none;
 }
 
 .chat__logs-resizer::after {
   content: "";
   position: absolute;
-  left: 4px;
+  left: 50%;
   top: var(--space-3);
   bottom: var(--space-3);
-  width: 2px;
+  width: 1px;
+  transform: translateX(-50%);
   border-radius: var(--radius-pill);
-  background: transparent;
-  transition: background var(--duration-fast) var(--ease-out);
+  background: var(--border-subtle);
+  transition: background var(--duration-fast) var(--ease-out),
+              width var(--duration-fast) var(--ease-out);
 }
 
 .chat__logs-resizer:hover::after,
 .chat__logs-resizer:focus-visible::after,
 .is-resizing-chat-logs .chat__logs-resizer::after {
+  width: 2px;
   background: var(--accent-fg);
 }
 
@@ -5521,34 +5553,13 @@ optgroup {
   outline-offset: -2px;
 }
 
-.chat__logs-close {
-  position: absolute;
-  top: var(--space-3);
-  right: var(--space-3);
-  z-index: 4;
-  width: 32px;
-  height: 32px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0;
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--radius-md);
-  background: var(--surface-raised);
-  color: var(--text-secondary);
-  box-shadow: var(--shadow-sm);
-  cursor: pointer;
-}
-
-.chat__logs-close:hover {
-  color: var(--text-primary);
-  border-color: var(--border-strong);
-  background: var(--surface-2);
-}
-
 .is-resizing-chat-logs {
   cursor: col-resize;
   user-select: none;
+}
+
+.is-resizing-chat-logs .chat {
+  transition: none;
 }
 
 .chat__logs .logs-view {
@@ -5811,17 +5822,24 @@ optgroup {
   z-index: 3;
 }
 
-@media (max-width: 980px) {
+@media (max-width: 768px) {
+  .chat.chat--with-logs.rail-expanded,
+  .chat.chat--with-logs:not(.rail-expanded) {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-rows: minmax(220px, 40%) minmax(0, 1fr) auto;
+    grid-template-areas:
+      "logs"
+      "main"
+      "composer";
+  }
+
+  .chat__logs {
+    border-right: 0;
+    border-bottom: 1px solid var(--border-subtle);
+  }
+
   .chat__logs-resizer {
     display: none;
-  }
-}
-
-@media (max-width: 768px) {
-  .chat__logs,
-  .chat.rail-expanded .chat__logs {
-    width: min(var(--chat-logs-width, 640px), calc(100% - var(--space-3)));
-    max-width: max(340px, calc(100% - 160px));
   }
 }
 
@@ -10290,6 +10308,50 @@ optgroup {
   .composer__audio-lyrics { grid-column: 1 / -1; }
   .model3d-viewer { height: 320px; min-height: 320px; }
   .model3d-viewer canvas { min-height: 320px; }
+}
+
+/* Generated-audio and 3D settings can become narrow while the desktop
+   viewport stays wide when the logs splitter moves right. Reflow from the
+   composer shell itself, just like image mode, so controls never overflow. */
+@container composer-settings (max-width: 760px) {
+  .composer__capability-settings,
+  .composer__audio-generation-settings,
+  .composer__model3d-settings {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: var(--space-1-5);
+    padding: var(--space-2);
+  }
+
+  .composer__openmoss-settings {
+    grid-template-columns: minmax(120px, 0.8fr) minmax(0, 2fr);
+    gap: var(--space-1-5);
+    padding: var(--space-2);
+  }
+}
+
+@container composer-settings (max-width: 500px) {
+  .composer__capability-settings,
+  .composer__audio-generation-settings,
+  .composer__openmoss-settings,
+  .composer__model3d-settings {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .composer__image-setting--model,
+  .composer__openmoss-description,
+  .composer__audio-lyrics {
+    grid-column: 1 / -1;
+  }
+}
+
+@container composer-settings (max-width: 360px) {
+  .composer__openmoss-settings {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .composer__openmoss-description {
+    grid-column: 1;
+  }
 }
 
 .message__audio-download {

--- a/src/app/src/styles/styles.css
+++ b/src/app/src/styles/styles.css
@@ -553,6 +553,7 @@ input[type="checkbox"]:disabled {
   grid-template-areas:
     "rail main"
     "rail composer";
+  position: relative;
   height: 100%;
   transition: grid-template-columns var(--duration-base) var(--ease-out);
 }
@@ -5455,23 +5456,35 @@ optgroup {
 }
 
 .chat--with-logs {
-  grid-template-columns: var(--rail-collapsed) minmax(320px, 1fr) minmax(340px, var(--chat-logs-width, 34vw));
+  /* Keep logs out of the grid so changing panel width cannot move either
+     the conversation or the composer. */
+  grid-template-columns: var(--rail-collapsed) minmax(0, 1fr);
   grid-template-areas:
-    "rail main logs"
-    "rail composer logs";
+    "rail main"
+    "rail composer";
 }
 
 .chat--with-logs.rail-expanded {
-  grid-template-columns: var(--rail-expanded) minmax(320px, 1fr) minmax(360px, var(--chat-logs-width, 34vw));
+  grid-template-columns: var(--rail-expanded) minmax(0, 1fr);
 }
 
 .chat__logs {
-  grid-area: logs;
-  position: relative;
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: var(--chat-logs-width, 640px);
+  max-width: max(340px, calc(100% - var(--rail-collapsed) - 160px));
   min-width: 0;
-  border-left: 1px solid var(--border-subtle);
-  background: color-mix(in srgb, var(--surface-1) 90%, transparent);
+  z-index: 60;
+  border-left: 1px solid var(--border-strong);
+  background: var(--surface-base);
+  box-shadow: var(--shadow-lg);
   overflow: hidden;
+}
+
+.chat.rail-expanded .chat__logs {
+  max-width: max(340px, calc(100% - var(--rail-expanded) - 160px));
 }
 
 .chat__logs-resizer {
@@ -5481,7 +5494,7 @@ optgroup {
   bottom: 0;
   width: 10px;
   cursor: col-resize;
-  z-index: 5;
+  z-index: 3;
   touch-action: none;
 }
 
@@ -5506,6 +5519,31 @@ optgroup {
 .chat__logs-resizer:focus-visible {
   outline: 2px solid var(--accent-focus);
   outline-offset: -2px;
+}
+
+.chat__logs-close {
+  position: absolute;
+  top: var(--space-3);
+  right: var(--space-3);
+  z-index: 4;
+  width: 32px;
+  height: 32px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--surface-raised);
+  color: var(--text-secondary);
+  box-shadow: var(--shadow-sm);
+  cursor: pointer;
+}
+
+.chat__logs-close:hover {
+  color: var(--text-primary);
+  border-color: var(--border-strong);
+  background: var(--surface-2);
 }
 
 .is-resizing-chat-logs {
@@ -5774,42 +5812,17 @@ optgroup {
 }
 
 @media (max-width: 980px) {
-  .chat--with-logs,
-  .chat--with-logs.rail-expanded {
-    grid-template-columns: var(--rail-collapsed) 1fr;
-    grid-template-areas:
-      "rail main"
-      "rail logs"
-      "rail composer";
-  }
-
-  .chat__logs {
-    min-height: 280px;
-    border-left: 0;
-    border-top: 1px solid var(--border-subtle);
-  }
-
   .chat__logs-resizer {
     display: none;
   }
-
-  .composer__model-button {
-
-  }
 }
 
-@media (max-width: 480px) {
-  /* With-logs layout: collapse rail on phone */
-  .chat--with-logs,
-  .chat--with-logs.rail-expanded {
-    grid-template-columns: 1fr;
-    grid-template-areas:
-      "main"
-      "logs"
-      "composer";
+@media (max-width: 768px) {
+  .chat__logs,
+  .chat.rail-expanded .chat__logs {
+    width: min(var(--chat-logs-width, 640px), calc(100% - var(--space-3)));
+    max-width: max(340px, calc(100% - 160px));
   }
-
-  /* Composer model button: tighter on phone */
 }
 
 /* ===== Mobile bottom sheet for conversations ===== */


### PR DESCRIPTION
<img width="1829" height="936" alt="image" src="https://github.com/user-attachments/assets/df3bea4a-7d7a-458e-997d-535edcae4ac4" />

This fixes the log overlay error in the chat page.
Starts well inside of the screen depending on it's size to be clearly visible. After Initial usage the position is remembered as originally intended.

The issue that image mode controls where on top or that moving the log moved the whole chat panel are resolved now.