### PR TITLE
fix(flm): correctly report downloaded model size

### DIFF
--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -2518,7 +2518,7 @@ void ModelManager::build_cache() {
 
     for (auto& [name, info] : all_models) {
         populate_model_metadata(info);
-        if (info.downloaded) {
+        if (info.downloaded && !backend_self_manages_downloads(info.recipe)) {
             refresh_on_disk_size(info);
         }
         models_cache_[name] = info;


### PR DESCRIPTION
# Summary

Fixes #3165 

### Before
<img width="310" height="232" alt="image" src="https://github.com/user-attachments/assets/81b0ef52-ea91-4694-9be6-f515da66275d" />


### After
<img width="319" height="181" alt="image" src="https://github.com/user-attachments/assets/60f1f9d4-22e8-4eaa-b271-cf9b28cfb207" />


