### PR TITLE
GUI3 fix: remove the "Loaded right now" cards from the chat tab

### DIFF
--- a/src/app/src/App.tsx
+++ b/src/app/src/App.tsx
@@ -880,11 +880,6 @@ const App: React.FC = () => {
     return () => window.removeEventListener('keydown', onKeyDown);
   }, []);
 
-  const openModelDetails = useCallback((modelName: string) => {
-    setModelDetailsRequest({ modelName, nonce: Date.now() });
-    setView('models');
-  }, [setView]);
-
   // Desktop host deep-links use the same canonical routes as browser navigation.
   useEffect(() => {
     let cancelled = false;
@@ -1218,7 +1213,6 @@ const App: React.FC = () => {
                 serverModels={serverModels}
                 connectionStatus={status}
                 onModelSelect={handleModelSelect}
-                onOpenModelDetails={openModelDetails}
                 onRefresh={handleRefreshModels}
               />
             </ViewErrorBoundary>

--- a/src/app/src/components/ChatView.tsx
+++ b/src/app/src/components/ChatView.tsx
@@ -329,10 +329,6 @@ function mcpToolNamesForServers(servers: McpServerToolOption[], serverIds: strin
     .flatMap(server => server.toolOptions.map(tool => tool.runtimeName));
 }
 
-function modelModeBadge(capability: ModelCapability, recipe?: string | null): string {
-  return isRouterRecipe(recipe) ? 'router' : capabilityBadge(capability);
-}
-
 const ModelModeIcons: React.FC<{
   capability: ModelCapability;
   recipe?: string | null;
@@ -406,7 +402,6 @@ interface ChatViewProps {
   serverModels: ModelInfo[];
   connectionStatus: ConnectionStatus;
   onModelSelect: (model: string) => void;
-  onOpenModelDetails: (model: string) => void;
   onRefresh: () => void | Promise<void>;
 }
 
@@ -755,7 +750,7 @@ function friendlyChatError(message: string): string {
   return `I couldn't complete that request.\n\n${cleaned}`;
 }
 
-const ChatView: React.FC<ChatViewProps> = ({ currentModel: selectedModel, loadedModels, serverModels, connectionStatus, onModelSelect, onOpenModelDetails, onRefresh }) => {
+const ChatView: React.FC<ChatViewProps> = ({ currentModel: selectedModel, loadedModels, serverModels, connectionStatus, onModelSelect, onRefresh }) => {
   const [fallbackModelOverride, setFallbackModelOverride] = useState<string | null>(null);
   const [preferredDefaultModelName, setPreferredDefaultModelName] = useState(() => loadPreferredDefaultModelName());
   const [lastReadyModelName, setLastReadyModelName] = useState<string | null>(() => loadLastReadyModelName());
@@ -2901,21 +2896,6 @@ ${finalText}`
     }
   }, [modelPickerUnloading, onRefresh]);
 
-  const handleLoadedCardUnload = useCallback((modelName: string) => {
-    if (modelPickerUnloading) return;
-    setModelPickerUnloading(modelName);
-    void (async () => {
-      try {
-        const api = await getApiClient();
-        await api.unloadModel(modelName);
-        await Promise.resolve(onRefresh());
-        setUnloadAnnouncement(`${modelName} unloaded`);
-      } finally {
-        setModelPickerUnloading(null);
-      }
-    })();
-  }, [modelPickerUnloading, onRefresh]);
-
   const handleModelPickerSelect = useCallback(async (option: ModelPickerOption) => {
     if (option.loaded) {
       setFallbackModelOverride(null);
@@ -3223,13 +3203,7 @@ ${finalText}`
           {!hasMessages ? (
             <EmptyState
               loadedModels={loadedModels}
-              currentModel={currentModel}
-              onModelSelect={onModelSelect}
-              onOpenModelDetails={onOpenModelDetails}
-              onUnloadModel={handleLoadedCardUnload}
-              unloadingModel={modelPickerUnloading}
               onChipClick={startLemonadeToolPrompt}
-              customModelInfos={customModelInfos}
             />
           ) : (
             <div className="thread">
@@ -4106,113 +4080,37 @@ ${finalText}`
 
 interface EmptyStateProps {
   loadedModels: LoadedModel[];
-  currentModel: string | null;
-  onModelSelect: (model: string) => void;
-  onOpenModelDetails: (model: string) => void;
-  onUnloadModel: (model: string) => void;
-  unloadingModel: string | null;
   onChipClick: (text: string) => void;
-  customModelInfos: ModelInfo[];
 }
 
-const EmptyState: React.FC<EmptyStateProps> = ({ loadedModels, currentModel, onModelSelect, onOpenModelDetails, onUnloadModel, unloadingModel, onChipClick, customModelInfos }) => (
-  <>
-    <div className="hero">
-      <h1 className="hero__title">Get to know Lemonade</h1>
-      <p className="hero__subtitle">
-        {loadedModels.length > 0
-          ? `${loadedModels.length} model${loadedModels.length > 1 ? 's' : ''} ready. Ask a question or explore what Lemonade can do.`
-          : 'Ask a question to learn how Lemonade works and get started with your first model.'}
-      </p>
+const EmptyState: React.FC<EmptyStateProps> = ({ loadedModels, onChipClick }) => (
+  <div className="hero">
+    <h1 className="hero__title">Get to know Lemonade</h1>
+    <p className="hero__subtitle">
+      {loadedModels.length > 0
+        ? `${loadedModels.length} model${loadedModels.length > 1 ? 's' : ''} ready. Ask a question or explore what Lemonade can do.`
+        : 'Ask a question to learn how Lemonade works and get started with your first model.'}
+    </p>
 
-      <div className="chips" role="list">
-        <button className="chip" role="listitem" onClick={() => onChipClick('How do I get started with Lemonade?')}>
-          <span className="chip__icon" aria-hidden="true"><Icon name="info" size={16} /></span>
-          How do I use Lemonade?
-        </button>
-        <button className="chip" role="listitem" onClick={() => onChipClick('How do I download and load a model in Lemonade?')}>
-          <span className="chip__icon" aria-hidden="true"><Icon name="download" size={16} /></span>
-          How do I add a model?
-        </button>
-        <button className="chip" role="listitem" onClick={() => onChipClick('What are Lemonade tools, and how do I use them?')}>
-          <span className="chip__icon" aria-hidden="true"><Icon name="tools" size={16} /></span>
-          What are Lemonade tools?
-        </button>
-        <button className="chip" role="listitem" onClick={() => onChipClick('What can my hardware run well with Lemonade?')}>
-          <span className="chip__icon" aria-hidden="true"><Icon name="gauge" size={16} /></span>
-          What can my hardware run?
-        </button>
-      </div>
+    <div className="chips" role="list">
+      <button className="chip" role="listitem" onClick={() => onChipClick('How do I get started with Lemonade?')}>
+        <span className="chip__icon" aria-hidden="true"><Icon name="info" size={16} /></span>
+        How do I use Lemonade?
+      </button>
+      <button className="chip" role="listitem" onClick={() => onChipClick('How do I download and load a model in Lemonade?')}>
+        <span className="chip__icon" aria-hidden="true"><Icon name="download" size={16} /></span>
+        How do I add a model?
+      </button>
+      <button className="chip" role="listitem" onClick={() => onChipClick('What are Lemonade tools, and how do I use them?')}>
+        <span className="chip__icon" aria-hidden="true"><Icon name="tools" size={16} /></span>
+        What are Lemonade tools?
+      </button>
+      <button className="chip" role="listitem" onClick={() => onChipClick('What can my hardware run well with Lemonade?')}>
+        <span className="chip__icon" aria-hidden="true"><Icon name="gauge" size={16} /></span>
+        What can my hardware run?
+      </button>
     </div>
-
-    {loadedModels.length > 0 && (
-      <>
-        <div className="section-label">
-          <span>Loaded right now</span>
-          <span className="section-label__rule" />
-        </div>
-        <div className="active-models">
-          {loadedModels.map(m => {
-            const customInfo = customModelInfos.find(cm => (cm.name || cm.id) === m.model_name);
-            const cap = customInfo ? capabilityFromModelInfo(customInfo) : capabilityFromLoaded(m);
-            const audioInput = modelSupportsChatAudioInput(customInfo || null, m);
-            const modeLabel = modelModeDisplayLabel(cap, audioInput, m.recipe);
-            const modeBadge = modelModeBadge(cap, m.recipe);
-            const selectable = canSelectInComposer(m) || ['chat', 'omni', 'image', 'audio', 'audio-generation', 'tts', 'model3d'].includes(cap);
-            const isActive = currentModel === m.model_name;
-            return (
-              <article className="active-card" key={m.model_name}>
-                <div className="active-card__head">
-                  <div>
-                    <div className="active-card__name-row">
-                      <button
-                        type="button"
-                        className="active-card__name"
-                        onClick={() => onOpenModelDetails(m.model_name)}
-                        title={`Open ${m.model_name} in Models`}
-                      >
-                        {m.model_name}
-                      </button>
-                    </div>
-                    <div className="active-card__meta">{m.recipe || 'runtime'} · {m.checkpoint || 'default'}</div>
-                  </div>
-                  <span className="active-card__device">{m.device || 'device unknown'}</span>
-                </div>
-                <div className="active-card__badges">
-                  <span className={`cap-badge cap-badge--${modeBadge}`}><ModelModeIcons capability={cap} recipe={m.recipe} audioInput={audioInput} size={13} /> {modeLabel}</span>
-                </div>
-                <div className="active-card__actions">
-                  {isActive ? (
-                    <span className="active-card__status">● Active {modeLabel} mode</span>
-                  ) : selectable ? (
-                    <button className="active-card__action" onClick={() => onModelSelect(m.model_name)}>
-                      Use in {modeLabel}
-                    </button>
-                  ) : (
-                    <span className="active-card__status active-card__status--muted">Utility model only</span>
-                  )}
-                </div>
-                <div className="active-card__footer">
-                  <button type="button" className="active-card__details" onClick={() => onOpenModelDetails(m.model_name)}>
-                    View details
-                  </button>
-                  <button
-                    type="button"
-                    className="active-card__eject"
-                    onClick={() => onUnloadModel(m.model_name)}
-                    disabled={unloadingModel === m.model_name}
-                    title={`Unload ${m.model_name}`}
-                  >
-                    {unloadingModel === m.model_name ? 'Unloading…' : 'Unload'}
-                  </button>
-                </div>
-              </article>
-            );
-          })}
-        </div>
-      </>
-    )}
-  </>
+  </div>
 );
 
 /* ─── Message bubble ──────────────────────────────────── */

--- a/src/app/src/styles/critical.generated.css
+++ b/src/app/src/styles/critical.generated.css
@@ -860,168 +860,7 @@
   background: var(--surface-2);
   border-color: var(--border-strong);
   color: var(--text-primary);
-}.chip:active { transform: scale(0.97); }.chip__icon { font-size: var(--text-base); line-height: 1; }.section-label {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  margin: var(--space-10) 0 var(--space-3);
-  font-size: var(--text-xs);
-  font-weight: var(--weight-semibold);
-  letter-spacing: var(--tracking-caps);
-  text-transform: uppercase;
-  color: var(--text-tertiary);
-}.section-label__rule {
-  flex: 1;
-  height: 1px;
-  background: var(--border-subtle);
-}.active-models {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-  gap: var(--space-3);
-}.active-card {
-  background: var(--surface-1);
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--radius-lg);
-  padding: var(--space-4);
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-3);
-  min-height: 190px;
-  transition: border-color var(--duration-fast) var(--ease-out),
-              box-shadow var(--duration-fast) var(--ease-out),
-              transform var(--duration-fast) var(--ease-out);
-}.active-card:hover {
-  border-color: var(--border-strong);
-  box-shadow: 0 10px 30px color-mix(in srgb, #000 24%, transparent);
-  transform: translateY(-1px);
-}.active-card__head {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  gap: var(--space-3);
-}.active-card__head > div:first-child {
-  min-width: 0;
-}.active-card__name {
-  display: block;
-  width: 100%;
-  min-width: 0;
-  padding: 0;
-  border: 0;
-  background: transparent;
-  font-size: var(--text-base);
-  font-weight: var(--weight-semibold);
-  color: var(--text-primary);
-  line-height: 1.35;
-  text-align: left;
-  overflow-wrap: anywhere;
-  cursor: pointer;
-}.active-card__name:hover,
-.active-card__name:focus-visible {
-  color: var(--accent-fg);
-  text-decoration: underline;
-  text-underline-offset: 3px;
-}.active-card__meta {
-  font-size: var(--text-xs);
-  color: var(--text-tertiary);
-  line-height: 1.35;
-  margin-top: var(--space-1);
-  overflow-wrap: anywhere;
-}.active-card__device {
-  flex: 0 0 auto;
-  margin-top: 1px;
-  font-size: var(--type-overline-size);
-  letter-spacing: var(--tracking-caps);
-  text-transform: uppercase;
-  padding: 2px 8px;
-  border-radius: var(--radius-pill);
-  background: var(--surface-3);
-  color: var(--text-secondary);
-}.active-card__badges {
-  display: flex;
-  gap: var(--space-1);
-  flex-wrap: wrap;
-}.active-card__actions {
-  display: flex;
-  align-items: center;
-  min-height: 28px;
-}.active-card__action {
-  align-self: flex-start;
-  min-height: 28px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  font-size: var(--text-xs);
-  font-weight: var(--weight-medium);
-  color: var(--accent-fg);
-  padding: 6px var(--space-3);
-  border: 1px solid color-mix(in srgb, var(--accent-fg) 25%, transparent);
-  border-radius: var(--radius-pill);
-  background: var(--accent-soft);
-  transition: background var(--duration-fast) var(--ease-out),
-              border-color var(--duration-fast) var(--ease-out),
-              transform var(--duration-fast) var(--ease-out);
-}.active-card__action:hover {
-  background: var(--accent-strong);
-  border-color: color-mix(in srgb, var(--accent-fg) 45%, transparent);
-  transform: translateY(-1px);
-}.active-card__details {
-  padding: 5px var(--space-2);
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--radius-pill);
-  background: var(--surface-1);
-  color: var(--text-tertiary);
-  font-size: var(--text-xs);
-  font-weight: var(--weight-medium);
-  cursor: pointer;
-  transition: color var(--duration-fast) var(--ease-out),
-              border-color var(--duration-fast) var(--ease-out),
-              background var(--duration-fast) var(--ease-out);
-}.active-card__details:hover,
-.active-card__details:focus-visible {
-  color: var(--accent-fg);
-  border-color: color-mix(in srgb, var(--accent-fg) 35%, var(--border-subtle));
-  background: color-mix(in srgb, var(--accent) 8%, var(--surface-1));
-}.active-card__footer {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--space-2);
-  flex-wrap: wrap;
-  margin-top: auto;
-  padding-top: var(--space-3);
-  border-top: 1px solid var(--border-subtle);
-}.active-card__eject {
-  padding: 5px var(--space-2);
-  border: 1px solid color-mix(in srgb, var(--danger) 24%, transparent);
-  border-radius: var(--radius-pill);
-  background: color-mix(in srgb, var(--danger) 7%, transparent);
-  color: var(--danger);
-  font-size: var(--text-xs);
-  font-weight: var(--weight-medium);
-  cursor: pointer;
-  transition: background var(--duration-fast) var(--ease-out),
-              border-color var(--duration-fast) var(--ease-out);
-}.active-card__eject:hover,
-.active-card__eject:focus-visible {
-  border-color: color-mix(in srgb, var(--danger) 42%, transparent);
-  background: color-mix(in srgb, var(--danger) 12%, transparent);
-}.active-card__eject:disabled {
-  cursor: progress;
-  opacity: 0.7;
-  text-decoration: none;
-}.active-card__status {
-  align-self: flex-start;
-  min-height: 28px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  font-size: var(--text-xs);
-  font-weight: var(--weight-medium);
-  color: var(--success);
-  padding: 6px var(--space-3);
-  border-radius: var(--radius-pill);
-  background: var(--success-soft);
-}.cap-badge {
+}.chip:active { transform: scale(0.97); }.chip__icon { font-size: var(--text-base); line-height: 1; }.cap-badge {
   font-size: var(--type-overline-size);
   letter-spacing: 0.04em;
   font-weight: var(--weight-semibold);
@@ -1717,7 +1556,7 @@ option:checked {
     grid-template-areas:
       "main"
       "composer";
-  }.rail { display: none; }.chat__inner { padding: var(--space-5) var(--space-4); overflow-x: hidden; }.composer { padding: var(--space-3) var(--space-4); }.manager__custom-actions .btn { flex: 1; justify-content: center; }.hero { padding: var(--space-8) 0 var(--space-6); }.hero__title { font-size: var(--text-2xl); }.hero__subtitle { font-size: var(--text-base); }.chips { gap: var(--space-1); }.chip { padding: 8px var(--space-3); font-size: var(--text-xs); }.active-models { grid-template-columns: 1fr; }}@media (max-width: 480px) {.composer__send,
+  }.rail { display: none; }.chat__inner { padding: var(--space-5) var(--space-4); overflow-x: hidden; }.composer { padding: var(--space-3) var(--space-4); }.manager__custom-actions .btn { flex: 1; justify-content: center; }.hero { padding: var(--space-8) 0 var(--space-6); }.hero__title { font-size: var(--text-2xl); }.hero__subtitle { font-size: var(--text-base); }.chips { gap: var(--space-1); }.chip { padding: 8px var(--space-3); font-size: var(--text-xs); }}@media (max-width: 480px) {.composer__send,
   .composer__stop {
     width: 44px;
     height: 44px;
@@ -1744,7 +1583,7 @@ option:checked {
     grid-template-areas:
       "main"
       "composer";
-  }.rail { display: none; }.chat__inner { padding: var(--space-4) var(--space-3); }.active-card { padding: var(--space-3); gap: var(--space-2); }.active-card__name { font-size: var(--text-sm); }.hero__title { font-size: var(--text-xl); }.hero__subtitle { font-size: var(--text-sm); }.section-label { font-size: var(--type-overline-size); margin-bottom: var(--space-2); }.composer__toolbar .btn,
+  }.rail { display: none; }.chat__inner { padding: var(--space-4) var(--space-3); }.hero__title { font-size: var(--text-xl); }.hero__subtitle { font-size: var(--text-sm); }.composer__toolbar .btn,
   .composer__toolbar .chip,
   .composer__toolbar button {
     font-size: var(--text-xs);
@@ -1999,9 +1838,6 @@ option:checked {
 }.message__image--generated {
   max-width: min(100%, 512px);
   max-height: 512px;
-}.active-card__status--muted {
-  background: var(--surface-3);
-  color: var(--text-tertiary);
 }.composer__mode-badge--omni, .cap-badge--omni, .cap-chip--omni, .rail__model-badge--omni { color: var(--cap-omni); background: color-mix(in srgb, var(--cap-omni) 18%, transparent); }.rail__model-badge--router { color: var(--cap-router); background: color-mix(in srgb, var(--cap-router) 18%, transparent); }.custom-model-form__grid .input, .custom-model-form__grid .select { width: 100%; }.custom-model-form__grid .textarea { min-height: 192px; font-family: var(--font-mono); font-size: var(--text-xs); line-height: var(--leading-relaxed); }.chat:not(.rail-expanded) .rail__list,
 .chat:not(.rail-expanded) .rail__privacy {
   display: none;
@@ -2013,7 +1849,6 @@ option:checked {
 }.chat:not(.rail-expanded) .rail__new-wrap {
   display: flex;
 }.message__author-row,
-.active-card__name-row,
 .row__name-wrap,
 .applied-row__model-name-wrap {
   display: inline-flex;
@@ -2022,17 +1857,11 @@ option:checked {
   min-width: 0;
   max-width: 100%;
 }.row__name-wrap .row__name,
-.active-card__name-row .active-card__name,
 .applied-row__model-name-wrap .applied-row__model-name {
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-}.active-card__name-row .active-card__name {
-  overflow: visible;
-  text-overflow: clip;
-  white-space: normal;
-  overflow-wrap: anywhere;
 }.copy-inline {
   width: 22px;
   height: 22px;

--- a/src/app/src/styles/styles.css
+++ b/src/app/src/styles/styles.css
@@ -693,212 +693,6 @@ input[type="checkbox"]:disabled {
 
 .chip__icon { font-size: var(--text-base); line-height: 1; }
 
-/* Active models section */
-.section-label {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  margin: var(--space-10) 0 var(--space-3);
-  font-size: var(--text-xs);
-  font-weight: var(--weight-semibold);
-  letter-spacing: var(--tracking-caps);
-  text-transform: uppercase;
-  color: var(--text-tertiary);
-}
-
-.section-label__rule {
-  flex: 1;
-  height: 1px;
-  background: var(--border-subtle);
-}
-
-.active-models {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-  gap: var(--space-3);
-}
-
-.active-card {
-  background: var(--surface-1);
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--radius-lg);
-  padding: var(--space-4);
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-3);
-  min-height: 190px;
-  transition: border-color var(--duration-fast) var(--ease-out),
-              box-shadow var(--duration-fast) var(--ease-out),
-              transform var(--duration-fast) var(--ease-out);
-}
-
-.active-card:hover {
-  border-color: var(--border-strong);
-  box-shadow: 0 10px 30px color-mix(in srgb, #000 24%, transparent);
-  transform: translateY(-1px);
-}
-
-.active-card__head {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  gap: var(--space-3);
-}
-
-.active-card__head > div:first-child {
-  min-width: 0;
-}
-
-.active-card__name {
-  display: block;
-  width: 100%;
-  min-width: 0;
-  padding: 0;
-  border: 0;
-  background: transparent;
-  font-size: var(--text-base);
-  font-weight: var(--weight-semibold);
-  color: var(--text-primary);
-  line-height: 1.35;
-  text-align: left;
-  overflow-wrap: anywhere;
-  cursor: pointer;
-}
-
-.active-card__name:hover,
-.active-card__name:focus-visible {
-  color: var(--accent-fg);
-  text-decoration: underline;
-  text-underline-offset: 3px;
-}
-
-.active-card__meta {
-  font-size: var(--text-xs);
-  color: var(--text-tertiary);
-  line-height: 1.35;
-  margin-top: var(--space-1);
-  overflow-wrap: anywhere;
-}
-
-.active-card__device {
-  flex: 0 0 auto;
-  margin-top: 1px;
-  font-size: var(--type-overline-size);
-  letter-spacing: var(--tracking-caps);
-  text-transform: uppercase;
-  padding: 2px 8px;
-  border-radius: var(--radius-pill);
-  background: var(--surface-3);
-  color: var(--text-secondary);
-}
-
-.active-card__badges {
-  display: flex;
-  gap: var(--space-1);
-  flex-wrap: wrap;
-}
-
-.active-card__actions {
-  display: flex;
-  align-items: center;
-  min-height: 28px;
-}
-
-.active-card__action {
-  align-self: flex-start;
-  min-height: 28px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  font-size: var(--text-xs);
-  font-weight: var(--weight-medium);
-  color: var(--accent-fg);
-  padding: 6px var(--space-3);
-  border: 1px solid color-mix(in srgb, var(--accent-fg) 25%, transparent);
-  border-radius: var(--radius-pill);
-  background: var(--accent-soft);
-  transition: background var(--duration-fast) var(--ease-out),
-              border-color var(--duration-fast) var(--ease-out),
-              transform var(--duration-fast) var(--ease-out);
-}
-
-.active-card__action:hover {
-  background: var(--accent-strong);
-  border-color: color-mix(in srgb, var(--accent-fg) 45%, transparent);
-  transform: translateY(-1px);
-}
-
-.active-card__details {
-  padding: 5px var(--space-2);
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--radius-pill);
-  background: var(--surface-1);
-  color: var(--text-tertiary);
-  font-size: var(--text-xs);
-  font-weight: var(--weight-medium);
-  cursor: pointer;
-  transition: color var(--duration-fast) var(--ease-out),
-              border-color var(--duration-fast) var(--ease-out),
-              background var(--duration-fast) var(--ease-out);
-}
-
-.active-card__details:hover,
-.active-card__details:focus-visible {
-  color: var(--accent-fg);
-  border-color: color-mix(in srgb, var(--accent-fg) 35%, var(--border-subtle));
-  background: color-mix(in srgb, var(--accent) 8%, var(--surface-1));
-}
-
-.active-card__footer {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--space-2);
-  flex-wrap: wrap;
-  margin-top: auto;
-  padding-top: var(--space-3);
-  border-top: 1px solid var(--border-subtle);
-}
-
-.active-card__eject {
-  padding: 5px var(--space-2);
-  border: 1px solid color-mix(in srgb, var(--danger) 24%, transparent);
-  border-radius: var(--radius-pill);
-  background: color-mix(in srgb, var(--danger) 7%, transparent);
-  color: var(--danger);
-  font-size: var(--text-xs);
-  font-weight: var(--weight-medium);
-  cursor: pointer;
-  transition: background var(--duration-fast) var(--ease-out),
-              border-color var(--duration-fast) var(--ease-out);
-}
-
-.active-card__eject:hover,
-.active-card__eject:focus-visible {
-  border-color: color-mix(in srgb, var(--danger) 42%, transparent);
-  background: color-mix(in srgb, var(--danger) 12%, transparent);
-}
-
-.active-card__eject:disabled {
-  cursor: progress;
-  opacity: 0.7;
-  text-decoration: none;
-}
-
-.active-card__status {
-  align-self: flex-start;
-  min-height: 28px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  font-size: var(--text-xs);
-  font-weight: var(--weight-medium);
-  color: var(--success);
-  padding: 6px var(--space-3);
-  border-radius: var(--radius-pill);
-  background: var(--success-soft);
-}
-
 /* Capability badges */
 .cap-badge {
   font-size: var(--type-overline-size);
@@ -3526,7 +3320,6 @@ optgroup {
   .hero__subtitle { font-size: var(--text-base); }
   .chips { gap: var(--space-1); }
   .chip { padding: 8px var(--space-3); font-size: var(--text-xs); }
-  .active-models { grid-template-columns: 1fr; }
   .applied-row { grid-template-columns: 1fr; gap: var(--space-2); }
   .backends__head { padding: var(--space-5) var(--space-4) var(--space-3); }
   .matrix { margin: var(--space-3) var(--space-4); }
@@ -3634,16 +3427,9 @@ optgroup {
   /* ── Chat inner: use smaller padding ── */
   .chat__inner { padding: var(--space-4) var(--space-3); }
 
-  /* ── Active-model cards in hero: more compact on phone ── */
-  .active-card { padding: var(--space-3); gap: var(--space-2); }
-  .active-card__name { font-size: var(--text-sm); }
-
   /* ── Hero title/subtitle: tighten for mobile ── */
   .hero__title { font-size: var(--text-xl); }
   .hero__subtitle { font-size: var(--text-sm); }
-
-  /* ── Section labels (e.g. "LOADED RIGHT NOW"): smaller ── */
-  .section-label { font-size: var(--type-overline-size); margin-bottom: var(--space-2); }
 
   /* ── Composer pills row: smaller font + tighter padding to reduce chrome ── */
   .composer__toolbar .btn,
@@ -4899,11 +4685,6 @@ optgroup {
   max-height: 512px;
 }
 
-.active-card__status--muted {
-  background: var(--surface-3);
-  color: var(--text-tertiary);
-}
-
 .form-field__hint {
   font-size: var(--text-xs);
   color: var(--text-tertiary);
@@ -5055,7 +4836,6 @@ optgroup {
 }
 
 .message__author-row,
-.active-card__name-row,
 .row__name-wrap,
 .applied-row__model-name-wrap {
   display: inline-flex;
@@ -5071,19 +4851,11 @@ optgroup {
 }
 
 .row__name-wrap .row__name,
-.active-card__name-row .active-card__name,
 .applied-row__model-name-wrap .applied-row__model-name {
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-}
-
-.active-card__name-row .active-card__name {
-  overflow: visible;
-  text-overflow: clip;
-  white-space: normal;
-  overflow-wrap: anywhere;
 }
 
 .copy-inline {


### PR DESCRIPTION
Closes #2978.

Deletes the "Loaded right now" card grid from the chat tab empty state, plus the dead code it leaves behind: the `EmptyState` props that only fed it, `handleLoadedCardUnload`, `modelModeBadge`, `ChatView`'s `onOpenModelDetails` prop and its `openModelDetails` callback in `App.tsx`, and the `.section-label` / `.active-models` / `.active-card*` rules in both `styles.css` and `critical.generated.css`.

There are already 3 other ways to see what models are loaded — the chat tab dropdown, the models tab list, and the performance dashboard models widget — so we shouldn't spend time trying to optimize the design of a 4th.

🤖 Generated with [Claude Code](https://claude.com/claude-code)