### PR TITLE
Remove emoji from FAQ title

### DIFF
--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -1,4 +1,4 @@
-# 🍋 Lemonade Frequently Asked Questions
+# Lemonade Frequently Asked Questions
 
 ## Overview
 


### PR DESCRIPTION
It creates a duplicate icon next to the favicon in the browser tab

<img width="306" height="56" alt="image" src="https://github.com/user-attachments/assets/7d0894e0-4be3-4c79-b940-b9048cef38fb" />
