### PR TITLE
fix(server): add --no-broadcast CLI flag and LEMONADE_NO_BROADCAST env var

### DIFF
--- a/docs/dev/getting-started.md
+++ b/docs/dev/getting-started.md
@@ -609,7 +609,7 @@ The client automatically:
 - Uses port 13305 to broadcast to the network that it exists
 - Clients can read the json broadcast message to add server to server picker.
 - Uses machine hostname as broadcast name.
-- The custom flag --no-broadcast is available in the command line to disable.
+- The `--no-broadcast` command-line flag disables it and persists to `config.json`, same as setting the `no_broadcast` key directly. `LEMONADE_NO_BROADCAST` (accepts exactly `1`, `true`, `True`, `TRUE`, `yes`, or `YES` — no other casing) disables it for the life of the process without touching `config.json`, and takes precedence over both whenever it's set — for container use.
 - Auto protection, doesnt broadcast on non RFC1918 Networks.
 
 ### Internal Endpoints

--- a/docs/guide/install/docker.md
+++ b/docs/guide/install/docker.md
@@ -56,6 +56,32 @@ docker run -d \
 
 > This will run the server on port 5000 inside the container, mapped to port 4000 on your host.
 
+### Docker/Podman Run with the Discovery Beacon Disabled
+
+`lemond` periodically broadcasts a small UDP beacon on port 13305 so LAN clients can auto-discover it. In some container networking setups — notably rootless Podman with the `pasta` network plugin — the container isn't permitted to send broadcast traffic, and every failed attempt logs a `Permission denied` message to the host's journal every couple of seconds.
+
+Disable the beacon with the `LEMONADE_NO_BROADCAST` environment variable (no need to override the container's command). Unlike the flag/config.json forms below, this is not persisted, so it must be passed on every `run`:
+
+> `LEMONADE_NO_BROADCAST` always takes precedence while it's set (over both `config.json` and any `--no-broadcast` flag). It accepts exactly `1`, `true`, `True`, `TRUE`, `yes`, or `YES` — other casings (e.g. `Yes`, `TRUe`) are not recognized and are treated as unset.
+
+```bash
+podman run -d \
+  --name lemonade-server \
+  -p 13305:13305 \
+  -e LEMONADE_NO_BROADCAST=true \
+  ghcr.io/lemonade-sdk/lemonade-server:latest
+```
+
+Equivalently, pass `--no-broadcast` on the command line (this requires specifying the full command, since it replaces the image's default `CMD`), or set `"no_broadcast": true` in `config.json`:
+
+```bash
+podman run -d \
+  --name lemonade-server \
+  -p 13305:13305 \
+  ghcr.io/lemonade-sdk/lemonade-server:latest \
+  ./lemond --host 0.0.0.0 --no-broadcast
+```
+
 ### Docker Run with CPU backend
 
 To use the CPU backend, create or modify the `config.json` file in the `lemonade-recipe` volume:

--- a/src/cpp/include/lemon/cli_parser.h
+++ b/src/cpp/include/lemon/cli_parser.h
@@ -9,6 +9,7 @@ struct ServerConfig {
     std::string cache_dir;     // Positional arg: lemonade cache dir (optional, platform default)
     int port = -1;             // -1 = not specified on CLI, use config.json value
     std::string host;          // Empty = not specified on CLI, use config.json value
+    bool no_broadcast = false;
 };
 
 class CLIParser {

--- a/src/cpp/include/lemon/runtime_config.h
+++ b/src/cpp/include/lemon/runtime_config.h
@@ -135,7 +135,10 @@ private:
     void apply_changes(const json& changes, json& applied_diff);
 
     // Helpers to retrieve configuration options with environment variable override
-    // and fallback to config JSON under a shared lock.
+    // and fallback to config JSON under a shared lock. Callers must not already
+    // hold mutex_ (in any mode) when calling these — std::shared_mutex doesn't
+    // guarantee a second shared lock from the same thread won't deadlock behind
+    // a writer queued in between the two acquisitions.
     bool get_bool_opt(const char* env_name, const std::vector<std::string>& path, bool default_val) const;
     int get_int_opt(const char* env_name, const std::vector<std::string>& path, int default_val) const;
     double get_double_opt(const char* env_name, const std::vector<std::string>& path, double default_val) const;

--- a/src/cpp/server/cli_parser.cpp
+++ b/src/cpp/server/cli_parser.cpp
@@ -24,6 +24,9 @@ CLIParser::CLIParser()
 
     app_.add_option("--host", config_.host, "Address to bind for connections (overrides config.json)")
         ->type_name("HOST");
+
+    app_.add_flag("--no-broadcast", config_.no_broadcast,
+                  "Disable the UDP discovery beacon (overrides config.json; LEMONADE_NO_BROADCAST env var also works)");
 }
 
 int CLIParser::parse(int argc, char** argv) {

--- a/src/cpp/server/main.cpp
+++ b/src/cpp/server/main.cpp
@@ -78,7 +78,9 @@ int main(int argc, char** argv) {
         utils::set_cache_dir(cli_config.cache_dir);
         json config_json = ConfigFile::load(cli_config.cache_dir);
 
-        // CLI --port/--host override config.json and persist
+        // CLI --port/--host/--no-broadcast override config.json and persist.
+        // LEMONADE_NO_BROADCAST is handled separately, live, by RuntimeConfig::no_broadcast()
+        // (via get_bool_opt) so it's never written to config.json.
         bool cli_overrides = false;
         if (cli_config.port != -1) {
             config_json["port"] = cli_config.port;
@@ -86,6 +88,10 @@ int main(int argc, char** argv) {
         }
         if (!cli_config.host.empty()) {
             config_json["host"] = cli_config.host;
+            cli_overrides = true;
+        }
+        if (cli_config.no_broadcast) {
+            config_json["no_broadcast"] = cli_config.no_broadcast;
             cli_overrides = true;
         }
         auto config = std::make_shared<RuntimeConfig>(config_json);
@@ -101,6 +107,9 @@ int main(int argc, char** argv) {
             }
             if (!cli_config.host.empty()) {
                 LOG(INFO) << "Persisted host=" << cli_config.host << " to config.json" << std::endl;
+            }
+            if (cli_config.no_broadcast) {
+                LOG(INFO) << "Persisted no_broadcast=true to config.json" << std::endl;
             }
         }
 

--- a/src/cpp/server/runtime_config.cpp
+++ b/src/cpp/server/runtime_config.cpp
@@ -281,8 +281,7 @@ std::string RuntimeConfig::extra_models_dir() const {
 }
 
 bool RuntimeConfig::no_broadcast() const {
-    std::shared_lock lock(mutex_);
-    return config_["no_broadcast"].get<bool>();
+    return get_bool_opt("LEMONADE_NO_BROADCAST", {"no_broadcast"}, false);
 }
 
 long RuntimeConfig::global_timeout() const {

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -2039,7 +2039,7 @@ void Server::run() {
                 2
             );
         } else if (!rfc1918Interfaces.empty() && no_bcast) {
-            LOG(INFO, "Server") << "Broadcasting disabled by --no-broadcast option" << std::endl;
+            LOG(INFO, "Server") << "Broadcasting disabled by no_broadcast config option" << std::endl;
         } else {
             LOG(INFO, "Server") << "Unable to broadcast my existance please use a RFC1918 IPv4," << std::endl
                         << "or hostname that resolves to RFC1918 IPv4." << std::endl;

--- a/src/cpp/tray/main.cpp
+++ b/src/cpp/tray/main.cpp
@@ -183,6 +183,10 @@ int WINAPI wWinMain(HINSTANCE, HINSTANCE, LPWSTR, int) {
         config_json["host"] = cli_config.host;
         cli_overrides = true;
     }
+    if (cli_config.no_broadcast) {
+        config_json["no_broadcast"] = cli_config.no_broadcast;
+        cli_overrides = true;
+    }
     if (cli_overrides) {
         lemon::ConfigFile::save(cli_config.cache_dir, config_json);
     }


### PR DESCRIPTION
## Summary
- Adds a real `--no-broadcast` CLI flag to `lemond` and `LemonadeServer.exe`, persisting to `config.json` the same way `--port`/`--host` already do.
- Adds a `LEMONADE_NO_BROADCAST` env var for container deployments (e.g. rootless Podman with the `pasta` network plugin, which rejects the UDP beacon's broadcast and floods the host's journald). It's checked live via `RuntimeConfig::get_bool_opt` rather than written into `config.json`, so it never persists past the process that set it.
- Fixes a misleading log message and docs that referenced this CLI flag before it actually existed.

Fixes #3143

## Test plan
- [ ] `lemond --no-broadcast` and confirm the UDP beacon doesn't start, and that `config.json` gets `"no_broadcast": true`
- [ ] `LEMONADE_NO_BROADCAST=true lemond` and confirm the beacon doesn't start, and `config.json` is left untouched
- [ ] Verify `LemonadeServer.exe --no-broadcast` behaves the same as `lemond --no-broadcast`