### PR TITLE
Replace /load/command with /models/{id}/options

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@ All core endpoints are registered under **4 path prefixes**:
 - `/v0/` — Legacy short
 - `/v1/` — OpenAI SDK / LiteLLM compatibility
 
-**Core endpoints:** `chat/completions`, `completions`, `embeddings`, `reranking`, `models`, `models/{id}`, `health`, `pull`, `pull/variants`, `registry/search`, `load`, `load/command`, `unload`, `delete`, `params`, `install`, `uninstall`, `audio/transcriptions`, `audio/speech`, `images/generations`, `images/edits`, `images/variations`, `responses`, `stats`, `system-info`, `system-stats`, `log-level`, `logs/stream`, `jobs`, `jobs/{id}`, `jobs/{id}/pause`, `jobs/{id}/interrupt`, `jobs/{id}/resume`
+**Core endpoints:** `chat/completions`, `completions`, `embeddings`, `reranking`, `models`, `models/{id}`, `models/{id}/options`, `health`, `pull`, `pull/variants`, `registry/search`, `load`, `unload`, `delete`, `params`, `install`, `uninstall`, `audio/transcriptions`, `audio/speech`, `images/generations`, `images/edits`, `images/variations`, `responses`, `stats`, `system-info`, `system-stats`, `log-level`, `logs/stream`, `jobs`, `jobs/{id}`, `jobs/{id}/pause`, `jobs/{id}/interrupt`, `jobs/{id}/resume`
 
 **Job engine** (`POST jobs`, `GET jobs`, `GET/DELETE jobs/{id}`, `POST jobs/{id}/{pause,interrupt,resume}`): server-side sequences of ops (`system_info`, `system_stats`, `models`, `sleep`, `load`, `unload`, `chat`) with data passing, forward-only branching, and a pause/interrupt/resume lifecycle persisted across restart. Exclusive ops hold a Router slot so normal traffic queues. See `docs/dev/job-system.md` and `docs/dev/job-expression-language.md`.
 

--- a/src/app/src/api.ts
+++ b/src/app/src/api.ts
@@ -228,13 +228,15 @@ export interface LoadedModel {
   recipe_options?: Record<string, unknown>;
 }
 
-export interface EffectiveLoadCommand {
+/** Response shape of GET/POST/DELETE /api/v1/models/{id}/options. */
+export interface ModelOptions {
   model_name: string;
   recipe: string;
-  backend: string;
-  options: Record<string, unknown>;
-  args: string[];
-  ctx_size_auto_resolved?: boolean;
+  saved: Record<string, unknown>;
+  effective: Record<string, unknown>;
+  defaults: Record<string, unknown>;
+  resolved_ctx_size: number;
+  load_command: string;
 }
 
 export interface ModelInfo {
@@ -1391,15 +1393,39 @@ class LemonadeAPI {
     return result;
   }
 
-  async effectiveLoadCommand(modelName: string, recipeOptions?: Record<string, unknown>, modelInfo?: ModelInfo | null): Promise<EffectiveLoadCommand> {
+  async effectiveModelOptions(modelName: string, recipeOptions?: Record<string, unknown>, modelInfo?: ModelInfo | null): Promise<ModelOptions> {
+    const path = `/api/v1/models/${encodeURIComponent(modelName)}/options`;
+    const current = await this._json<ModelOptions>(path);
+
     const target = modelName.trim().toLowerCase();
     const cachedModelInfo = modelInfo || this.allModels.find(model => modelInfoKey(model).toLowerCase() === target) || null;
     const { recipeOptionsForModel } = await import(
       /* webpackChunkName: "model-configuration" */ './modelConfiguration'
     );
     const stagedOptions = recipeOptionsForModel(modelName, cachedModelInfo, recipeOptions as RecipeOptions | undefined, this._systemInfoData);
-    const body: Record<string, unknown> = { model_name: modelName, ...(stagedOptions || {}), ...recipeOptions };
-    return this._json<EffectiveLoadCommand>('/api/v1/load/command', { method: 'POST', body });
+
+    // Options staged in this client are not on the server, so only a dry run
+    // reports the load this app would actually send. `defaults` names exactly
+    // what the model's recipe accepts: the staged set spans every recipe, and
+    // a name from another one is a 400.
+    const overrides: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries({ ...stagedOptions, ...recipeOptions })) {
+      if (value !== undefined && key in current.defaults
+          && JSON.stringify(value) !== JSON.stringify(current.effective[key])) {
+        overrides[key] = value;
+      }
+    }
+    if (Object.keys(overrides).length === 0) return this._resolveLoadCommand(current);
+    const preview = await this._json<ModelOptions>(path, { method: 'POST', body: { ...overrides, dry_run: true } });
+    return this._resolveLoadCommand(preview);
+  }
+
+  private _resolveLoadCommand(result: ModelOptions): ModelOptions {
+    if (!result?.load_command) return result;
+    // The API key stays a variable reference: this command is rendered for the
+    // user to copy, which is not somewhere a live credential belongs.
+    const base = this.baseUrl.replace(/\/+$/, '');
+    return { ...result, load_command: result.load_command.split('$LEMONADE_BASE_URL').join(base) };
   }
 
   async unloadModel(modelName?: string): Promise<unknown> {

--- a/src/app/src/components/EffectiveSettingsModal.tsx
+++ b/src/app/src/components/EffectiveSettingsModal.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
-import api, { type ModelInfo, type EffectiveLoadCommand, type LoadedModel, friendlyErrorMessage } from '../api';
+import api, { type ModelInfo, type ModelOptions, type LoadedModel, friendlyErrorMessage } from '../api';
 import {
   type RecipeOptions,
   type SamplingParams,
@@ -85,17 +85,6 @@ function isAutoContextSize(value: unknown): boolean {
   return value === 'auto' || Number(value) === -1;
 }
 
-function shellQuote(token: string): string {
-  if (token === '') return "''";
-  if (/^[A-Za-z0-9_\-./:=@]+$/.test(token)) return token;
-  return `'${token.replace(/'/g, `'\\''`)}'`;
-}
-
-function formatCommand(modelName: string, args: string[]): string {
-  const parts = ['lemonade', 'load', shellQuote(modelName), ...args.map(shellQuote)];
-  return parts.join(' ');
-}
-
 interface SourceRow {
   key: string;
   label: string;
@@ -124,13 +113,13 @@ const EffectiveSettingsModal: React.FC<EffectiveSettingsModalProps> = ({
   const argsField = backendArgsFieldForRecipe(recipe);
   const canEditArgs = backendSupportsArgs(recipe) && !!argsField;
 
-  const [effective, setEffective] = useState<EffectiveLoadCommand | null>(null);
+  const [effective, setEffective] = useState<ModelOptions | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const [unlocked, setUnlocked] = useState(false);
   const [draft, setDraft] = useState('');
-  const [preview, setPreview] = useState<EffectiveLoadCommand | null>(null);
+  const [preview, setPreview] = useState<ModelOptions | null>(null);
   const [previewError, setPreviewError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [notice, setNotice] = useState<string | null>(null);
@@ -160,9 +149,9 @@ const EffectiveSettingsModal: React.FC<EffectiveSettingsModalProps> = ({
     setLoading(true);
     setError(null);
     try {
-      const result = await api.effectiveLoadCommand(modelName, undefined, modelInfo);
+      const result = await api.effectiveModelOptions(modelName, undefined, modelInfo);
       setEffective(result);
-      const committed = argsField ? result.options[argsField] : undefined;
+      const committed = argsField ? result.effective[argsField] : undefined;
       setDraft(typeof committed === 'string' ? committed : '');
     } catch (err) {
       setError(friendlyErrorMessage(err));
@@ -223,7 +212,7 @@ const EffectiveSettingsModal: React.FC<EffectiveSettingsModalProps> = ({
     const handle = setTimeout(async () => {
       setPreviewError(null);
       try {
-        const result = await api.effectiveLoadCommand(modelName, { [argsField]: draft, merge_args: false }, modelInfo);
+        const result = await api.effectiveModelOptions(modelName, { [argsField]: draft, merge_args: false }, modelInfo);
         if (!cancelled) setPreview(result);
       } catch (err) {
         if (!cancelled) { setPreview(null); setPreviewError(friendlyErrorMessage(err)); }
@@ -313,7 +302,7 @@ const EffectiveSettingsModal: React.FC<EffectiveSettingsModalProps> = ({
       return { value: runtimeContext.toLocaleString(), source: 'Runtime' };
     }
 
-    const effectiveContext = positiveContextSize(effective?.options?.ctx_size);
+    const effectiveContext = positiveContextSize(effective?.resolved_ctx_size);
     if (effectiveContext !== null) {
       return { value: effectiveContext.toLocaleString(), source: 'Effective load' };
     }
@@ -373,8 +362,10 @@ const EffectiveSettingsModal: React.FC<EffectiveSettingsModalProps> = ({
 
   if (!open) return null;
 
-  const previewArgs = preview?.args ?? effective?.args ?? [];
-  const backendLabel = effective?.backend || '—';
+  const shown = preview ?? effective;
+  const loadCommand = shown?.load_command ?? '';
+  const backend = shown ? shown.effective[`${shown.recipe}_backend`] : undefined;
+  const backendLabel = typeof backend === 'string' && backend ? backend : '—';
 
   const body = (
     <div className="inspect-modal-overlay effective-settings-overlay" onClick={onClose}>
@@ -501,7 +492,7 @@ const EffectiveSettingsModal: React.FC<EffectiveSettingsModalProps> = ({
             {error && <p className="effective-settings__error">{error}</p>}
             {!loading && !error && (
               <>
-                <pre className="effective-settings__command"><code>{formatCommand(modelName, previewArgs)}</code></pre>
+                <pre className="effective-settings__command"><code>{loadCommand}</code></pre>
                 <p className="effective-settings__note">
                   <Icon name="info" size={12} /> Fixed launch flags (model path, port, chat template, metrics) are added by the server at load time and are not shown here.
                 </p>

--- a/src/cpp/include/lemon/recipe_options.h
+++ b/src/cpp/include/lemon/recipe_options.h
@@ -25,7 +25,6 @@ public:
     /// Add recipe options as CLI flags (used by lemonade CLI client only)
     static void add_cli_options(CLI::App& app, json& storage);
 #endif
-    static std::vector<std::string> to_cli_options(const json& raw_options);
     static std::vector<std::string> known_keys();
 
     /// Option names this recipe accepts, in declaration order.

--- a/src/cpp/include/lemon/router.h
+++ b/src/cpp/include/lemon/router.h
@@ -209,9 +209,6 @@ public:
 
     RecipeOptions get_model_recipe_options(const std::string& model_name) const;
 
-    RecipeOptions resolve_effective_recipe_options(const ModelInfo& model_info,
-                                                   const RecipeOptions& options) const;
-
     ModelType get_model_type(const std::string& model_name = "") const;
 
     std::string get_backend_address() const;

--- a/src/cpp/include/lemon/server.h
+++ b/src/cpp/include/lemon/server.h
@@ -178,7 +178,6 @@ private:
     // model, so it's parsed fresh from the request body each call.
     void handle_routing_validate(const httplib::Request& req, httplib::Response& res);
     void handle_load(const httplib::Request& req, httplib::Response& res);
-    void handle_load_command(const httplib::Request& req, httplib::Response& res);
     void handle_unload(const httplib::Request& req, httplib::Response& res);
     void handle_pin(const httplib::Request& req, httplib::Response& res);
     void handle_delete(const httplib::Request& req, httplib::Response& res);

--- a/src/cpp/server/recipe_options.cpp
+++ b/src/cpp/server/recipe_options.cpp
@@ -45,26 +45,6 @@ static const json& get_defaults() {
     return defaults;
 }
 
-// Flat option name -> CLI flag, for to_cli_options(). ctx_size/merge_args are
-// the common flags; the rest come from descriptor options that declare a flag.
-static const std::map<std::string, std::string>& get_option_to_cli_flag() {
-    static const std::map<std::string, std::string> mapping = [] {
-        std::map<std::string, std::string> m{
-            {"ctx_size", "--ctx-size"},
-            {"merge_args", "--merge-args"},
-        };
-        for (const auto* desc : lemon::backends::all_descriptors()) {
-            for (const auto& opt : desc->options) {
-                if (!opt.cli_flag.empty()) {
-                    m[opt.name] = opt.cli_flag;
-                }
-            }
-        }
-        return m;
-    }();
-    return mapping;
-}
-
 static std::vector<std::string> get_keys_for_recipe(const std::string& recipe) {
     std::vector<std::string> keys;
     if (const auto* desc = lemon::backends::descriptor_for(recipe)) {
@@ -139,32 +119,6 @@ static bool try_get_backend_options(const std::string& opt_name, SystemInfo::Sup
     return is_backend_option;
 }
 #endif
-
-std::vector<std::string> RecipeOptions::to_cli_options(const json& raw_options) {
-    std::vector<std::string> cli;
-
-    for (auto& [opt_name, cli_flag] : get_option_to_cli_flag()) {
-        if (raw_options.contains(opt_name)) {
-            auto val = raw_options[opt_name];
-            if (!val.is_null() && val != "") {
-                if (val.is_boolean()) {
-                    cli.push_back(val.get<bool>() ? cli_flag : lemon::utils::negate_flag(cli_flag));
-                } else {
-                    cli.push_back(cli_flag);
-                    if (val.is_number_float()) {
-                        cli.push_back(std::to_string((double) val));
-                    } else if (val.is_number_integer()) {
-                        cli.push_back(std::to_string((int) val));
-                    } else {
-                        cli.push_back(val);
-                    }
-                }
-            }
-        }
-    }
-
-    return cli;
-}
 
 std::vector<std::string> RecipeOptions::known_keys() {
     std::vector<std::string> keys;

--- a/src/cpp/server/router.cpp
+++ b/src/cpp/server/router.cpp
@@ -1385,23 +1385,6 @@ RecipeOptions Router::get_model_recipe_options(const std::string& model_name) co
     return RecipeOptions();
 }
 
-RecipeOptions Router::resolve_effective_recipe_options(const ModelInfo& model_info,
-                                                       const RecipeOptions& options) const {
-    const std::string backend_option = model_info.recipe + "_backend";
-
-    RecipeOptions tentative = options.inherit(model_info.recipe_options.inherit(
-        RecipeOptions(model_info.recipe, config_->recipe_options(""))));
-    json backend_json = tentative.get_option(backend_option);
-    const std::string backend = backend_json.is_string() ? backend_json.get<std::string>() : "";
-
-    // Second pass: rebuild defaults using the resolved backend.
-    // Per-architecture defaults sit between global config and model-level recipe_options.
-    RecipeOptions default_opt = RecipeOptions(model_info.recipe, config_->recipe_options(backend));
-    RecipeOptions arch_opts(model_info.recipe,
-                            model_manager_->get_architecture_defaults(model_info.gguf.architecture));
-    return options.inherit(model_info.recipe_options.inherit(arch_opts.inherit(default_opt)));
-}
-
 ModelType Router::get_model_type(const std::string& model_name) const {
     std::lock_guard<std::mutex> lock(load_mutex_);
     WrappedServer* server = model_name.empty()

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -1264,10 +1264,6 @@ void Server::setup_routes(httplib::Server &web_server) {
         handle_load(req, res);
     });
 
-    register_post("load/command", [this](const httplib::Request& req, httplib::Response& res) {
-        handle_load_command(req, res);
-    });
-
     register_post("unload", [this](const httplib::Request& req, httplib::Response& res) {
         handle_unload(req, res);
     });
@@ -5905,57 +5901,6 @@ void Server::handle_load(const httplib::Request& req, httplib::Response& res) {
             }}};
             res.set_content(error.dump(), "application/json");
         }
-    }
-}
-
-void Server::handle_load_command(const httplib::Request& req, httplib::Response& res) {
-    nlohmann::json request_json;
-    if (!parse_required_json_body(req, res, request_json)) return;
-
-    std::string model_name;
-    try {
-        model_name = request_json.value("model_name", "");
-        if (model_name.empty()) {
-            res.status = 400;
-            res.set_content(nlohmann::json{{"error", "model_name is required"}}.dump(), "application/json");
-            return;
-        }
-
-        if (!model_manager_->model_exists(model_name)) {
-            res.status = 404;
-            res.set_content(create_model_error(model_name, "Model not found").dump(), "application/json");
-            return;
-        }
-
-        auto info = model_manager_->get_model_info(model_name);
-        RecipeOptions options = RecipeOptions(info.recipe, request_json);
-        RecipeOptions effective = router_->resolve_effective_recipe_options(info, options);
-
-        bool ctx_size_auto_resolved = false;
-        int64_t auto_ctx = resolve_auto_ctx_size(effective, info);
-        if (auto_ctx > 0) {
-            effective.set_option("ctx_size", auto_ctx);
-            ctx_size_auto_resolved = true;
-        }
-
-        json backend_json = effective.get_option(info.recipe + "_backend");
-
-        nlohmann::json response = {
-            {"model_name", model_name},
-            {"recipe", info.recipe},
-            {"backend", backend_json.is_string() ? backend_json.get<std::string>() : ""},
-            {"options", effective.to_json()},
-            {"args", RecipeOptions::to_cli_options(effective.to_json())},
-            {"ctx_size_auto_resolved", ctx_size_auto_resolved}
-        };
-        res.set_content(response.dump(), "application/json");
-    } catch (const std::exception& e) {
-        LOG(ERROR, "Server") << "ERROR in handle_load_command: " << e.what() << std::endl;
-        res.status = 500;
-        auto error_response = model_name.empty()
-            ? nlohmann::json{{"error", e.what()}}
-            : create_model_error(model_name, e.what());
-        res.set_content(error_response.dump(), "application/json");
     }
 }
 


### PR DESCRIPTION
The effective-settings modal was the only caller of the experimental `/load/command`. It now uses `/models/{id}/options`, and shows that endpoint's curl command instead of the synthesized `lemonade load` one.

- Client-staged options still have to reach the server for the command to describe the load the app would actually send, so the modal's calls go through `dry_run: true` (resolves, persists nothing). The staged set spans every recipe, so it's filtered against `defaults` — an unrecognized name is a 400.
- `$LEMONADE_BASE_URL` is substituted with the client's base URL; `$LEMONADE_API_KEY` deliberately stays a variable rather than pasting a live credential into copyable UI text.
- Dead after the removal, both deleted: `Router::resolve_effective_recipe_options` (the merge kept it alongside main's identically-bodied `resolve_effective_options`) and `RecipeOptions::to_cli_options` plus its CLI-flag table.

`router.cpp` now matches main's blob exactly.

Verified: `ctest -L cpp-ci` 36/36; `test/server_endpoints.py` 132 passed; `test/server_cli2.py` 63 passed; `tsc --noEmit` clean. Against a live server, `/v1/load/command` returns 404 and the dry-run preview reflects draft args while leaving `saved` empty.

<img width="618" height="251" alt="image" src="https://github.com/user-attachments/assets/c5583b84-1558-47c7-952a-efd7cd7c9513" />

The Effective Settings GUI now shows the actual HTTP request the GUI will send, not the CLI request (I did not understand why the GUI should reference the CLI before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)