### PR TITLE
fix(npu): pre-reject NPU loads when auto-tune can only reserve fallback ctx (#1151)

### DIFF
--- a/src/cpp/server/router.cpp
+++ b/src/cpp/server/router.cpp
@@ -989,9 +989,15 @@ void Router::load_model(const std::string& model_name,
         // reserve the fallback ctx_size, the NPU driver's own runtime overhead
         // will push the system past its memory limit during first inference,
         // causing the backend to hang. Reject early with a clear error.
+        //
+        // AUTO_CTX_FALLBACK is also returned when memory cannot be determined at
+        // all (get_available_memory_gb() == 0, e.g. some Windows NPU/iGPU
+        // systems), so gate on known-low memory to avoid rejecting large models
+        // on high-memory machines where the driver overhead would fit fine.
         if (auto_ctx == AUTO_CTX_FALLBACK
             && (model_info.device & DEVICE_NPU)
-            && model_info.size > 10.0) {
+            && model_info.size > 10.0
+            && get_available_memory_gb(model_info.device) > 0) {
             throw std::runtime_error(
                 "Not enough memory to load " + canonical_model_name
                 + " (" + std::to_string(static_cast<int>(model_info.size))

--- a/src/cpp/server/router.cpp
+++ b/src/cpp/server/router.cpp
@@ -985,6 +985,20 @@ void Router::load_model(const std::string& model_name,
             effective_options.set_option("ctx_size", auto_ctx);
         }
 
+        // NPU models on memory-constrained systems: when auto-tune can only
+        // reserve the fallback ctx_size, the NPU driver's own runtime overhead
+        // will push the system past its memory limit during first inference,
+        // causing the backend to hang. Reject early with a clear error.
+        if (auto_ctx == AUTO_CTX_FALLBACK
+            && (model_info.device & DEVICE_NPU)
+            && model_info.size > 10.0) {
+            throw std::runtime_error(
+                "Not enough memory to load " + canonical_model_name
+                + " (" + std::to_string(static_cast<int>(model_info.size))
+                + " GB). The NPU driver needs additional working memory beyond"
+                + " model weights. Free up memory or try a smaller model.");
+        }
+
         LOG(DEBUG, "Router") << "Effective settings: " << effective_options.to_log_string() << std::endl;
 
         // Create new backend server


### PR DESCRIPTION
## What

Focused extract from #2459 (commit 55d5133), which was blocked on scope — this is the single #1151 piece that has **not** already landed on main.

When auto-tune cannot compute a real memory budget it returns `AUTO_CTX_FALLBACK` (4096). On those systems, an NPU model >10GB still loads, but the RyzenAI driver's runtime overhead pushes the machine past its RAM limit during first inference — the backend hangs silently (issue #1151). This rejects early with a clear error instead.

```cpp
if (auto_ctx == AUTO_CTX_FALLBACK
    && (model_info.device & DEVICE_NPU)
    && model_info.size > 10.0) {
    throw std::runtime_error("Not enough memory to load ...");
}
```

## Status of the other two layers (already on main)

- CURL 300s timeout — `HttpClient::default_timeout_seconds_` (http_client.cpp)
- Backend watchdog — generalized via `WrappedServer` (backends now subclass it; ryzenai included)

## Caveat

This prevents the *hang* on memory-constrained boxes. The underlying `maskedsoftmax_maskedsoftmax_v2_a16_40_128_128_128` "Transaction not found" error (also reported on 890M machines with plenty of RAM) is a RyzenAI runtime/transaction-cache bug — needs AMD driver repro, out of lemonade's scope.

Closes #1151