### PR TITLE
GUI enhancements to the router

### DIFF
--- a/src/app/src/App.tsx
+++ b/src/app/src/App.tsx
@@ -1191,8 +1191,8 @@ const App: React.FC = () => {
                 className="titlebar__window-btn titlebar__window-btn--close"
                 data-tauri-drag-region="false"
                 onClick={() => window.api?.closeWindow?.()}
-                aria-label="Close"
-                title="Close"
+                aria-label="Cancel"
+                title="Cancel"
               >
                 <Icon name="x" size={14} />
               </button>

--- a/src/app/src/components/EffectiveSettingsModal.tsx
+++ b/src/app/src/components/EffectiveSettingsModal.tsx
@@ -395,8 +395,8 @@ const EffectiveSettingsModal: React.FC<EffectiveSettingsModalProps> = ({
             iconOnly
             className="close-modal-btn"
             onClick={onClose}
-            aria-label="Close"
-            title="Close"
+            aria-label="Cancel"
+            title="Cancel"
           />
         </div>
 

--- a/src/app/src/components/ModelListPanel.tsx
+++ b/src/app/src/components/ModelListPanel.tsx
@@ -465,8 +465,6 @@ export interface ModelListPanelProps {
   onOpenCustomModels?: () => void;
   onOpenRouter?: () => void;
   onUpdateAllModels?: () => void;
-  onToggleListPanel?: () => void;
-  listPanelCollapsed?: boolean;
   /** Lowercased set of pinned model names. Pinned rows float to the top. Client-local. */
   pinnedNames?: Set<string>;
   /** Toggle a model's pinned state. Receives the model name. */
@@ -501,8 +499,6 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
   onOpenCustomModels,
   onOpenRouter,
   onUpdateAllModels,
-  onToggleListPanel,
-  listPanelCollapsed,
   pinnedNames,
   onTogglePin,
   favoriteNames,
@@ -703,7 +699,7 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
 
   return (
     <WorkspaceListPanel
-      className={`model-list-panel${listPanelCollapsed ? ' is-collapsed' : ''}`}
+      className="model-list-panel"
       headerClassName="manager__title"
       title="Models"
       subtitle={`${flatList.length} ${flatList.length === 1 ? 'model' : 'models'}`}
@@ -740,16 +736,7 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
               title="Update all downloaded models"
             />
           )}
-          {onToggleListPanel && (
-            <WorkspaceActionButton
-              size="toolbar"
-              icon={listPanelCollapsed ? 'panel-left-open' : 'panel-left-close'}
-              iconOnly
-              onClick={onToggleListPanel}
-              aria-label={listPanelCollapsed ? 'Expand model list' : 'Collapse model list'}
-              title={listPanelCollapsed ? 'Expand model list' : 'Collapse model list'}
-            />
-          )}
+
         </WorkspaceActionGroup>
       )}
     >

--- a/src/app/src/components/ModelListPanel.tsx
+++ b/src/app/src/components/ModelListPanel.tsx
@@ -465,6 +465,8 @@ export interface ModelListPanelProps {
   onOpenCustomModels?: () => void;
   onOpenRouter?: () => void;
   onUpdateAllModels?: () => void;
+  onToggleListPanel?: () => void;
+  listPanelCollapsed?: boolean;
   /** Lowercased set of pinned model names. Pinned rows float to the top. Client-local. */
   pinnedNames?: Set<string>;
   /** Toggle a model's pinned state. Receives the model name. */
@@ -499,6 +501,8 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
   onOpenCustomModels,
   onOpenRouter,
   onUpdateAllModels,
+  onToggleListPanel,
+  listPanelCollapsed,
   pinnedNames,
   onTogglePin,
   favoriteNames,
@@ -699,7 +703,7 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
 
   return (
     <WorkspaceListPanel
-      className="model-list-panel"
+      className={`model-list-panel${listPanelCollapsed ? ' is-collapsed' : ''}`}
       headerClassName="manager__title"
       title="Models"
       subtitle={`${flatList.length} ${flatList.length === 1 ? 'model' : 'models'}`}
@@ -734,6 +738,16 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
               onClick={onUpdateAllModels}
               aria-label="Update all models"
               title="Update all downloaded models"
+            />
+          )}
+          {onToggleListPanel && (
+            <WorkspaceActionButton
+              size="toolbar"
+              icon={listPanelCollapsed ? 'panel-left-open' : 'panel-left-close'}
+              iconOnly
+              onClick={onToggleListPanel}
+              aria-label={listPanelCollapsed ? 'Expand model list' : 'Collapse model list'}
+              title={listPanelCollapsed ? 'Expand model list' : 'Collapse model list'}
             />
           )}
         </WorkspaceActionGroup>

--- a/src/app/src/components/ModelManager.tsx
+++ b/src/app/src/components/ModelManager.tsx
@@ -2917,7 +2917,7 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
                 >
                   Save
                 </WorkspaceActionButton>
-                <WorkspaceActionButton appearance="secondary" icon="x" onClick={closeCustomForm}>Cancel</WorkspaceActionButton>
+                <WorkspaceActionButton appearance="secondary" icon="x" onClick={closeCustomForm}>Close</WorkspaceActionButton>
                 <span className="workspace-action-group__spacer" />
                 <WorkspaceActionButton appearance="quiet" icon="file" onClick={handleExportCustomModels}>Export</WorkspaceActionButton>
                 <WorkspaceActionButton appearance="quiet" icon="file-up" onClick={() => customJsonInputRef.current?.click()}>Import</WorkspaceActionButton>

--- a/src/app/src/components/ModelManager.tsx
+++ b/src/app/src/components/ModelManager.tsx
@@ -1085,7 +1085,6 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
   const [tagFilters, setTagFilters] = useState<Set<string>>(() => new Set());
   const mobileRail = useWorkspaceMobileRail();
   const [navRailCollapsed, setNavRailCollapsed] = useState(false);
-  const [listPanelCollapsed, setListPanelCollapsed] = useState(false);
   const panelResize = useWorkspacePanelResize<HTMLDivElement>({
     storageKey: 'lemonade_workspace_models_list_width_v2',
     railCollapsed: navRailCollapsed,
@@ -2777,8 +2776,8 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
   return (
     <div
       ref={panelResize.containerRef}
-      className={`manager manager--detail workspace-three-panel${mobileDetailOpen ? ' manager--detail-mobile-open' : ''}${mobileRail.isOpen ? ' manager--nav-open' : ''}${navRailCollapsed ? ' workspace--rail-collapsed' : ''}${listPanelCollapsed ? ' workspace--list-collapsed' : ''}`}
-      style={listPanelCollapsed ? undefined : panelResize.style}
+      className={`manager manager--detail workspace-three-panel${mobileDetailOpen ? ' manager--detail-mobile-open' : ''}${mobileRail.isOpen ? ' manager--nav-open' : ''}${navRailCollapsed ? ' workspace--rail-collapsed' : ''}`}
+      style={panelResize.style}
     >
       {mobileRail.isOpen && <div className="workspace-mobile-rail-backdrop" onClick={mobileRail.close} aria-hidden="true" />}
       <WorkspaceMobileMenuButton
@@ -2862,8 +2861,6 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
         onOpenRouter={() => openRouterEditor(selectedDetailModel)}
         onUpdateAllModels={() => { void handleUpdateAllModels(); }}
         onOpenCustomModels={() => openCustomForm('model')}
-        onToggleListPanel={() => setListPanelCollapsed(v => !v)}
-        listPanelCollapsed={listPanelCollapsed}
         pinnedNames={pinnedNameSet}
         onTogglePin={togglePinnedModel}
         favoriteNames={favoriteNameSet}

--- a/src/app/src/components/ModelManager.tsx
+++ b/src/app/src/components/ModelManager.tsx
@@ -1085,6 +1085,7 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
   const [tagFilters, setTagFilters] = useState<Set<string>>(() => new Set());
   const mobileRail = useWorkspaceMobileRail();
   const [navRailCollapsed, setNavRailCollapsed] = useState(false);
+  const [listPanelCollapsed, setListPanelCollapsed] = useState(false);
   const panelResize = useWorkspacePanelResize<HTMLDivElement>({
     storageKey: 'lemonade_workspace_models_list_width_v2',
     railCollapsed: navRailCollapsed,
@@ -2776,8 +2777,8 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
   return (
     <div
       ref={panelResize.containerRef}
-      className={`manager manager--detail workspace-three-panel${mobileDetailOpen ? ' manager--detail-mobile-open' : ''}${mobileRail.isOpen ? ' manager--nav-open' : ''}${navRailCollapsed ? ' workspace--rail-collapsed' : ''}`}
-      style={panelResize.style}
+      className={`manager manager--detail workspace-three-panel${mobileDetailOpen ? ' manager--detail-mobile-open' : ''}${mobileRail.isOpen ? ' manager--nav-open' : ''}${navRailCollapsed ? ' workspace--rail-collapsed' : ''}${listPanelCollapsed ? ' workspace--list-collapsed' : ''}`}
+      style={listPanelCollapsed ? undefined : panelResize.style}
     >
       {mobileRail.isOpen && <div className="workspace-mobile-rail-backdrop" onClick={mobileRail.close} aria-hidden="true" />}
       <WorkspaceMobileMenuButton
@@ -2861,6 +2862,8 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
         onOpenRouter={() => openRouterEditor(selectedDetailModel)}
         onUpdateAllModels={() => { void handleUpdateAllModels(); }}
         onOpenCustomModels={() => openCustomForm('model')}
+        onToggleListPanel={() => setListPanelCollapsed(v => !v)}
+        listPanelCollapsed={listPanelCollapsed}
         pinnedNames={pinnedNameSet}
         onTogglePin={togglePinnedModel}
         favoriteNames={favoriteNameSet}
@@ -2898,15 +2901,11 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
             ariaLabel={customFormTitle}
             leading={<Icon name="compose" size={20} aria-hidden="true" />}
             title={<h2 className="workspace-detail-panel__title custom-model-editor__title">{customFormTitle}</h2>}
-            metadata={(
-              <>
-                <WorkspaceMetadataChip emphasis="high" tone="accent">
-                  {isCustomOmniCollectionDraft ? 'Omni collection' : 'Custom model'}
-                </WorkspaceMetadataChip>
-                {editingCustomModelName && <WorkspaceMetadataChip emphasis="medium">Editing saved definition</WorkspaceMetadataChip>}
-              </>
-            )}
+            metadata={editingCustomModelName ? (
+              <WorkspaceMetadataChip emphasis="medium">Editing saved definition</WorkspaceMetadataChip>
+            ) : undefined}
             description={<p>Register a model or collection that is not included in the Lemonade catalog.</p>}
+            descriptionPlacement="identity"
             actions={(
               <WorkspaceActionGroup className="custom-model-editor__actions" label={`${customFormTitle} actions`}>
                 <WorkspaceActionButton
@@ -2919,12 +2918,11 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
                   Save
                 </WorkspaceActionButton>
                 <WorkspaceActionButton appearance="secondary" icon="x" onClick={closeCustomForm}>Cancel</WorkspaceActionButton>
+                <span className="workspace-action-group__spacer" />
                 <WorkspaceActionButton appearance="quiet" icon="file" onClick={handleExportCustomModels}>Export</WorkspaceActionButton>
                 <WorkspaceActionButton appearance="quiet" icon="file-up" onClick={() => customJsonInputRef.current?.click()}>Import</WorkspaceActionButton>
               </WorkspaceActionGroup>
             )}
-            onClose={closeCustomForm}
-            closeLabel="Close custom model editor"
           >
             <div className="custom-model-form__body">
             <div className="custom-model-form__toolbar">
@@ -2938,7 +2936,7 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
                     aria-pressed={!isCustomOmniCollectionDraft}
                     onClick={() => openCustomForm('model')}
                   >
-                    Custom model
+                    Custom Model
                   </button>
                   <button
                     type="button"
@@ -2946,7 +2944,7 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
                     aria-pressed={isCustomOmniCollectionDraft}
                     onClick={() => openCustomForm('omni-collection')}
                   >
-                    Omni collection
+                    Omni Collection
                   </button>
                 </div>
               )}

--- a/src/app/src/components/RouterEditorPanel.tsx
+++ b/src/app/src/components/RouterEditorPanel.tsx
@@ -218,6 +218,10 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
   const [dragRuleIndex, setDragRuleIndex] = useState<number | null>(null);
   const [selectedRuleIndex, setSelectedRuleIndex] = useState(0);
   const [expandedRuleIndex, setExpandedRuleIndex] = useState<number | null>(null);
+  // Tracks rule indices whose graph has been committed at least once. Needed to
+  // pass initialCommitted=true to the expanded RouterRuleGraph so a blank
+  // keywords_any node (textValue='') isn't mistaken for the initial empty state.
+  const committedRuleIndicesRef = useRef<Set<number>>(new Set());
   const [cloudProviders, setCloudProviders] = useState<CloudProviderRow[]>([]);
   const [connectionsError, setConnectionsError] = useState<string | null>(null);
   const [editingProvider, setEditingProvider] = useState<string | null>(null);
@@ -1323,7 +1327,10 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
                         key={`rule-${selectedRuleIndex}`}
                         node={selectedRule.condition}
                         classifiers={draft.classifiers}
-                        onChange={condition => setPatch({ rules: draft.rules.map((item, itemIndex) => itemIndex === selectedRuleIndex ? { ...item, condition } : item) })}
+                        onChange={condition => {
+                          committedRuleIndicesRef.current.add(selectedRuleIndex);
+                          setPatch({ rules: draft.rules.map((item, itemIndex) => itemIndex === selectedRuleIndex ? { ...item, condition } : item) });
+                        }}
                         onExpand={() => setExpandedRuleIndex(selectedRuleIndex)}
                       />
                       <details className="router-editor__outputs">
@@ -1378,6 +1385,7 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
               node={expandedRule.condition}
               classifiers={draft.classifiers}
               expanded
+              initialCommitted={committedRuleIndicesRef.current.has(expandedRuleIndex)}
               onChange={condition => setPatch({
                 rules: draft.rules.map((item, itemIndex) => itemIndex === expandedRuleIndex ? { ...item, condition } : item),
               })}

--- a/src/app/src/components/RouterEditorPanel.tsx
+++ b/src/app/src/components/RouterEditorPanel.tsx
@@ -5,6 +5,7 @@ import { Icon } from './Icon';
 import Modal from './inspect/Modal';
 import RouterModelPicker from './RouterModelPicker';
 import RouterRuleGraph from './RouterRuleGraph';
+import { RouterSelect } from './RouterNodeEditor';
 import {
   WorkspaceActionButton,
   WorkspaceActionGroup,
@@ -908,13 +909,15 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
       actions={(
         <WorkspaceActionGroup label="Router editor actions">
           <WorkspaceActionButton appearance="primary" icon="check" disabled={saving || deleting || savingProvider || validationErrors.length > 0} onClick={() => { void save(); }}>
-            {saving ? 'Registering…' : 'Save & register'}
+            {saving ? 'Saving…' : 'Save'}
           </WorkspaceActionButton>
           {draft.modelName && (
             <WorkspaceActionButton appearance="danger" icon="trash" disabled={saving || deleting || savingProvider} onClick={requestDeleteCurrent}>Delete</WorkspaceActionButton>
           )}
+          <WorkspaceActionButton appearance="secondary" icon="x" disabled={saving || deleting || savingProvider} onClick={requestClose}>Cancel</WorkspaceActionButton>
           <span className="workspace-action-group__spacer" />
-          <WorkspaceActionButton appearance="secondary" icon="x" disabled={saving || deleting || savingProvider} onClick={requestClose}>Close</WorkspaceActionButton>
+          <WorkspaceActionButton appearance="quiet" icon="file" disabled={!request} onClick={() => request && downloadJson(routerDisplayName(request.model_name), request)}>Export</WorkspaceActionButton>
+          <WorkspaceActionButton appearance="quiet" icon="file-up" disabled={saving} onClick={() => importRef.current?.click()}>Import</WorkspaceActionButton>
         </WorkspaceActionGroup>
       )}
       titleExtras={(
@@ -928,10 +931,6 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
                 {savedRecords.map(record => <option key={record.model_name} value={record.model_name}>{record.display_name}</option>)}
               </select>
             </label>
-          </div>
-          <div className="router-editor__toolbar-row router-editor__toolbar-row--files">
-            <WorkspaceActionButton size="small" icon="file-up" disabled={saving} onClick={() => importRef.current?.click()}>Import</WorkspaceActionButton>
-            <WorkspaceActionButton size="small" icon="file" disabled={!request} onClick={() => request && downloadJson(routerDisplayName(request.model_name), request)}>Export</WorkspaceActionButton>
           </div>
           <input ref={importRef} className="hidden-file-input" type="file" accept="application/json,.json" onChange={event => { void importFile(event.target.files?.[0]); }} />
         </div>
@@ -964,7 +963,7 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
           <>
             <section className="router-editor__section">
               <div className="router-editor__section-head">
-                <div><h3>Identity</h3><p>Saved as a virtual model.</p></div>
+                <div><h3>Identity</h3><p>Appears in your model list like any other model.</p></div>
               </div>
               <div className="router-editor__form-grid">
                 <label><span>Router Name</span><input className="input" value={draft.name} placeholder="Fast-or-smart" onChange={event => setPatch({ name: event.target.value })} /></label>
@@ -974,7 +973,7 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
 
             <section className="router-editor__section">
               <div className="router-editor__section-head">
-                <div><h3>Candidate Models</h3><p>The router may select only from these registered models.</p></div>
+                <div><h3>Candidate Models</h3><p>Traffic is distributed only among these models.</p></div>
                 <span className="router-editor__count">{draft.candidates.length} selected</span>
               </div>
               <div className="router-editor__candidate-search"><Icon name="search" size={14} /><input value={candidateSearch} placeholder="Search registered models" onChange={event => setCandidateSearch(event.target.value)} /></div>
@@ -1022,6 +1021,12 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
                             <strong>{connection.displayName}</strong>
                             {connection.modelName === draft.defaultModel && <span className="router-editor__default-badge">Default</span>}
                           </div>
+                          <div className="router-editor__connection-source">
+                            <span className={`router-editor__source-badge router-editor__source-badge--${connection.kind}`}>
+                              {connection.kind === 'external' ? 'External' : connection.kind === 'internal' ? 'Internal' : 'Unresolved'}
+                            </span>
+                            <small>{connection.kind === 'external' ? (connection.provider || 'Unknown provider') : (connection.backend || connection.recipe || 'Unknown source')}</small>
+                          </div>
                         </div>
                         {connection.kind === 'external' && (
                           <div className="router-editor__connection-endpoint">
@@ -1059,12 +1064,6 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
                           </div>
                         )}
                         <div className="router-editor__connection-trailing">
-                          <div className="router-editor__connection-source">
-                            <span className={`router-editor__source-badge router-editor__source-badge--${connection.kind}`}>
-                              {connection.kind === 'external' ? 'External' : connection.kind === 'internal' ? 'Internal' : 'Unresolved'}
-                            </span>
-                            <small>{connection.kind === 'external' ? (connection.provider || 'Unknown provider') : (connection.backend || connection.recipe || 'Unknown source')}</small>
-                          </div>
                           {draft.candidates.includes(connection.modelName) && (
                             <WorkspaceActionButton
                               appearance="danger"
@@ -1087,7 +1086,7 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
 
             <section className="router-editor__section">
               <div className="router-editor__section-head">
-                <div><h3>Routing Strategy</h3><p>Choose how the router selects a candidate. Switching modes clears incompatible configuration after confirmation.</p></div>
+                <div><h3>Routing Strategy</h3><p>Pick the mechanism that decides which model handles each request.</p></div>
               </div>
               <div className="router-editor__strategy" role="radiogroup" aria-label="Routing strategy">
                 <button
@@ -1098,7 +1097,7 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
                   onClick={() => setRoutingMode('rules')}
                 >
                   <Icon name="layers" size={18} />
-                  <span><strong>Ordered Rules</strong><small>Deterministic conditions and optional model-backed signals. First match wins.</small></span>
+                  <span><strong>Ordered Rules</strong><small>Pattern-based rules with optional classifier signals - first match wins.</small></span>
                 </button>
                 <button
                   type="button"
@@ -1108,7 +1107,7 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
                   onClick={() => setRoutingMode('llm')}
                 >
                   <Icon name="brain-circuit" size={18} />
-                  <span><strong>Natural-Language Router</strong><small>A routing model reads your instruction and chooses one candidate directly.</small></span>
+                  <span><strong>Natural-Language Router</strong><small>An LLM model reads your instruction and picks the right candidate for each request.</small></span>
                 </button>
               </div>
             </section>
@@ -1143,7 +1142,7 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
               <>
             <section className="router-editor__section">
               <div className="router-editor__section-head">
-                <div><h3>Classifiers</h3><p>Optional model-backed signals evaluated once per request.</p></div>
+                <div><h3>Classifiers</h3><p>Model-scored signals you can reference inside your rules.</p></div>
                 <div className="router-editor__section-actions">
                   <WorkspaceActionButton size="small" icon="plus" onClick={() => addClassifier('classifier')}>Classifier</WorkspaceActionButton>
                   <WorkspaceActionButton size="small" icon="plus" onClick={() => addClassifier('semantic_similarity')}>Semantic</WorkspaceActionButton>
@@ -1162,7 +1161,7 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
                         </div>
                         <div className="router-editor__form-grid router-editor__form-grid--classifier">
                           <label><span>ID</span><CommittedTextInput value={classifier.id} ariaLabel={`Classifier ${index + 1} ID`} normalize={input => input} onCommit={nextId => commitClassifierId(index, nextId)} /></label>
-                          <label><span>Type</span><select className="select" value={classifier.type} onChange={event => updateClassifier(index, { ...createRouterClassifier(index, event.target.value as RouterClassifier['type']), id: classifier.id })}><option value="classifier">classifier</option><option value="semantic_similarity">semantic_similarity</option><option value="llm">llm</option></select></label>
+                          <label><span>Type</span><RouterSelect value={classifier.type} options={[{ value: 'classifier', label: 'classifier' }, { value: 'semantic_similarity', label: 'semantic_similarity' }, { value: 'llm', label: 'llm' }]} onChange={(val: string) => updateClassifier(index, { ...createRouterClassifier(index, val as RouterClassifier['type']), id: classifier.id })} ariaLabel="Classifier type" /></label>
                           <div className="router-editor__wide router-editor__field">
                             <span>Model</span>
                             <RouterModelPicker
@@ -1219,8 +1218,8 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
                               /></label>
                             </>
                           )}
-                          <label><span>Default Label</span><select className="select" value={classifier.defaultLabel || ''} onChange={event => updateClassifier(index, { defaultLabel: event.target.value || undefined })}><option value="">None</option>{labels.map(label => <option key={label} value={label}>{label}</option>)}</select></label>
-                          <label><span>On Error</span><select className="select" value={classifier.onError} onChange={event => updateClassifier(index, { onError: event.target.value as RouterClassifier['onError'] })}><option value="match_false">Do not match</option><option value="match_true">Match rule</option></select></label>
+                          <label><span>Default Label</span><RouterSelect value={classifier.defaultLabel || ''} options={[{ value: '', label: 'None' }, ...labels.map(label => ({ value: label, label }))]} onChange={(val: string) => updateClassifier(index, { defaultLabel: val || undefined })} ariaLabel="Default label" /></label>
+                          <label><span>On Error</span><RouterSelect value={classifier.onError} options={[{ value: 'match_false', label: 'Do not match' }, { value: 'match_true', label: 'Match rule' }]} onChange={(val: string) => updateClassifier(index, { onError: val as RouterClassifier['onError'] })} ariaLabel="On error" /></label>
                         </div>
                       </article>
                     );
@@ -1231,7 +1230,7 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
 
             <section className="router-editor__section">
               <div className="router-editor__section-head">
-                <div><h3>Ordered Rules</h3><p>First matching rule wins. The default model handles the remainder.</p></div>
+                <div><h3>Ordered Rules</h3><p>Evaluated top to bottom - the first match wins, everything else falls back to the default.</p></div>
                 <WorkspaceActionButton size="small" icon="plus" onClick={addRule}>Rule</WorkspaceActionButton>
               </div>
               <div className="router-editor__rules-workspace">
@@ -1300,14 +1299,20 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
                   {selectedRule ? (
                     <>
                       <div className="router-editor__rule-builder-head">
-                        <div>
-                          <strong>Rule {selectedRuleIndex + 1}: {selectedRule.id || 'Untitled rule'}</strong>
-                          <span>Build the match expression by dragging gates and conditions onto the graph.</span>
-                        </div>
-                      </div>
-                      <div className="router-editor__rule-meta">
-                        <label><span>Rule ID</span><input className="input" value={selectedRule.id} onChange={event => setPatch({ rules: draft.rules.map((item, itemIndex) => itemIndex === selectedRuleIndex ? { ...item, id: event.target.value } : item) })} /></label>
-                        <label><span>Route To</span><select className="select" value={selectedRule.routeTo} onChange={event => setPatch({ rules: draft.rules.map((item, itemIndex) => itemIndex === selectedRuleIndex ? { ...item, routeTo: event.target.value } : item) })}><option value="">Select candidate</option>{draft.candidates.map(candidate => <option key={candidate} value={candidate}>{candidate}</option>)}</select></label>
+                        <span className="router-editor__rule-builder-label">Rule {selectedRuleIndex + 1}:</span>
+                        <input
+                          className="input router-editor__rule-id-input"
+                          value={selectedRule.id}
+                          aria-label="Rule ID"
+                          onChange={event => setPatch({ rules: draft.rules.map((item, itemIndex) => itemIndex === selectedRuleIndex ? { ...item, id: event.target.value } : item) })}
+                        />
+                        <RouterSelect
+                          className="router-editor__rule-route-select"
+                          value={selectedRule.routeTo}
+                          options={[{ value: '', label: 'Route to…' }, ...draft.candidates.map(c => ({ value: c, label: c }))]}
+                          onChange={(val: string) => setPatch({ rules: draft.rules.map((item, itemIndex) => itemIndex === selectedRuleIndex ? { ...item, routeTo: val } : item) })}
+                          ariaLabel="Route To"
+                        />
                       </div>
                       <RouterRuleGraph
                         key={`rule-${selectedRuleIndex}`}
@@ -1358,6 +1363,7 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
         onClose={() => setExpandedRuleIndex(null)}
         title={expandedRule && expandedRuleIndex != null ? `Rule ${expandedRuleIndex + 1}: ${expandedRule.id || 'Untitled Rule'}` : 'Graph Builder'}
         maxWidth="calc(100vw - 48px)"
+        className="inspect-modal-content--full-height"
         ariaLabelledBy="router-graph-expanded-title"
       >
         {expandedRule && expandedRuleIndex != null && (
@@ -1366,6 +1372,7 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
               key={`expanded-${expandedRuleIndex}`}
               node={expandedRule.condition}
               classifiers={draft.classifiers}
+              expanded
               onChange={condition => setPatch({
                 rules: draft.rules.map((item, itemIndex) => itemIndex === expandedRuleIndex ? { ...item, condition } : item),
               })}

--- a/src/app/src/components/RouterEditorPanel.tsx
+++ b/src/app/src/components/RouterEditorPanel.tsx
@@ -914,7 +914,7 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
           {draft.modelName && (
             <WorkspaceActionButton appearance="danger" icon="trash" disabled={saving || deleting || savingProvider} onClick={requestDeleteCurrent}>Delete</WorkspaceActionButton>
           )}
-          <WorkspaceActionButton appearance="secondary" icon="x" disabled={saving || deleting || savingProvider} onClick={requestClose}>Cancel</WorkspaceActionButton>
+          <WorkspaceActionButton appearance="secondary" icon="x" disabled={saving || deleting || savingProvider} onClick={requestClose}>Close</WorkspaceActionButton>
           <span className="workspace-action-group__spacer" />
           <WorkspaceActionButton appearance="quiet" icon="file" disabled={!request} onClick={() => request && downloadJson(routerDisplayName(request.model_name), request)}>Export</WorkspaceActionButton>
           <WorkspaceActionButton appearance="quiet" icon="file-up" disabled={saving} onClick={() => importRef.current?.click()}>Import</WorkspaceActionButton>
@@ -1398,7 +1398,7 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
           <p>{confirmation?.message}</p>
         </div>
         <div className="inspect-modal-footer">
-          <WorkspaceActionButton appearance="secondary" disabled={deleting} onClick={dismissConfirmation}>Cancel</WorkspaceActionButton>
+          <WorkspaceActionButton appearance="secondary" disabled={deleting} onClick={dismissConfirmation}>Close</WorkspaceActionButton>
           <WorkspaceActionButton appearance={confirmation?.tone || 'primary'} disabled={deleting} onClick={confirmPendingAction}>
             {deleting && confirmation?.kind === 'delete' ? 'Deleting…' : (confirmation?.confirmLabel || 'Continue')}
           </WorkspaceActionButton>

--- a/src/app/src/components/RouterEditorPanel.tsx
+++ b/src/app/src/components/RouterEditorPanel.tsx
@@ -1003,10 +1003,12 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
               </div>
               <label className="router-editor__default-model">
                 <span>Default Model <small>Used when no rule matches or evaluation fails.</small></span>
-                <select className="select" value={draft.defaultModel} onChange={event => setPatch({ defaultModel: event.target.value })}>
-                  <option value="">Select default</option>
-                  {draft.candidates.map(candidate => <option key={candidate} value={candidate}>{candidate}</option>)}
-                </select>
+                <RouterSelect
+                  value={draft.defaultModel}
+                  options={[{ value: '', label: 'Select default' }, ...draft.candidates.map(c => ({ value: c, label: c }))]}
+                  onChange={(val: string) => setPatch({ defaultModel: val })}
+                  ariaLabel="Default model"
+                />
               </label>
 
               <div className="router-editor__connections" aria-label="Connected model topology">

--- a/src/app/src/components/RouterEditorPanel.tsx
+++ b/src/app/src/components/RouterEditorPanel.tsx
@@ -926,10 +926,13 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
             <WorkspaceActionButton size="small" icon="compose" disabled={saving || deleting || savingProvider} onClick={requestResetDraft}>New</WorkspaceActionButton>
             <label className="router-editor__saved-select">
               <span className="sr-only">Saved routers</span>
-              <select className="select" value={draft.modelName || ''} disabled={saving || deleting || savingProvider} onChange={event => loadSaved(event.target.value)}>
-                <option value="">Unsaved router</option>
-                {savedRecords.map(record => <option key={record.model_name} value={record.model_name}>{record.display_name}</option>)}
-              </select>
+              <RouterSelect
+                value={draft.modelName || ''}
+                options={[{ value: '', label: 'Unsaved router' }, ...savedRecords.map(r => ({ value: r.model_name, label: r.display_name }))]}
+                onChange={(val: string) => loadSaved(val)}
+                ariaLabel="Saved routers"
+                disabled={saving || deleting || savingProvider}
+              />
             </label>
           </div>
           <input ref={importRef} className="hidden-file-input" type="file" accept="application/json,.json" onChange={event => { void importFile(event.target.files?.[0]); }} />

--- a/src/app/src/components/RouterNodeEditor.tsx
+++ b/src/app/src/components/RouterNodeEditor.tsx
@@ -42,7 +42,11 @@ export const RouterSelect: React.FC<RouterSelectProps> = ({ value, options, onCh
 
   useEffect(() => {
     if (!open) return;
-    const closeOnScroll = () => setOpen(false);
+    const closeOnScroll = (e: Event) => {
+      const t = e.target as Node;
+      if (popoverRef.current?.contains(t)) return;
+      setOpen(false);
+    };
     window.addEventListener('scroll', closeOnScroll, { capture: true, passive: true });
     window.addEventListener('resize', reposition, { passive: true });
     return () => {

--- a/src/app/src/components/RouterNodeEditor.tsx
+++ b/src/app/src/components/RouterNodeEditor.tsx
@@ -1,6 +1,92 @@
-import React from 'react';
+import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { Icon } from './Icon';
 import { WorkspaceActionButton } from './WorkspacePanels';
+
+interface RouterSelectOption {
+  value: string;
+  label: string;
+  disabled?: boolean;
+}
+
+interface RouterSelectProps {
+  value: string;
+  options: RouterSelectOption[];
+  onChange: (value: string) => void;
+  ariaLabel?: string;
+  className?: string;
+}
+
+export const RouterSelect: React.FC<RouterSelectProps> = ({ value, options, onChange, ariaLabel, className }) => {
+  const [open, setOpen] = useState(false);
+  const [coords, setCoords] = useState<{ top: number; left: number; width: number } | null>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const popoverRef = useRef<HTMLDivElement>(null);
+  const selected = options.find(o => o.value === value);
+
+  useLayoutEffect(() => {
+    if (!open || !triggerRef.current) return;
+    const r = triggerRef.current.getBoundingClientRect();
+    setCoords({ top: r.bottom + window.scrollY + 4, left: r.left + window.scrollX, width: r.width });
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      const t = e.target as Node;
+      if (!triggerRef.current?.contains(t) && !popoverRef.current?.contains(t)) setOpen(false);
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [open]);
+
+  const pick = (val: string, disabled?: boolean) => {
+    if (disabled) return;
+    onChange(val);
+    setOpen(false);
+  };
+
+  return (
+    <div className={`router-select${className ? ` ${className}` : ''}`}>
+      <button
+        ref={triggerRef}
+        type="button"
+        className={`router-select__trigger${open ? ' is-open' : ''}`}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-label={ariaLabel}
+        onClick={() => setOpen(v => !v)}
+      >
+        <span className={selected ? undefined : 'is-placeholder'}>{selected?.label ?? value}</span>
+        <Icon name="chevron-down" size={12} />
+      </button>
+      {open && coords && createPortal(
+        <div
+          ref={popoverRef}
+          className="router-select__popover"
+          role="listbox"
+          aria-label={ariaLabel}
+          style={{ top: coords.top, left: coords.left, minWidth: coords.width }}
+        >
+          {options.map(opt => (
+            <button
+              type="button"
+              key={opt.value}
+              role="option"
+              aria-selected={opt.value === value}
+              aria-disabled={opt.disabled}
+              className={`router-select__option${opt.value === value ? ' is-selected' : ''}${opt.disabled ? ' is-disabled' : ''}`}
+              onClick={() => pick(opt.value, opt.disabled)}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>,
+        document.body,
+      )}
+    </div>
+  );
+};
 import {
   classifierLabels,
   createRouterGroup,
@@ -32,6 +118,7 @@ interface RouterNodeEditorProps {
   node: RouterNode;
   classifiers: RouterClassifier[];
   onChange: (next: RouterNode) => void;
+  onRemoveSelf?: () => void;
   depth?: number;
 }
 
@@ -109,9 +196,12 @@ const RouterLeafEditor: React.FC<{
       <div className="router-node__leaf-row">
         <label className="router-node__type-field">
           <span className="sr-only">Condition type</span>
-          <select className="select" value={node.type} onChange={event => changeType(event.target.value as RouterLeafType)}>
-            {LEAF_TYPES.map(item => <option key={item.value} value={item.value}>{item.label}</option>)}
-          </select>
+          <RouterSelect
+            value={node.type}
+            options={LEAF_TYPES}
+            onChange={val => changeType(val as RouterLeafType)}
+            ariaLabel="Condition type"
+          />
         </label>
 
         {(node.type === 'keywords_any' || node.type === 'keywords_all') && (
@@ -142,10 +232,11 @@ const RouterLeafEditor: React.FC<{
           />
         )}
         {(node.type === 'has_tools' || node.type === 'has_images') && (
-          <select className="select" value={node.booleanValue === false ? 'false' : 'true'} onChange={event => update({ booleanValue: event.target.value === 'true' })}>
-            <option value="true">is true</option>
-            <option value="false">is false</option>
-          </select>
+          <RouterSelect
+            value={node.booleanValue === false ? 'false' : 'true'}
+            options={[{ value: 'true', label: 'is true' }, { value: 'false', label: 'is false' }]}
+            onChange={val => update({ booleanValue: val === 'true' })}
+          />
         )}
       </div>
 
@@ -153,33 +244,33 @@ const RouterLeafEditor: React.FC<{
         <div className="router-node__details router-node__details--classifier">
           <label>
             <span>Classifier</span>
-            <select
-              className="select"
+            <RouterSelect
               value={node.classifierId ?? ''}
-              onChange={event => {
-                // Keep label omitted when choosing a classifier so the condition
-                // continues to follow that classifier's default_label. Copying the
-                // current default into the rule would silently freeze the old value.
-                update({
-                  classifierId: event.target.value,
-                  label: undefined,
-                });
-              }}
-            >
-              <option value="">Select classifier</option>
-              {classifiers.map(item => <option key={item.id} value={item.id}>{item.id}</option>)}
-            </select>
+              options={[
+                { value: '', label: 'Select classifier' },
+                ...classifiers.map(item => ({ value: item.id, label: item.id })),
+              ]}
+              onChange={val => update({ classifierId: val, label: undefined })}
+              ariaLabel="Classifier"
+            />
           </label>
           <label>
             <span>Label</span>
-            <select className="select" value={node.label ?? ''} onChange={event => update({ label: event.target.value || undefined })}>
-              <option value="" disabled={labels.length > 0 && !selectedClassifier?.defaultLabel}>
-                {selectedClassifier?.defaultLabel
-                  ? `Use classifier default (${selectedClassifier.defaultLabel})`
-                  : labels.length > 0 ? 'Select label' : 'Use classifier output'}
-              </option>
-              {labels.map(label => <option key={label} value={label}>{label}</option>)}
-            </select>
+            <RouterSelect
+              value={node.label ?? ''}
+              options={[
+                {
+                  value: '',
+                  label: selectedClassifier?.defaultLabel
+                    ? `Use classifier default (${selectedClassifier.defaultLabel})`
+                    : labels.length > 0 ? 'Select label' : 'Use classifier output',
+                  disabled: labels.length > 0 && !selectedClassifier?.defaultLabel,
+                },
+                ...labels.map(label => ({ value: label, label })),
+              ]}
+              onChange={val => update({ label: val || undefined })}
+              ariaLabel="Label"
+            />
           </label>
           <ScoreInput label="Min score" value={node.minScore} onChange={minScore => update({ minScore })} />
           <ScoreInput label="Max score" value={node.maxScore} onChange={maxScore => update({ maxScore })} />
@@ -194,23 +285,26 @@ const RouterLeafEditor: React.FC<{
           </label>
           <label>
             <span>Comparator</span>
-            <select
-              className="select"
+            <RouterSelect
               value={node.metadataComparator ?? 'equals'}
-              onChange={event => update({ metadataComparator: event.target.value as RouterMetadataComparator })}
-            >
-              <option value="equals">equals</option>
-              <option value="any">contains any token</option>
-              <option value="exists">exists</option>
-            </select>
+              options={[
+                { value: 'equals', label: 'equals' },
+                { value: 'any', label: 'contains any token' },
+                { value: 'exists', label: 'exists' },
+              ]}
+              onChange={val => update({ metadataComparator: val as RouterMetadataComparator })}
+              ariaLabel="Comparator"
+            />
           </label>
           {(node.metadataComparator ?? 'equals') === 'exists' ? (
             <label>
               <span>Expected</span>
-              <select className="select" value={node.booleanValue === false ? 'false' : 'true'} onChange={event => update({ booleanValue: event.target.value === 'true' })}>
-                <option value="true">present</option>
-                <option value="false">missing</option>
-              </select>
+              <RouterSelect
+                value={node.booleanValue === false ? 'false' : 'true'}
+                options={[{ value: 'true', label: 'present' }, { value: 'false', label: 'missing' }]}
+                onChange={val => update({ booleanValue: val === 'true' })}
+                ariaLabel="Expected"
+              />
             </label>
           ) : node.metadataComparator === 'any' ? (
             <label className="router-node__grow-field">
@@ -235,7 +329,7 @@ const RouterLeafEditor: React.FC<{
   );
 };
 
-export const RouterNodeEditor: React.FC<RouterNodeEditorProps> = ({ node, classifiers, onChange, depth = 0 }) => {
+export const RouterNodeEditor: React.FC<RouterNodeEditorProps> = ({ node, classifiers, onChange, onRemoveSelf, depth = 0 }) => {
   if (node.kind === 'leaf') {
     return <RouterLeafEditor node={node} classifiers={classifiers} onChange={onChange} />;
   }
@@ -257,16 +351,29 @@ export const RouterNodeEditor: React.FC<RouterNodeEditorProps> = ({ node, classi
     onChange({ ...node, operator, children: node.children.length ? node.children : [createRouterLeaf()] });
   };
 
+  const handleRemoveChild = (index: number) => {
+    if (node.children.length === 1 && onRemoveSelf) {
+      onRemoveSelf();
+    } else {
+      onChange(removeChild(node, index));
+    }
+  };
+
   return (
     <div className="router-node router-node--group" style={{ '--router-depth': depth } as React.CSSProperties}>
       <div className="router-node__group-head">
         <div className="router-node__operator">
           <span>Match</span>
-          <select className="select" value={node.operator} onChange={event => changeOperator(event.target.value as RouterGroupNode['operator'])}>
-            <option value="all">ALL conditions</option>
-            <option value="any">ANY condition</option>
-            <option value="not">NOT condition</option>
-          </select>
+          <RouterSelect
+            value={node.operator}
+            options={[
+              { value: 'all', label: 'ALL conditions' },
+              { value: 'any', label: 'ANY condition' },
+              { value: 'not', label: 'NOT condition' },
+            ]}
+            onChange={val => changeOperator(val as RouterGroupNode['operator'])}
+            ariaLabel="Group operator"
+          />
         </div>
         {node.operator !== 'not' && (
           <div className="router-node__group-actions">
@@ -281,13 +388,14 @@ export const RouterNodeEditor: React.FC<RouterNodeEditorProps> = ({ node, classi
             <div className="router-node__child-actions" aria-label={`Condition ${index + 1} controls`}>
               <button type="button" disabled={index === 0} title="Move up" aria-label="Move condition up" onClick={() => onChange(moveChild(node, index, -1))}><Icon name="chevron-up" size={13} /></button>
               <button type="button" disabled={index === node.children.length - 1} title="Move down" aria-label="Move condition down" onClick={() => onChange(moveChild(node, index, 1))}><Icon name="chevron-down" size={13} /></button>
-              <button type="button" title="Remove condition" aria-label="Remove condition" onClick={() => onChange(removeChild(node, index))}><Icon name="trash" size={13} /></button>
+              <button type="button" title="Remove condition" aria-label="Remove condition" onClick={() => handleRemoveChild(index)}><Icon name="trash" size={13} /></button>
             </div>
             <RouterNodeEditor
               node={child}
               classifiers={classifiers}
               depth={depth + 1}
               onChange={next => onChange(replaceChild(node, index, next))}
+              onRemoveSelf={() => handleRemoveChild(index)}
             />
           </div>
         ))}

--- a/src/app/src/components/RouterNodeEditor.tsx
+++ b/src/app/src/components/RouterNodeEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { Icon } from './Icon';
 import { WorkspaceActionButton } from './WorkspacePanels';
@@ -18,18 +18,38 @@ interface RouterSelectProps {
   disabled?: boolean;
 }
 
+function computeCoords(trigger: HTMLButtonElement) {
+  const r = trigger.getBoundingClientRect();
+  return { top: r.bottom + 4, left: r.left, width: r.width };
+}
+
 export const RouterSelect: React.FC<RouterSelectProps> = ({ value, options, onChange, ariaLabel, className, disabled }) => {
   const [open, setOpen] = useState(false);
   const [coords, setCoords] = useState<{ top: number; left: number; width: number } | null>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const popoverRef = useRef<HTMLDivElement>(null);
+  const optionRefs = useRef<(HTMLButtonElement | null)[]>([]);
   const selected = options.find(o => o.value === value);
+
+  const reposition = useCallback(() => {
+    if (triggerRef.current) setCoords(computeCoords(triggerRef.current));
+  }, []);
 
   useLayoutEffect(() => {
     if (!open || !triggerRef.current) return;
-    const r = triggerRef.current.getBoundingClientRect();
-    setCoords({ top: r.bottom + window.scrollY + 4, left: r.left + window.scrollX, width: r.width });
+    setCoords(computeCoords(triggerRef.current));
   }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const closeOnScroll = () => setOpen(false);
+    window.addEventListener('scroll', closeOnScroll, { capture: true, passive: true });
+    window.addEventListener('resize', reposition, { passive: true });
+    return () => {
+      window.removeEventListener('scroll', closeOnScroll, { capture: true });
+      window.removeEventListener('resize', reposition);
+    };
+  }, [open, reposition]);
 
   useEffect(() => {
     if (!open) return;
@@ -41,10 +61,60 @@ export const RouterSelect: React.FC<RouterSelectProps> = ({ value, options, onCh
     return () => document.removeEventListener('mousedown', handler);
   }, [open]);
 
-  const pick = (val: string, disabled?: boolean) => {
-    if (disabled) return;
+  const close = useCallback(() => {
+    setOpen(false);
+    triggerRef.current?.focus();
+  }, []);
+
+  const pick = useCallback((val: string, isDisabled?: boolean) => {
+    if (isDisabled) return;
     onChange(val);
     setOpen(false);
+    triggerRef.current?.focus();
+  }, [onChange]);
+
+  const onTriggerKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+      e.preventDefault();
+      if (!open) {
+        setOpen(true);
+        // Focus first (ArrowDown) or last (ArrowUp) enabled option after open
+        window.setTimeout(() => {
+          const enabled = optionRefs.current.filter(Boolean) as HTMLButtonElement[];
+          const target = e.key === 'ArrowDown' ? enabled[0] : enabled[enabled.length - 1];
+          target?.focus();
+        }, 0);
+      } else {
+        const enabled = optionRefs.current.filter(Boolean) as HTMLButtonElement[];
+        const target = e.key === 'ArrowDown' ? enabled[0] : enabled[enabled.length - 1];
+        target?.focus();
+      }
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      e.stopPropagation();
+      setOpen(false);
+    }
+  };
+
+  const onOptionKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>, index: number, opt: RouterSelectOption) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      const next = optionRefs.current.slice(index + 1).find(Boolean) as HTMLButtonElement | undefined;
+      next?.focus();
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      const prev = optionRefs.current.slice(0, index).reverse().find(Boolean) as HTMLButtonElement | undefined;
+      if (prev) prev.focus(); else close();
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      e.stopPropagation();
+      close();
+    } else if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      pick(opt.value, opt.disabled);
+    } else if (e.key === 'Tab') {
+      close();
+    }
   };
 
   return (
@@ -58,6 +128,7 @@ export const RouterSelect: React.FC<RouterSelectProps> = ({ value, options, onCh
         aria-label={ariaLabel}
         disabled={disabled}
         onClick={() => setOpen(v => !v)}
+        onKeyDown={onTriggerKeyDown}
       >
         <span className={selected ? undefined : 'is-placeholder'}>{selected?.label ?? value}</span>
         <Icon name="chevron-down" size={12} />
@@ -70,15 +141,18 @@ export const RouterSelect: React.FC<RouterSelectProps> = ({ value, options, onCh
           aria-label={ariaLabel}
           style={{ top: coords.top, left: coords.left, minWidth: coords.width }}
         >
-          {options.map(opt => (
+          {options.map((opt, index) => (
             <button
+              ref={el => { optionRefs.current[index] = el; }}
               type="button"
               key={opt.value}
               role="option"
               aria-selected={opt.value === value}
               aria-disabled={opt.disabled}
+              tabIndex={-1}
               className={`router-select__option${opt.value === value ? ' is-selected' : ''}${opt.disabled ? ' is-disabled' : ''}`}
               onClick={() => pick(opt.value, opt.disabled)}
+              onKeyDown={e => onOptionKeyDown(e, index, opt)}
             >
               {opt.label}
             </button>

--- a/src/app/src/components/RouterNodeEditor.tsx
+++ b/src/app/src/components/RouterNodeEditor.tsx
@@ -15,9 +15,10 @@ interface RouterSelectProps {
   onChange: (value: string) => void;
   ariaLabel?: string;
   className?: string;
+  disabled?: boolean;
 }
 
-export const RouterSelect: React.FC<RouterSelectProps> = ({ value, options, onChange, ariaLabel, className }) => {
+export const RouterSelect: React.FC<RouterSelectProps> = ({ value, options, onChange, ariaLabel, className, disabled }) => {
   const [open, setOpen] = useState(false);
   const [coords, setCoords] = useState<{ top: number; left: number; width: number } | null>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
@@ -55,6 +56,7 @@ export const RouterSelect: React.FC<RouterSelectProps> = ({ value, options, onCh
         aria-haspopup="listbox"
         aria-expanded={open}
         aria-label={ariaLabel}
+        disabled={disabled}
         onClick={() => setOpen(v => !v)}
       >
         <span className={selected ? undefined : 'is-placeholder'}>{selected?.label ?? value}</span>

--- a/src/app/src/components/RouterRuleGraph.tsx
+++ b/src/app/src/components/RouterRuleGraph.tsx
@@ -265,12 +265,16 @@ interface RouterRuleGraphProps {
   // Full-modal layout: workspace and inspector sit side by side and the
   // divider between them becomes draggable.
   expanded?: boolean;
+  // Allows a freshly-mounted expanded instance to inherit committed state from
+  // the inline instance. Without this, a blank keywords_any node (textValue='')
+  // looks identical to the initial empty graph and would be hidden on expand.
+  initialCommitted?: boolean;
 }
 
 const INSPECTOR_MIN_WIDTH = 320;
 const WORKSPACE_MIN_WIDTH = 360;
 
-export const RouterRuleGraph: React.FC<RouterRuleGraphProps> = ({ node, classifiers, onChange, onExpand, expanded = false }) => {
+export const RouterRuleGraph: React.FC<RouterRuleGraphProps> = ({ node, classifiers, onChange, onExpand, expanded = false, initialCommitted }) => {
   const [toolboxCollapsed, setToolboxCollapsed] = useState(false);
   const [toolboxSearch, setToolboxSearch] = useState('');
   const [selectedPath, setSelectedPath] = useState<RouterNodePath | null>(null);
@@ -290,8 +294,10 @@ export const RouterRuleGraph: React.FC<RouterRuleGraphProps> = ({ node, classifi
   // True once the user has explicitly dropped or committed a node. Prevents a
   // freshly-dropped blank keywords_any (textValue='') from being hidden by the
   // isBlankRouterGraphNode check, which also matches the initial default state.
-  // Initialized from the node so inline↔expanded instances agree on first render.
-  const hasCommittedRef = useRef(!isBlankRouterGraphNode(node));
+  // initialCommitted lets the expanded modal inherit committed state from the
+  // inline instance for nodes that look blank but were explicitly placed.
+  const hasCommittedRef = useRef(initialCommitted ?? !isBlankRouterGraphNode(node));
+  const isMountedRef = useRef(false);
 
   const selectedNode = selectedPath ? routerNodeAtPath(node, selectedPath) : null;
   const blank = isBlankRouterGraphNode(node) && !hasCommittedRef.current;
@@ -301,6 +307,14 @@ export const RouterRuleGraph: React.FC<RouterRuleGraphProps> = ({ node, classifi
   }, [node, selectedPath]);
 
   useEffect(() => {
+    // Skip on initial mount — hasCommittedRef is correctly seeded by useRef
+    // (using initialCommitted when provided, otherwise derived from the node).
+    // Running on mount would overwrite that with a stale isBlankRouterGraphNode
+    // check and drop a committed-but-empty keywords_any node on the canvas.
+    if (!isMountedRef.current) {
+      isMountedRef.current = true;
+      return;
+    }
     // Inline and expanded builders may edit the same rule. If this instance
     // receives a node it did not emit itself, its undo/redo snapshots belong to
     // an older tree and must not be allowed to overwrite the external change.
@@ -310,8 +324,6 @@ export const RouterRuleGraph: React.FC<RouterRuleGraphProps> = ({ node, classifi
     }
     historyRef.current = [];
     futureRef.current = [];
-    // Derive committed state from the node itself so that switching between
-    // inline and expanded instances always agrees: a non-blank node is committed.
     hasCommittedRef.current = !isBlankRouterGraphNode(node);
     setSelectedPath(null);
   }, [node]);

--- a/src/app/src/components/RouterRuleGraph.tsx
+++ b/src/app/src/components/RouterRuleGraph.tsx
@@ -287,10 +287,11 @@ export const RouterRuleGraph: React.FC<RouterRuleGraphProps> = ({ node, classifi
   const historyRef = useRef<RouterNode[]>([]);
   const futureRef = useRef<RouterNode[]>([]);
   const lastEmittedNodeRef = useRef<RouterNode | null>(null);
-  // True once the user has explicitly dropped or committed a node in this
-  // session. Prevents a freshly-dropped blank keywords_any from being hidden
-  // by the isBlankRouterGraphNode check (which also matches the initial state).
-  const hasCommittedRef = useRef(false);
+  // True once the user has explicitly dropped or committed a node. Prevents a
+  // freshly-dropped blank keywords_any (textValue='') from being hidden by the
+  // isBlankRouterGraphNode check, which also matches the initial default state.
+  // Initialized from the node so inline↔expanded instances agree on first render.
+  const hasCommittedRef = useRef(!isBlankRouterGraphNode(node));
 
   const selectedNode = selectedPath ? routerNodeAtPath(node, selectedPath) : null;
   const blank = isBlankRouterGraphNode(node) && !hasCommittedRef.current;
@@ -309,7 +310,9 @@ export const RouterRuleGraph: React.FC<RouterRuleGraphProps> = ({ node, classifi
     }
     historyRef.current = [];
     futureRef.current = [];
-    hasCommittedRef.current = false;
+    // Derive committed state from the node itself so that switching between
+    // inline and expanded instances always agrees: a non-blank node is committed.
+    hasCommittedRef.current = !isBlankRouterGraphNode(node);
     setSelectedPath(null);
   }, [node]);
 
@@ -638,12 +641,32 @@ export const RouterRuleGraph: React.FC<RouterRuleGraphProps> = ({ node, classifi
           role="separator"
           aria-orientation="vertical"
           aria-label="Resize node inspector"
+          aria-valuemin={INSPECTOR_MIN_WIDTH}
+          aria-valuemax={INSPECTOR_MIN_WIDTH + (graphRef.current ? Math.max(0, graphRef.current.offsetWidth - WORKSPACE_MIN_WIDTH - INSPECTOR_MIN_WIDTH) : 400)}
+          aria-valuenow={inspectorWidth ?? INSPECTOR_MIN_WIDTH}
+          tabIndex={0}
           title="Drag to resize · double-click to reset"
           onPointerDown={startResize}
           onPointerMove={onResizeMove}
           onPointerUp={stopResize}
           onPointerCancel={stopResize}
           onDoubleClick={() => setInspectorWidth(null)}
+          onKeyDown={e => {
+            const STEP = 20;
+            if (e.key === 'ArrowLeft') {
+              e.preventDefault();
+              if (!graphRef.current) return;
+              const rect = graphRef.current.getBoundingClientRect();
+              const max = Math.max(INSPECTOR_MIN_WIDTH, rect.width - WORKSPACE_MIN_WIDTH);
+              setInspectorWidth(w => Math.round(Math.min(max, Math.max(INSPECTOR_MIN_WIDTH, (w ?? INSPECTOR_MIN_WIDTH) + STEP))));
+            } else if (e.key === 'ArrowRight') {
+              e.preventDefault();
+              setInspectorWidth(w => Math.round(Math.max(INSPECTOR_MIN_WIDTH, (w ?? INSPECTOR_MIN_WIDTH) - STEP)));
+            } else if (e.key === 'Home') {
+              e.preventDefault();
+              setInspectorWidth(null);
+            }
+          }}
         >
           <span className="router-graph__resizer-grip" aria-hidden="true">
             <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">

--- a/src/app/src/components/RouterRuleGraph.tsx
+++ b/src/app/src/components/RouterRuleGraph.tsx
@@ -232,9 +232,7 @@ const GraphNode: React.FC<GraphNodeProps> = ({
               <button type="button" className={node.operator === 'any' ? 'is-active' : ''} onClick={() => onChangeOperator(path, 'any')}>OR</button>
             </>
           )}
-          {path.length > 0 && (
-            <button type="button" aria-label="Remove gate" title="Remove gate" onClick={() => onRemove(path)}><Icon name="x" size={11} /></button>
-          )}
+          <button type="button" aria-label="Remove gate" title="Remove gate" onClick={() => onRemove(path)}><Icon name="x" size={11} /></button>
         </div>
       </div>
       <div className="router-graph__children">
@@ -264,9 +262,15 @@ interface RouterRuleGraphProps {
   classifiers: RouterClassifier[];
   onChange: (node: RouterNode) => void;
   onExpand?: () => void;
+  // Full-modal layout: workspace and inspector sit side by side and the
+  // divider between them becomes draggable.
+  expanded?: boolean;
 }
 
-export const RouterRuleGraph: React.FC<RouterRuleGraphProps> = ({ node, classifiers, onChange, onExpand }) => {
+const INSPECTOR_MIN_WIDTH = 320;
+const WORKSPACE_MIN_WIDTH = 360;
+
+export const RouterRuleGraph: React.FC<RouterRuleGraphProps> = ({ node, classifiers, onChange, onExpand, expanded = false }) => {
   const [toolboxCollapsed, setToolboxCollapsed] = useState(false);
   const [toolboxSearch, setToolboxSearch] = useState('');
   const [selectedPath, setSelectedPath] = useState<RouterNodePath | null>(null);
@@ -274,14 +278,22 @@ export const RouterRuleGraph: React.FC<RouterRuleGraphProps> = ({ node, classifi
   const [pan, setPan] = useState({ x: 18, y: 18 });
   const [panning, setPanning] = useState(false);
   const [rejection, setRejection] = useState<string | null>(null);
+  const [inspectorWidth, setInspectorWidth] = useState<number | null>(null);
+  const [resizing, setResizing] = useState(false);
+  const graphRef = useRef<HTMLDivElement>(null);
+  const resizeStateRef = useRef<{ pointerId: number } | null>(null);
   const canvasRef = useRef<HTMLDivElement>(null);
   const panStateRef = useRef<{ pointerId: number; x: number; y: number } | null>(null);
   const historyRef = useRef<RouterNode[]>([]);
   const futureRef = useRef<RouterNode[]>([]);
   const lastEmittedNodeRef = useRef<RouterNode | null>(null);
+  // True once the user has explicitly dropped or committed a node in this
+  // session. Prevents a freshly-dropped blank keywords_any from being hidden
+  // by the isBlankRouterGraphNode check (which also matches the initial state).
+  const hasCommittedRef = useRef(false);
 
   const selectedNode = selectedPath ? routerNodeAtPath(node, selectedPath) : null;
-  const blank = isBlankRouterGraphNode(node);
+  const blank = isBlankRouterGraphNode(node) && !hasCommittedRef.current;
 
   useEffect(() => {
     if (selectedPath && !routerNodeAtPath(node, selectedPath)) setSelectedPath(null);
@@ -297,6 +309,7 @@ export const RouterRuleGraph: React.FC<RouterRuleGraphProps> = ({ node, classifi
     }
     historyRef.current = [];
     futureRef.current = [];
+    hasCommittedRef.current = false;
     setSelectedPath(null);
   }, [node]);
 
@@ -308,6 +321,7 @@ export const RouterRuleGraph: React.FC<RouterRuleGraphProps> = ({ node, classifi
   const commit = useCallback((next: RouterNode) => {
     historyRef.current = [...historyRef.current.slice(-29), node];
     futureRef.current = [];
+    hasCommittedRef.current = true;
     emitChange(next);
   }, [emitChange, node]);
 
@@ -339,15 +353,19 @@ export const RouterRuleGraph: React.FC<RouterRuleGraphProps> = ({ node, classifi
 
   const removeAtPath = useCallback((path: RouterNodePath) => {
     const next = removeRouterNodeAtPath(node, path);
-    const currentConflict = routerDuplicateConditionConflict(node);
-    const nextConflict = routerDuplicateConditionConflict(next);
-    if (!currentConflict && nextConflict) {
-      reject(nextConflict);
+    if (isBlankRouterGraphNode(next)) {
+      // Removal produced the canonical blank leaf — treat as a full reset so
+      // the canvas returns to the empty-state placeholder.
+      historyRef.current = [...historyRef.current.slice(-29), node];
+      futureRef.current = [];
+      hasCommittedRef.current = false;
+      setSelectedPath(null);
+      emitChange(next);
       return;
     }
     commit(next);
     setSelectedPath(null);
-  }, [commit, node, reject]);
+  }, [commit, emitChange, node]);
 
   const changeOperator = useCallback((path: RouterNodePath, operator: RouterGroupOperator) => {
     const current = routerNodeAtPath(node, path);
@@ -441,8 +459,33 @@ export const RouterRuleGraph: React.FC<RouterRuleGraphProps> = ({ node, classifi
     setPanning(false);
   };
 
+  const startResize = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (event.button !== 0) return;
+    event.preventDefault();
+    resizeStateRef.current = { pointerId: event.pointerId };
+    event.currentTarget.setPointerCapture(event.pointerId);
+    setResizing(true);
+  };
+
+  const onResizeMove = (event: React.PointerEvent<HTMLDivElement>) => {
+    const state = resizeStateRef.current;
+    if (!state || state.pointerId !== event.pointerId || !graphRef.current) return;
+    const rect = graphRef.current.getBoundingClientRect();
+    const max = Math.max(INSPECTOR_MIN_WIDTH, rect.width - WORKSPACE_MIN_WIDTH);
+    const next = rect.right - event.clientX;
+    setInspectorWidth(Math.round(Math.min(max, Math.max(INSPECTOR_MIN_WIDTH, next))));
+  };
+
+  const stopResize = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (resizeStateRef.current?.pointerId === event.pointerId && event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+    resizeStateRef.current = null;
+    setResizing(false);
+  };
+
   return (
-    <div className="router-graph">
+    <div className={`router-graph ${resizing ? 'is-resizing' : ''}`} ref={graphRef}>
       <div className={`router-graph__workspace ${toolboxCollapsed ? 'is-toolbox-collapsed' : ''}`}>
         <aside className={`router-graph__toolbox ${toolboxCollapsed ? 'is-collapsed' : ''}`} aria-label="Router condition toolbox">
           <button type="button" className="router-graph__toolbox-toggle" onClick={() => setToolboxCollapsed(current => !current)} aria-expanded={!toolboxCollapsed}>
@@ -529,7 +572,13 @@ export const RouterRuleGraph: React.FC<RouterRuleGraphProps> = ({ node, classifi
           <div className="router-graph__toolbar">
             <button type="button" disabled={historyRef.current.length === 0} onClick={undo}>Undo</button>
             <button type="button" disabled={futureRef.current.length === 0} onClick={redo}>Redo</button>
-            {!blank && <button type="button" className="is-danger" onClick={() => { commit(createRouterLeaf()); setSelectedPath(null); }}>Clear</button>}
+            {!blank && <button type="button" className="is-danger" onClick={() => {
+              historyRef.current = [...historyRef.current.slice(-29), node];
+              futureRef.current = [];
+              hasCommittedRef.current = false;
+              setSelectedPath(null);
+              emitChange(createRouterLeaf());
+            }}>Clear</button>}
             {rejection && <span className="router-graph__rejection" role="status"><Icon name="alert" size={12} /> {rejection}</span>}
             <span className="router-graph__toolbar-hint">Drag items from the toolbox. Select a gate and click a toolbox item to add there. Ctrl/⌘ + wheel zooms.</span>
             <span className="router-graph__toolbar-spacer" />
@@ -583,8 +632,33 @@ export const RouterRuleGraph: React.FC<RouterRuleGraphProps> = ({ node, classifi
         </div>
       </div>
 
+      {selectedNode && expanded && (
+        <div
+          className="router-graph__resizer"
+          role="separator"
+          aria-orientation="vertical"
+          aria-label="Resize node inspector"
+          title="Drag to resize · double-click to reset"
+          onPointerDown={startResize}
+          onPointerMove={onResizeMove}
+          onPointerUp={stopResize}
+          onPointerCancel={stopResize}
+          onDoubleClick={() => setInspectorWidth(null)}
+        >
+          <span className="router-graph__resizer-grip" aria-hidden="true">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
+              <circle cx="9" cy="5" r="1.4" /><circle cx="9" cy="12" r="1.4" /><circle cx="9" cy="19" r="1.4" />
+              <circle cx="15" cy="5" r="1.4" /><circle cx="15" cy="12" r="1.4" /><circle cx="15" cy="19" r="1.4" />
+            </svg>
+          </span>
+        </div>
+      )}
+
       {selectedNode && (
-        <div className="router-graph__inspector">
+        <div
+          className="router-graph__inspector"
+          style={expanded && inspectorWidth != null ? { flex: `0 0 ${inspectorWidth}px` } : undefined}
+        >
           <div className="router-graph__inspector-head">
             <div>
               <strong>Node Inspector</strong>

--- a/src/app/src/components/inspect/Modal.tsx
+++ b/src/app/src/components/inspect/Modal.tsx
@@ -8,6 +8,7 @@ interface ModalProps {
   children: React.ReactNode;
   maxWidth?: string;
   ariaLabelledBy?: string;
+  className?: string;
 }
 
 export default function Modal({
@@ -16,7 +17,8 @@ export default function Modal({
   title,
   children,
   maxWidth = '600px',
-  ariaLabelledBy
+  ariaLabelledBy,
+  className,
 }: ModalProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const titleRef = useRef<HTMLHeadingElement>(null);
@@ -83,7 +85,7 @@ export default function Modal({
       aria-labelledby={titleId}
     >
       <div
-        className="inspect-modal-content flex-col"
+        className={`inspect-modal-content flex-col${className ? ` ${className}` : ''}`}
         onClick={(e) => e.stopPropagation()}
         style={{ maxWidth }}
       >

--- a/src/app/src/features/router/routerGraph.ts
+++ b/src/app/src/features/router/routerGraph.ts
@@ -91,18 +91,18 @@ export function removeRouterNodeAtPath(root: RouterNode, path: RouterNodePath): 
     if (root.operator === 'not' && root.children.length === 1) {
       return { ...root, children: [] };
     }
-    return normalizeRouterNode({
-      ...root,
-      children: root.children.filter((_, childIndex) => childIndex !== index),
-    });
+    // Preserve AND/OR groups even when they drop to 1 child — the graph shows
+    // a validation error prompting the user to add a second condition, and the
+    // gate shape is still visible so the intent is not silently discarded.
+    return { ...root, children: root.children.filter((_, i) => i !== index) };
   }
 
-  return normalizeRouterNode({
+  return {
     ...root,
     children: root.children.map((child, childIndex) =>
       childIndex === index ? removeRouterNodeAtPath(child, rest) : child
     ),
-  });
+  };
 }
 
 export function createEmptyRouterGraphGroup(operator: RouterGroupOperator): RouterGroupNode {

--- a/src/app/src/features/router/routerTypes.ts
+++ b/src/app/src/features/router/routerTypes.ts
@@ -360,7 +360,8 @@ export function normalizeRouterNode(node: RouterNode): RouterNode {
     return { ...node, children: children.slice(0, 1).length ? children.slice(0, 1) : [createRouterLeaf()] };
   }
   if (children.length === 0) return createRouterLeaf();
-  if (children.length === 1) return children[0];
+  // Preserve AND/OR groups even with 1 child so gate structure is not silently
+  // discarded — validation will prompt the user to add a second condition.
   return { ...node, children };
 }
 
@@ -478,7 +479,8 @@ function validateNode(
   }
   if (node.kind === 'group') {
     if (node.operator === 'not' && node.children.length !== 1) errors.push(`${path}: NOT requires exactly one condition.`);
-    if ((node.operator === 'all' || node.operator === 'any') && node.children.length === 0) errors.push(`${path}: ${node.operator.toUpperCase()} requires at least one condition.`);
+    if ((node.operator === 'all' || node.operator === 'any') && node.children.length === 0) errors.push(`${path}: ${node.operator.toUpperCase()} gate requires at least one condition.`);
+    if ((node.operator === 'all' || node.operator === 'any') && node.children.length === 1) errors.push(`${path}: ${node.operator.toUpperCase()} gate needs at least 2 conditions - add another or remove the gate.`);
 
     const directConditions = new Set<string>();
     node.children.forEach((child, index) => {

--- a/src/app/src/styles/styles.css
+++ b/src/app/src/styles/styles.css
@@ -12561,7 +12561,8 @@ a.backend-card__version:focus-visible {
 }
 .router-editor__toolbar-row--files { justify-content: flex-end; }
 .router-editor__saved-select { min-width: 0; flex: 1 1 180px; }
-.router-editor__saved-select select { width: 100%; }
+.router-editor__saved-select .router-select,
+.router-editor__saved-select .router-select__trigger { width: 100%; }
 .router-editor__tabs { display: flex; padding: 0 var(--space-5); border-bottom: 1px solid var(--border-subtle); background: var(--surface-1); }
 .router-editor__tabs button { height: 38px; padding: 0 var(--space-3); border: 0; border-bottom: 2px solid transparent; background: transparent; color: var(--text-tertiary); font-size: var(--text-sm); cursor: pointer; }
 .router-editor__tabs button:hover { color: var(--text-primary); }
@@ -12911,7 +12912,8 @@ a.backend-card__version:focus-visible {
   .router-editor .workspace-detail-panel__title-row > .router-editor__toolbar { flex: 1 1 100%; }
   .router-editor__toolbar { flex-wrap: wrap; }
   .router-editor__saved-select { flex: 1 1 180px; }
-  .router-editor__saved-select select { width: 100%; }
+  .router-editor__saved-select .router-select,
+  .router-editor__saved-select .router-select__trigger { width: 100%; }
   .router-editor__form-grid,
   .router-editor__rule-meta,
   .router-editor__strategy { grid-template-columns: 1fr; }

--- a/src/app/src/styles/styles.css
+++ b/src/app/src/styles/styles.css
@@ -6512,10 +6512,7 @@ optgroup {
 /* 3–5. Collapsible filter groups */
 .model-nav-rail__section { display: flex; flex-direction: column; gap: var(--space-0-5); }
 
-.model-nav-rail__scroll > .model-nav-rail__section {
-  border-top: 1px solid rgba(255,255,255,0.12);
-  padding-top: var(--space-2);
-}
+
 
 .model-nav-rail__section-head { margin: 0; }
 
@@ -13396,9 +13393,7 @@ a.backend-card__version:focus-visible {
   --workspace-rail-width: var(--rail-collapsed);
 }
 
-.workspace-three-panel.workspace--list-collapsed {
-  --workspace-list-panel-width: var(--workspace-header);
-}
+
 
 .workspace-two-panel {
   --detail-chip-gap: 6px;
@@ -13514,28 +13509,7 @@ a.backend-card__version:focus-visible {
   flex: 0 0 auto;
 }
 
-.workspace-list-panel {
-  transition: width 240ms var(--ease-out), min-width 240ms var(--ease-out);
-}
 
-.workspace-list-panel.is-collapsed {
-  width: var(--workspace-header);
-  min-width: var(--workspace-header);
-  overflow: hidden;
-}
-.workspace-list-panel.is-collapsed .workspace-list-panel__heading,
-.workspace-list-panel.is-collapsed ~ .workspace-panel-resizer {
-  display: none;
-}
-.workspace-list-panel.is-collapsed .workspace-list-panel__header {
-  flex-direction: column;
-  align-items: center;
-  padding: var(--space-2) var(--space-1);
-  gap: var(--space-1);
-}
-.workspace-list-panel.is-collapsed > *:not(.workspace-list-panel__header) {
-  display: none;
-}
 
 .workspace-list-panel__actions .workspace-action-group {
   gap: var(--space-0-5);

--- a/src/app/src/styles/styles.css
+++ b/src/app/src/styles/styles.css
@@ -6512,6 +6512,11 @@ optgroup {
 /* 3–5. Collapsible filter groups */
 .model-nav-rail__section { display: flex; flex-direction: column; gap: var(--space-0-5); }
 
+.model-nav-rail__scroll > .model-nav-rail__section {
+  border-top: 1px solid rgba(255,255,255,0.12);
+  padding-top: var(--space-2);
+}
+
 .model-nav-rail__section-head { margin: 0; }
 
 .model-nav-rail__section-toggle {
@@ -9779,6 +9784,11 @@ optgroup {
   animation: inspectModalSlideUp 240ms cubic-bezier(0.16, 1, 0.3, 1);
 }
 
+.inspect-modal-content--full-height {
+  height: 90vh;
+  width: calc(100vw - 48px);
+}
+
 @keyframes inspectModalSlideUp {
   from { transform: translateY(16px); opacity: 0; }
   to { transform: translateY(0); opacity: 1; }
@@ -12592,6 +12602,58 @@ a.backend-card__version:focus-visible {
 .router-editor .select {
   min-width: 0;
 }
+.router-select { position: relative; min-width: 0; }
+.router-select__trigger {
+  width: 100%;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: var(--space-2);
+  height: var(--control-height-sm);
+  padding: 0 var(--space-3);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  background: var(--surface-base);
+  color: var(--text-primary);
+  font-size: var(--text-sm);
+  font-family: var(--font-sans);
+  text-align: left;
+  cursor: pointer;
+  transition: border-color var(--duration-fast) var(--ease-out);
+}
+.router-select__trigger:hover,
+.router-select__trigger.is-open { border-color: color-mix(in srgb, var(--accent-fg) 55%, var(--border-subtle)); }
+.router-select__trigger.is-open { box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent-fg) 12%, transparent); }
+.router-select__trigger > span { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.router-select__trigger .is-placeholder { color: var(--text-tertiary); }
+.router-select__trigger .app-icon { color: var(--text-tertiary); flex-shrink: 0; }
+.router-select__popover {
+  position: fixed;
+  z-index: 260;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-lg);
+  background: var(--surface-raised);
+  box-shadow: var(--shadow-lg);
+  overflow: hidden;
+  padding: var(--space-1);
+}
+.router-select__option {
+  width: 100%;
+  display: block;
+  padding: var(--space-2) var(--space-3);
+  border: 0;
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  font-family: var(--font-sans);
+  text-align: left;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.router-select__option:hover { background: var(--surface-2); color: var(--text-primary); }
+.router-select__option.is-selected { background: color-mix(in srgb, var(--accent-fg) 7%, var(--surface-1)); color: var(--text-primary); }
+.router-select__option.is-disabled { opacity: 0.45; cursor: default; pointer-events: none; }
 .router-editor .textarea {
   min-height: 90px;
   font-family: var(--font-mono);
@@ -12689,16 +12751,35 @@ a.backend-card__version:focus-visible {
 .router-editor__default-rule small { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: var(--type-overline-size); }
 .router-editor__rule-builder { min-width: 0; background: var(--surface-base); }
 .router-editor__rule-builder-head {
-  min-height: 48px;
+  min-height: 44px;
   display: flex;
   align-items: center;
-  padding: var(--space-2) var(--space-4);
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
   border-bottom: 1px solid var(--border-subtle);
   background: var(--surface-1);
 }
-.router-editor__rule-builder-head > div { min-width: 0; display: grid; gap: 2px; }
-.router-editor__rule-builder-head strong { color: var(--text-primary); font-size: var(--text-sm); }
-.router-editor__rule-builder-head span { color: var(--text-tertiary); font-size: var(--text-xs); }
+.router-editor__rule-builder-label {
+  color: var(--text-tertiary);
+  font-size: var(--text-xs);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+.router-editor__rule-id-input {
+  width: 120px;
+  flex-shrink: 0;
+  font-size: var(--text-xs);
+  padding: 3px var(--space-2);
+  height: 28px;
+}
+.router-editor__rule-route-select {
+  flex: 1 1 0;
+  min-width: 0;
+  max-width: 220px;
+  font-size: var(--text-xs);
+  padding: 3px var(--space-2);
+  height: 28px;
+}
 .router-editor__rule-builder-empty { min-height: 430px; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: var(--space-2); color: var(--text-tertiary); text-align: center; }
 .router-editor__rule-builder-empty .app-icon { color: var(--accent-fg); }
 .router-editor__rule-builder-empty strong { color: var(--text-secondary); font-size: var(--text-sm); }
@@ -12760,13 +12841,9 @@ a.backend-card__version:focus-visible {
   border-end-end-radius: var(--radius-md);
   background: transparent;
   color: var(--text-tertiary);
-  visibility: hidden;
   transition: color var(--duration-fast) var(--ease-out),
               background var(--duration-fast) var(--ease-out);
 }
-.router-editor__rule-summary:hover .router-editor__rule-remove,
-.router-editor__rule-summary:focus-within .router-editor__rule-remove,
-.router-editor__rule-remove:focus { visibility: visible; }
 .router-editor__rule-actions .router-editor__rule-remove:hover:not(:disabled) {
   color: var(--text-primary);
   background: color-mix(in srgb, var(--text-primary) 8%, transparent);
@@ -13303,11 +13380,16 @@ a.backend-card__version:focus-visible {
   min-height: 0;
   overflow: hidden;
   position: relative;
+  transition: grid-template-columns 240ms var(--ease-out);
 }
 
 .workspace-three-panel.workspace--rail-collapsed,
 .workspace-three-panel.context-rail-collapsed {
   --workspace-rail-width: var(--rail-collapsed);
+}
+
+.workspace-three-panel.workspace--list-collapsed {
+  --workspace-list-panel-width: var(--workspace-header);
 }
 
 .workspace-two-panel {
@@ -13422,6 +13504,29 @@ a.backend-card__version:focus-visible {
   align-items: center;
   gap: var(--space-1-5);
   flex: 0 0 auto;
+}
+
+.workspace-list-panel {
+  transition: width 240ms var(--ease-out), min-width 240ms var(--ease-out);
+}
+
+.workspace-list-panel.is-collapsed {
+  width: var(--workspace-header);
+  min-width: var(--workspace-header);
+  overflow: hidden;
+}
+.workspace-list-panel.is-collapsed .workspace-list-panel__heading,
+.workspace-list-panel.is-collapsed ~ .workspace-panel-resizer {
+  display: none;
+}
+.workspace-list-panel.is-collapsed .workspace-list-panel__header {
+  flex-direction: column;
+  align-items: center;
+  padding: var(--space-2) var(--space-1);
+  gap: var(--space-1);
+}
+.workspace-list-panel.is-collapsed > *:not(.workspace-list-panel__header) {
+  display: none;
 }
 
 .workspace-list-panel__actions .workspace-action-group {
@@ -14151,7 +14256,7 @@ button.workspace-metadata-chip:hover {
   flex-direction: column;
   gap: var(--space-4);
   overflow-y: auto;
-  padding: var(--detail-section-space) var(--detail-gutter);
+  padding: var(--space-3) var(--detail-gutter) var(--detail-section-space);
   scrollbar-gutter: stable;
 }
 
@@ -14519,10 +14624,15 @@ button.workspace-metadata-chip:hover {
   grid-template-columns: minmax(180px, 1fr) minmax(150px, auto);
 }
 .router-editor__connection-main,
-.router-editor__connection-source,
 .router-editor__connection-endpoint {
   display: grid;
   gap: 3px;
+  min-width: 0;
+}
+.router-editor__connection-source {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1-5);
   min-width: 0;
 }
 .router-editor__connection-main > div {
@@ -14564,10 +14674,6 @@ button.workspace-metadata-chip:hover {
   align-items: center;
   justify-content: flex-end;
   gap: var(--space-2);
-}
-.router-editor__connection-source {
-  justify-items: end;
-  text-align: right;
 }
 .router-editor__default-badge {
   display: inline-flex;
@@ -14730,20 +14836,144 @@ button.workspace-metadata-chip:hover {
   margin: 0;
 }
 
-/* Router graph expanded view mirrors GUI2's full-canvas editing mode. */
+/* Router graph expanded view: full-modal 3-column layout.
+   toolbox | canvas | inspector
+   Toolbox is reordered to the left via grid-area so the canvas
+   has the full center, and the inspector gets a clean right panel. */
 .router-editor__graph-modal {
-  width: min(1500px, 100%);
-  max-height: calc(90vh - 66px);
-  padding: var(--space-3);
-  overflow: auto;
+  /* Override inspect-modal-body defaults so the graph fills the modal content.
+     The 1500px cap lives on .inspect-modal-content--full-height (the modal
+     content) so the body fills it fully with no empty space on the right. */
+  width: 100%;
+  flex: 1 1 0;
+  min-height: 0;
+  max-height: none;
+  padding: 0;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
 }
+
 .router-editor__graph-modal .router-graph {
-  min-height: min(680px, calc(90vh - 110px));
+  flex: 1 1 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: row;
+  border-top: 0;
+  overflow: hidden;
 }
+
+/* Workspace becomes just the canvas shell — toolbox breaks out to its own column */
 .router-editor__graph-modal .router-graph__workspace {
-  min-height: min(560px, calc(90vh - 220px));
+  flex: 1 1 0;
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: row;
+}
+
+/* Toolbox on the left; order:-1 pulls it before canvas-shell in visual order */
+.router-editor__graph-modal .router-graph__toolbox {
+  flex: 0 0 auto;
+  order: -1;
+  border-left: 0;
+  border-right: 1px solid var(--border-subtle);
+  width: 210px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+.router-editor__graph-modal .router-graph__toolbox.is-collapsed {
+  width: 42px;
+}
+.router-editor__graph-modal .router-graph__toolbox-content {
+  flex: 1 1 0;
+  min-height: 0;
+  max-height: none;
+  overflow-y: auto;
+}
+
+/* Canvas shell expands to fill all remaining horizontal space */
+.router-editor__graph-modal .router-graph__canvas-shell {
+  flex: 1 1 0;
+  min-width: 0;
+  min-height: 0;
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
 }
 .router-editor__graph-modal .router-graph__canvas,
 .router-editor__graph-modal .router-graph__empty {
-  min-height: min(520px, calc(90vh - 260px));
+  min-height: 0;
+  height: 100%;
+}
+
+/* Inspector slides in from the right — only rendered when a node is selected,
+   so the canvas naturally expands to fill the gap when inspector is absent.
+   It claims the larger share of the modal's extra width (grow 2 vs the
+   workspace's 1) since editing deeply nested nodes is the priority here. */
+.router-editor__graph-modal .router-graph__inspector {
+  flex: 2 1 560px;
+  min-width: 320px;
+  border-top: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: var(--surface-1);
+}
+
+/* Draggable divider between the graph workspace and the node inspector.
+   Only rendered in the expanded modal, so it lives under that scope. */
+.router-editor__graph-modal .router-graph__resizer {
+  flex: 0 0 12px;
+  align-self: stretch;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: col-resize;
+  border-left: 1px solid var(--border-subtle);
+  border-right: 1px solid var(--border-subtle);
+  background: var(--surface-1);
+  touch-action: none;
+  user-select: none;
+}
+.router-editor__graph-modal .router-graph__resizer:hover,
+.router-graph.is-resizing .router-graph__resizer {
+  background: var(--surface-2);
+}
+.router-graph__resizer-grip {
+  display: flex;
+  color: var(--text-tertiary);
+  pointer-events: none;
+}
+.router-editor__graph-modal .router-graph__resizer:hover .router-graph__resizer-grip,
+.router-graph.is-resizing .router-graph__resizer-grip {
+  color: var(--accent-fg);
+}
+/* Suppress the col-resize→text cursor flip and stray selection during a drag. */
+.router-graph.is-resizing,
+.router-graph.is-resizing * {
+  cursor: col-resize !important;
+  user-select: none;
+}
+.router-editor__graph-modal .router-graph__inspector-head {
+  flex-shrink: 0;
+}
+/* Block scroll container: scrolls vertically for tall trees and horizontally
+   for deep ones. min-content tracks (below) plus a min-content floor on the
+   root node let the tree stretch to fill when it fits and grow past the panel
+   (scrolling) when nesting gets deep. */
+.router-editor__graph-modal .router-graph__inspector-body {
+  flex: 1 1 0;
+  min-height: 0;
+  overflow: auto;
+  padding: var(--space-4);
+}
+.router-editor__graph-modal .router-graph__inspector-body .router-node {
+  min-width: auto;
+}
+.router-editor__graph-modal .router-graph__inspector-body > .router-node {
+  min-width: min-content;
+}
+.router-editor__graph-modal .router-graph__inspector-body .router-node__child {
+  grid-template-columns: 26px minmax(min-content, 1fr);
 }

--- a/src/app/src/styles/styles.css
+++ b/src/app/src/styles/styles.css
@@ -12635,7 +12635,8 @@ a.backend-card__version:focus-visible {
   border-radius: var(--radius-lg);
   background: var(--surface-raised);
   box-shadow: var(--shadow-lg);
-  overflow: hidden;
+  overflow-y: auto;
+  max-height: min(320px, 40vh);
   padding: var(--space-1);
 }
 .router-select__option {
@@ -12842,8 +12843,13 @@ a.backend-card__version:focus-visible {
   border-end-end-radius: var(--radius-md);
   background: transparent;
   color: var(--text-tertiary);
+  visibility: hidden;
   transition: color var(--duration-fast) var(--ease-out),
               background var(--duration-fast) var(--ease-out);
+}
+.router-editor__rule-summary:hover .router-editor__rule-remove,
+.router-editor__rule-summary:focus-within .router-editor__rule-remove {
+  visibility: visible;
 }
 .router-editor__rule-actions .router-editor__rule-remove:hover:not(:disabled) {
   color: var(--text-primary);

--- a/src/app/src/styles/styles.css
+++ b/src/app/src/styles/styles.css
@@ -12778,7 +12778,7 @@ a.backend-card__version:focus-visible {
   min-width: 0;
   max-width: 220px;
   font-size: var(--text-xs);
-  padding: 3px var(--space-2);
+  padding: 0px var(--space-2);
   height: 28px;
 }
 .router-editor__rule-builder-empty { min-height: 430px; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: var(--space-2); color: var(--text-tertiary); text-align: center; }

--- a/src/app/tests/a11y.spec.ts
+++ b/src/app/tests/a11y.spec.ts
@@ -63,7 +63,7 @@ async function openCustomModelEditor(
   await page.waitForSelector('.custom-model-form');
 
   if (mode === 'omni-collection') {
-    await page.getByRole('button', { name: 'Omni collection', exact: true }).click();
+    await page.getByRole('button', { name: 'Omni Collection', exact: true }).click();
   }
 }
 
@@ -1885,8 +1885,8 @@ test.describe('Accessibility — master-detail model view (#2355 Slice 1)', () =
     await openCustomModels.click();
 
     const typeGroup = page.getByRole('group', { name: 'Custom model type' });
-    const customBtn = typeGroup.getByRole('button', { name: 'Custom model', exact: true });
-    const omniBtn = typeGroup.getByRole('button', { name: 'Omni collection', exact: true });
+    const customBtn = typeGroup.getByRole('button', { name: 'Custom Model', exact: true });
+    const omniBtn = typeGroup.getByRole('button', { name: 'Omni Collection', exact: true });
     await expect(typeGroup).toBeVisible();
     await expect(customBtn).toBeVisible();
     await expect(omniBtn).toBeVisible();


### PR DESCRIPTION
1. Added collapsable panels to give the router builder more space
<img width="623" height="334" alt="image" src="https://github.com/user-attachments/assets/b0001fd0-c23e-471c-940c-1d5ee4743da2" />

2. Added these separators
<img width="217" height="631" alt="image" src="https://github.com/user-attachments/assets/31fd3bae-971a-43f6-98d5-bc24e4c1a4f7" />

3. Made the trash icon always visible. 
Included the rule and model routes into this panel for better spacing
<img width="763" height="141" alt="image" src="https://github.com/user-attachments/assets/297fff29-4b32-46ad-a36a-828bd53cf265" />

4. Earlier gates with a single condition would blindly collapse but now you'll get a warning that at least 2 conditions are needed to form a gate.
<img width="1002" height="605" alt="image" src="https://github.com/user-attachments/assets/cbe729a7-0640-43d5-bcf3-940dbaf647fb" />

5. Fixed a bug where adding a single keywords-any gate would not display it on the canvas but only on the node inspector

6. Better aligned these
<img width="1357" height="201" alt="image" src="https://github.com/user-attachments/assets/5dbc58c4-6b65-45dd-bc80-b44ec51d50d0" />

7. Cleaned the router and model headers
8. Expanded the graph builder size and added a scroll bar to adjust the node inspector and graph canvas size
<img width="1914" height="1012" alt="image" src="https://github.com/user-attachments/assets/c2e6d8ed-2f93-4d37-9227-c6560ab7c51a" />

9. Following a uniformed dropdown style
<img width="392" height="257" alt="image" src="https://github.com/user-attachments/assets/13e44ea7-8601-49b8-89cf-f8745418e4ab" />

10. The dropdown for the latest classifier is cut off
<img width="695" height="151" alt="image" src="https://github.com/user-attachments/assets/22380472-da94-4dab-abf6-cd8328bdbb17" />
to
<img width="691" height="169" alt="image" src="https://github.com/user-attachments/assets/86da86de-c881-4622-a727-701e44774325" />