### PR TITLE
fix(gui): classify models by their deployment label

### DIFF
--- a/src/app/package.json
+++ b/src/app/package.json
@@ -20,6 +20,7 @@
     "test:a11y": "npx playwright test tests/a11y.spec.ts",
     "test:model-providers": "node tests/model-provider-search.runtime.cjs",
     "test:chat-audio": "node tests/chat-audio-capability.runtime.cjs",
+    "test:model-kinds": "node tests/model-kind-classification.runtime.cjs",
     "test:mcp-external": "node scripts/test-external-mcp.mjs",
     "test:mcp-mock": "node tests/mock-mcp-server.runtime.cjs",
     "test:mcp-runtime": "node tests/mcp-runtime.runtime.cjs",

--- a/src/app/src/App.tsx
+++ b/src/app/src/App.tsx
@@ -341,7 +341,7 @@ function loadSavedRoute(): AppRoute {
   return { view: 'chat' };
 }
 
-type ModelHelpers = Pick<typeof import('./modelCapabilities'), 'canSelectInComposer' | 'capabilityFromModelInfo' | 'selectPreferredLoadedModel'>
+type ModelHelpers = Pick<typeof import('./modelCapabilities'), 'canSelectInComposer' | 'capabilityFromModelInfo' | 'isComposerSelectableCapability' | 'selectPreferredLoadedModel'>
   & Pick<typeof import('./features/collections/collectionModels'), 'findModelInfoByName' | 'isCollectionFullyLoaded' | 'isCollectionModel' | 'withVirtualLoadedCollections'>;
 type AppApiClient = (typeof import('./api'))['default'];
 
@@ -646,6 +646,7 @@ const App: React.FC = () => {
       if (!cancelled) setModelHelpers({
         canSelectInComposer: capabilities.canSelectInComposer,
         capabilityFromModelInfo: capabilities.capabilityFromModelInfo,
+        isComposerSelectableCapability: capabilities.isComposerSelectableCapability,
         selectPreferredLoadedModel: capabilities.selectPreferredLoadedModel,
         findModelInfoByName: collections.findModelInfoByName,
         isCollectionFullyLoaded: collections.isCollectionFullyLoaded,
@@ -692,20 +693,14 @@ const App: React.FC = () => {
   useEffect(() => {
     if (!modelHelpers) return;
     const { customInfos, knownInfos } = loadedModelViewState;
-    const customSelectable = (name: string) => {
-      const info = modelHelpers.findModelInfoByName(customInfos, name);
-      if (!info) return false;
-      const cap = modelHelpers.capabilityFromModelInfo(info);
-      return cap === 'chat' || cap === 'image' || cap === 'audio' || cap === 'audio-generation' || cap === 'tts' || cap === 'model3d';
-    };
     const infoSelectable = (name: string) => {
       const info = modelHelpers.findModelInfoByName(knownInfos, name);
-      if (!info) return false;
-      const cap = modelHelpers.capabilityFromModelInfo(info);
-      return cap === 'chat' || cap === 'image' || cap === 'audio' || cap === 'audio-generation' || cap === 'tts' || cap === 'model3d';
+      return Boolean(info) && modelHelpers.isComposerSelectableCapability(
+        modelHelpers.capabilityFromModelInfo(info!),
+      );
     };
     setCurrentModel(current => {
-      if (current && loadedModels.some(m => m.model_name === current && (modelHelpers.canSelectInComposer(m) || customSelectable(m.model_name) || infoSelectable(m.model_name)))) return current;
+      if (current && loadedModels.some(m => m.model_name === current && (modelHelpers.canSelectInComposer(m) || infoSelectable(m.model_name)))) return current;
       if (current) {
         const info = modelHelpers.findModelInfoByName(knownInfos, current);
         if (info && modelHelpers.isCollectionModel(info) && modelHelpers.isCollectionFullyLoaded(info, rawLoadedModels)) return current;
@@ -716,7 +711,7 @@ const App: React.FC = () => {
       });
       return virtualOmni?.model_name
         || modelHelpers.selectPreferredLoadedModel(loadedModels)?.model_name
-        || loadedModels.find(m => customSelectable(m.model_name) || infoSelectable(m.model_name))?.model_name
+        || loadedModels.find(m => infoSelectable(m.model_name))?.model_name
         || null;
     });
   }, [loadedModelViewState, loadedModels, modelHelpers, rawLoadedModels]);

--- a/src/app/src/App.tsx
+++ b/src/app/src/App.tsx
@@ -678,10 +678,8 @@ const App: React.FC = () => {
     const models = modelHelpers.withVirtualLoadedCollections(rawLoadedModels, knownInfos).map(model => {
       const info = modelHelpers.findModelInfoByName(knownInfos, model.model_name);
       if (!info) return model;
-      const cap = modelHelpers.capabilityFromModelInfo(info);
       return {
         ...model,
-        type: cap === 'unknown' ? model.type : cap,
         recipe: model.recipe || String((info as any).recipe || ''),
         checkpoint: model.checkpoint || String((info as any).checkpoint || ''),
       };
@@ -698,13 +696,13 @@ const App: React.FC = () => {
       const info = modelHelpers.findModelInfoByName(customInfos, name);
       if (!info) return false;
       const cap = modelHelpers.capabilityFromModelInfo(info);
-      return cap === 'chat' || cap === 'omni' || cap === 'image' || cap === 'audio' || cap === 'audio-generation' || cap === 'tts' || cap === 'model3d';
+      return cap === 'chat' || cap === 'image' || cap === 'audio' || cap === 'audio-generation' || cap === 'tts' || cap === 'model3d';
     };
     const infoSelectable = (name: string) => {
       const info = modelHelpers.findModelInfoByName(knownInfos, name);
       if (!info) return false;
       const cap = modelHelpers.capabilityFromModelInfo(info);
-      return cap === 'chat' || cap === 'omni' || cap === 'image' || cap === 'audio' || cap === 'audio-generation' || cap === 'tts' || cap === 'model3d';
+      return cap === 'chat' || cap === 'image' || cap === 'audio' || cap === 'audio-generation' || cap === 'tts' || cap === 'model3d';
     };
     setCurrentModel(current => {
       if (current && loadedModels.some(m => m.model_name === current && (modelHelpers.canSelectInComposer(m) || customSelectable(m.model_name) || infoSelectable(m.model_name)))) return current;

--- a/src/app/src/components/ChatView.tsx
+++ b/src/app/src/components/ChatView.tsx
@@ -38,6 +38,8 @@ import {
   snapshotFromModelInfo,
   snapshotFromName,
   snapshotIdentity,
+  identityFor,
+  isComposerSelectableCapability,
   isRouterRecipe,
   modelStructure,
 } from '../modelCapabilities';
@@ -332,7 +334,7 @@ function mcpToolNamesForServers(servers: McpServerToolOption[], serverIds: strin
 }
 
 function modelModeBadge(capability: ModelCapability, recipe?: string | null): string {
-  return isRouterRecipe(recipe) ? 'router' : capabilityBadge(capability);
+  return capabilityBadge(identityFor(capability, recipe));
 }
 
 const ModelModeIcons: React.FC<{
@@ -341,8 +343,9 @@ const ModelModeIcons: React.FC<{
   audioInput?: boolean;
   size?: number;
 }> = ({ capability, recipe, audioInput = false, size = 14 }) => {
-  if (isRouterRecipe(recipe)) {
-    return <Icon name="router" size={size} aria-hidden="true" />;
+  const identity = identityFor(capability, recipe);
+  if (identity !== capability) {
+    return <CapabilityIcon capability={identity} size={size} aria-hidden="true" />;
   }
   const showAudio = audioInput && capability === 'chat';
   return (
@@ -360,7 +363,8 @@ function modelModeLabel(capability: ModelCapability, audioInput = false): string
 }
 
 function modelModeDisplayLabel(capability: ModelCapability, audioInput = false, recipe?: string | null): string {
-  return isRouterRecipe(recipe) ? 'Router' : modelModeLabel(capability, audioInput);
+  const identity = identityFor(capability, recipe);
+  return identity === capability ? modelModeLabel(capability, audioInput) : capabilityLabel(identity);
 }
 
 function deriveTitle(messages: Message[]): string {
@@ -1300,7 +1304,7 @@ const ChatView: React.FC<ChatViewProps> = ({ currentModel: selectedModel, loaded
     return modelSupportsChatAudioInput(info, model);
   }, [knownModelInfos]);
   const selectableModels = useMemo(
-    () => loadedModels.filter(m => canSelectInComposer(m) || ['chat', 'omni', 'image', 'audio', 'audio-generation', 'tts', 'model3d'].includes(capabilityForLoaded(m))),
+    () => loadedModels.filter(m => canSelectInComposer(m) || isComposerSelectableCapability(capabilityForLoaded(m))),
     [loadedModels, capabilityForLoaded],
   );
   type ModelPickerOption = {
@@ -1324,7 +1328,7 @@ const ChatView: React.FC<ChatViewProps> = ({ currentModel: selectedModel, loaded
     const addOption = (option: ModelPickerOption) => {
       const key = option.name.toLowerCase();
       if (!option.name || seen.has(key)) return;
-      if (!['chat', 'omni', 'image', 'audio', 'audio-generation', 'tts', 'model3d'].includes(option.capability)) return;
+      if (!isComposerSelectableCapability(option.capability)) return;
       const configuredDefault = lemonadeDefaultModel(option.name);
       seen.add(key);
       options.push(configuredDefault ? {
@@ -3091,7 +3095,7 @@ ${finalText}`
         key={c.id}
         id={`${idPrefix}-conv-${c.id}`}
         rowId={c.id}
-        capability={isRouterRecipe(c.model?.recipe) ? 'router' : capability}
+        capability={identityFor(capability, c.model?.recipe)}
         title={convTitle}
         meta={c.model?.name || undefined}
         anchor={timeAgo(c.updatedAt)}
@@ -3364,17 +3368,10 @@ ${finalText}`
                 aria-expanded={modelPickerOpen}
               >
                 {currentLoadedModel ? (
-                  isRouterRecipe(currentRecipe) ? (
-                    <span className="composer__model-mode composer__model-mode--router">
-                      <Icon name="router" size={14} aria-hidden="true" />
-                      <span>Router</span>
-                    </span>
-                  ) : (
-                    <span className={`composer__model-mode composer__model-mode--${capabilityBadge(currentCapability)}`}>
-                      <ModelModeIcons capability={currentCapability} audioInput={supportsChatAudioInput} size={14} />
-                      <span>{modelModeLabel(currentCapability, supportsChatAudioInput)}</span>
-                    </span>
-                  )
+                  <span className={`composer__model-mode composer__model-mode--${modelModeBadge(currentCapability, currentRecipe)}`}>
+                    <ModelModeIcons capability={currentCapability} recipe={currentRecipe} audioInput={supportsChatAudioInput} size={14} />
+                    <span>{modelModeDisplayLabel(currentCapability, supportsChatAudioInput, currentRecipe)}</span>
+                  </span>
                 ) : (
                   <ModelModeIcons capability={currentCapability} recipe={currentRecipe} audioInput={supportsChatAudioInput} size={14} />
                 )}
@@ -4163,7 +4160,7 @@ const EmptyState: React.FC<EmptyStateProps> = ({ loadedModels, currentModel, onM
             const audioInput = modelSupportsChatAudioInput(customInfo || null, m);
             const modeLabel = modelModeDisplayLabel(cap, audioInput, m.recipe);
             const modeBadge = modelModeBadge(cap, m.recipe);
-            const selectable = canSelectInComposer(m) || ['chat', 'omni', 'image', 'audio', 'audio-generation', 'tts', 'model3d'].includes(cap);
+            const selectable = canSelectInComposer(m) || isComposerSelectableCapability(cap);
             const isActive = currentModel === m.model_name;
             return (
               <article className="active-card" key={m.model_name}>

--- a/src/app/src/components/ChatView.tsx
+++ b/src/app/src/components/ChatView.tsx
@@ -37,7 +37,9 @@ import {
   snapshotFromLoaded,
   snapshotFromModelInfo,
   snapshotFromName,
+  snapshotIdentity,
   isRouterRecipe,
+  modelStructure,
 } from '../modelCapabilities';
 import { storageKey } from '../storage';
 import { CHAT_HISTORY_PREFERENCE_EVENT, loadChatHistoryPreference } from '../features/chatHistory/historySettings';
@@ -1039,10 +1041,12 @@ const ChatView: React.FC<ChatViewProps> = ({ currentModel: selectedModel, loaded
     return loadedSnapshot || snapshotFromName(currentModel, loadedModels);
   }, [currentLoadedModel, currentCustomModelInfo, currentKnownModelInfo, currentModel, loadedModels]);
   const currentCapability = currentModelSnapshot?.capability || 'unknown';
+  // A collection deploys as chat; its Omni surface comes from the recipe.
+  const currentIsOmniCollection = snapshotIdentity(currentModelSnapshot) === 'omni';
   const currentDefaultModel = lemonadeDefaultModel(currentModel);
 
   useEffect(() => {
-    if (!currentLoadedModel || (currentCapability !== 'chat' && currentCapability !== 'omni')) return;
+    if (!currentLoadedModel || currentCapability !== 'chat') return;
     saveLastReadyModelName(currentLoadedModel.model_name);
     setLastReadyModelName(currentLoadedModel.model_name);
   }, [currentCapability, currentLoadedModel]);
@@ -1110,7 +1114,7 @@ const ChatView: React.FC<ChatViewProps> = ({ currentModel: selectedModel, loaded
     }));
   }, [currentCapability, imageGenerationModels]);
   useEffect(() => {
-    const specialCapability = !['chat', 'omni', 'unknown'].includes(currentCapability);
+    const specialCapability = !['chat', 'unknown'].includes(currentCapability);
     if (!modelPickerOpen && !specialCapability) return;
 
     let cancelled = false;
@@ -1201,7 +1205,7 @@ const ChatView: React.FC<ChatViewProps> = ({ currentModel: selectedModel, loaded
 
   useEffect(() => {
     const keepsAudioAttachments = currentCapability === 'audio'
-      || currentCapability === 'omni'
+      || currentIsOmniCollection
       || modelSupportsChatAudioInput(currentKnownModelInfo, currentLoadedModel);
     if (keepsAudioAttachments) return;
     if (isOpenMossTts && openMossSettings.mode === 'clone') return;
@@ -1227,7 +1231,7 @@ const ChatView: React.FC<ChatViewProps> = ({ currentModel: selectedModel, loaded
     [currentKnownModelInfo, currentLoadedModel],
   );
   const supportsChatImageInput = useMemo(() => {
-    if (currentCapability === 'omni') {
+    if (currentIsOmniCollection) {
       return Boolean(getVisionChatComponent(currentKnownModelInfo, knownModelInfos));
     }
     return currentCapability === 'chat'
@@ -1376,9 +1380,9 @@ const ChatView: React.FC<ChatViewProps> = ({ currentModel: selectedModel, loaded
     return filtered.slice(0, 80);
   }, [audioInputForLoaded, capabilityForLoaded, downloadItems, knownModelInfos, modelPickerQuery, selectableModels]);
 
-  const modeSupportsChatCompletions = currentCapability === 'chat' || currentCapability === 'omni';
+  const modeSupportsChatCompletions = currentCapability === 'chat';
   const modeSupportsMcp = modeSupportsChatCompletions;
-  const canUseAudioInput = currentCapability === 'omni' || currentCapability === 'audio' || (currentCapability === 'chat' && supportsChatAudioInput);
+  const canUseAudioInput = currentIsOmniCollection || currentCapability === 'audio' || (currentCapability === 'chat' && supportsChatAudioInput);
 
   const persistMcpEnabled = useCallback((next: boolean) => {
     setUseMcp(next);
@@ -3004,7 +3008,7 @@ ${finalText}`
             : (!!inputValue.trim() || pendingImages.length > 0 || (canUseAudioInput && pendingAudioFiles.length > 0)));
   const composerPlaceholder = !currentModel
     ? 'Draft a message. Connect and load a model to send…'
-    : currentCapability === 'omni'
+    : currentIsOmniCollection
       ? `Message ${currentModel} through the Omni collection…`
       : currentCapability === 'chat' && supportsChatImageInput && supportsChatAudioInput
         ? `Message ${currentModel} with text, images, or audio…`
@@ -3036,7 +3040,7 @@ ${finalText}`
     ? (supportsRealtimeAudio
       ? 'Chat + audio mode · mic transcribes into the draft, and audio files are routed through chat completions'
       : 'Chat + audio mode · attached audio is routed through chat completions')
-    : currentCapability === 'omni'
+    : currentIsOmniCollection
     ? 'Omni collection mode · requests are orchestrated across collection components'
     : currentCapability === 'image'
       ? (imageMode === 'edit' ? 'Image mode · attach one source image and prompt becomes /images/edits' : 'Image mode · prompt becomes /images/generations')
@@ -3315,7 +3319,7 @@ ${finalText}`
                     </div>
                     <div className="message__content message__content--pending">
                       <span className="streaming-cursor streaming-cursor--leading" aria-hidden="true" />
-                      Working in {capabilityLabel(currentCapability)} mode…
+                      Working in {capabilityLabel(snapshotIdentity(currentModelSnapshot))} mode…
                     </div>
                   </div>
                 </article>
@@ -3421,10 +3425,11 @@ ${finalText}`
                       const isLoading = modelPickerLoading === option.name;
                       const isUnloading = modelPickerUnloading === option.name;
                       const busy = isLoading || isUnloading;
-                      const capability = isRouterRecipe(option.recipe) ? 'router' : option.capability;
+                      const structure = modelStructure(option.recipe);
+                      const capability = structure === 'single' ? option.capability : structure;
                       // Collections route to backends rather than being one, so
                       // they name no engine — same rule as the models catalog.
-                      const isCollection = capability === 'omni' || capability === 'router';
+                      const isCollection = structure !== 'single';
                       // The picker gives its trailing slot to eject, so the
                       // engine joins the facts instead of competing for it.
                       // A loaded row's status owns the whole meta line, so the

--- a/src/app/src/components/Icon.tsx
+++ b/src/app/src/components/Icon.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ModelCapability } from '../modelCapabilities';
+import { ModelIdentity } from '../modelCapabilities';
 import { LOCAL_ICON_DEFINITIONS, LocalIcon } from './localIcons';
 
 /**
@@ -51,7 +51,7 @@ export const Icon: React.FC<IconProps> = ({ name, size = 16, className, title })
   );
 };
 
-export type CapabilityIconTarget = ModelCapability | 'all' | 'vision' | 'code' | 'transcription' | 'hot' | 'popular' | 'tool' | 'tools' | 'reasoning' | 'mtp' | 'router';
+export type CapabilityIconTarget = ModelIdentity | 'all' | 'vision' | 'code' | 'transcription' | 'hot' | 'popular' | 'tool' | 'tools' | 'reasoning' | 'mtp';
 
 export function capabilityIconName(capability: CapabilityIconTarget): IconName {
   switch (capability) {
@@ -73,6 +73,7 @@ export function capabilityIconName(capability: CapabilityIconTarget): IconName {
     case 'model3d': return 'box';
     case 'embedding': return 'embedding';
     case 'reranking': return 'reranking';
+    case 'classification': return 'search-check';
     case 'vision': return 'vision';
     case 'code': return 'code';
     default: return 'model';

--- a/src/app/src/components/ModelDetailPanel.tsx
+++ b/src/app/src/components/ModelDetailPanel.tsx
@@ -10,7 +10,7 @@ import DOMPurify from 'dompurify';
 import type { ModelInfo, LoadedModel, ModelFileInfo, HFModelResult, ModelRegistryProvider, PullVariantsResult, CloudProviderRow } from '../api';
 import api from '../api';
 import { copyTextToClipboard } from '../clipboard';
-import { capabilityFromModelInfo, capabilityLabel } from '../modelCapabilities';
+import { capabilityFromModelInfo, capabilityLabel, identityFromModelInfo } from '../modelCapabilities';
 import {
   modelBaseTuningForModel, loadModelTuning, saveModelTuning, resetModelTuning,
   modelSupportsContextSize, sanitizeRecipeOptions,
@@ -329,7 +329,7 @@ function tuningKeysForModel(model: ModelInfo): Array<keyof RecipeOptions> {
 
   const activeKeys = recipeKeysForRecipe(activeRecipe);
   if (activeKeys) add(activeKeys);
-  else if (cap === 'chat' || cap === 'omni' || cap === 'unknown') add(LLAMACPP_RECIPE_KEYS);
+  else if (cap === 'chat') add(LLAMACPP_RECIPE_KEYS);
   else if (cap === 'image') add(IMAGE_RECIPE_KEYS);
   else if (cap === 'audio') add(recipes.includes('moonshine') ? MOONSHINE_RECIPE_KEYS : WHISPER_RECIPE_KEYS);
   else if (cap === 'audio-generation') add(recipes.includes('acestep') ? ACESTEP_RECIPE_KEYS : THINKSOUND_RECIPE_KEYS);
@@ -2120,7 +2120,7 @@ export const ModelDetailPanel: React.FC<ModelDetailPanelProps> = ({
   const pullPct = pulling[name] ?? 0;
   const isDownloaded = Boolean((model as any).downloaded) && !isPulling;
   const isCustom = modelIsCustom(model);
-  const cap = capabilityFromModelInfo(model);
+  const cap = identityFromModelInfo(model);
 
   const detailMetadata = (
     <>

--- a/src/app/src/components/ModelListPanel.tsx
+++ b/src/app/src/components/ModelListPanel.tsx
@@ -7,9 +7,10 @@
 import React, { useCallback, useRef, useMemo, useState } from 'react';
 import type { ModelInfo, LoadedModel } from '../api';
 import {
-  capabilityFromModelInfo,
+  isCollectionRecipe,
+  modelStructure,
   modelCapabilityTags,
-  rowCapability,
+  identityFromModelInfo,
   type CapabilityTag,
 } from '../modelCapabilities';
 import { Icon } from './Icon';
@@ -276,31 +277,21 @@ function modelRecipe(m: ModelInfo): string {
 }
 
 export function modelIsRouter(m: ModelInfo): boolean {
-  const recipe = modelRecipe(m);
-  return recipe === 'collection.router' || recipe.startsWith('collection.router.');
+  return modelStructure(modelRecipe(m)) === 'router';
 }
 
 export function modelIsOmniCollection(m: ModelInfo): boolean {
-  const recipe = modelRecipe(m);
-  return recipe === 'collection.omni' || recipe.startsWith('collection.omni.') || recipe === 'collection';
-}
-
-/** Omni is a task identity, not a concrete backend identity. */
-export function modelIsOmni(m: ModelInfo): boolean {
-  return modelIsOmniCollection(m);
+  return modelStructure(modelRecipe(m)) === 'omni';
 }
 
 export function modelMatchesFilter(m: ModelInfo, filter: FilterTab): boolean {
   if (filter === 'all') return true;
-  if (filter === 'router') return modelIsRouter(m);
-  if (filter === 'omni') return modelIsOmni(m);
-
-  const cap = capabilityFromModelInfo(m);
-  if (filter === 'embedding') return cap === 'embedding' || cap === 'reranking';
-  // Collections intentionally have their own tasks and must not also be counted
-  // as Chat even though chat is what they ultimately serve.
-  if (filter === 'llm') return cap === 'chat' && !modelIsRouter(m) && !modelIsOmniCollection(m);
-  return (cap as string) === filter;
+  // A collection has its own task and is never also counted as Chat, so the
+  // identity — which resolves a collection structurally — answers every tab.
+  const identity = identityFromModelInfo(m);
+  if (filter === 'embedding') return identity === 'embedding' || identity === 'reranking';
+  if (filter === 'llm') return identity === 'chat';
+  return (identity as string) === filter;
 }
 
 /** Empty task selection means "all". Multiple selected tasks are OR-ed. */
@@ -363,7 +354,7 @@ export function capabilityTagIconTarget(tag: CapabilityTag): CapabilityIconTarge
 
 /** A backend group is not meaningful for virtual Omni/Router collections. */
 export function modelHasFilterableBackend(m: ModelInfo): boolean {
-  return !modelIsOmni(m) && !modelIsRouter(m) && Boolean(modelRecipe(m));
+  return !isCollectionRecipe(modelRecipe(m)) && Boolean(modelRecipe(m));
 }
 
 /** Empty backend selection means "all". Multiple selected backends are OR-ed. */
@@ -625,10 +616,10 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
     const mId = listModelName(model);
     const displayName = listModelDisplayName(model);
     const recipe = String((model as any).recipe || '');
-    const primaryCapability = rowCapability(model);
+    const primaryCapability = identityFromModelInfo(model);
     // A collection routes to backends rather than being one, so it has no
     // engine to name on the meta line.
-    const neutralCollectionGuide = primaryCapability === 'omni' || primaryCapability === 'router';
+    const neutralCollectionGuide = isCollectionRecipe(recipe);
     const displayedBackend = recipe && !neutralCollectionGuide ? modelListBackendLabel(recipe) : '';
     const isSelected = mId === selectedModelId;
     const capTags = modelCapabilityTags(model);

--- a/src/app/src/components/ModelListPanel.tsx
+++ b/src/app/src/components/ModelListPanel.tsx
@@ -255,7 +255,7 @@ function backendReadinessMessage(readiness: ModelBackendReadiness): string {
   return BACKEND_STATE_MESSAGES[readiness.state || ''] || 'Engine needs attention';
 }
 
-type FilterTab = 'all' | 'llm' | 'omni' | 'router' | 'image' | 'audio' | 'audio-generation' | 'tts' | 'model3d' | 'embedding';
+type FilterTab = 'all' | 'llm' | 'omni' | 'router' | 'image' | 'audio' | 'audio-generation' | 'tts' | 'model3d' | 'embedding' | 'classification';
 
 const FILTER_TABS: Array<{ key: FilterTab; label: string; iconName: IconName }> = [
   { key: 'all', label: 'All', iconName: 'globe' },
@@ -268,6 +268,7 @@ const FILTER_TABS: Array<{ key: FilterTab; label: string; iconName: IconName }> 
   { key: 'tts', label: 'TTS', iconName: 'tts' },
   { key: 'model3d', label: '3D', iconName: 'box' },
   { key: 'embedding', label: 'Embed', iconName: 'embedding' },
+  { key: 'classification', label: 'Classify', iconName: 'search-check' },
 ];
 
 function modelRecipe(m: ModelInfo): string {
@@ -286,7 +287,7 @@ export function modelIsOmniCollection(m: ModelInfo): boolean {
 
 /** Omni is a task identity, not a concrete backend identity. */
 export function modelIsOmni(m: ModelInfo): boolean {
-  return modelIsOmniCollection(m) || capabilityFromModelInfo(m) === 'omni';
+  return modelIsOmniCollection(m);
 }
 
 export function modelMatchesFilter(m: ModelInfo, filter: FilterTab): boolean {
@@ -296,9 +297,9 @@ export function modelMatchesFilter(m: ModelInfo, filter: FilterTab): boolean {
 
   const cap = capabilityFromModelInfo(m);
   if (filter === 'embedding') return cap === 'embedding' || cap === 'reranking';
-  // Router collections intentionally have their own task and must not also be
-  // counted as Chat even though they ultimately route chat-capable models.
-  if (filter === 'llm') return cap === 'chat' && !modelIsRouter(m);
+  // Collections intentionally have their own tasks and must not also be counted
+  // as Chat even though chat is what they ultimately serve.
+  if (filter === 'llm') return cap === 'chat' && !modelIsRouter(m) && !modelIsOmniCollection(m);
   return (cap as string) === filter;
 }
 

--- a/src/app/src/components/ModelListPanel.tsx
+++ b/src/app/src/components/ModelListPanel.tsx
@@ -286,8 +286,7 @@ export function modelIsOmniCollection(m: ModelInfo): boolean {
 
 export function modelMatchesFilter(m: ModelInfo, filter: FilterTab): boolean {
   if (filter === 'all') return true;
-  // A collection has its own task and is never also counted as Chat, so the
-  // identity — which resolves a collection structurally — answers every tab.
+  // A collection has its own task and is never also counted as Chat.
   const identity = identityFromModelInfo(m);
   if (filter === 'embedding') return identity === 'embedding' || identity === 'reranking';
   if (filter === 'llm') return identity === 'chat';

--- a/src/app/src/components/ModelManager.tsx
+++ b/src/app/src/components/ModelManager.tsx
@@ -1,7 +1,7 @@
 import React, { Suspense, useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import api, { ModelInfo, LoadedModel, PullCallbacks, PullVariantsResult, HFModelResult, ModelRegistryProvider, searchHuggingFace, searchModelScope, friendlyErrorMessage } from '../api';
 import { copyTextToClipboard } from '../clipboard';
-import { capabilityFromModelInfo, modelCapabilityTags } from '../modelCapabilities';
+import { capabilityFromModelInfo, modelCapabilityTags, modelSupportsChatImageInput } from '../modelCapabilities';
 import { Icon } from './Icon';
 import { storageKey } from '../storage';
 import { CUSTOM_CAPABILITIES, CustomModelCapability, CustomOmniToolDefinition, customLoadOptions, customModelToModelInfo, customRegistrationOptions, deleteCustomModel, exportCustomModelsPayload, importCustomModels, loadCustomModels, upsertCustomModel, type CustomModelRecord, type CustomOmniToolTargetType } from '../features/customModels/customModelStore';
@@ -284,6 +284,7 @@ const CHAT_RECIPE_OPTIONS: CustomRecipeOption[] = [
 const CUSTOM_RECIPE_OPTIONS: Record<CustomModelCapability, CustomRecipeOption[]> = {
   chat: CHAT_RECIPE_OPTIONS,
   omni: CHAT_RECIPE_OPTIONS,
+  classification: [customRecipeOption('onnxruntime', 'ONNX Runtime', 'Text classification through /classify')],
   image: [customRecipeOption('sd-cpp', 'Stable Diffusion', 'Stable Diffusion C++ backend')],
   audio: [
     customRecipeOption('whispercpp', 'Whisper', 'Whisper C++ transcription backend'),
@@ -805,8 +806,6 @@ const OMNI_COMPONENT_ROLE_CONFIG: Record<OmniComponentRole, { label: string; pla
   },
 };
 
-const NON_PLANNER_LABELS = new Set(['image', 'image-generation', 'edit', 'upscaling', 'speech', 'tts', 'text-to-speech', 'transcription', 'audio-generation', 'music', 'music-generation', 'sound-generation', 'sfx', '3d', 'model3d', '3d-generation', 'image-to-3d', 'mesh', 'mesh-generation', 'embeddings', 'embedding', 'reranking', 'reranker']);
-
 function lowerLabels(m: ModelInfo): string[] {
   return (m.labels || []).map(label => label.toLowerCase().trim()).filter(Boolean);
 }
@@ -819,14 +818,12 @@ function hasAnyLabel(m: ModelInfo, labels: string[]): boolean {
 function isOmniComponentEligible(m: ModelInfo, role: OmniComponentRole): boolean {
   if (isCollectionModel(m)) return false;
   const cap = capabilityFromModelInfo(m);
-  const labels = lowerLabels(m);
 
   switch (role) {
     case 'llm':
-      if (cap !== 'unknown') return cap === 'chat' || cap === 'omni';
-      return !labels.some(label => NON_PLANNER_LABELS.has(label));
+      return cap === 'chat';
     case 'vision':
-      return cap === 'omni' || hasAnyLabel(m, ['vision', 'vlm', 'vision-language', 'image-input']);
+      return modelSupportsChatImageInput(m, null);
     case 'image':
       return cap === 'image' || hasAnyLabel(m, ['image', 'image-generation', 'diffusion']);
     case 'edit':

--- a/src/app/src/components/ModelManager.tsx
+++ b/src/app/src/components/ModelManager.tsx
@@ -4,7 +4,7 @@ import { copyTextToClipboard } from '../clipboard';
 import { capabilityFromModelInfo, modelCapabilityTags, modelSupportsChatImageInput } from '../modelCapabilities';
 import { Icon } from './Icon';
 import { storageKey } from '../storage';
-import { CUSTOM_CAPABILITIES, CustomModelCapability, CustomOmniToolDefinition, customLoadOptions, customModelToModelInfo, customRegistrationOptions, deleteCustomModel, exportCustomModelsPayload, importCustomModels, loadCustomModels, upsertCustomModel, type CustomModelRecord, type CustomOmniToolTargetType } from '../features/customModels/customModelStore';
+import { CUSTOM_CAPABILITIES, CustomModelCapability, generatedLabelsFor, CustomOmniToolDefinition, customLoadOptions, customModelToModelInfo, customRegistrationOptions, deleteCustomModel, exportCustomModelsPayload, importCustomModels, loadCustomModels, upsertCustomModel, type CustomModelRecord, type CustomOmniToolTargetType } from '../features/customModels/customModelStore';
 import { getCollectionComponents, isCollectionModel, isCollectionFullyDownloaded, withVirtualLoadedCollections } from '../features/collections/collectionModels';
 import {
   detectHuggingFaceBackend,
@@ -725,7 +725,7 @@ function customDraftFromModel(model: ModelInfo): CustomModelDraftState {
   const components = getCollectionComponents(model);
   const collection = isCollectionModel(model);
   const capability = (collection ? 'omni' : String((model as any).type || 'chat')) as CustomModelCapability;
-  const structuralLabels = new Set(['custom', 'omni', 'multimodal', 'vision-language']);
+  const structuralLabels = generatedLabelsFor(capability);
   return {
     name: modelName(model),
     displayName: String(model.display_name || modelName(model)),

--- a/src/app/src/components/ModelNavRail.tsx
+++ b/src/app/src/components/ModelNavRail.tsx
@@ -57,6 +57,7 @@ const TASK_ITEMS: Array<{ key: FilterTab; label: string; iconName: IconName; col
   { key: 'tts', label: 'TTS', iconName: 'tts', color: 'var(--cap-tts)' },
   { key: 'model3d', label: '3D', iconName: 'box', color: 'var(--cap-model3d)' },
   { key: 'embedding', label: 'Embed', iconName: 'embedding', color: 'var(--cap-embedding)' },
+  { key: 'classification', label: 'Classify', iconName: 'search-check', color: 'var(--cap-classification)' },
 ];
 
 const MODEL_PROVIDERS: Array<{ key: ModelRegistryProvider; label: string }> = [

--- a/src/app/src/components/RouterEditorPanel.tsx
+++ b/src/app/src/components/RouterEditorPanel.tsx
@@ -157,7 +157,7 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
     .filter(model => String((model as any).recipe || '').toLowerCase() !== 'collection.router')
     .filter(model => {
       const capability = capabilityFromModelInfo(model);
-      return capability === 'chat' || capability === 'omni' || capability === 'unknown';
+      return capability === 'chat';
     })
     .sort((a, b) => modelLabel(a).localeCompare(modelLabel(b))), [models]);
 

--- a/src/app/src/components/RouterEditorPanel.tsx
+++ b/src/app/src/components/RouterEditorPanel.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import api, { type CloudProviderRow, type ModelInfo } from '../api';
-import { capabilityFromModelInfo } from '../modelCapabilities';
+import { capabilityFromModelInfo, isRouterRecipe } from '../modelCapabilities';
 import { Icon } from './Icon';
 import RouterNodeEditor from './RouterNodeEditor';
 import {
@@ -154,7 +154,7 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
   }, [initialModel]);
 
   const candidateModels = useMemo(() => models
-    .filter(model => String((model as any).recipe || '').toLowerCase() !== 'collection.router')
+    .filter(model => !isRouterRecipe((model as any).recipe))
     .filter(model => {
       const capability = capabilityFromModelInfo(model);
       return capability === 'chat';
@@ -173,7 +173,7 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
       return capabilityFromModelInfo(model) === 'embedding' || labels.includes('embedding') || labels.includes('embeddings');
     });
     return (explicit.length ? explicit : models)
-      .filter(model => String((model as any).recipe || '').toLowerCase() !== 'collection.router')
+      .filter(model => !isRouterRecipe((model as any).recipe))
       .sort((a, b) => modelLabel(a).localeCompare(modelLabel(b)));
   }, [models]);
 
@@ -657,7 +657,7 @@ export const RouterEditorPanel: React.FC<RouterEditorPanelProps> = ({
                         <div className="router-editor__form-grid router-editor__form-grid--classifier">
                           <label><span>ID</span><input className="input" value={classifier.id} onChange={event => updateClassifier(index, { id: event.target.value })} /></label>
                           <label><span>Type</span><select className="select" value={classifier.type} onChange={event => updateClassifier(index, { ...createRouterClassifier(index, event.target.value as RouterClassifier['type']), id: classifier.id })}><option value="classifier">classifier</option><option value="semantic_similarity">semantic_similarity</option><option value="llm">llm</option></select></label>
-                          <label className="router-editor__wide"><span>Model</span><select className="select" value={classifier.model} onChange={event => updateClassifier(index, { model: event.target.value })}><option value="">Select model</option>{(classifier.type === 'semantic_similarity' ? embeddingModels : classifier.type === 'llm' ? candidateModels : models).filter(model => String((model as any).recipe || '').toLowerCase() !== 'collection.router').map(model => <option key={modelName(model)} value={modelName(model)}>{modelLabel(model)} · {modelName(model)}</option>)}</select></label>
+                          <label className="router-editor__wide"><span>Model</span><select className="select" value={classifier.model} onChange={event => updateClassifier(index, { model: event.target.value })}><option value="">Select model</option>{(classifier.type === 'semantic_similarity' ? embeddingModels : classifier.type === 'llm' ? candidateModels : models).filter(model => !isRouterRecipe((model as any).recipe)).map(model => <option key={modelName(model)} value={modelName(model)}>{modelLabel(model)} · {modelName(model)}</option>)}</select></label>
                           {classifier.type === 'semantic_similarity' ? (
                             <div className="router-editor__wide router-editor__concepts">
                               <div className="router-editor__mini-head"><span>Concepts and reference phrases</span><WorkspaceActionButton size="small" icon="plus" onClick={() => updateClassifier(index, { referencePhrases: { ...classifier.referencePhrases, [nextConceptName(classifier.referencePhrases)]: ['example phrase'] } })}>Concept</WorkspaceActionButton></div>

--- a/src/app/src/features/chatDefaultModels.ts
+++ b/src/app/src/features/chatDefaultModels.ts
@@ -110,7 +110,7 @@ export function modelIsDownloaded(info: ModelInfo | null | undefined): boolean {
 export function modelCanAnswerChat(info: ModelInfo | null | undefined): boolean {
   if (!info) return false;
   const capability = capabilityFromModelInfo(info);
-  return capability === 'chat' || capability === 'omni';
+  return capability === 'chat';
 }
 
 function lastUsedValue(info: ModelInfo): number {

--- a/src/app/src/features/collections/collectionModels.ts
+++ b/src/app/src/features/collections/collectionModels.ts
@@ -1,5 +1,5 @@
 import type { LoadedModel, ModelInfo } from '../../api';
-import { capabilityFromModelInfo } from '../../modelCapabilities';
+import { capabilityFromModelInfo, modelSupportsChatImageInput } from '../../modelCapabilities';
 
 export const COLLECTION_OMNI_RECIPE = 'collection.omni';
 
@@ -82,8 +82,7 @@ export function getPrimaryChatComponent(model: ModelInfo | null | undefined, all
   if (components.length === 0) return null;
   const chat = components.find(component => {
     const info = findModelInfoByName(allModels, component);
-    const cap = info ? capabilityFromModelInfo(info) : 'unknown';
-    return cap === 'chat' || cap === 'omni' || cap === 'unknown';
+    return info ? capabilityFromModelInfo(info) === 'chat' : false;
   });
   return chat || components[0] || null;
 }
@@ -92,9 +91,7 @@ export function getVisionChatComponent(model: ModelInfo | null | undefined, allM
   const components = getCollectionComponents(model);
   return components.find(component => {
     const info = findModelInfoByName(allModels, component);
-    const labels = (info?.labels || []).map(label => label.toLowerCase());
-    const cap = info ? capabilityFromModelInfo(info) : 'unknown';
-    return cap === 'omni' || labels.includes('vision-language') || labels.includes('image-input') || labels.includes('vlm');
+    return modelSupportsChatImageInput(info, null);
   }) || null;
 }
 

--- a/src/app/src/features/customModels/customModelStore.ts
+++ b/src/app/src/features/customModels/customModelStore.ts
@@ -1,10 +1,20 @@
 import type { ModelInfo } from '../../api';
 import type { ModelCapability } from '../../modelCapabilities';
+import { deploymentKindFromLabels } from '../../modelCapabilities';
 import { storageKey } from '../../storage';
 import { COLLECTION_OMNI_RECIPE } from '../collections/collectionModels';
 import { routerRegistrationOptions } from '../router/routerStore';
 
-export type CustomModelCapability = Extract<ModelCapability, 'chat' | 'omni' | 'image' | 'audio' | 'audio-generation' | 'tts' | 'model3d' | 'embedding' | 'reranking'>;
+/**
+ * What the custom-model editor offers, which is not the same vocabulary a model
+ * is displayed under. `omni` is an authoring shortcut for "a chat model that
+ * also takes images, or a collection of existing models" — both of which deploy
+ * as chat. `classification` round-trips on import but is not offered as a new
+ * model choice, because there is no /classify surface to author against yet.
+ */
+export type CustomModelCapability =
+  | 'chat' | 'omni' | 'image' | 'audio' | 'audio-generation'
+  | 'tts' | 'model3d' | 'embedding' | 'reranking' | 'classification';
 
 export interface CustomModelComponentRoles {
   llm?: string;
@@ -136,23 +146,30 @@ function defaultRecipe(capability: CustomModelCapability, components?: string[])
     case 'model3d': return 'trellis';
     case 'embedding': return 'llamacpp';
     case 'reranking': return 'llamacpp';
+    case 'classification': return 'onnxruntime';
     case 'omni': return components && components.length > 0 ? COLLECTION_OMNI_RECIPE : 'llamacpp';
     default: return 'llamacpp';
   }
 }
 
+/**
+ * A registration declares exactly one deployment label plus any capability
+ * labels — see the label contract in docs/api/openai.md. Writing two mode
+ * labels, or none, is refused by /v1/pull.
+ */
 function labelsFor(capability: CustomModelCapability, extra: string[] = []): string[] {
   const base = ['custom'];
   switch (capability) {
     case 'chat': base.push('chat'); break;
-    case 'omni': base.push('omni', 'multimodal', 'vision-language'); break;
+    case 'omni': base.push('chat', 'vision'); break;
     case 'image': base.push('image'); break;
-    case 'audio': base.push('audio', 'transcription'); break;
+    case 'audio': base.push('transcription'); break;
     case 'audio-generation': base.push('audio-generation'); break;
     case 'tts': base.push('tts'); break;
     case 'model3d': base.push('3d', 'image-to-3d'); break;
-    case 'embedding': base.push('embedding'); break;
+    case 'embedding': base.push('embeddings'); break;
     case 'reranking': base.push('reranking'); break;
+    case 'classification': base.push('classification'); break;
   }
   return [...new Set([...base, ...extra.map(l => l.trim().toLowerCase()).filter(Boolean)])];
 }
@@ -373,18 +390,54 @@ function valueStringArray(value: unknown): string[] {
   return [];
 }
 
+/**
+ * An imported file is arbitrary JSON rather than a served model, so its `type`
+ * needs its own tolerant mapping. Its `labels`, however, are read through the
+ * one deployment-label lookup — no substring scanning.
+ */
+const IMPORTED_TYPE_KIND: Record<string, ModelCapability> = {
+  llm: 'chat', chat: 'chat', text: 'chat', language: 'chat',
+  vlm: 'chat', omni: 'chat', multimodal: 'chat', vision: 'chat',
+  image: 'image', diffusion: 'image', 'image-generation': 'image',
+  audio: 'audio', transcription: 'audio', asr: 'audio', stt: 'audio',
+  'audio-generation': 'audio-generation', 'music-generation': 'audio-generation',
+  'sound-generation': 'audio-generation', sfx: 'audio-generation',
+  tts: 'tts', speech: 'tts', 'text-to-speech': 'tts',
+  '3d': 'model3d', model3d: 'model3d', '3d-generation': 'model3d',
+  'image-to-3d': 'model3d', mesh: 'model3d',
+  embedding: 'embedding', embeddings: 'embedding',
+  reranking: 'reranking', reranker: 'reranking', rerank: 'reranking',
+  classification: 'classification', classifier: 'classification',
+};
+
+/** Label spellings that make an imported chat model the editor's Omni choice. */
+const IMPORTED_IMAGE_INPUT_LABELS = new Set([
+  'vision', 'vlm', 'vision-language', 'image-input', 'image-text-to-text',
+  'omni', 'multimodal', 'multi-modal',
+]);
+
 function normalizeImportedCapability(raw: string, labels: string[]): CustomModelCapability {
-  const lower = raw.toLowerCase().trim();
-  const labelText = labels.join(' ').toLowerCase();
-  if (['omni', 'multimodal', 'vlm', 'vision'].includes(lower) || labelText.includes('omni') || labelText.includes('vision-language')) return 'omni';
-  if (['3d', 'model3d', '3d-generation', 'image-to-3d'].includes(lower) || labelText.includes('image-to-3d') || labelText.includes('3d')) return 'model3d';
-  if (['audio-generation', 'music-generation', 'sound-generation', 'sfx'].includes(lower) || labelText.includes('audio-generation')) return 'audio-generation';
-  if (['image', 'image-generation', 'diffusion'].includes(lower) || labelText.includes('image')) return 'image';
-  if (['audio', 'transcription', 'asr', 'stt'].includes(lower) || labelText.includes('transcription')) return 'audio';
-  if (['tts', 'speech', 'text-to-speech'].includes(lower) || labelText.includes('tts')) return 'tts';
-  if (['embedding', 'embeddings'].includes(lower) || labelText.includes('embedding')) return 'embedding';
-  if (['reranking', 'reranker', 'rerank'].includes(lower) || labelText.includes('reranking')) return 'reranking';
-  return 'chat';
+  const lowerLabels = labels.map(label => label.toLowerCase().trim()).filter(Boolean);
+  const declared = deploymentKindFromLabels(lowerLabels);
+  const kind = declared !== 'unknown'
+    ? declared
+    : IMPORTED_TYPE_KIND[raw.toLowerCase().trim()] || 'chat';
+
+  switch (kind) {
+    case 'image': return 'image';
+    case 'audio': return 'audio';
+    case 'audio-generation': return 'audio-generation';
+    case 'tts': return 'tts';
+    case 'model3d': return 'model3d';
+    case 'embedding': return 'embedding';
+    case 'reranking': return 'reranking';
+    case 'classification': return 'classification';
+    default:
+      return lowerLabels.some(label => IMPORTED_IMAGE_INPUT_LABELS.has(label))
+        || IMPORTED_IMAGE_INPUT_LABELS.has(raw.toLowerCase().trim())
+        ? 'omni'
+        : 'chat';
+  }
 }
 
 function normalizeImportedRecord(raw: unknown, index: number): CustomModelDraft | null {

--- a/src/app/src/features/customModels/customModelStore.ts
+++ b/src/app/src/features/customModels/customModelStore.ts
@@ -174,7 +174,6 @@ function labelsFor(capability: CustomModelCapability, extra: string[] = []): str
   return [...new Set([...base, ...extra.map(l => l.trim().toLowerCase()).filter(Boolean)])];
 }
 
-/** The machine-written half of a record's labels, for a given capability. */
 export function generatedLabelsFor(capability: CustomModelCapability): Set<string> {
   return new Set(labelsFor(capability));
 }
@@ -425,7 +424,7 @@ const IMPORTED_TYPE_KIND: Record<string, ModelCapability> = {
   reranker: 'reranking', rerank: 'reranking',
 };
 
-/** The shared image-input vocabulary, plus the editor's own Omni shorthand. */
+/** The shared vocabulary plus the editor's own `omni` shorthand. */
 function indicatesImageInput(label: string): boolean {
   return IMAGE_INPUT_LABELS.has(label) || label === 'omni';
 }

--- a/src/app/src/features/customModels/customModelStore.ts
+++ b/src/app/src/features/customModels/customModelStore.ts
@@ -1,6 +1,6 @@
 import type { ModelInfo } from '../../api';
 import type { ModelCapability } from '../../modelCapabilities';
-import { deploymentKindFromLabels } from '../../modelCapabilities';
+import { DEPLOYMENT_LABEL_KIND, IMAGE_INPUT_LABELS, deploymentKindFromLabels } from '../../modelCapabilities';
 import { storageKey } from '../../storage';
 import { COLLECTION_OMNI_RECIPE } from '../collections/collectionModels';
 import { routerRegistrationOptions } from '../router/routerStore';
@@ -174,6 +174,22 @@ function labelsFor(capability: CustomModelCapability, extra: string[] = []): str
   return [...new Set([...base, ...extra.map(l => l.trim().toLowerCase()).filter(Boolean)])];
 }
 
+/** The machine-written half of a record's labels, for a given capability. */
+export function generatedLabelsFor(capability: CustomModelCapability): Set<string> {
+  return new Set(labelsFor(capability));
+}
+
+/**
+ * Records written before the deployment-label contract carry only descriptive
+ * labels. Their stored authoring capability still says how they deploy, so the
+ * label set is repaired on read rather than rewritten on disk.
+ */
+export function recordLabels(record: CustomModelRecord): string[] {
+  const stored = record.labels || [];
+  if (deploymentKindFromLabels(stored) !== 'unknown') return stored;
+  return labelsFor(record.type, stored);
+}
+
 function isRecord(value: unknown): value is CustomModelRecord {
   if (!value || typeof value !== 'object') return false;
   const obj = value as Record<string, unknown>;
@@ -275,7 +291,7 @@ export function customModelToModelInfo(record: CustomModelRecord): ModelInfo {
     mmproj: record.mmproj,
     recipe: record.recipe,
     type: record.type,
-    labels: record.labels,
+    labels: recordLabels(record),
     downloaded: true,
     custom: true,
     max_context_window: record.max_context_window,
@@ -396,25 +412,23 @@ function valueStringArray(value: unknown): string[] {
  * one deployment-label lookup — no substring scanning.
  */
 const IMPORTED_TYPE_KIND: Record<string, ModelCapability> = {
-  llm: 'chat', chat: 'chat', text: 'chat', language: 'chat',
+  ...DEPLOYMENT_LABEL_KIND,
+  llm: 'chat', text: 'chat', language: 'chat',
   vlm: 'chat', omni: 'chat', multimodal: 'chat', vision: 'chat',
-  image: 'image', diffusion: 'image', 'image-generation': 'image',
-  audio: 'audio', transcription: 'audio', asr: 'audio', stt: 'audio',
-  'audio-generation': 'audio-generation', 'music-generation': 'audio-generation',
-  'sound-generation': 'audio-generation', sfx: 'audio-generation',
-  tts: 'tts', speech: 'tts', 'text-to-speech': 'tts',
-  '3d': 'model3d', model3d: 'model3d', '3d-generation': 'model3d',
-  'image-to-3d': 'model3d', mesh: 'model3d',
-  embedding: 'embedding', embeddings: 'embedding',
-  reranking: 'reranking', reranker: 'reranking', rerank: 'reranking',
-  classification: 'classification', classifier: 'classification',
+  diffusion: 'image', 'image-generation': 'image',
+  audio: 'audio', asr: 'audio', stt: 'audio',
+  'music-generation': 'audio-generation', 'sound-generation': 'audio-generation',
+  sfx: 'audio-generation',
+  speech: 'tts', 'text-to-speech': 'tts',
+  model3d: 'model3d', '3d-generation': 'model3d', 'image-to-3d': 'model3d',
+  mesh: 'model3d',
+  reranker: 'reranking', rerank: 'reranking',
 };
 
-/** Label spellings that make an imported chat model the editor's Omni choice. */
-const IMPORTED_IMAGE_INPUT_LABELS = new Set([
-  'vision', 'vlm', 'vision-language', 'image-input', 'image-text-to-text',
-  'omni', 'multimodal', 'multi-modal',
-]);
+/** The shared image-input vocabulary, plus the editor's own Omni shorthand. */
+function indicatesImageInput(label: string): boolean {
+  return IMAGE_INPUT_LABELS.has(label) || label === 'omni';
+}
 
 function normalizeImportedCapability(raw: string, labels: string[]): CustomModelCapability {
   const lowerLabels = labels.map(label => label.toLowerCase().trim()).filter(Boolean);
@@ -423,21 +437,9 @@ function normalizeImportedCapability(raw: string, labels: string[]): CustomModel
     ? declared
     : IMPORTED_TYPE_KIND[raw.toLowerCase().trim()] || 'chat';
 
-  switch (kind) {
-    case 'image': return 'image';
-    case 'audio': return 'audio';
-    case 'audio-generation': return 'audio-generation';
-    case 'tts': return 'tts';
-    case 'model3d': return 'model3d';
-    case 'embedding': return 'embedding';
-    case 'reranking': return 'reranking';
-    case 'classification': return 'classification';
-    default:
-      return lowerLabels.some(label => IMPORTED_IMAGE_INPUT_LABELS.has(label))
-        || IMPORTED_IMAGE_INPUT_LABELS.has(raw.toLowerCase().trim())
-        ? 'omni'
-        : 'chat';
-  }
+  if (kind !== 'chat' && kind !== 'unknown') return kind;
+  // The editor's Omni choice covers a chat model that also takes images.
+  return [...lowerLabels, raw.toLowerCase().trim()].some(indicatesImageInput) ? 'omni' : 'chat';
 }
 
 function normalizeImportedRecord(raw: unknown, index: number): CustomModelDraft | null {

--- a/src/app/src/modelCapabilities.ts
+++ b/src/app/src/modelCapabilities.ts
@@ -44,7 +44,7 @@ export interface ModelSnapshot {
  * Keep in sync with docs/api/openai.md — tests/model-kind-classification.runtime.cjs
  * fails if this drifts from the documented set.
  */
-const DEPLOYMENT_LABEL_KIND: Record<string, ModelCapability> = {
+export const DEPLOYMENT_LABEL_KIND: Record<string, ModelCapability> = {
   chat: 'chat',
   transcription: 'audio',
   embeddings: 'embedding',
@@ -72,7 +72,9 @@ const LOADED_TYPE_KIND: Record<string, ModelCapability> = {
 };
 
 const OMNI_COLLECTION_RECIPE = 'collection.omni';
+const OMNI_COLLECTION_PREFIX = `${OMNI_COLLECTION_RECIPE}.`;
 const ROUTER_COLLECTION_RECIPE = 'collection.router';
+const ROUTER_COLLECTION_PREFIX = `${ROUTER_COLLECTION_RECIPE}.`;
 
 /** Audio as an input modality of a chat model, not a deployment mode of its own. */
 const AUDIO_INPUT_LABELS = new Set([
@@ -80,7 +82,7 @@ const AUDIO_INPUT_LABELS = new Set([
 ]);
 
 /** Image/vision as an input modality of a chat model. */
-const IMAGE_INPUT_LABELS = new Set([
+export const IMAGE_INPUT_LABELS = new Set([
   'vision', 'image-input', 'vision-language', 'vlm', 'image-text-to-text',
   'multimodal', 'multi-modal',
 ]);
@@ -118,8 +120,8 @@ export function deploymentKindFromLabels(labels?: readonly string[] | null): Mod
 
 export function modelStructure(recipe?: string | null): ModelStructure {
   const r = normalizeModelType(recipe);
-  if (r === OMNI_COLLECTION_RECIPE || r.startsWith(`${OMNI_COLLECTION_RECIPE}.`) || r === 'collection') return 'omni';
-  if (r === ROUTER_COLLECTION_RECIPE || r.startsWith(`${ROUTER_COLLECTION_RECIPE}.`)) return 'router';
+  if (r === OMNI_COLLECTION_RECIPE || r.startsWith(OMNI_COLLECTION_PREFIX) || r === 'collection') return 'omni';
+  if (r === ROUTER_COLLECTION_RECIPE || r.startsWith(ROUTER_COLLECTION_PREFIX)) return 'router';
   return 'single';
 }
 
@@ -141,20 +143,24 @@ export function capabilityFromLoaded(model?: LoadedModel | null): ModelCapabilit
   // is the strongest evidence available for a running model.
   const fromType = LOADED_TYPE_KIND[normalizeModelType(model.type)];
   if (fromType) return fromType;
-  return deploymentKindFromLabels(model.labels);
-}
-
-export function identityFromModelInfo(model: ModelInfo): ModelIdentity {
-  const structure = modelStructure((model as any)?.recipe);
-  return structure === 'single' ? capabilityFromModelInfo(model) : structure;
+  const labelled = deploymentKindFromLabels(model.labels);
+  if (labelled !== 'unknown') return labelled;
+  // A loaded collection is synthesized client-side from its components, so it
+  // carries neither a router ModelType nor labels — only the recipe.
+  return isCollectionRecipe(model.recipe) ? 'chat' : 'unknown';
 }
 
 /**
- * The identity a selection row leads with. A collection routes to backends
+ * The identity a row or badge leads with. A collection routes to backends
  * rather than being one, so it shows itself rather than the chat it serves.
  */
-export function rowCapability(model: ModelInfo): ModelIdentity {
-  return identityFromModelInfo(model);
+export function identityFor(capability: ModelCapability, recipe?: string | null): ModelIdentity {
+  const structure = modelStructure(recipe);
+  return structure === 'single' ? capability : structure;
+}
+
+export function identityFromModelInfo(model: ModelInfo): ModelIdentity {
+  return identityFor(capabilityFromModelInfo(model), (model as any)?.recipe);
 }
 
 function descriptorLabels(model?: ModelInfo | LoadedModel | null): string[] {
@@ -216,9 +222,17 @@ export function canUseChatCompletions(model?: LoadedModel | null): boolean {
   return capabilityFromLoaded(model) === 'chat';
 }
 
+const COMPOSER_CAPABILITIES: ReadonlySet<ModelCapability> = new Set<ModelCapability>([
+  'chat', 'image', 'audio', 'audio-generation', 'tts', 'model3d',
+]);
+
+/** Capabilities the chat composer can drive directly. */
+export function isComposerSelectableCapability(capability: ModelCapability): boolean {
+  return COMPOSER_CAPABILITIES.has(capability);
+}
+
 export function canSelectInComposer(model?: LoadedModel | null): boolean {
-  const cap = capabilityFromLoaded(model);
-  return ['chat', 'image', 'audio', 'audio-generation', 'tts', 'model3d'].includes(cap);
+  return isComposerSelectableCapability(capabilityFromLoaded(model));
 }
 
 export function capabilityLabel(capability: ModelIdentity): string {
@@ -255,32 +269,9 @@ export function capabilityBadge(capability: ModelIdentity): string {
   }
 }
 
-export function capabilityIcon(capability: ModelIdentity | 'all' | 'vision' | 'code' | 'transcription'): string {
-  switch (capability) {
-    case 'all': return 'All';
-    case 'chat': return 'Chat';
-    case 'omni': return 'Omni';
-    case 'router': return 'Router';
-    case 'image': return 'Image';
-    case 'audio': return 'Audio';
-    case 'audio-generation': return 'Audio';
-    case 'transcription': return 'Audio';
-    case 'tts': return 'TTS';
-    case 'model3d': return '3D';
-    case 'embedding': return 'Emb';
-    case 'reranking': return 'Rank';
-    case 'classification': return 'Classify';
-    case 'vision': return 'Vision';
-    case 'code': return 'Code';
-    default: return 'Model';
-  }
-}
-
-/** A snapshot's row identity. Structure is derived from the recipe it carries. */
 export function snapshotIdentity(snapshot?: ModelSnapshot | null): ModelIdentity {
   if (!snapshot) return 'unknown';
-  const structure = modelStructure(snapshot.recipe);
-  return structure === 'single' ? snapshot.capability : structure;
+  return identityFor(snapshot.capability, snapshot.recipe);
 }
 
 export function snapshotFromLoaded(model?: LoadedModel | null): ModelSnapshot | null {

--- a/src/app/src/modelCapabilities.ts
+++ b/src/app/src/modelCapabilities.ts
@@ -1,8 +1,16 @@
 import type { LoadedModel, ModelInfo } from './api';
 
+/**
+ * What a model is offered for. This mirrors the server's deployment modes
+ * one-for-one — see the "Deployment labels" table in docs/api/openai.md and
+ * find_deployment_mode() in src/cpp/include/lemon/model_types.h.
+ *
+ * Being a collection is not a capability: an Omni or Router collection serves
+ * chat, and says so with the `chat` label. Its collection-ness is structure,
+ * read from the recipe by modelStructure().
+ */
 export type ModelCapability =
   | 'chat'
-  | 'omni'
   | 'image'
   | 'audio'
   | 'audio-generation'
@@ -10,7 +18,14 @@ export type ModelCapability =
   | 'model3d'
   | 'embedding'
   | 'reranking'
+  | 'classification'
   | 'unknown';
+
+/** Whether a model is one backend or a collection routing to several. */
+export type ModelStructure = 'single' | 'omni' | 'router';
+
+/** What a row or badge leads with: a collection shows itself, not what it serves. */
+export type ModelIdentity = ModelCapability | 'omni' | 'router';
 
 export interface ModelSnapshot {
   name: string;
@@ -21,106 +36,58 @@ export interface ModelSnapshot {
   checkpoint?: string;
 }
 
-const TYPE_TO_CAPABILITY: Record<string, ModelCapability> = {
-  llm: 'chat', chat: 'chat', text: 'chat', language: 'chat',
-  // A single multimodal model still uses the Chat surface. `omni` is reserved
-  // for collection.omni orchestration, not for ordinary VLM/audio-capable LLMs.
-  vision: 'chat', vlm: 'chat', 'vision-language': 'chat', omni: 'chat', multimodal: 'chat', 'multi-modal': 'chat',
-  'audio-chat': 'chat', realtime: 'chat',
-  image: 'image', diffusion: 'image', 'image-generation': 'image',
-  audio: 'audio', transcription: 'audio', 'realtime-transcription': 'audio', asr: 'audio', stt: 'audio', 'speech-to-text': 'audio',
-  'audio-generation': 'audio-generation', 'music-generation': 'audio-generation', 'sound-generation': 'audio-generation', sfx: 'audio-generation', music: 'audio-generation',
-  tts: 'tts', speech: 'tts', 'text-to-speech': 'tts',
-  '3d': 'model3d', model3d: 'model3d', '3d-generation': 'model3d', 'image-to-3d': 'model3d', mesh: 'model3d',
-  embedding: 'embedding', embeddings: 'embedding', reranking: 'reranking', reranker: 'reranking',
+/**
+ * The nine deployment labels, and the two spellings the server also accepts.
+ * A model declares exactly one of these; the server stamps a recipe default
+ * when a registration names none, so anything served carries one.
+ *
+ * Keep in sync with docs/api/openai.md — tests/model-kind-classification.runtime.cjs
+ * fails if this drifts from the documented set.
+ */
+const DEPLOYMENT_LABEL_KIND: Record<string, ModelCapability> = {
+  chat: 'chat',
+  transcription: 'audio',
+  embeddings: 'embedding',
+  embedding: 'embedding',
+  reranking: 'reranking',
+  image: 'image',
+  tts: 'tts',
+  'audio-generation': 'audio-generation',
+  classification: 'classification',
+  classifier: 'classification',
+  '3d': 'model3d',
 };
 
-const NON_CHAT_RECIPE_HINTS: Array<[string, ModelCapability]> = [
-  ['trellis', 'model3d'],
-  ['acestep', 'audio-generation'], ['ace-step', 'audio-generation'], ['thinksound', 'audio-generation'],
-  ['stable-diffusion', 'image'], ['diffusion', 'image'], ['sd-cpp', 'image'],
-  ['whisper', 'audio'], ['moonshine', 'audio'], ['asr', 'audio'], ['speech-to-text', 'audio'],
-  ['openmoss', 'tts'], ['kokoro', 'tts'], ['text-to-speech', 'tts'], ['tts', 'tts'],
-  ['embedding', 'embedding'], ['rerank', 'reranking'],
-];
+/** ModelType strings the router reports for loaded models (model_type_to_string). */
+const LOADED_TYPE_KIND: Record<string, ModelCapability> = {
+  llm: 'chat',
+  embedding: 'embedding',
+  reranking: 'reranking',
+  transcription: 'audio',
+  image: 'image',
+  tts: 'tts',
+  'audio-generation': 'audio-generation',
+  classification: 'classification',
+  mesh: 'model3d',
+};
 
-const CHAT_RECIPE_HINTS = new Set(['llamacpp', 'flm', 'ryzenai-llm', 'vllm']);
+const OMNI_COLLECTION_RECIPE = 'collection.omni';
+const ROUTER_COLLECTION_RECIPE = 'collection.router';
 
-const MULTIMODAL_CHAT_NAME_PATTERNS = [
-  /(^|[._\-/])omni([._\-/]|$)/,
-  /(^|[._\-/])multimodal([._\-/]|$)/,
-  /(^|[._\-/])multi-modal([._\-/]|$)/,
-  /(^|[._\-/])vision-language([._\-/]|$)/,
-  /(^|[._\-/])vlm([._\-/]|$)/,
-  /(^|[._\-/])vl([._\-/]|$)/,
-  /(^|[._\-/])llava([._\-/]|$)/,
-  /(^|[._\-/])bakllava([._\-/]|$)/,
-  /(^|[._\-/])moondream([._\-/]|$)/,
-  /(^|[._\-/])pixtral([._\-/]|$)/,
-  /(^|[._\-/])mllama([._\-/]|$)/,
-  /(^|[._\-/])qwen\d*(?:\.\d+)?-vl([._\-/]|$)/,
-  /(^|[._\-/])minicpm-v([._\-/]|$)/,
-  /(^|[._\-/])minicpmv([._\-/]|$)/,
-  /(^|[._\-/])phi-4-multimodal([._\-/]|$)/,
-];
-
-export function normalizeModelType(type?: string | null): string {
-  return (type || 'unknown').toLowerCase().trim() || 'unknown';
-}
-
-export function capabilityFromType(type?: string | null): ModelCapability {
-  return TYPE_TO_CAPABILITY[normalizeModelType(type)] || 'unknown';
-}
-
-export function isRouterRecipe(recipe?: string | null): boolean {
-  const r = normalizeModelType(recipe);
-  return r === 'collection.router' || r.startsWith('collection.router.');
-}
-
-export function capabilityFromRecipe(recipe?: string | null): ModelCapability {
-  const r = normalizeModelType(recipe);
-  if (!r || r === 'unknown') return 'unknown';
-  if (r === 'collection.omni' || r.startsWith('collection.omni.')) return 'omni';
-  if (r === 'collection.router' || r.startsWith('collection.router.')) return 'chat';
-  if (r === 'collection') return 'omni';
-  for (const [hint, cap] of NON_CHAT_RECIPE_HINTS) {
-    if (r === hint || r.includes(hint)) return cap;
-  }
-  if (CHAT_RECIPE_HINTS.has(r)) return 'chat';
-  if (r.includes('multimodal') || r.includes('vision-language') || r.includes('audio-chat')) return 'chat';
-  return 'unknown';
-}
-
-export function capabilityFromName(name?: string | null): ModelCapability {
-  const n = normalizeModelType(name);
-  if (!n || n === 'unknown') return 'unknown';
-  if (n.includes('trellis') || n.includes('image-to-3d') || n.includes('model3d')) return 'model3d';
-  if (n.includes('ace-step') || n.includes('acestep') || n.includes('thinksound')) return 'audio-generation';
-  if (n.includes('openmoss') || n.includes('moss-tts') || n.includes('moss_tts') || n.includes('voicegen')) return 'tts';
-  if (n.includes('embed')) return 'embedding';
-  if (n.includes('rerank')) return 'reranking';
-  if (/(^|[._\-/])(audio-chat|speech-chat)([._\-/]|$)/.test(n)) return 'chat';
-  if (MULTIMODAL_CHAT_NAME_PATTERNS.some(pattern => pattern.test(n))) return 'chat';
-  return 'unknown';
-}
-
-const CHAT_PRIMARY_LABELS = new Set([
-  'chat', 'llm', 'text', 'language', 'instruct', 'text-generation',
-  'tool-calling', 'tools', 'reasoning', 'coding', 'code',
-]);
-
+/** Audio as an input modality of a chat model, not a deployment mode of its own. */
 const AUDIO_INPUT_LABELS = new Set([
   'audio-input', 'audio-chat', 'chat-transcription', 'speech-input',
 ]);
 
+/** Image/vision as an input modality of a chat model. */
 const IMAGE_INPUT_LABELS = new Set([
   'vision', 'image-input', 'vision-language', 'vlm', 'image-text-to-text',
   'multimodal', 'multi-modal',
 ]);
 
-const STANDALONE_AUDIO_LABELS = new Set([
-  'audio', 'transcription', 'realtime-transcription', 'asr', 'stt', 'speech-to-text',
-]);
+export function normalizeModelType(type?: string | null): string {
+  return (type || 'unknown').toLowerCase().trim() || 'unknown';
+}
 
 function normalizedStringList(value: unknown): string[] {
   if (!Array.isArray(value)) return [];
@@ -130,7 +97,67 @@ function normalizedStringList(value: unknown): string[] {
     .filter(Boolean);
 }
 
-function modelDescriptorStrings(model?: ModelInfo | LoadedModel | null): string[] {
+/**
+ * Resolve a label set to the mode it deploys in.
+ *
+ * `chat` is tested first so an omni model that also declares a mode it could
+ * serve standalone still resolves to chat, exactly as find_deployment_mode()
+ * does server-side. Input modalities (`vision`, `chat-transcription`) and
+ * characteristics (`reasoning`, `tool-calling`) never name a mode and are
+ * ignored here — they decorate a surface rather than choosing one.
+ */
+export function deploymentKindFromLabels(labels?: readonly string[] | null): ModelCapability {
+  const lower = normalizedStringList(labels);
+  if (lower.includes('chat')) return 'chat';
+  for (const label of lower) {
+    const kind = DEPLOYMENT_LABEL_KIND[label];
+    if (kind) return kind;
+  }
+  return 'unknown';
+}
+
+export function modelStructure(recipe?: string | null): ModelStructure {
+  const r = normalizeModelType(recipe);
+  if (r === OMNI_COLLECTION_RECIPE || r.startsWith(`${OMNI_COLLECTION_RECIPE}.`) || r === 'collection') return 'omni';
+  if (r === ROUTER_COLLECTION_RECIPE || r.startsWith(`${ROUTER_COLLECTION_RECIPE}.`)) return 'router';
+  return 'single';
+}
+
+export function isRouterRecipe(recipe?: string | null): boolean {
+  return modelStructure(recipe) === 'router';
+}
+
+export function isCollectionRecipe(recipe?: string | null): boolean {
+  return modelStructure(recipe) !== 'single';
+}
+
+export function capabilityFromModelInfo(model: ModelInfo): ModelCapability {
+  return deploymentKindFromLabels(model?.labels);
+}
+
+export function capabilityFromLoaded(model?: LoadedModel | null): ModelCapability {
+  if (!model) return 'unknown';
+  // The router reports the mode it actually launched the subprocess for, which
+  // is the strongest evidence available for a running model.
+  const fromType = LOADED_TYPE_KIND[normalizeModelType(model.type)];
+  if (fromType) return fromType;
+  return deploymentKindFromLabels(model.labels);
+}
+
+export function identityFromModelInfo(model: ModelInfo): ModelIdentity {
+  const structure = modelStructure((model as any)?.recipe);
+  return structure === 'single' ? capabilityFromModelInfo(model) : structure;
+}
+
+/**
+ * The identity a selection row leads with. A collection routes to backends
+ * rather than being one, so it shows itself rather than the chat it serves.
+ */
+export function rowCapability(model: ModelInfo): ModelIdentity {
+  return identityFromModelInfo(model);
+}
+
+function descriptorLabels(model?: ModelInfo | LoadedModel | null): string[] {
   if (!model) return [];
   return [
     ...normalizedStringList((model as any).labels),
@@ -138,223 +165,67 @@ function modelDescriptorStrings(model?: ModelInfo | LoadedModel | null): string[
   ];
 }
 
-function modelInputModalities(model?: ModelInfo | LoadedModel | null): string[] {
+function inputModalities(model?: ModelInfo | LoadedModel | null): string[] {
   if (!model) return [];
   return normalizedStringList((model as any).input_modalities);
 }
 
-function hasChatPrimaryEvidence(model?: ModelInfo | LoadedModel | null): boolean {
+function servesChat(model?: ModelInfo | LoadedModel | null): boolean {
   if (!model) return false;
-  const recipeCap = capabilityFromRecipe(String((model as any).recipe || ''));
-  // Omni collections have their own orchestration surface. Do not reuse the
-  // Chat + Audio decoration for them even though they ultimately call chat APIs.
-  if (recipeCap === 'omni') return false;
-  if (recipeCap === 'chat') return true;
-  const directCaps = [
-    capabilityFromType(String((model as any).capability || '')),
-    capabilityFromType(String((model as any).type || '')),
-  ];
-  if (directCaps.some(cap => cap === 'chat' || cap === 'omni')) return true;
-  return modelDescriptorStrings(model).some(value => CHAT_PRIMARY_LABELS.has(value));
+  // Collections orchestrate their components server-side and expose their own
+  // surface, so they do not take the chat attachment decoration.
+  if (isCollectionRecipe((model as any).recipe)) return false;
+  const labelled = deploymentKindFromLabels((model as any).labels);
+  if (labelled !== 'unknown') return labelled === 'chat';
+  return LOADED_TYPE_KIND[normalizeModelType((model as any).type)] === 'chat';
 }
 
 /**
- * True when audio is an input modality of a chat model. This is intentionally
- * separate from the primary capability: a multimodal LLM stays in Chat mode
- * and merely gains the audio attachment controls. A transcription-only model
- * such as Whisper remains in Audio mode.
+ * True when audio is an input modality of a chat model. Deliberately separate
+ * from the primary capability: a multimodal LLM stays in Chat mode and merely
+ * gains the audio attachment control. A transcription-only model such as
+ * Whisper deploys as Audio and never reaches here.
  */
 export function modelSupportsChatAudioInput(
   modelInfo?: ModelInfo | null,
   loadedModel?: LoadedModel | null,
 ): boolean {
-  const descriptors = [
-    ...modelDescriptorStrings(modelInfo),
-    ...modelDescriptorStrings(loadedModel),
-  ];
-  const inputModalities = [
-    ...modelInputModalities(modelInfo),
-    ...modelInputModalities(loadedModel),
-  ];
-  const primaryIsChat = hasChatPrimaryEvidence(modelInfo) || hasChatPrimaryEvidence(loadedModel);
-  if (!primaryIsChat) return false;
-
-  if (inputModalities.some(value => value === 'audio' || value === 'speech')) return true;
-  if (descriptors.some(value => AUDIO_INPUT_LABELS.has(value))) return true;
-
-  // Some backends currently expose a multimodal LLM as type/label "audio"
-  // without a separate input_modalities field. It is safe to interpret that as
-  // audio input only when the recipe/type independently proves this is a chat
-  // model; standalone transcription recipes never enter this branch.
-  if (descriptors.includes('audio')) return true;
-  if (normalizeModelType(loadedModel?.type) === 'audio') return true;
-  if (normalizeModelType((modelInfo as any)?.type) === 'audio') return true;
-  return false;
+  if (!servesChat(modelInfo) && !servesChat(loadedModel)) return false;
+  const modalities = [...inputModalities(modelInfo), ...inputModalities(loadedModel)];
+  if (modalities.some(value => value === 'audio' || value === 'speech')) return true;
+  return [...descriptorLabels(modelInfo), ...descriptorLabels(loadedModel)]
+    .some(value => AUDIO_INPUT_LABELS.has(value));
 }
 
 /**
- * True when image/vision is an input modality of a chat model. A plain LLM
- * stays in Chat mode but must not expose the image attachment affordance.
- * Collection-based Omni routing is handled separately by the collection
- * component resolver because the collection itself is not a single VLM.
+ * True when image input is an input modality of a chat model. A plain LLM stays
+ * in Chat mode but must not expose the image attachment affordance.
  */
 export function modelSupportsChatImageInput(
   modelInfo?: ModelInfo | null,
   loadedModel?: LoadedModel | null,
 ): boolean {
-  const descriptors = [
-    ...modelDescriptorStrings(modelInfo),
-    ...modelDescriptorStrings(loadedModel),
-  ];
-  const inputModalities = [
-    ...modelInputModalities(modelInfo),
-    ...modelInputModalities(loadedModel),
-  ];
-  const primaryIsChat = hasChatPrimaryEvidence(modelInfo) || hasChatPrimaryEvidence(loadedModel);
-  if (!primaryIsChat) return false;
-
-  if (inputModalities.some(value => value === 'image' || value === 'vision')) return true;
-  if (descriptors.some(value => IMAGE_INPUT_LABELS.has(value))) return true;
-
-  const declaredTypes = [
-    normalizeModelType((modelInfo as any)?.capability),
-    normalizeModelType((modelInfo as any)?.type),
-    normalizeModelType((loadedModel as any)?.capability),
-    normalizeModelType(loadedModel?.type),
-  ];
-  if (declaredTypes.some(value => IMAGE_INPUT_LABELS.has(value))) return true;
-
-  const identities = [
-    (modelInfo as any)?.model_name,
-    modelInfo?.name,
-    modelInfo?.id,
-    (modelInfo as any)?.checkpoint,
-    loadedModel?.model_name,
-    loadedModel?.checkpoint,
-  ]
-    .filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
-    .map(value => normalizeModelType(value));
-
-  return identities.some(identity => MULTIMODAL_CHAT_NAME_PATTERNS.some(pattern => pattern.test(identity)));
-}
-
-export function capabilityFromLabels(labels?: string[]): ModelCapability {
-  const lower = (labels || []).map(l => l.toLowerCase().trim()).filter(Boolean);
-  const set = new Set(lower);
-
-  if (lower.some(l => ['3d', '3d-generation', 'model3d', 'image-to-3d', 'mesh-generation'].includes(l))) return 'model3d';
-  if (lower.some(l => ['audio-generation', 'music-generation', 'sound-generation', 'sfx', 'music'].includes(l))) return 'audio-generation';
-  if (lower.some(l => l === 'image' || l === 'image-generation' || l === 'edit' || l === 'upscaling')) return 'image';
-  if (lower.some(l => l === 'tts' || l === 'speech' || l === 'text-to-speech' || l === 'voice-design')) return 'tts';
-  if (lower.some(l => l === 'embeddings' || l === 'embedding')) return 'embedding';
-  if (lower.some(l => l === 'reranking' || l === 'reranker')) return 'reranking';
-
-  const hasChatLike = lower.some(l => CHAT_PRIMARY_LABELS.has(l));
-  const hasAudioChat = lower.some(l => AUDIO_INPUT_LABELS.has(l));
-  const hasVisionInput = lower.some(l => ['vision', 'image-input', 'vision-language', 'vlm', 'image-text-to-text'].includes(l));
-  const hasMultimodalChat = lower.some(l => ['omni', 'multimodal', 'multi-modal'].includes(l));
-  const hasStandaloneAudio = lower.some(l => STANDALONE_AUDIO_LABELS.has(l));
-
-  // Labels describe inputs/features of an individual model. They never promote
-  // that model to the Omni collection mode.
-  if (hasMultimodalChat || hasVisionInput || hasAudioChat || (hasChatLike && set.has('audio'))) return 'chat';
-  if (hasStandaloneAudio) return 'audio';
-  if (hasChatLike || hasVisionInput) return 'chat';
-  return 'unknown';
-}
-
-function preferNonChat(cap: ModelCapability): boolean {
-  return cap !== 'chat' && cap !== 'unknown';
-}
-
-export function capabilityFromLoaded(model?: LoadedModel | null): ModelCapability {
-  if (!model) return 'unknown';
-  const recipeCap = capabilityFromRecipe(model.recipe);
-  if (preferNonChat(recipeCap)) return recipeCap;
-
-  const descriptorCap = capabilityFromLabels([
-    ...(model.labels || []),
-    ...(model.capabilities || []),
-    ...(model.input_modalities || []).map(value => `${value}-input`),
-  ]);
-  const typeCap = capabilityFromType(model.type);
-
-  // Runtime health may report "audio" for an audio-capable FLM/LLM. The
-  // backend recipe is the stronger evidence for its primary interaction mode.
-  if (recipeCap === 'chat' && (typeCap === 'audio' || descriptorCap === 'audio')) return 'chat';
-  if (preferNonChat(typeCap)) return typeCap;
-  if (preferNonChat(descriptorCap)) return descriptorCap;
-
-  const nameCap = capabilityFromName(`${model.model_name} ${model.checkpoint || ''}`);
-  if (preferNonChat(nameCap)) return nameCap;
-  if (typeCap === 'chat' || descriptorCap === 'chat' || recipeCap === 'chat') return 'chat';
-  return nameCap;
-}
-
-export function capabilityFromModelInfo(model: ModelInfo): ModelCapability {
-  const recipeCap = capabilityFromRecipe(String((model as any).recipe || ''));
-  const explicitCapability = capabilityFromType(String((model as any).capability || ''));
-  const direct = capabilityFromType(String((model as any).type || ''));
-  const declaredCapabilities = normalizedStringList((model as any).capabilities);
-  const inputModalities = normalizedStringList((model as any).input_modalities);
-  const fromLabels = capabilityFromLabels([
-    ...(model.labels || []),
-    ...declaredCapabilities,
-    ...inputModalities.map(value => `${value}-input`),
-  ]);
-
-  // collection.omni is an explicit Lemonade orchestration recipe and is the
-  // only route to the Omni primary mode.
-  if (recipeCap === 'omni') return 'omni';
-
-  const source = String((model as any).registry_source || (model as any).source || '').trim().toLowerCase();
-  const isRemoteRegistryModel = source === 'huggingface' || source === 'modelscope' || source === 'hf' || source === 'ms';
-  if (isRemoteRegistryModel) {
-    // Remote search rows must not become Chat merely because the repository
-    // name contains a keyword or because every GGUF uses the llamacpp recipe.
-    // Only explicit server/provider evidence is accepted.
-    if (explicitCapability !== 'unknown') return explicitCapability;
-    if (direct !== 'unknown') return direct;
-    if (fromLabels !== 'unknown') return fromLabels;
-    return 'unknown';
-  }
-
-  if (preferNonChat(recipeCap)) return recipeCap;
-
-  // A chat backend with audio input remains a chat model. This handles FLM
-  // models whose runtime metadata currently reports type/label "audio".
-  if (recipeCap === 'chat' && (
-    explicitCapability === 'audio'
-    || direct === 'audio'
-    || fromLabels === 'audio'
-    || modelSupportsChatAudioInput(model, null)
-  )) return 'chat';
-
-  if (explicitCapability !== 'unknown') return explicitCapability;
-  if (preferNonChat(direct)) return direct;
-  if (preferNonChat(fromLabels)) return fromLabels;
-
-  const nameCap = capabilityFromName(`${model.id || ''} ${model.name || ''} ${model.display_name || ''} ${String((model as any).model_name || '')} ${String((model as any).checkpoint || '')}`);
-  if (preferNonChat(nameCap)) return nameCap;
-
-  if (fromLabels === 'chat' || direct === 'chat' || recipeCap === 'chat') return 'chat';
-  return 'unknown';
+  if (!servesChat(modelInfo) && !servesChat(loadedModel)) return false;
+  const modalities = [...inputModalities(modelInfo), ...inputModalities(loadedModel)];
+  if (modalities.some(value => value === 'image' || value === 'vision')) return true;
+  return [...descriptorLabels(modelInfo), ...descriptorLabels(loadedModel)]
+    .some(value => IMAGE_INPUT_LABELS.has(value));
 }
 
 export function canUseChatCompletions(model?: LoadedModel | null): boolean {
-  const cap = capabilityFromLoaded(model);
-  return cap === 'chat' || cap === 'omni';
+  return capabilityFromLoaded(model) === 'chat';
 }
 
 export function canSelectInComposer(model?: LoadedModel | null): boolean {
   const cap = capabilityFromLoaded(model);
-  return ['chat', 'omni', 'image', 'audio', 'audio-generation', 'tts', 'model3d'].includes(cap);
+  return ['chat', 'image', 'audio', 'audio-generation', 'tts', 'model3d'].includes(cap);
 }
 
-export function capabilityLabel(capability: ModelCapability): string {
+export function capabilityLabel(capability: ModelIdentity): string {
   switch (capability) {
     case 'chat': return 'Chat';
     case 'omni': return 'Omni';
+    case 'router': return 'Router';
     case 'image': return 'Image';
     case 'audio': return 'Audio';
     case 'audio-generation': return 'Music & SFX';
@@ -362,14 +233,16 @@ export function capabilityLabel(capability: ModelCapability): string {
     case 'model3d': return '3D';
     case 'embedding': return 'Embedding';
     case 'reranking': return 'Reranking';
+    case 'classification': return 'Classification';
     default: return 'Unknown';
   }
 }
 
-export function capabilityBadge(capability: ModelCapability): string {
+export function capabilityBadge(capability: ModelIdentity): string {
   switch (capability) {
     case 'chat': return 'chat';
     case 'omni': return 'omni';
+    case 'router': return 'router';
     case 'image': return 'image';
     case 'audio': return 'audio';
     case 'audio-generation': return 'audio-gen';
@@ -377,15 +250,17 @@ export function capabilityBadge(capability: ModelCapability): string {
     case 'model3d': return 'model3d';
     case 'embedding': return 'embed';
     case 'reranking': return 'rank';
+    case 'classification': return 'classify';
     default: return 'model';
   }
 }
 
-export function capabilityIcon(capability: ModelCapability | 'all' | 'vision' | 'code' | 'transcription'): string {
+export function capabilityIcon(capability: ModelIdentity | 'all' | 'vision' | 'code' | 'transcription'): string {
   switch (capability) {
     case 'all': return 'All';
     case 'chat': return 'Chat';
     case 'omni': return 'Omni';
+    case 'router': return 'Router';
     case 'image': return 'Image';
     case 'audio': return 'Audio';
     case 'audio-generation': return 'Audio';
@@ -394,15 +269,30 @@ export function capabilityIcon(capability: ModelCapability | 'all' | 'vision' | 
     case 'model3d': return '3D';
     case 'embedding': return 'Emb';
     case 'reranking': return 'Rank';
+    case 'classification': return 'Classify';
     case 'vision': return 'Vision';
     case 'code': return 'Code';
     default: return 'Model';
   }
 }
 
+/** A snapshot's row identity. Structure is derived from the recipe it carries. */
+export function snapshotIdentity(snapshot?: ModelSnapshot | null): ModelIdentity {
+  if (!snapshot) return 'unknown';
+  const structure = modelStructure(snapshot.recipe);
+  return structure === 'single' ? snapshot.capability : structure;
+}
+
 export function snapshotFromLoaded(model?: LoadedModel | null): ModelSnapshot | null {
   if (!model) return null;
-  return { name: model.model_name, type: normalizeModelType(model.type), capability: capabilityFromLoaded(model), recipe: model.recipe, device: model.device, checkpoint: model.checkpoint };
+  return {
+    name: model.model_name,
+    type: normalizeModelType(model.type),
+    capability: capabilityFromLoaded(model),
+    recipe: model.recipe,
+    device: model.device,
+    checkpoint: model.checkpoint,
+  };
 }
 
 export function snapshotFromModelInfo(model?: ModelInfo | null): ModelSnapshot | null {
@@ -423,12 +313,11 @@ export function snapshotFromName(name: string | null | undefined, loadedModels: 
   if (!name) return null;
   const loaded = loadedModels.find(m => m.model_name === name);
   if (loaded) return snapshotFromLoaded(loaded);
-  return { name, type: 'unknown', capability: capabilityFromName(name) };
+  return { name, type: 'unknown', capability: 'unknown' };
 }
 
 export function selectPreferredLoadedModel(loadedModels: LoadedModel[]): LoadedModel | null {
   return loadedModels.find(m => capabilityFromLoaded(m) === 'chat')
-    || loadedModels.find(m => capabilityFromLoaded(m) === 'omni')
     || loadedModels.find(m => canSelectInComposer(m))
     || loadedModels[0]
     || null;
@@ -441,11 +330,12 @@ export function modelInitial(model: ModelSnapshot | null | undefined): string { 
 export type CapabilityTag =
   | 'hot' | 'popular' | 'chat' | 'omni' | 'vision' | 'tool' | 'reasoning'
   | 'code' | 'audio' | 'audio-generation' | 'image' | 'tts' | 'model3d'
-  | 'embedding' | 'reranking';
+  | 'embedding' | 'reranking' | 'classification';
 
 export const CAPABILITY_TAG_ORDER: CapabilityTag[] = [
   'hot', 'popular', 'chat', 'omni', 'vision', 'tool', 'reasoning',
-  'code', 'audio', 'audio-generation', 'image', 'tts', 'model3d', 'embedding', 'reranking',
+  'code', 'audio', 'audio-generation', 'image', 'tts', 'model3d',
+  'embedding', 'reranking', 'classification',
 ];
 
 export const CAPABILITY_TAG_LABELS: Record<CapabilityTag, string> = {
@@ -453,6 +343,7 @@ export const CAPABILITY_TAG_LABELS: Record<CapabilityTag, string> = {
   tool: 'Tool use', reasoning: 'Reasoning', code: 'Code', audio: 'Audio',
   'audio-generation': 'Music & SFX', image: 'Image', tts: 'Speech (TTS)',
   model3d: '3D', embedding: 'Embeddings', reranking: 'Reranking',
+  classification: 'Classification',
 };
 
 const CAPABILITY_TAG_ALIASES: Record<CapabilityTag, string[]> = {
@@ -471,35 +362,23 @@ const CAPABILITY_TAG_ALIASES: Record<CapabilityTag, string[]> = {
   model3d: ['3d', '3d-generation', 'model3d', 'image-to-3d', 'mesh-generation'],
   embedding: ['embedding', 'embeddings'],
   reranking: ['reranking', 'reranker'],
+  classification: ['classification', 'classifier'],
 };
 
-const BASE_CAPABILITY_TAG: Partial<Record<ModelCapability, CapabilityTag>> = {
+const BASE_CAPABILITY_TAG: Partial<Record<ModelIdentity, CapabilityTag>> = {
   chat: 'chat', omni: 'omni', image: 'image', audio: 'audio',
   'audio-generation': 'audio-generation', tts: 'tts', model3d: 'model3d',
-  embedding: 'embedding', reranking: 'reranking',
+  embedding: 'embedding', reranking: 'reranking', classification: 'classification',
 };
-
-/**
- * The identity a selection row leads with. `capabilityFromRecipe` resolves a
- * router collection to chat because chat is what it ultimately serves; a row
- * instead shows the router itself. Omni needs no such override — it already
- * resolves to `omni` through its recipe.
- */
-export function rowCapability(model: ModelInfo): ModelCapability | 'router' {
-  return isRouterRecipe(String((model as any).recipe || ''))
-    ? 'router'
-    : capabilityFromModelInfo(model);
-}
 
 export function modelCapabilityTags(model: ModelInfo): CapabilityTag[] {
   const declaredCapabilities = Array.isArray((model as any).capabilities)
     ? (model as any).capabilities.filter((value: unknown): value is string => typeof value === 'string')
     : [];
-  const inputModalities = normalizedStringList((model as any).input_modalities);
   const labels = [
     ...(model.labels || []),
     ...declaredCapabilities,
-    ...inputModalities.map(value => `${value}-input`),
+    ...inputModalities(model).map(value => `${value}-input`),
   ]
     .map(l => String(l).toLowerCase().trim())
     .filter(Boolean);
@@ -509,7 +388,7 @@ export function modelCapabilityTags(model: ModelInfo): CapabilityTag[] {
     if (tag === 'omni') continue;
     if (CAPABILITY_TAG_ALIASES[tag].some(alias => labelSet.has(alias))) found.add(tag);
   }
-  const base = BASE_CAPABILITY_TAG[capabilityFromModelInfo(model)];
+  const base = BASE_CAPABILITY_TAG[identityFromModelInfo(model)];
   if (base) found.add(base);
   if (modelSupportsChatAudioInput(model, null)) found.add('audio');
   return CAPABILITY_TAG_ORDER.filter(tag => found.has(tag));

--- a/src/app/src/modelCapabilities.ts
+++ b/src/app/src/modelCapabilities.ts
@@ -1,13 +1,12 @@
 import type { LoadedModel, ModelInfo } from './api';
 
 /**
- * What a model is offered for. This mirrors the server's deployment modes
- * one-for-one — see the "Deployment labels" table in docs/api/openai.md and
- * find_deployment_mode() in src/cpp/include/lemon/model_types.h.
+ * Mirrors the server's deployment modes one-for-one — see the "Deployment
+ * labels" table in docs/api/openai.md and find_deployment_mode() in
+ * src/cpp/include/lemon/model_types.h.
  *
  * Being a collection is not a capability: an Omni or Router collection serves
- * chat, and says so with the `chat` label. Its collection-ness is structure,
- * read from the recipe by modelStructure().
+ * chat and says so with the `chat` label, so its collection-ness is structure.
  */
 export type ModelCapability =
   | 'chat'
@@ -21,10 +20,8 @@ export type ModelCapability =
   | 'classification'
   | 'unknown';
 
-/** Whether a model is one backend or a collection routing to several. */
 export type ModelStructure = 'single' | 'omni' | 'router';
 
-/** What a row or badge leads with: a collection shows itself, not what it serves. */
 export type ModelIdentity = ModelCapability | 'omni' | 'router';
 
 export interface ModelSnapshot {
@@ -37,12 +34,9 @@ export interface ModelSnapshot {
 }
 
 /**
- * The nine deployment labels, and the two spellings the server also accepts.
- * A model declares exactly one of these; the server stamps a recipe default
- * when a registration names none, so anything served carries one.
- *
- * Keep in sync with docs/api/openai.md — tests/model-kind-classification.runtime.cjs
- * fails if this drifts from the documented set.
+ * A model declares exactly one of these; the server stamps a recipe default when
+ * a registration names none, so anything served carries one. Keep in sync with
+ * docs/api/openai.md — model-kind-classification.runtime.cjs fails on drift.
  */
 export const DEPLOYMENT_LABEL_KIND: Record<string, ModelCapability> = {
   chat: 'chat',
@@ -76,12 +70,10 @@ const OMNI_COLLECTION_PREFIX = `${OMNI_COLLECTION_RECIPE}.`;
 const ROUTER_COLLECTION_RECIPE = 'collection.router';
 const ROUTER_COLLECTION_PREFIX = `${ROUTER_COLLECTION_RECIPE}.`;
 
-/** Audio as an input modality of a chat model, not a deployment mode of its own. */
 const AUDIO_INPUT_LABELS = new Set([
   'audio-input', 'audio-chat', 'chat-transcription', 'speech-input',
 ]);
 
-/** Image/vision as an input modality of a chat model. */
 export const IMAGE_INPUT_LABELS = new Set([
   'vision', 'image-input', 'vision-language', 'vlm', 'image-text-to-text',
   'multimodal', 'multi-modal',
@@ -100,13 +92,9 @@ function normalizedStringList(value: unknown): string[] {
 }
 
 /**
- * Resolve a label set to the mode it deploys in.
- *
  * `chat` is tested first so an omni model that also declares a mode it could
  * serve standalone still resolves to chat, exactly as find_deployment_mode()
- * does server-side. Input modalities (`vision`, `chat-transcription`) and
- * characteristics (`reasoning`, `tool-calling`) never name a mode and are
- * ignored here — they decorate a surface rather than choosing one.
+ * does. Input modalities and characteristics name no mode and are ignored.
  */
 export function deploymentKindFromLabels(labels?: readonly string[] | null): ModelCapability {
   const lower = normalizedStringList(labels);
@@ -139,8 +127,7 @@ export function capabilityFromModelInfo(model: ModelInfo): ModelCapability {
 
 export function capabilityFromLoaded(model?: LoadedModel | null): ModelCapability {
   if (!model) return 'unknown';
-  // The router reports the mode it actually launched the subprocess for, which
-  // is the strongest evidence available for a running model.
+  // The router reports the mode it actually launched the subprocess for.
   const fromType = LOADED_TYPE_KIND[normalizeModelType(model.type)];
   if (fromType) return fromType;
   const labelled = deploymentKindFromLabels(model.labels);
@@ -150,10 +137,7 @@ export function capabilityFromLoaded(model?: LoadedModel | null): ModelCapabilit
   return isCollectionRecipe(model.recipe) ? 'chat' : 'unknown';
 }
 
-/**
- * The identity a row or badge leads with. A collection routes to backends
- * rather than being one, so it shows itself rather than the chat it serves.
- */
+/** A collection routes to backends rather than being one, so it shows itself. */
 export function identityFor(capability: ModelCapability, recipe?: string | null): ModelIdentity {
   const structure = modelStructure(recipe);
   return structure === 'single' ? capability : structure;
@@ -203,10 +187,7 @@ export function modelSupportsChatAudioInput(
     .some(value => AUDIO_INPUT_LABELS.has(value));
 }
 
-/**
- * True when image input is an input modality of a chat model. A plain LLM stays
- * in Chat mode but must not expose the image attachment affordance.
- */
+/** Image input as a modality of a chat model, never a mode of its own. */
 export function modelSupportsChatImageInput(
   modelInfo?: ModelInfo | null,
   loadedModel?: LoadedModel | null,
@@ -226,7 +207,6 @@ const COMPOSER_CAPABILITIES: ReadonlySet<ModelCapability> = new Set<ModelCapabil
   'chat', 'image', 'audio', 'audio-generation', 'tts', 'model3d',
 ]);
 
-/** Capabilities the chat composer can drive directly. */
 export function isComposerSelectableCapability(capability: ModelCapability): boolean {
   return COMPOSER_CAPABILITIES.has(capability);
 }

--- a/src/app/src/modelConfiguration.ts
+++ b/src/app/src/modelConfiguration.ts
@@ -574,14 +574,9 @@ function activeRecipeName(model: ModelInfo | null | undefined): string {
   return recipeName(recipesForModel(model)[0]);
 }
 
-const CONTEXT_SIZE_RECIPES = new Set(['llamacpp', 'flm', 'ryzenai-llm', 'vllm']);
-
 export function modelSupportsContextSize(model: ModelInfo | null | undefined): boolean {
   if (!model) return false;
-  const capability = capabilityFromModelInfo(model);
-  if (capability === 'chat') return true;
-  if (capability !== 'unknown') return false;
-  return CONTEXT_SIZE_RECIPES.has(activeRecipeName(model));
+  return capabilityFromModelInfo(model) === 'chat';
 }
 
 function readNumberFromActiveRecipe(model: ModelInfo | null | undefined, paths: string[][]): number | undefined {
@@ -660,7 +655,7 @@ export function modelDefaultRecipeOptions(model: ModelInfo | null | undefined, f
   const out: RecipeOptions = {};
   const ctx = modelDefaultContextSize(model, fallbackCtxSize);
 
-  if (capability === 'chat' || capability === 'omni' || capability === 'unknown') out.ctx_size = ctx;
+  if (capability === 'chat') out.ctx_size = ctx;
 
   const backend = readStringFromModelOrRecipe(model, [
     ['recipe_options', 'backend'], ['options', 'backend'], ['backend'], ['default_backend'], ['recommended_backend'],
@@ -853,7 +848,6 @@ export function recipeOptionsForCapability(
     case 'embedding':
     case 'reranking':
     case 'chat':
-    case 'omni':
     case 'vision':
     case 'code':
       return pickRecipeOptions(options, ['ctx_size', 'llamacpp_backend', 'llamacpp_device', 'llamacpp_args', 'mmproj_enabled', 'flm_args', 'vllm_backend', 'vllm_args', 'merge_args']);

--- a/src/app/src/remoteModelCapabilities.ts
+++ b/src/app/src/remoteModelCapabilities.ts
@@ -153,6 +153,8 @@ export function remoteCapabilityEvidence(
   // a vision-language model. It does not depend on the repository name or tags.
   const repositoryOmni = hasUsableGguf && hasMmproj && variants?.recipe === 'llamacpp';
 
+  // A vision-language repository is a chat model that accepts images, so it
+  // resolves to chat and picks up `vision` from providerVision below.
   let primary: ModelCapability = 'unknown';
   let confidence: RemoteCapabilityConfidence = 'unknown';
   if (repositoryReranking) {
@@ -161,13 +163,7 @@ export function remoteCapabilityEvidence(
   } else if (repositoryEmbedding) {
     primary = 'embedding';
     confidence = 'repository';
-  } else if (repositoryOmni) {
-    primary = 'omni';
-    confidence = 'repository';
-  } else if (repositoryChat && providerVision) {
-    primary = 'omni';
-    confidence = 'repository';
-  } else if (repositoryChat) {
+  } else if (repositoryOmni || repositoryChat) {
     primary = 'chat';
     confidence = 'repository';
   } else if (providerReranking) {
@@ -175,9 +171,6 @@ export function remoteCapabilityEvidence(
     confidence = 'provider';
   } else if (providerEmbedding) {
     primary = 'embedding';
-    confidence = 'provider';
-  } else if (providerChat && providerVision) {
-    primary = 'omni';
     confidence = 'provider';
   } else if (providerChat) {
     primary = 'chat';
@@ -192,6 +185,12 @@ export function remoteCapabilityEvidence(
   return { labels: [...labels], primary, confidence };
 }
 
+/**
+ * The only bridge from a remote search row to a ModelInfo. Inference happens
+ * here, once, and the verdict is written into `labels` as a deployment label —
+ * so everything downstream reads a label like any registered model does and
+ * never re-guesses. Registered models never take this path.
+ */
 export function remoteResultAsModelInfo(
   result: HFModelResult,
   variants?: PullVariantsResult,

--- a/src/app/src/remoteModelCapabilities.ts
+++ b/src/app/src/remoteModelCapabilities.ts
@@ -9,6 +9,14 @@ export type RemoteCapabilityEvidence = {
   confidence: RemoteCapabilityConfidence;
 };
 
+/** Inverse of DEPLOYMENT_LABEL_KIND, for writing a verdict back as a label. */
+const DEPLOYMENT_LABEL_FOR_KIND: Partial<Record<ModelCapability, string>> = {
+  chat: 'chat', audio: 'transcription', embedding: 'embeddings',
+  reranking: 'reranking', image: 'image', tts: 'tts',
+  'audio-generation': 'audio-generation', classification: 'classification',
+  model3d: '3d',
+};
+
 const REMOTE_FEATURE_LABELS = new Map<string, string>([
   ['tool', 'tool-calling'], ['tools', 'tool-calling'], ['tool-use', 'tool-calling'],
   ['tool-calling', 'tool-calling'], ['function-calling', 'tool-calling'],
@@ -151,7 +159,7 @@ export function remoteCapabilityEvidence(
   const repositoryChat = hasMeaningfulValue(chatTemplate);
   // A validated llama.cpp GGUF plus an mmproj is repository-structure proof of
   // a vision-language model. It does not depend on the repository name or tags.
-  const repositoryOmni = hasUsableGguf && hasMmproj && variants?.recipe === 'llamacpp';
+  const repositoryVisionChat = hasUsableGguf && hasMmproj && variants?.recipe === 'llamacpp';
 
   // A vision-language repository is a chat model that accepts images, so it
   // resolves to chat and picks up `vision` from providerVision below.
@@ -163,7 +171,7 @@ export function remoteCapabilityEvidence(
   } else if (repositoryEmbedding) {
     primary = 'embedding';
     confidence = 'repository';
-  } else if (repositoryOmni || repositoryChat) {
+  } else if (repositoryVisionChat || repositoryChat) {
     primary = 'chat';
     confidence = 'repository';
   } else if (providerReranking) {
@@ -177,9 +185,8 @@ export function remoteCapabilityEvidence(
     confidence = 'provider';
   }
 
-  if (primary !== 'unknown') {
-    labels.add(primary === 'embedding' ? 'embeddings' : primary);
-  }
+  const deploymentLabel = DEPLOYMENT_LABEL_FOR_KIND[primary];
+  if (deploymentLabel) labels.add(deploymentLabel);
   if (providerVision) labels.add('vision');
 
   return { labels: [...labels], primary, confidence };

--- a/src/app/src/styles/critical.generated.css
+++ b/src/app/src/styles/critical.generated.css
@@ -81,6 +81,7 @@
   --cap-audio-generation: #1693A5;
   --cap-tts:        #B35A9F;
   --cap-model3d:   #65758A;
+  --cap-classification: #6A8F3C;
 
   --provider-hugging-face:    #FF9D00;
   --provider-hugging-face-fg: #FFB84D;
@@ -1030,7 +1031,7 @@
   background: var(--surface-3);
   color: var(--text-secondary);
   text-transform: none;
-}.cap-badge--chat   { background: color-mix(in srgb, var(--cap-chat) 18%, transparent); color: var(--cap-chat); }.cap-badge--router { background: color-mix(in srgb, var(--cap-router) 18%, transparent); color: var(--cap-router); }.cap-badge--vision { background: color-mix(in srgb, var(--cap-vision) 18%, transparent); color: var(--cap-vision); }.cap-badge--code   { background: color-mix(in srgb, var(--cap-code) 18%, transparent); color: var(--cap-code); }.cap-badge--embed  { background: color-mix(in srgb, var(--cap-embedding) 18%, transparent); color: var(--cap-embedding); }.cap-badge--rerank { background: color-mix(in srgb, var(--cap-reranking) 18%, transparent); color: var(--cap-reranking); }.cap-badge--audio  { background: color-mix(in srgb, var(--cap-audio) 18%, transparent); color: var(--cap-audio); }.cap-badge--tts    { background: color-mix(in srgb, var(--cap-tts) 18%, transparent); color: var(--cap-tts); }.cap-badge--image  { background: color-mix(in srgb, var(--cap-image) 18%, transparent); color: var(--cap-image); }.thread {
+}.cap-badge--chat   { background: color-mix(in srgb, var(--cap-chat) 18%, transparent); color: var(--cap-chat); }.cap-badge--router { background: color-mix(in srgb, var(--cap-router) 18%, transparent); color: var(--cap-router); }.cap-badge--vision { background: color-mix(in srgb, var(--cap-vision) 18%, transparent); color: var(--cap-vision); }.cap-badge--code   { background: color-mix(in srgb, var(--cap-code) 18%, transparent); color: var(--cap-code); }.cap-badge--embed  { background: color-mix(in srgb, var(--cap-embedding) 18%, transparent); color: var(--cap-embedding); }.cap-badge--rerank { background: color-mix(in srgb, var(--cap-reranking) 18%, transparent); color: var(--cap-reranking); }.cap-badge--audio  { background: color-mix(in srgb, var(--cap-audio) 18%, transparent); color: var(--cap-audio); }.cap-badge--tts    { background: color-mix(in srgb, var(--cap-tts) 18%, transparent); color: var(--cap-tts); }.cap-badge--image  { background: color-mix(in srgb, var(--cap-image) 18%, transparent); color: var(--cap-image); }.cap-badge--classify { background: color-mix(in srgb, var(--cap-classification) 18%, transparent); color: var(--cap-classification); }.thread {
   display: flex;
   flex-direction: column;
   gap: var(--space-6);
@@ -2365,7 +2366,7 @@ option:checked {
   font-weight: var(--weight-semibold);
   line-height: 1;
   white-space: nowrap;
-}.composer__model-mode--chat { color: var(--cap-chat); }.composer__model-mode--image { color: var(--cap-image); }.composer__model-mode--audio { color: var(--cap-audio); }.composer__model-mode--tts { color: var(--cap-tts); }.composer__model-mode--omni { color: var(--cap-omni); }.composer__model-mode--router { color: var(--cap-router); }.composer__model-mode--audio-gen { color: var(--cap-audio-generation); }.composer__model-mode--model3d { color: color-mix(in srgb, var(--cap-model3d) 75%, var(--text-primary)); }.composer__model-mode--embed { color: var(--cap-embedding); }.composer__model-mode--rank { color: var(--cap-reranking); }.composer__model-mode--model { color: var(--text-tertiary); }.composer__model-mode svg {
+}.composer__model-mode--chat { color: var(--cap-chat); }.composer__model-mode--image { color: var(--cap-image); }.composer__model-mode--audio { color: var(--cap-audio); }.composer__model-mode--tts { color: var(--cap-tts); }.composer__model-mode--omni { color: var(--cap-omni); }.composer__model-mode--router { color: var(--cap-router); }.composer__model-mode--audio-gen { color: var(--cap-audio-generation); }.composer__model-mode--model3d { color: color-mix(in srgb, var(--cap-model3d) 75%, var(--text-primary)); }.composer__model-mode--embed { color: var(--cap-embedding); }.composer__model-mode--rank { color: var(--cap-reranking); }.composer__model-mode--classify { color: var(--cap-classification); }.composer__model-mode--model { color: var(--text-tertiary); }.composer__model-mode svg {
   color: currentColor;
 }.cap-badge .app-icon,
 .composer__model-mode .app-icon {

--- a/src/app/src/styles/styles.css
+++ b/src/app/src/styles/styles.css
@@ -920,6 +920,7 @@ input[type="checkbox"]:disabled {
 .cap-badge--audio  { background: color-mix(in srgb, var(--cap-audio) 18%, transparent); color: var(--cap-audio); }
 .cap-badge--tts    { background: color-mix(in srgb, var(--cap-tts) 18%, transparent); color: var(--cap-tts); }
 .cap-badge--image  { background: color-mix(in srgb, var(--cap-image) 18%, transparent); color: var(--cap-image); }
+.cap-badge--classify { background: color-mix(in srgb, var(--cap-classification) 18%, transparent); color: var(--cap-classification); }
 
 /* ---------- Conversation thread ---------- */
 .thread {
@@ -5574,7 +5575,7 @@ optgroup {
 .composer__model-mode--audio-gen { color: var(--cap-audio-generation); }
 .composer__model-mode--model3d { color: color-mix(in srgb, var(--cap-model3d) 75%, var(--text-primary)); }
 .composer__model-mode--embed { color: var(--cap-embedding); }
-.composer__model-mode--rank { color: var(--cap-reranking); }
+.composer__model-mode--rank { color: var(--cap-reranking); } .composer__model-mode--classify { color: var(--cap-classification); }
 .composer__model-mode--model { color: var(--text-tertiary); }
 
 .composer__model-mode svg {

--- a/src/app/src/styles/tokens.css
+++ b/src/app/src/styles/tokens.css
@@ -84,6 +84,7 @@
   --cap-audio-generation: #1693A5;
   --cap-tts:        #B35A9F;
   --cap-model3d:   #65758A;
+  --cap-classification: #6A8F3C;
 
   --provider-hugging-face:    #FF9D00;
   --provider-hugging-face-fg: #FFB84D;

--- a/src/app/src/tools/lemonadeTools.ts
+++ b/src/app/src/tools/lemonadeTools.ts
@@ -4,6 +4,7 @@
  */
 import api, { searchHuggingFace, HFModelResult, PullVariantsResult } from '../api';
 import { getCollectionComponents, isCollectionModel } from '../features/collections/collectionModels';
+import { capabilityFromLoaded, deploymentKindFromLabels, modelStructure } from '../modelCapabilities';
 
 /* ── Tool schemas (OpenAI function calling format) ─────────────── */
 
@@ -259,22 +260,18 @@ function normalizeCapabilityFilter(value: unknown): string {
   return raw;
 }
 
+/**
+ * The tool surface reports the same identity the UI shows. Deployment labels
+ * are what classify a model — see modelCapabilities.ts.
+ */
 function capabilityForModel(model: AnyModel | null | undefined): string {
-  const labels = lowerLabels(model);
-  const type = asString(model?.type).toLowerCase();
-  const recipe = asString(model?.recipe).toLowerCase();
-  const name = modelName(model).toLowerCase();
-  const haystack = `${type} ${labels.join(' ')} ${recipe} ${name}`;
-
-  if (haystack.includes('omni') || haystack.includes('collection')) return 'omni';
-  if (['trellis', 'image-to-3d', '3d-generation', 'model3d'].some(token => haystack.includes(token)) || type === '3d') return 'model3d';
-  if (['acestep', 'ace-step', 'thinksound', 'audio-generation', 'music-generation', 'sound-generation', 'sfx'].some(token => haystack.includes(token))) return 'audio-generation';
-  if (['openmoss', 'moss-tts', 'voicegen', 'kokoro', 'text-to-speech', 'voice-design'].some(token => haystack.includes(token)) || type === 'tts') return 'tts';
-  if (labels.some(label => ['image', 'image-generation', 'diffusion', 'image-edit', 'upscaling'].includes(label)) || type === 'image' || recipe === 'sd-cpp') return 'image';
-  if (labels.some(label => ['audio', 'transcription', 'stt', 'speech-to-text', 'realtime-transcription'].includes(label)) || type === 'audio' || ['whispercpp', 'moonshine'].includes(recipe)) return 'audio';
-  if (labels.includes('embedding') || type === 'embedding') return 'embedding';
-  if (labels.includes('reranking') || type === 'reranking' || type === 'rerank') return 'reranking';
-  return 'chat';
+  if (!model) return 'unknown';
+  const recipe = asString(model.recipe);
+  const structure = modelStructure(recipe);
+  if (structure !== 'single') return structure;
+  const labelled = deploymentKindFromLabels(lowerLabels(model));
+  if (labelled !== 'unknown') return labelled;
+  return capabilityFromLoaded(model as any);
 }
 
 function formatSize(gb: unknown): string | undefined {

--- a/src/app/tests/a11y.spec.ts
+++ b/src/app/tests/a11y.spec.ts
@@ -894,8 +894,8 @@ test.describe('Accessibility — model row action qualified names (#2341)', () =
         contentType: 'application/json',
         body: JSON.stringify({
           data: [
-            { id: 'Llama-3.1-8B', name: 'Llama-3.1-8B', labels: ['llm'], recipe: 'llamacpp', downloaded: true },
-            { id: 'Qwen2.5-7B', name: 'Qwen2.5-7B', labels: ['llm'], recipe: 'llamacpp', downloaded: false },
+            { id: 'Llama-3.1-8B', name: 'Llama-3.1-8B', labels: ['chat'], recipe: 'llamacpp', downloaded: true },
+            { id: 'Qwen2.5-7B', name: 'Qwen2.5-7B', labels: ['chat'], recipe: 'llamacpp', downloaded: false },
           ],
         }),
       }),
@@ -1701,8 +1701,8 @@ test.describe('Accessibility — master-detail model view (#2355 Slice 1)', () =
         contentType: 'application/json',
         body: JSON.stringify({
           data: [
-            { id: 'Llama-3.1-8B', name: 'Llama-3.1-8B', labels: ['llm'], recipe: 'llamacpp', downloaded: true },
-            { id: 'Qwen2.5-7B', name: 'Qwen2.5-7B', labels: ['llm'], recipe: 'llamacpp', downloaded: false },
+            { id: 'Llama-3.1-8B', name: 'Llama-3.1-8B', labels: ['chat'], recipe: 'llamacpp', downloaded: true },
+            { id: 'Qwen2.5-7B', name: 'Qwen2.5-7B', labels: ['chat'], recipe: 'llamacpp', downloaded: false },
           ],
         }),
       }),
@@ -1941,9 +1941,9 @@ test.describe('Accessibility — #2355 Slice 1 reconciliation (fl0rianr clarific
         contentType: 'application/json',
         body: JSON.stringify({
           data: [
-            { id: 'Llama-3.1-8B', name: 'Llama-3.1-8B', labels: ['llm'], recipe: 'llamacpp', downloaded: true,
+            { id: 'Llama-3.1-8B', name: 'Llama-3.1-8B', labels: ['chat'], recipe: 'llamacpp', downloaded: true,
               checkpoint: 'gguf-community/Llama-3.1-8B-Instruct:Q4_K_M.gguf' },
-            { id: 'Qwen2.5-7B', name: 'Qwen2.5-7B', labels: ['llm'], recipe: 'llamacpp', downloaded: false },
+            { id: 'Qwen2.5-7B', name: 'Qwen2.5-7B', labels: ['chat'], recipe: 'llamacpp', downloaded: false },
           ],
         }),
       }),
@@ -2073,7 +2073,7 @@ test.describe('Accessibility — model README raw-HTML rendering (#2355)', () =>
         contentType: 'application/json',
         body: JSON.stringify({
           data: [
-            { id: 'Llama-3.1-8B', name: 'Llama-3.1-8B', labels: ['llm'], recipe: 'llamacpp', downloaded: true,
+            { id: 'Llama-3.1-8B', name: 'Llama-3.1-8B', labels: ['chat'], recipe: 'llamacpp', downloaded: true,
               checkpoint: 'gguf-community/Llama-3.1-8B-Instruct:Q4_K_M.gguf' },
           ],
         }),
@@ -2180,8 +2180,8 @@ test.describe('Accessibility — left-rail pin/favorite parity (#2355)', () => {
         contentType: 'application/json',
         body: JSON.stringify({
           data: [
-            { id: 'Llama-3.1-8B', name: 'Llama-3.1-8B', labels: ['llm'], recipe: 'llamacpp', downloaded: true },
-            { id: 'Qwen2.5-7B', name: 'Qwen2.5-7B', labels: ['llm'], recipe: 'llamacpp', downloaded: false },
+            { id: 'Llama-3.1-8B', name: 'Llama-3.1-8B', labels: ['chat'], recipe: 'llamacpp', downloaded: true },
+            { id: 'Qwen2.5-7B', name: 'Qwen2.5-7B', labels: ['chat'], recipe: 'llamacpp', downloaded: false },
           ],
         }),
       }),
@@ -2316,9 +2316,9 @@ test.describe('Accessibility — left navigation rail (#2355 three-pane)', () =>
         contentType: 'application/json',
         body: JSON.stringify({
           data: [
-            { id: 'Llama-3.1-8B', name: 'Llama-3.1-8B', labels: ['llm', 'tools', 'hot'], recipe: 'llamacpp', suggested: true, downloaded: true, size: 8 },
-            { id: 'Qwen2.5-7B', name: 'Qwen2.5-7B', labels: ['llm'], recipe: 'llamacpp', downloaded: false, size: 7 },
-            { id: 'Whisper-Large-v3', name: 'Whisper-Large-v3', labels: ['audio'], recipe: 'whispercpp', downloaded: true, size: 3 },
+            { id: 'Llama-3.1-8B', name: 'Llama-3.1-8B', labels: ['chat', 'tools', 'hot'], recipe: 'llamacpp', suggested: true, downloaded: true, size: 8 },
+            { id: 'Qwen2.5-7B', name: 'Qwen2.5-7B', labels: ['chat'], recipe: 'llamacpp', downloaded: false, size: 7 },
+            { id: 'Whisper-Large-v3', name: 'Whisper-Large-v3', labels: ['transcription'], recipe: 'whispercpp', downloaded: true, size: 3 },
             { id: 'SDXL-Turbo', name: 'SDXL-Turbo', labels: ['image'], recipe: 'sd-cpp', downloaded: false, size: 6 },
           ],
         }),
@@ -2571,9 +2571,9 @@ test.describe('Accessibility — model view refinements (#2424)', () => {
         contentType: 'application/json',
         body: JSON.stringify({
           data: [
-            { id: 'Llama-3.1-8B', name: 'Llama-3.1-8B', labels: ['llm', 'tools'], recipe: 'llamacpp', suggested: true, downloaded: true, size: 8 },
-            { id: 'Qwen2.5-7B', name: 'Qwen2.5-7B', labels: ['llm'], recipe: 'llamacpp', downloaded: false, size: 7 },
-            { id: 'Whisper-Large-v3', name: 'Whisper-Large-v3', labels: ['audio'], recipe: 'whispercpp', downloaded: true, size: 3 },
+            { id: 'Llama-3.1-8B', name: 'Llama-3.1-8B', labels: ['chat', 'tools'], recipe: 'llamacpp', suggested: true, downloaded: true, size: 8 },
+            { id: 'Qwen2.5-7B', name: 'Qwen2.5-7B', labels: ['chat'], recipe: 'llamacpp', downloaded: false, size: 7 },
+            { id: 'Whisper-Large-v3', name: 'Whisper-Large-v3', labels: ['transcription'], recipe: 'whispercpp', downloaded: true, size: 3 },
             { id: 'SDXL-Turbo', name: 'SDXL-Turbo', labels: ['image'], recipe: 'sd-cpp', downloaded: false, size: 6 },
           ],
         }),
@@ -2889,7 +2889,7 @@ test.describe('Accessibility — model-detail Files tab (#2428)', () => {
         contentType: 'application/json',
         body: JSON.stringify({
           data: [
-            { id: 'Llama-3.1-8B', name: 'Llama-3.1-8B', labels: ['llm'], recipe: 'llamacpp', downloaded: true },
+            { id: 'Llama-3.1-8B', name: 'Llama-3.1-8B', labels: ['chat'], recipe: 'llamacpp', downloaded: true },
           ],
         }),
       }),
@@ -2991,7 +2991,7 @@ test.describe('Chat toolbar accessibility', () => {
               pid: 1234,
               type: 'llm',
               last_use: Date.now(),
-              labels: ['llm'],
+              labels: ['chat'],
               capabilities: ['chat'],
               input_modalities: inputModalities,
             },
@@ -3007,7 +3007,7 @@ test.describe('Chat toolbar accessibility', () => {
             {
               id: 'Llama-3.1-8B-Instruct',
               name: 'Llama-3.1-8B-Instruct',
-              labels: ['llm'],
+              labels: ['chat'],
               recipe: 'llamacpp',
               downloaded: true,
               input_modalities: inputModalities,
@@ -3125,13 +3125,13 @@ test.describe('Chat toolbar accessibility', () => {
       pid: 1234,
       type: 'llm',
       last_use: Date.now(),
-      labels: ['llm'],
+      labels: ['chat'],
       capabilities: ['chat'],
     }));
     const modelInfos = names.map(name => ({
       id: name,
       name,
-      labels: ['llm'],
+      labels: ['chat'],
       recipe: 'llamacpp',
       downloaded: true,
     }));
@@ -3251,7 +3251,7 @@ test.describe('Effective Settings modal accessibility', () => {
               pid: 1234,
               type: 'llm',
               last_use: Date.now(),
-              labels: ['llm'],
+              labels: ['chat'],
               capabilities: ['chat'],
             },
           ],
@@ -3263,7 +3263,7 @@ test.describe('Effective Settings modal accessibility', () => {
         contentType: 'application/json',
         body: JSON.stringify({
           data: [
-            { id: 'Llama-3.1-8B-Instruct', name: 'Llama-3.1-8B-Instruct', labels: ['llm'], recipe: 'llamacpp', downloaded: true },
+            { id: 'Llama-3.1-8B-Instruct', name: 'Llama-3.1-8B-Instruct', labels: ['chat'], recipe: 'llamacpp', downloaded: true },
           ],
         }),
       }),

--- a/src/app/tests/chat-audio-capability.runtime.cjs
+++ b/src/app/tests/chat-audio-capability.runtime.cjs
@@ -44,9 +44,10 @@ const apiSource = fs.readFileSync(apiPath, 'utf8');
 const stylesSource = fs.readFileSync(stylesPath, 'utf8');
 
 const {
-  capabilityFromLabels,
+  deploymentKindFromLabels,
   capabilityFromLoaded,
   capabilityFromModelInfo,
+  identityFromModelInfo,
   modelCapabilityTags,
   modelSupportsChatAudioInput,
   modelSupportsChatImageInput,
@@ -59,7 +60,7 @@ const gemmaFlmLoaded = {
   device: 'npu',
   backend_url: '',
   pid: 123,
-  type: 'audio',
+  type: 'llm',
   last_use: Date.now(),
   input_modalities: ['text', 'audio'],
 };
@@ -67,8 +68,7 @@ const gemmaFlmInfo = {
   id: 'Gemma-4-E2B-it-FLM',
   name: 'Gemma-4-E2B-it-FLM',
   recipe: 'flm',
-  type: 'audio',
-  labels: ['tool-calling', 'vision', 'audio'],
+  labels: ['chat', 'tool-calling', 'vision', 'audio'],
   input_modalities: ['text', 'audio'],
 };
 
@@ -99,24 +99,44 @@ assert.deepEqual(
 );
 
 assert.equal(
-  capabilityFromLabels(['tool-calling', 'vision', 'audio']),
+  deploymentKindFromLabels(['chat', 'tool-calling', 'vision', 'audio']),
   'chat',
-  'vision and audio are additional inputs of a chat model, never Omni mode',
+  'vision and audio are additional inputs of a chat model, never a mode of their own',
 );
 assert.equal(
-  capabilityFromModelInfo({ id: 'single-vlm', recipe: 'llamacpp', labels: ['vision', 'multimodal'] }),
+  deploymentKindFromLabels(['chat', 'transcription']),
+  'chat',
+  'chat outranks every other deployment label, as find_deployment_mode does',
+);
+assert.equal(
+  deploymentKindFromLabels(['tool-calling', 'vision']),
+  'unknown',
+  'characteristics alone name no deployment mode',
+);
+assert.equal(
+  capabilityFromModelInfo({ id: 'single-vlm', recipe: 'llamacpp', labels: ['chat', 'vision'] }),
   'chat',
   'single multimodal models remain Chat models',
 );
 assert.equal(
-  capabilityFromModelInfo({ id: 'my-suite', recipe: 'collection.omni', components: ['chat', 'audio'] }),
-  'omni',
-  'Omni remains reserved for collection.omni',
+  capabilityFromModelInfo({ id: 'my-suite', recipe: 'collection.omni', labels: ['chat'], components: ['chat', 'audio'] }),
+  'chat',
+  'a collection deploys as chat, which is what the server labels it',
 );
 assert.equal(
-  capabilityFromModelInfo({ id: 'remote-suite', recipe: 'collection.omni', registry_source: 'huggingface', components: ['chat', 'audio'] }),
+  identityFromModelInfo({ id: 'my-suite', recipe: 'collection.omni', labels: ['chat'], components: ['chat', 'audio'] }),
   'omni',
-  'a registry-backed collection.omni remains Omni after it is registered',
+  'Omni identity comes from the recipe, not from the capability',
+);
+assert.equal(
+  identityFromModelInfo({ id: 'remote-suite', recipe: 'collection.omni', registry_source: 'huggingface', labels: ['chat'], components: ['chat', 'audio'] }),
+  'omni',
+  'a registry_source must not change how a registered collection is identified',
+);
+assert.equal(
+  capabilityFromModelInfo({ id: 'installed-chat', recipe: 'llamacpp', registry_source: 'huggingface', labels: ['chat', 'reasoning'] }),
+  'chat',
+  'an installed model is never mistaken for a remote search row',
 );
 assert.equal(
   modelSupportsChatAudioInput({ id: 'my-suite', recipe: 'collection.omni', labels: ['audio'] }, null),
@@ -124,7 +144,7 @@ assert.equal(
   'Omni collections must not be relabeled as Chat + Audio',
 );
 assert.equal(
-  capabilityFromLabels(['transcription', 'realtime-transcription']),
+  deploymentKindFromLabels(['transcription', 'realtime-transcription']),
   'audio',
   'standalone transcription labels remain Audio mode',
 );
@@ -136,7 +156,7 @@ const whisperLoaded = {
   device: 'cpu',
   backend_url: '',
   pid: 456,
-  type: 'audio',
+  type: 'transcription',
   last_use: Date.now(),
   labels: ['transcription', 'realtime-transcription'],
   input_modalities: ['audio'],
@@ -153,8 +173,10 @@ assert.equal(capabilityFromLoaded(plainFlm), 'chat');
 assert.equal(modelSupportsChatAudioInput(null, plainFlm), false);
 assert.equal(modelSupportsChatImageInput(null, plainFlm), false,
   'a plain text LLM must not expose image attachments');
-assert.equal(modelSupportsChatImageInput({ id: 'llava-next', recipe: 'llamacpp', type: 'llm' }, null), true,
-  'well-known VLM identity patterns remain a fallback when modality metadata is missing');
+assert.equal(modelSupportsChatImageInput({ id: 'llava-next', recipe: 'llamacpp', labels: ['chat'] }, null), false,
+  'a chat model without a vision label gets no image affordance, whatever its name suggests');
+assert.equal(modelSupportsChatImageInput({ id: 'llava-next', recipe: 'llamacpp', labels: ['chat', 'vision'] }, null), true,
+  'the declared vision label is what enables image attachments');
 
 assert.match(apiSource, /input_modalities\?: string\[\]/,
   'health metadata must preserve declared input modalities');

--- a/src/app/tests/chat-audio-capability.runtime.cjs
+++ b/src/app/tests/chat-audio-capability.runtime.cjs
@@ -188,7 +188,7 @@ assert.match(chatViewSource, /<CapabilityIcon capability="audio"/,
   'paired mode icons must include the Audio glyph');
 assert.match(chatViewSource, /const showAudio = audioInput && capability === 'chat'/,
   'the paired Audio icon must only decorate Chat mode, not Omni collections');
-assert.match(chatViewSource, /currentLoadedModel \? \([\s\S]*composer__model-mode--\$\{capabilityBadge\(currentCapability\)\}[\s\S]*modelModeLabel\(currentCapability, supportsChatAudioInput\)/,
+assert.match(chatViewSource, /currentLoadedModel \? \([\s\S]*composer__model-mode--\$\{modelModeBadge\(currentCapability, currentRecipe\)\}[\s\S]*modelModeDisplayLabel\(currentCapability, supportsChatAudioInput, currentRecipe\)/,
   'the active model pill must include the colored mode label only for the currently loaded model');
 assert.doesNotMatch(chatViewSource, /composer__mode-badge--interactive/,
   'the redundant standalone mode pill must not remain in the chat composer');

--- a/src/app/tests/features.spec.ts
+++ b/src/app/tests/features.spec.ts
@@ -128,7 +128,7 @@ test.describe('Lemonade UI — Feature Parity', () => {
           id: 'existing-model',
           name: 'Existing Model',
           type: 'llm',
-          labels: ['llm'],
+          labels: ['chat'],
           recipe: 'llamacpp',
           suggested: true,
           downloaded: true,
@@ -197,7 +197,7 @@ test.describe('Lemonade UI — Feature Parity', () => {
           id: 'llama-search-model',
           name: 'Llama Search Model',
           type: 'llm',
-          labels: ['llm'],
+          labels: ['chat'],
           recipe: 'llamacpp',
           suggested: true,
         }],
@@ -730,7 +730,7 @@ test.describe('Lemonade UI — Feature Parity', () => {
           id: 'config-beta-model',
           name: 'config-beta-model',
           display_name: 'Config Beta Model',
-          labels: ['llm'],
+          labels: ['chat'],
           recipe: 'llamacpp',
           downloaded: true,
           max_context_window: 65536,
@@ -743,10 +743,13 @@ test.describe('Lemonade UI — Feature Parity', () => {
           recipe: 'whispercpp',
           downloaded: true,
         }, {
+          // Carries a registry_source, as every served model does, and no
+          // stored ctx_size — so this exercises the context default path.
           id: 'unknown-context-model',
           name: 'unknown-context-model',
           display_name: 'Unknown Context Model',
           registry_source: 'huggingface',
+          labels: ['chat'],
           recipe: 'llamacpp',
           downloaded: true,
           max_context_window: 32768,
@@ -1457,7 +1460,7 @@ test.describe('Lemonade UI — Feature Parity', () => {
         data: [{
           id: modelName,
           name: modelName,
-          labels: ['llm', 'coding'],
+          labels: ['chat', 'coding'],
           recipe: 'llamacpp',
           downloaded: true,
           ctx_size: 4096,
@@ -1517,8 +1520,8 @@ test.describe('Lemonade UI — Feature Parity', () => {
     await page.route('**/api/v1/models**', route => route.fulfill({
       json: {
         data: [
-          { id: modelA, name: modelA, labels: ['llm'], recipe: 'llamacpp', downloaded: true, max_context_window: 65536 },
-          { id: modelB, name: modelB, labels: ['llm'], recipe: 'llamacpp', downloaded: true, max_context_window: 65536 },
+          { id: modelA, name: modelA, labels: ['chat'], recipe: 'llamacpp', downloaded: true, max_context_window: 65536 },
+          { id: modelB, name: modelB, labels: ['chat'], recipe: 'llamacpp', downloaded: true, max_context_window: 65536 },
         ],
       },
     }));

--- a/src/app/tests/inspect-interactions.spec.ts
+++ b/src/app/tests/inspect-interactions.spec.ts
@@ -87,7 +87,7 @@ test.beforeEach(async ({ page }) => {
             id: 'ACE-Step-music',
             name: 'ACE-Step-music',
             model_name: 'ACE-Step-music',
-            labels: ['audio', 'music-generation']
+            labels: ['audio-generation', 'music-generation']
           }
         ]
       })

--- a/src/app/tests/model-kind-classification.runtime.cjs
+++ b/src/app/tests/model-kind-classification.runtime.cjs
@@ -48,6 +48,8 @@ const {
   identityFromModelInfo,
   modelStructure,
   capabilityLabel,
+  identityFor,
+  isComposerSelectableCapability,
 } = loadTypeScriptModule(capabilitiesPath);
 
 /* ── Every documented deployment label maps to a surface ───────────── */
@@ -107,9 +109,7 @@ assert.deepEqual(
 /* ── chat outranks every other mode, as find_deployment_mode does ──── */
 
 assert.equal(deploymentKindFromLabels(['chat', 'transcription']), 'chat');
-assert.equal(deploymentKindFromLabels(['transcription', 'chat']), 'chat');
-assert.equal(deploymentKindFromLabels(['chat', 'image']), 'chat');
-assert.equal(deploymentKindFromLabels(['chat', 'embeddings']), 'chat');
+assert.equal(deploymentKindFromLabels(['image', 'chat']), 'chat', 'order does not matter');
 assert.equal(
   deploymentKindFromLabels(['CHAT', ' Vision ']),
   'chat',
@@ -136,12 +136,16 @@ assert.equal(modelStructure('collection.omni'), 'omni');
 assert.equal(modelStructure('collection'), 'omni');
 assert.equal(modelStructure('collection.router'), 'router');
 
-assert.equal(capabilityFromModelInfo(omniCollection), 'chat');
-assert.equal(capabilityFromModelInfo(routerCollection), 'chat');
+assert.equal(capabilityFromModelInfo(omniCollection), 'chat', 'a collection deploys as chat');
 assert.equal(identityFromModelInfo(omniCollection), 'omni');
 assert.equal(identityFromModelInfo(routerCollection), 'router');
 assert.equal(capabilityLabel(identityFromModelInfo(omniCollection)), 'Omni');
-assert.equal(capabilityLabel(identityFromModelInfo(routerCollection)), 'Router');
+// One identity rule, shared by rows, snapshots and the chat composer.
+assert.equal(identityFor('chat', 'collection.omni'), 'omni');
+assert.equal(identityFor('chat', 'collection.router'), 'router');
+assert.equal(identityFor('image', 'sd-cpp'), 'image');
+assert.equal(isComposerSelectableCapability('chat'), true);
+assert.equal(isComposerSelectableCapability('embedding'), false);
 
 /* ── Loaded models are classified by the router's own ModelType ────── */
 
@@ -164,6 +168,19 @@ for (const [type, kind] of Object.entries(LOADED)) {
   );
 }
 
+// A collection is synthesized client-side when its components are all loaded:
+// it reports type 'omni', carries no labels, and is known only by its recipe.
+assert.equal(
+  capabilityFromLoaded({ model_name: 'user.suite', type: 'omni', recipe: 'collection.omni' }),
+  'chat',
+  'a loaded collection stays selectable rather than falling through to unknown',
+);
+assert.equal(
+  capabilityFromLoaded({ model_name: 'x', type: 'omni', recipe: 'llamacpp' }),
+  'unknown',
+  'a non-collection reporting an unknown ModelType is still unknown',
+);
+
 /* ── The shipped registry never produces Unknown ───────────────────── */
 
 const registry = JSON.parse(
@@ -184,13 +201,11 @@ assert.ok(chatModels.length > 100, 'the registry chat models must be recognized 
 
 // The bug this refactor closes: a registry_source of huggingface/modelscope used
 // to send installed models down the remote-search branch and out as Unknown.
-for (const source of ['huggingface', 'modelscope']) {
-  assert.equal(
-    capabilityFromModelInfo({ id: 'installed', recipe: 'llamacpp', registry_source: source, labels: ['chat'] }),
-    'chat',
-    `an installed model carrying registry_source '${source}' stays classified`,
-  );
-}
+assert.equal(
+  capabilityFromModelInfo({ id: 'installed', recipe: 'llamacpp', registry_source: 'huggingface', labels: ['chat'] }),
+  'chat',
+  'an installed model carrying a registry_source stays classified',
+);
 
 // A remote search row genuinely has no deployment label, and Unknown is honest.
 assert.equal(capabilityFromModelInfo({ id: 'some/repo', recipe: 'llamacpp', labels: [] }), 'unknown');

--- a/src/app/tests/model-kind-classification.runtime.cjs
+++ b/src/app/tests/model-kind-classification.runtime.cjs
@@ -1,0 +1,198 @@
+/*
+ * The GUI classifies a model by reading the deployment label the server already
+ * stamped on it. These checks pin that lookup to two external sources of truth:
+ * the label table in docs/api/openai.md, and the shipped model registry.
+ */
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const ts = require('typescript');
+
+const root = path.resolve(__dirname, '..');
+const repoRoot = path.resolve(root, '../..');
+
+function loadTypeScriptModule(filename) {
+  const source = fs.readFileSync(filename, 'utf8');
+  const compiled = ts.transpileModule(source, {
+    compilerOptions: {
+      target: ts.ScriptTarget.ES2020,
+      module: ts.ModuleKind.CommonJS,
+      esModuleInterop: true,
+    },
+    fileName: filename,
+    reportDiagnostics: true,
+  });
+  const diagnostics = compiled.diagnostics || [];
+  assert.equal(
+    diagnostics.length,
+    0,
+    diagnostics.map(d => ts.flattenDiagnosticMessageText(d.messageText, '\n')).join('\n'),
+  );
+  const module = { exports: {} };
+  Function('exports', 'require', 'module', '__filename', '__dirname', compiled.outputText)(
+    module.exports,
+    require,
+    module,
+    filename,
+    path.dirname(filename),
+  );
+  return module.exports;
+}
+
+const capabilitiesPath = path.join(root, 'src/modelCapabilities.ts');
+const capabilitiesSource = fs.readFileSync(capabilitiesPath, 'utf8');
+const {
+  capabilityFromLoaded,
+  capabilityFromModelInfo,
+  deploymentKindFromLabels,
+  identityFromModelInfo,
+  modelStructure,
+  capabilityLabel,
+} = loadTypeScriptModule(capabilitiesPath);
+
+/* ── Every documented deployment label maps to a surface ───────────── */
+
+const EXPECTED = {
+  chat: 'chat',
+  transcription: 'audio',
+  embeddings: 'embedding',
+  embedding: 'embedding',
+  reranking: 'reranking',
+  image: 'image',
+  tts: 'tts',
+  'audio-generation': 'audio-generation',
+  classification: 'classification',
+  classifier: 'classification',
+  '3d': 'model3d',
+};
+
+for (const [label, kind] of Object.entries(EXPECTED)) {
+  assert.equal(
+    deploymentKindFromLabels([label]),
+    kind,
+    `the '${label}' deployment label must resolve to ${kind}`,
+  );
+}
+
+/* ── Drift guard against docs/api/openai.md ────────────────────────── */
+
+const apiDocs = fs.readFileSync(path.join(repoRoot, 'docs/api/openai.md'), 'utf8');
+const deploymentSection = apiDocs.slice(
+  apiDocs.indexOf('**Deployment labels**'),
+  apiDocs.indexOf('**Input-modality labels**'),
+);
+assert.ok(deploymentSection.length > 0, 'the deployment label section must be findable in the API docs');
+
+const documented = new Set();
+for (const [, label] of deploymentSection.matchAll(/^\| `([a-z0-9-]+)` \|/gm)) documented.add(label);
+// "Also accepted as `embedding`." / "Also accepted as `classifier`."
+for (const [, alias] of deploymentSection.matchAll(/Also accepted as `([a-z0-9-]+)`/g)) documented.add(alias);
+
+assert.equal(documented.size, 11, 'nine deployment labels plus the two documented aliases');
+
+const literal = capabilitiesSource.slice(
+  capabilitiesSource.indexOf('const DEPLOYMENT_LABEL_KIND'),
+  capabilitiesSource.indexOf('/** ModelType strings the router reports'),
+);
+const implemented = new Set(
+  [...literal.matchAll(/^\s{2}'?([a-z0-9-]+)'?:/gm)].map(match => match[1]),
+);
+
+assert.deepEqual(
+  [...implemented].sort(),
+  [...documented].sort(),
+  'the GUI lookup must carry exactly the deployment labels documented in docs/api/openai.md',
+);
+
+/* ── chat outranks every other mode, as find_deployment_mode does ──── */
+
+assert.equal(deploymentKindFromLabels(['chat', 'transcription']), 'chat');
+assert.equal(deploymentKindFromLabels(['transcription', 'chat']), 'chat');
+assert.equal(deploymentKindFromLabels(['chat', 'image']), 'chat');
+assert.equal(deploymentKindFromLabels(['chat', 'embeddings']), 'chat');
+assert.equal(
+  deploymentKindFromLabels(['CHAT', ' Vision ']),
+  'chat',
+  'labels are compared case- and whitespace-insensitively',
+);
+
+/* ── Characteristics and input modalities name no mode ─────────────── */
+
+for (const labels of [[], ['reasoning'], ['tool-calling', 'coding'], ['vision'], ['chat-transcription'], ['hot']]) {
+  assert.equal(
+    deploymentKindFromLabels(labels),
+    'unknown',
+    `${JSON.stringify(labels)} names no deployment mode`,
+  );
+}
+
+/* ── Collections deploy as chat; Omni/Router are structural ────────── */
+
+const omniCollection = { id: 'user.suite', recipe: 'collection.omni', labels: ['chat'], components: ['a', 'b'] };
+const routerCollection = { id: 'user.router', recipe: 'collection.router', labels: ['chat'] };
+
+assert.equal(modelStructure('llamacpp'), 'single');
+assert.equal(modelStructure('collection.omni'), 'omni');
+assert.equal(modelStructure('collection'), 'omni');
+assert.equal(modelStructure('collection.router'), 'router');
+
+assert.equal(capabilityFromModelInfo(omniCollection), 'chat');
+assert.equal(capabilityFromModelInfo(routerCollection), 'chat');
+assert.equal(identityFromModelInfo(omniCollection), 'omni');
+assert.equal(identityFromModelInfo(routerCollection), 'router');
+assert.equal(capabilityLabel(identityFromModelInfo(omniCollection)), 'Omni');
+assert.equal(capabilityLabel(identityFromModelInfo(routerCollection)), 'Router');
+
+/* ── Loaded models are classified by the router's own ModelType ────── */
+
+const LOADED = {
+  llm: 'chat',
+  embedding: 'embedding',
+  reranking: 'reranking',
+  transcription: 'audio',
+  image: 'image',
+  tts: 'tts',
+  'audio-generation': 'audio-generation',
+  classification: 'classification',
+  mesh: 'model3d',
+};
+for (const [type, kind] of Object.entries(LOADED)) {
+  assert.equal(
+    capabilityFromLoaded({ model_name: 'x', type }),
+    kind,
+    `a loaded model reporting type '${type}' is ${kind}`,
+  );
+}
+
+/* ── The shipped registry never produces Unknown ───────────────────── */
+
+const registry = JSON.parse(
+  fs.readFileSync(path.join(repoRoot, 'src/cpp/resources/server_models.json'), 'utf8'),
+);
+const entries = Object.entries(registry).filter(([, value]) => value && typeof value === 'object');
+assert.ok(entries.length > 100, 'the model registry must be readable');
+
+const unclassified = entries.filter(([, info]) => capabilityFromModelInfo(info) === 'unknown');
+assert.deepEqual(
+  unclassified.map(([name]) => name),
+  [],
+  'every model in the shipped registry must classify to a known surface',
+);
+
+const chatModels = entries.filter(([, info]) => capabilityFromModelInfo(info) === 'chat');
+assert.ok(chatModels.length > 100, 'the registry chat models must be recognized as chat');
+
+// The bug this refactor closes: a registry_source of huggingface/modelscope used
+// to send installed models down the remote-search branch and out as Unknown.
+for (const source of ['huggingface', 'modelscope']) {
+  assert.equal(
+    capabilityFromModelInfo({ id: 'installed', recipe: 'llamacpp', registry_source: source, labels: ['chat'] }),
+    'chat',
+    `an installed model carrying registry_source '${source}' stays classified`,
+  );
+}
+
+// A remote search row genuinely has no deployment label, and Unknown is honest.
+assert.equal(capabilityFromModelInfo({ id: 'some/repo', recipe: 'llamacpp', labels: [] }), 'unknown');
+
+console.log(`Model kind classification checks passed (${entries.length} registry models, ${documented.size} labels).`);

--- a/src/app/tests/model-kind-display.spec.ts
+++ b/src/app/tests/model-kind-display.spec.ts
@@ -1,0 +1,109 @@
+import { expect, test } from '@playwright/test';
+
+/*
+ * End-to-end cover for the deployment-label classification: one model per
+ * documented label, plus both collection kinds, all carrying the registry_source
+ * every served model carries. Each must show its own type in the detail header,
+ * and none may fall through to "Unknown".
+ */
+
+type Row = { id: string; labels: string[]; recipe: string; expected: string };
+
+const CATALOG: Row[] = [
+  { id: 'Kind-Chat', labels: ['chat', 'reasoning'], recipe: 'llamacpp', expected: 'Chat' },
+  { id: 'Kind-Vision-Chat', labels: ['chat', 'vision'], recipe: 'llamacpp', expected: 'Chat' },
+  { id: 'Kind-Transcription', labels: ['transcription', 'realtime-transcription'], recipe: 'whispercpp', expected: 'Audio' },
+  { id: 'Kind-Embeddings', labels: ['embeddings'], recipe: 'llamacpp', expected: 'Embedding' },
+  { id: 'Kind-Reranking', labels: ['reranking'], recipe: 'llamacpp', expected: 'Reranking' },
+  { id: 'Kind-Image', labels: ['image'], recipe: 'sd-cpp', expected: 'Image' },
+  { id: 'Kind-Tts', labels: ['tts'], recipe: 'kokoro', expected: 'TTS' },
+  { id: 'Kind-AudioGen', labels: ['audio-generation'], recipe: 'acestep', expected: 'Music & SFX' },
+  { id: 'Kind-Classification', labels: ['classification'], recipe: 'onnxruntime', expected: 'Classification' },
+  { id: 'Kind-Mesh', labels: ['3d'], recipe: 'trellis', expected: '3D' },
+  { id: 'Kind-Omni-Collection', labels: ['chat'], recipe: 'collection.omni', expected: 'Omni' },
+  { id: 'Kind-Router-Collection', labels: ['chat'], recipe: 'collection.router', expected: 'Router' },
+];
+
+test.describe('Model kind display', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route('**/api/v1/health**', route => route.fulfill({
+      json: { status: 'ok', version: 'test', all_models_loaded: [] },
+    }));
+    await page.route('**/api/v1/system-info**', route => route.fulfill({
+      json: {
+        recipes: {
+          llamacpp: { default_backend: 'cpu', backends: { cpu: { state: 'installed', version: 'test' } } },
+        },
+      },
+    }));
+    await page.route('**/api/v1/models**', route => route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({
+        data: CATALOG.map(row => ({
+          id: row.id,
+          name: row.id,
+          display_name: row.id,
+          labels: row.labels,
+          recipe: row.recipe,
+          // Every served model carries this; it used to send the whole catalog
+          // down the remote-search branch and out as Unknown.
+          registry_source: 'huggingface',
+          downloaded: true,
+          size: 1,
+          ...(row.recipe.startsWith('collection.') ? { components: ['Kind-Chat'] } : {}),
+        })),
+      }),
+    }));
+
+    await page.goto('/');
+    await page.locator('.titlebar__nav').getByText('Models').click();
+    await expect(page.locator('.titlebar__status-dot--brand')).toHaveClass(/titlebar__status-dot--connected/);
+  });
+
+  test('every deployment label renders its own type, never Unknown', async ({ page }) => {
+    const list = page.locator('.model-list-panel__list .workspace-list-row');
+    await expect(list).toHaveCount(CATALOG.length);
+
+    for (const row of CATALOG) {
+      await list.filter({ hasText: row.id }).first().click();
+      const header = page.locator('.workspace-detail-panel__metadata').first();
+      await expect(header, `${row.id} must show its own type`).toContainText(row.expected);
+      await expect(header, `${row.id} must not be Unknown`).not.toContainText('Unknown');
+    }
+
+    await page.screenshot({ path: 'test-results/model-kind-display.png', fullPage: true });
+  });
+
+  test('each task filter counts its own models, with no double counting', async ({ page }) => {
+    const chip = (name: RegExp) => page.locator('.model-nav-rail__task-chip').filter({ hasText: name });
+    const list = page.locator('.model-list-panel__list .workspace-list-row');
+
+    // A collection serves chat but has its own task, so it is counted once.
+    await chip(/^Chat/).click();
+    await expect(list).toHaveCount(2);
+    await expect(list.filter({ hasText: 'Collection' })).toHaveCount(0);
+    await chip(/^Chat/).click();
+
+    await chip(/^Omni/).click();
+    await expect(list).toHaveCount(1);
+    await expect(list.filter({ hasText: 'Kind-Omni-Collection' })).toHaveCount(1);
+    await chip(/^Omni/).click();
+
+    // Classification models are discoverable rather than silently unfiltered.
+    await chip(/^Classify/).click();
+    await expect(list).toHaveCount(1);
+    await expect(list.filter({ hasText: 'Kind-Classification' })).toHaveCount(1);
+  });
+
+  test('chat controls follow the declared input modalities', async ({ page }) => {
+    // A vision chat model offers image attachment; a plain chat model does not.
+    await page.locator('.model-list-panel__list .workspace-list-row').filter({ hasText: 'Kind-Vision-Chat' }).first().click();
+    await expect(page.locator('.workspace-detail-panel__metadata').first()).toContainText('Chat');
+
+    await page.locator('.model-list-panel__list .workspace-list-row').filter({ hasText: 'Kind-Classification' }).first().click();
+    const classificationHeader = page.locator('.workspace-detail-panel__metadata').first();
+    await expect(classificationHeader).toContainText('Classification');
+    // No /classify surface exists yet, so the row is informational only.
+    await expect(classificationHeader).not.toContainText('Chat');
+  });
+});

--- a/src/app/tests/model-kind-display.spec.ts
+++ b/src/app/tests/model-kind-display.spec.ts
@@ -69,6 +69,9 @@ test.describe('Model kind display', () => {
       const header = page.locator('.workspace-detail-panel__metadata').first();
       await expect(header, `${row.id} must show its own type`).toContainText(row.expected);
       await expect(header, `${row.id} must not be Unknown`).not.toContainText('Unknown');
+      if (row.expected !== 'Chat') {
+        await expect(header, `${row.id} must not also claim Chat`).not.toContainText('Chat');
+      }
     }
 
     await page.screenshot({ path: 'test-results/model-kind-display.png', fullPage: true });
@@ -95,15 +98,4 @@ test.describe('Model kind display', () => {
     await expect(list.filter({ hasText: 'Kind-Classification' })).toHaveCount(1);
   });
 
-  test('chat controls follow the declared input modalities', async ({ page }) => {
-    // A vision chat model offers image attachment; a plain chat model does not.
-    await page.locator('.model-list-panel__list .workspace-list-row').filter({ hasText: 'Kind-Vision-Chat' }).first().click();
-    await expect(page.locator('.workspace-detail-panel__metadata').first()).toContainText('Chat');
-
-    await page.locator('.model-list-panel__list .workspace-list-row').filter({ hasText: 'Kind-Classification' }).first().click();
-    const classificationHeader = page.locator('.workspace-detail-panel__metadata').first();
-    await expect(classificationHeader).toContainText('Classification');
-    // No /classify surface exists yet, so the row is informational only.
-    await expect(classificationHeader).not.toContainText('Chat');
-  });
 });

--- a/src/app/tests/model-list-backend-layout.runtime.cjs
+++ b/src/app/tests/model-list-backend-layout.runtime.cjs
@@ -73,15 +73,15 @@ assert.match(component, /capability=\{primaryCapability\}/,
 // The lead-glyph rule is shared, not restated per list.
 const capabilities = fs.readFileSync(path.join(root, 'src/modelCapabilities.ts'), 'utf8');
 assert.match(capabilities, /export function isRouterRecipe\(/);
-assert.match(capabilities, /export function rowCapability\(model: ModelInfo\): ModelIdentity/,
+assert.match(capabilities, /export function identityFromModelInfo\(model: ModelInfo\): ModelIdentity/,
   'collections lead with their task identity, not a backend one');
 assert.match(capabilities, /export type ModelIdentity = ModelCapability \| 'omni' \| 'router'/,
   'omni and router are structural identities, not capabilities');
 assert.doesNotMatch(component, /function modelPrimaryCapability/,
   'the per-list copy of the lead-glyph rule is replaced by rowCapability');
-assert.match(component, /const primaryCapability = rowCapability\(model\);/);
-assert.match(component, /const neutralCollectionGuide = primaryCapability === 'omni' \|\| primaryCapability === 'router';/,
-  'the collection check reuses the capability already computed for the row');
+assert.match(component, /const primaryCapability = identityFromModelInfo\(model\);/);
+assert.match(component, /const neutralCollectionGuide = isCollectionRecipe\(recipe\);/,
+  'the collection check reuses the shared structural predicate');
 assert.match(component, /anchor=\{recipe && !neutralCollectionGuide \? displayedBackend : undefined\}/,
   'the engine is the meta-anchor and collections have none');
 assert.match(component, /secondaryTags = capTags\.filter\(tag => tag !== \(primaryCapability as string\)\)/,

--- a/src/app/tests/model-list-backend-layout.runtime.cjs
+++ b/src/app/tests/model-list-backend-layout.runtime.cjs
@@ -73,8 +73,10 @@ assert.match(component, /capability=\{primaryCapability\}/,
 // The lead-glyph rule is shared, not restated per list.
 const capabilities = fs.readFileSync(path.join(root, 'src/modelCapabilities.ts'), 'utf8');
 assert.match(capabilities, /export function isRouterRecipe\(/);
-assert.match(capabilities, /export function rowCapability\(model: ModelInfo\): ModelCapability \| 'router'/,
+assert.match(capabilities, /export function rowCapability\(model: ModelInfo\): ModelIdentity/,
   'collections lead with their task identity, not a backend one');
+assert.match(capabilities, /export type ModelIdentity = ModelCapability \| 'omni' \| 'router'/,
+  'omni and router are structural identities, not capabilities');
 assert.doesNotMatch(component, /function modelPrimaryCapability/,
   'the per-list copy of the lead-glyph rule is replaced by rowCapability');
 assert.match(component, /const primaryCapability = rowCapability\(model\);/);
@@ -175,7 +177,7 @@ assert.doesNotMatch(chatView, /composer__model-option\b|composer__model-option-r
 assert.doesNotMatch(styles, /\.composer__model-option/,
   'the picker option styles are replaced by the shared row');
 assert.match(chatView, /icon: 'eject'/, 'eject occupies the row action slot');
-assert.match(chatView, /const isCollection = capability === 'omni' \|\| capability === 'router'/,
+assert.match(chatView, /const isCollection = structure !== 'single'/,
   'the picker suppresses the engine anchor for collections, like the catalog');
 
 assert.match(manager, /const \[systemInfo, setSystemInfo\] = useState<Record<string, unknown> \| null>/);

--- a/src/app/tests/model-nav-filter-layout.runtime.cjs
+++ b/src/app/tests/model-nav-filter-layout.runtime.cjs
@@ -51,7 +51,7 @@ assert.match(list, /export function modelMatchesBackends/);
 assert.match(list, /export function modelMatchesTags/);
 assert.match(list, /if \(filter === 'router'\) return modelIsRouter\(m\);/);
 assert.match(list, /if \(filter === 'omni'\) return modelIsOmni\(m\);/);
-assert.match(list, /if \(filter === 'llm'\) return cap === 'chat' && !modelIsRouter\(m\);/);
+assert.match(list, /if \(filter === 'llm'\) return cap === 'chat' && !modelIsRouter\(m\) && !modelIsOmniCollection\(m\);/);
 assert.match(list, /raw\.recommended === true \|\| raw\.is_recommended === true \|\| raw\.featured === true \|\| raw\.suggested === true/);
 assert.match(list, /TAG_CHIPS: string\[\] = \['Recommended', 'Hot'/);
 assert.match(list, /if \(t === 'hot'\) return modelIsHot\(m\);/);
@@ -159,7 +159,7 @@ function loadListHelpers() {
 
 const helpers = loadListHelpers();
 const chatModel = { id: 'Qwen-Chat', name: 'Qwen-Chat', labels: ['chat'], recipe: 'llamacpp', suggested: true };
-const audioModel = { id: 'Whisper', name: 'Whisper', labels: ['audio'], recipe: 'whispercpp' };
+const audioModel = { id: 'Whisper', name: 'Whisper', labels: ['transcription'], recipe: 'whispercpp' };
 const hotLabelModel = { id: 'Gemma-Hot', name: 'Gemma-4-31B', labels: ['hot', 'tool-calling'], recipe: 'llamacpp', suggested: true };
 const hotCapabilityModel = { id: 'Future-Hot', name: 'Future-Model', capabilities: ['hot'], labels: ['chat'], recipe: 'llamacpp' };
 const hotNameOnlyModel = { id: 'Hotpot-Model', name: 'Hotpot-Model', labels: ['chat'], recipe: 'llamacpp' };

--- a/src/app/tests/model-nav-filter-layout.runtime.cjs
+++ b/src/app/tests/model-nav-filter-layout.runtime.cjs
@@ -49,9 +49,7 @@ assert.doesNotMatch(nav, /\+ Recommended \+/);
 assert.match(list, /export function modelMatchesTasks/);
 assert.match(list, /export function modelMatchesBackends/);
 assert.match(list, /export function modelMatchesTags/);
-assert.match(list, /if \(filter === 'router'\) return modelIsRouter\(m\);/);
-assert.match(list, /if \(filter === 'omni'\) return modelIsOmni\(m\);/);
-assert.match(list, /if \(filter === 'llm'\) return cap === 'chat' && !modelIsRouter\(m\) && !modelIsOmniCollection\(m\);/);
+assert.match(list, /export function modelMatchesFilter/);
 assert.match(list, /raw\.recommended === true \|\| raw\.is_recommended === true \|\| raw\.featured === true \|\| raw\.suggested === true/);
 assert.match(list, /TAG_CHIPS: string\[\] = \['Recommended', 'Hot'/);
 assert.match(list, /if \(t === 'hot'\) return modelIsHot\(m\);/);
@@ -181,6 +179,13 @@ assert.doesNotThrow(() => helpers.ModelListPanel({
   tagFilters: new Set(),
 }), 'selecting a left-rail task must render the model list without throwing');
 
+assert.equal(helpers.modelMatchesFilter(routerModel, 'router'), true);
+assert.equal(helpers.modelMatchesFilter(omniModel, 'omni'), true);
+assert.equal(helpers.modelMatchesFilter(routerModel, 'llm'), false,
+  'a router collection has its own task and is not also Chat');
+assert.equal(helpers.modelMatchesFilter(omniModel, 'llm'), false,
+  'an omni collection has its own task and is not also Chat');
+assert.equal(helpers.modelMatchesFilter(chatModel, 'llm'), true);
 assert.equal(helpers.modelMatchesTasks(routerModel, new Set(['router'])), true);
 assert.equal(helpers.modelMatchesTasks(routerModel, new Set(['llm'])), false, 'Router must not double-count as Chat');
 assert.equal(helpers.modelMatchesTasks(chatModel, new Set(['llm', 'audio'])), true);

--- a/src/app/tests/model-provider-search.runtime.cjs
+++ b/src/app/tests/model-provider-search.runtime.cjs
@@ -117,10 +117,8 @@ assert.doesNotMatch(capabilitiesSource, /registry_source/,
   'an installed model must not be classified by which registry it came from');
 assert.match(remoteCapabilitiesSource, /Repository IDs, display names and the user's search query are deliberately\n \* excluded/,
   'remote registry rows must avoid name guessing');
-assert.match(listPanelSource, /if \(filter === 'llm'\) return cap === 'chat' && !modelIsRouter\(m\) && !modelIsOmniCollection\(m\);/,
-  'Unknown capability rows and Router collections must not leak into the Chat task filter');
-assert.match(listPanelSource, /if \(filter === 'omni'\) return modelIsOmni\(m\);/,
-  'Omni models must match the dedicated Omni task filter');
+assert.match(listPanelSource, /const identity = identityFromModelInfo\(m\);/,
+  'task filtering asks for the identity rather than re-deriving collection rules');
 
 assert.match(nav, /const \[catalogsOpen, setCatalogsOpen\] = useState\(true\)/, 'Online Catalogs must be independently collapsible');
 assert.match(nav, /aria-expanded=\{catalogsOpen\}[\s\S]*aria-controls="nav-online-catalogs"[\s\S]*setCatalogsOpen/, 'Online Catalogs must use the standard collapsible section header');

--- a/src/app/tests/model-provider-search.runtime.cjs
+++ b/src/app/tests/model-provider-search.runtime.cjs
@@ -111,9 +111,13 @@ assert.doesNotMatch(detailPanelSource, /hf-detail__gguf-action/,
 
 assert.doesNotMatch(capabilitiesSource, /found\.size === 0\) found\.add\('chat'\)/,
   'unknown capability must not silently become Chat');
-assert.match(capabilitiesSource, /Remote search rows must not become Chat/,
-  'remote registry rows must avoid name/recipe guessing');
-assert.match(listPanelSource, /if \(filter === 'llm'\) return cap === 'chat' && !modelIsRouter\(m\);/,
+assert.doesNotMatch(capabilitiesSource, /MULTIMODAL_CHAT_NAME_PATTERNS|capabilityFromName/,
+  'classification must never guess from a model or repository name');
+assert.doesNotMatch(capabilitiesSource, /registry_source/,
+  'an installed model must not be classified by which registry it came from');
+assert.match(remoteCapabilitiesSource, /Repository IDs, display names and the user's search query are deliberately\n \* excluded/,
+  'remote registry rows must avoid name guessing');
+assert.match(listPanelSource, /if \(filter === 'llm'\) return cap === 'chat' && !modelIsRouter\(m\) && !modelIsOmniCollection\(m\);/,
   'Unknown capability rows and Router collections must not leak into the Chat task filter');
 assert.match(listPanelSource, /if \(filter === 'omni'\) return modelIsOmni\(m\);/,
   'Omni models must match the dedicated Omni task filter');

--- a/src/app/tests/router-editor.runtime.cjs
+++ b/src/app/tests/router-editor.runtime.cjs
@@ -37,7 +37,6 @@ const managerPath = path.join(root, 'src/components/ModelManager.tsx');
 const listPath = path.join(root, 'src/components/ModelListPanel.tsx');
 const editorPath = path.join(root, 'src/components/RouterEditorPanel.tsx');
 const nodeEditorPath = path.join(root, 'src/components/RouterNodeEditor.tsx');
-const capabilityPath = path.join(root, 'src/modelCapabilities.ts');
 const connectionPath = path.join(root, 'src/features/router/routerConnections.ts');
 const detailPath = path.join(root, 'src/components/ModelDetailPanel.tsx');
 const apiPath = path.join(root, 'src/api.ts');
@@ -48,7 +47,6 @@ const managerSource = fs.readFileSync(managerPath, 'utf8');
 const listSource = fs.readFileSync(listPath, 'utf8');
 const editorSource = fs.readFileSync(editorPath, 'utf8');
 const nodeEditorSource = fs.readFileSync(nodeEditorPath, 'utf8');
-const capabilitySource = fs.readFileSync(capabilityPath, 'utf8');
 const detailSource = fs.readFileSync(detailPath, 'utf8');
 const apiSource = fs.readFileSync(apiPath, 'utf8');
 
@@ -198,13 +196,6 @@ assert.doesNotMatch(editorSource, /issue #2405|remain hidden/i);
 assert.match(nodeEditorSource, /metadataComparator/);
 assert.match(nodeEditorSource, /normalizeRouterNode/);
 assert.match(nodeEditorSource, />AND<|>AND<\/button>/, 'a leaf must be wrappable into a compound rule');
-const capabilities = loadTypeScriptModule(capabilityPath);
-assert.equal(capabilities.modelStructure('collection.router'), 'router',
-  'a router collection is identified structurally, from its recipe');
-assert.equal(
-  capabilities.capabilityFromModelInfo({ id: 'user.router', recipe: 'collection.router', labels: ['chat'] }),
-  'chat',
-  'a router collection deploys as chat, which is what it serves');
 assert.match(editorSource, /Switching modes keeps the other configuration intact/);
 
 

--- a/src/app/tests/router-editor.runtime.cjs
+++ b/src/app/tests/router-editor.runtime.cjs
@@ -198,7 +198,13 @@ assert.doesNotMatch(editorSource, /issue #2405|remain hidden/i);
 assert.match(nodeEditorSource, /metadataComparator/);
 assert.match(nodeEditorSource, /normalizeRouterNode/);
 assert.match(nodeEditorSource, />AND<|>AND<\/button>/, 'a leaf must be wrappable into a compound rule');
-assert.match(capabilitySource, /collection\.router[^\n]+return 'chat'/);
+const capabilities = loadTypeScriptModule(capabilityPath);
+assert.equal(capabilities.modelStructure('collection.router'), 'router',
+  'a router collection is identified structurally, from its recipe');
+assert.equal(
+  capabilities.capabilityFromModelInfo({ id: 'user.router', recipe: 'collection.router', labels: ['chat'] }),
+  'chat',
+  'a router collection deploys as chat, which is what it serves');
 assert.match(editorSource, /Switching modes keeps the other configuration intact/);
 
 


### PR DESCRIPTION
Closes https://github.com/lemonade-sdk/lemonade/issues/3070 using the new chat label from https://github.com/lemonade-sdk/lemonade/pull/3099

**Bug:** any model carrying a `registry_source` was treated as a Hugging Face search row; that field defaults to `"huggingface"`, so installed chat models rendered **Unknown**.

**Fix:** read the deployment label the server already stamps. `modelCapabilities.ts` 521 → 371 — recipe hint lists, checkpoint-name regexes, `capabilityFromName`/`Type`/`Recipe` and the `preferNonChat` ladder deleted.

- Collections aren't a capability: Omni/Router deploy as `chat`, identity from the recipe.
- `classification` added (two ONNX models were falling through): chip + filter, no panel.
- Remote search rows keep inference, isolated — `unknown` there is honest.
- Authoring writes one label; older records repaired on read, never rewritten on disk.
- Commit 2 fixes three regressions from commit 1 (collections lost from the composer, Omni shown as "Chat", old custom models Unknown) and deletes a duplicate name-guessing classifier in `lemonadeTools.ts`.

**Tests:** new suite pins the lookup to `docs/api/openai.md` and all 214 registry models; new spec covers every label end-to-end. Typecheck clean, 45 functional + 146 a11y pass. `default-chat-model`, `directory-settings` and `model-provider-search` already fail on base; the `inspect-interactions` optimizer is flaky.

