### PR TITLE
ci: stop pinning lite validation legs to the 128gb runner

### DIFF
--- a/.github/workflows/validate_llamacpp.yml
+++ b/.github/workflows/validate_llamacpp.yml
@@ -294,7 +294,19 @@ jobs:
     # Label a PR `ci:upgrades` to opt it back in.
     if: (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci:upgrades')) && always() && !failure() && !cancelled()
     runs-on: windows-latest
+    outputs:
+      lite: ${{ steps.lite.outputs.lite }}
     steps:
+      - name: Resolve lite mode
+        # The env context is unavailable in a job's `strategy` block, so the
+        # validate matrix reads LITE_MODE through this output to size its
+        # runners from the same source of truth the validation itself uses.
+        id: lite
+        shell: PowerShell
+        run: |
+          "lite=$env:LITE_MODE" |
+            Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+
       - name: Prepare Windows runner for long paths and stale workspace caches
         if: runner.os == 'Windows'
         shell: PowerShell
@@ -412,15 +424,30 @@ jobs:
     strategy:
       fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:
+        # Full runs walk every hot model, topping out at gpt-oss-120b (59 GiB),
+        # which only fits the 128gb runner. Lite runs test just the smallest hot
+        # model (0.6 GiB), so they stay off that single contended machine.
+        # The lite rocm legs omit the `rocm` label because no Windows runner is
+        # known to carry it alongside `stx-halo`; ROCm backends already run on a
+        # bare [Windows, stx-halo] selector elsewhere in CI.
         include:
           - backend: vulkan
-            runner: [self-hosted, Windows, 128gb, vulkan, lemon-prod]
+            runner: >-
+              ${{ fromJSON(needs.build.outputs.lite == 'true'
+              && '["self-hosted","Windows","stx-halo","vulkan","lemon-prod"]'
+              || '["self-hosted","Windows","128gb","vulkan","lemon-prod"]') }}
           - backend: rocm
             channel: stable
-            runner: [self-hosted, Windows, 128gb, rocm, lemon-prod]
+            runner: >-
+              ${{ fromJSON(needs.build.outputs.lite == 'true'
+              && '["self-hosted","Windows","stx-halo","lemon-prod"]'
+              || '["self-hosted","Windows","128gb","rocm","lemon-prod"]') }}
           - backend: rocm
             channel: nightly
-            runner: [self-hosted, Windows, 128gb, rocm, lemon-prod]
+            runner: >-
+              ${{ fromJSON(needs.build.outputs.lite == 'true'
+              && '["self-hosted","Windows","stx-halo","lemon-prod"]'
+              || '["self-hosted","Windows","128gb","rocm","lemon-prod"]') }}
           # CUDA validation is prepared but intentionally disabled until an
           # NVIDIA self-hosted runner is available. To enable it, uncomment this
           # matrix entry.
@@ -628,7 +655,7 @@ jobs:
                 )
               }
           )
-  
+
           foreach ($process in $staleProcesses) {
             Write-Host "Stopping stale $($process.Name) PID $($process.ProcessId)." `
               -ForegroundColor Yellow
@@ -642,7 +669,7 @@ jobs:
               }
             }
           }
-  
+
       - uses: actions/checkout@v5
         with:
           clean: true
@@ -831,7 +858,7 @@ jobs:
           if ($validationExitCode -ne 0) {
             exit $validationExitCode
           }
-  
+
       - name: Upload results
         if: always()
         uses: actions/upload-artifact@v7

--- a/.github/workflows/validate_llamacpp.yml
+++ b/.github/workflows/validate_llamacpp.yml
@@ -427,9 +427,6 @@ jobs:
         # Full runs walk every hot model, topping out at gpt-oss-120b (59 GiB),
         # which only fits the 128gb runner. Lite runs test just the smallest hot
         # model (0.6 GiB), so they stay off that single contended machine.
-        # The lite rocm legs omit the `rocm` label because no Windows runner is
-        # known to carry it alongside `stx-halo`; ROCm backends already run on a
-        # bare [Windows, stx-halo] selector elsewhere in CI.
         include:
           - backend: vulkan
             runner: >-
@@ -440,13 +437,13 @@ jobs:
             channel: stable
             runner: >-
               ${{ fromJSON(needs.build.outputs.lite == 'true'
-              && '["self-hosted","Windows","stx-halo","lemon-prod"]'
+              && '["self-hosted","Windows","stx-halo","rocm","lemon-prod"]'
               || '["self-hosted","Windows","128gb","rocm","lemon-prod"]') }}
           - backend: rocm
             channel: nightly
             runner: >-
               ${{ fromJSON(needs.build.outputs.lite == 'true'
-              && '["self-hosted","Windows","stx-halo","lemon-prod"]'
+              && '["self-hosted","Windows","stx-halo","rocm","lemon-prod"]'
               || '["self-hosted","Windows","128gb","rocm","lemon-prod"]') }}
           # CUDA validation is prepared but intentionally disabled until an
           # NVIDIA self-hosted runner is available. To enable it, uncomment this

--- a/.github/workflows/validate_sdcpp.yml
+++ b/.github/workflows/validate_sdcpp.yml
@@ -271,10 +271,7 @@ jobs:
       matrix:
         # SDCPP_TEST_MODELS peaks at ~18 GB resident, so these legs never needed
         # the 128gb runner; the sd-cpp suite in cpp_server_build_test_release.yml
-        # already runs on hosts with no size label at all. The rocm leg omits the
-        # `rocm` label because no Windows runner is known to carry it alongside
-        # `stx-halo`; ROCm backends already run on a bare [Windows, stx-halo]
-        # selector elsewhere in CI.
+        # already runs on hosts with no size label at all.
         include:
           - label: cpu
             backend: cpu
@@ -287,7 +284,7 @@ jobs:
           - label: rocm-stable
             backend: rocm
             channel: stable
-            runner: [self-hosted, Windows, stx-halo]
+            runner: [self-hosted, Windows, stx-halo, rocm]
           # CUDA is pinned by the updater and its assets are required by the
           # verify-cuda-assets job after this validation matrix completes.
           # Validation stays disabled until a matching runner exists.

--- a/.github/workflows/validate_sdcpp.yml
+++ b/.github/workflows/validate_sdcpp.yml
@@ -276,15 +276,15 @@ jobs:
           - label: cpu
             backend: cpu
             channel: ""
-            runner: [self-hosted, Windows, stx-halo, vulkan]
+            runner: [self-hosted, Windows, stx-halo, vulkan, lemon-prod]
           - label: vulkan
             backend: vulkan
             channel: ""
-            runner: [self-hosted, Windows, stx-halo, vulkan]
+            runner: [self-hosted, Windows, stx-halo, vulkan, lemon-prod]
           - label: rocm-stable
             backend: rocm
             channel: stable
-            runner: [self-hosted, Windows, stx-halo, rocm]
+            runner: [self-hosted, Windows, stx-halo, rocm, lemon-prod]
           # CUDA is pinned by the updater and its assets are required by the
           # verify-cuda-assets job after this validation matrix completes.
           # Validation stays disabled until a matching runner exists.

--- a/.github/workflows/validate_sdcpp.yml
+++ b/.github/workflows/validate_sdcpp.yml
@@ -269,19 +269,25 @@ jobs:
     strategy:
       fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:
+        # SDCPP_TEST_MODELS peaks at ~18 GB resident, so these legs never needed
+        # the 128gb runner; the sd-cpp suite in cpp_server_build_test_release.yml
+        # already runs on hosts with no size label at all. The rocm leg omits the
+        # `rocm` label because no Windows runner is known to carry it alongside
+        # `stx-halo`; ROCm backends already run on a bare [Windows, stx-halo]
+        # selector elsewhere in CI.
         include:
           - label: cpu
             backend: cpu
             channel: ""
-            runner: [self-hosted, Windows, 128gb, vulkan]
+            runner: [self-hosted, Windows, stx-halo, vulkan]
           - label: vulkan
             backend: vulkan
             channel: ""
-            runner: [self-hosted, Windows, 128gb, vulkan]
+            runner: [self-hosted, Windows, stx-halo, vulkan]
           - label: rocm-stable
             backend: rocm
             channel: stable
-            runner: [self-hosted, Windows, 128gb, rocm]
+            runner: [self-hosted, Windows, stx-halo]
           # CUDA is pinned by the updater and its assets are required by the
           # verify-cuda-assets job after this validation matrix completes.
           # Validation stays disabled until a matching runner exists.


### PR DESCRIPTION
The `128gb` label matches a single runner, so every PR funnelled six Windows validate legs through one machine, one at a time.

## What actually needs 128 GB

**llama.cpp: only the scheduled run.** `validate_llamacpp.py` walks every `hot` model, unloading between each, so peak is the largest single model — `gpt-oss-120b-mxfp-GGUF` at 59 GiB. That does not fit a 64 GB budget.

But `LITE_MODE` is true for `pull_request` and `merge_group`, so PR runs test one model:

```
Found 14 hot llamacpp models:
  - gpt-oss-120b-mxfp-GGUF (59.0 GB)
  ...
Lite mode: testing only smallest model: MiniCPM5-1B-GGUF (0.641 GB)
```

Three legs on the only 128 GB machine, to infer against 0.641 GB.

**sd.cpp: never.** `SDCPP_TEST_MODELS` is `SD-Turbo-GGUF` (2 GB) + `Flux-2-Klein-4B` (16 GB) — ~18 GB peak with both resident. The `server_sd.py` suite in `cpp_server_build_test_release.yml` already runs sd-cpp on hosts with no size label at all.

**vLLM:** already on `stx-halo`, untouched.

## Changes

- `validate_sdcpp` — all three legs move to `stx-halo` unconditionally.
- `validate_llamacpp` — the validate matrix sizes its runners off the existing `LITE_MODE` env: `stx-halo` for lite runs, `128gb` for the weekly full run. `LITE_MODE` reaches the matrix as a `build` job output because the `env` context is unavailable inside a job's `strategy` block.

Backend labels (`vulkan`, `rocm`) are unchanged — the ROCm legs still require `rocm`.

## Measured effect

Before ([PR #3052 run](https://github.com/lemonade-sdk/lemonade/actions/runs/31810829139)), all six Windows legs landed on `sjlab-stx-halo-17` and ran back to back. After ([this PR](https://github.com/lemonade-sdk/lemonade/actions/runs/31817981330)), they spread across the `stx-halo` pool:

| | Before | After |
|---|---|---|
| sd.cpp legs | `-17`, `-17`, `-17` | `-06`, `-07`, `-08` (concurrent) |
| llama.cpp legs | `-17`, `-17`, `-17` | `-09` |

**sd.cpp is the win: 39m15s → 21m05s, measured build-completion to last-leg-completion.** Two effects, both from unpinning:

- Its first leg previously waited **11m38s** after the build finished, purely for `-17` to finish llama.cpp's legs. That wait is now gone.
- Its validate phase is now bounded by its longest leg (18m03s) rather than the sum of all three (27m37s).

**llama.cpp shows no gain in this sample.** The rest of the pool was busy, so all three legs serialized on `-09` anyway, and they paid first-use costs on a host that had not run this workflow recently — artifact download alone took 2m46s there versus seconds on the warmed-up `-17`. The structural change still holds (the legs are no longer restricted to one machine); the per-run benefit just depends on pool availability at the time.

The 128 GB machine is now reserved for the Sunday auto-update run that actually needs it.

## Runner labels confirmed

Windows hosts carrying `stx-halo` **and** `rocm` do exist — `sjlab-stx-halo-08` and `-09` both claimed ROCm legs with that selector and passed validation on it. Same for `stx-halo` + `vulkan` (`-06`, `-07`, `-09`).

## Note

Includes a whitespace-only fix on three lines of `validate_llamacpp.yml` that the `trailing-whitespace` pre-commit hook applies on touch. #3052 makes the identical change, so whichever lands second should merge cleanly.
