### PR TITLE
fix(flm): stop re-pulling already-downloaded models on every load

### DIFF
--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -3327,7 +3327,7 @@ bool ModelManager::is_model_downloaded(const std::string& model_name) {
         : model_name;
     auto it = models_cache_.find(canonical_name);
     if (it != models_cache_.end()) {
-        if (it->second.downloaded) {
+        if (it->second.downloaded && !backend_self_manages_downloads(it->second.recipe)) {
             bool still_complete = are_required_checkpoints_complete(it->second);
             if (!still_complete) {
                 it->second.downloaded = false;


### PR DESCRIPTION

Fixes #3129

## Summary

FLM's `resolve_checkpoint_path()` returns the checkpoint string itself, not a filesystem path:

https://github.com/lemonade-sdk/lemonade/blob/379ef10d1d58197ce4d6a3a04c97167d9616aa1f/src/cpp/server/backends/fastflowlm/fastflowlm_server.cpp#L466-L470

`is_checkpoint_path_complete()` doesn't know that. It takes whatever `resolved_path` resolves to and checks it straight against the filesystem:

https://github.com/lemonade-sdk/lemonade/blob/379ef10d1d58197ce4d6a3a04c97167d9616aa1f/src/cpp/server/model_manager.cpp#L2185-L2203

For FLM that resolved path is a tag like `"gemma4-it:e2b"`, never a real file, so `fs::exists()` always returns false.

`is_model_downloaded()` re-runs this check on every call, even when the cache already says a model is downloaded:

https://github.com/lemonade-sdk/lemonade/blob/379ef10d1d58197ce4d6a3a04c97167d9616aa1f/src/cpp/server/model_manager.cpp#L3319-L3339

Since the check always fails for flm, `downloaded` gets flipped back to `false` on every call, which forces a `pull --force` on every `/load` even for models already installed.

This PR skips that re-check for backends where `BackendDescriptor::self_manages_downloads` is set, since there's no local file for it to check in the first place. The backend (flm) is the sole authority on whether the model is present.


## Compare changes

Reloaded an already-downloaded model (`qwen3.5-9b-FLM`) against a live lemond instance, before and after the fix.

```mermaid
gantt
    dateFormat X
    axisFormat %S s
    title FLM /load: before vs after the fix
    section Before (~47s)
    force pull, re-verify every checkpoint file :crit, 0, 39
    cache invalidate + rebuild                  :39, 40
    force-free pull (backend's own load())      :40, 40
    NPU model startup                           :40, 47
    section After (~7.2s)
    force-free pull (backend's own load()) :0, 0
    NPU model startup                       :0, 7
```

### Before

`is_model_downloaded()` reports `false` for an already-installed model. `/load` logs `Model not downloaded, downloading...` and calls `download_registered_model()`, which pulls with `--force` and re-verifies every checkpoint file one by one. The backend's own `load()` then pulls again right after, without `--force`. The model gets pulled twice:

<details>
<summary>before.log</summary>

```
2026-08-16 20:10:19.970 [Debug] (Server) GET /api/v1/system-info
2026-08-16 20:10:20.009 [Debug] (Server) POST /api/v1/load
2026-08-16 20:10:20.009 [Debug] (Server) ===== LOAD ENDPOINT ENTERED (Thread: 134303652488896) =====
2026-08-16 20:10:20.010 [Info] (Server) Ensuring model loaded: qwen3.5-9b-FLM 
2026-08-16 20:10:20.010 [Info] (Server) Model not downloaded, downloading...
2026-08-16 20:10:20.010 [Info] (ModelManager) Pulling FLM model: qwen3.5:9b
2026-08-16 20:10:20.010 [Info] (ProcessManager) Starting process: "/var/lib/lemonade/.cache/lemonade/bin/flm/npu/flm" "pull" "qwen3.5:9b" "--force"
2026-08-16 20:10:20.033 [Info] (FLM) [FLM]  Pulling model from HuggingFace...
2026-08-16 20:10:20.033 [Info] (FLM) [FLM]  Model: qwen3.5:9b
2026-08-16 20:10:20.033 [Info] (FLM) [FLM]  Name: Qwen3.5-9B-NPU2
2026-08-16 20:10:20.235 [Info] (FLM) [FLM]  Checking file: config.json...
2026-08-16 20:10:20.235 [Info] (FLM) [FLM]  Success!
2026-08-16 20:10:20.235 [Info] (FLM) [FLM]  Checking file: model.q4nx...
2026-08-16 20:10:54.031 [Info] (FLM) [FLM]  Success!
2026-08-16 20:10:54.031 [Info] (FLM) [FLM]  Checking file: tokenizer.json...
2026-08-16 20:10:54.091 [Info] (FLM) [FLM]  Success!
2026-08-16 20:10:54.091 [Info] (FLM) [FLM]  Checking file: tokenizer_config.json...
2026-08-16 20:10:54.091 [Info] (FLM) [FLM]  Success!
2026-08-16 20:10:54.091 [Info] (FLM) [FLM]  Checking file: vision_weight.q4nx...
2026-08-16 20:10:58.508 [Info] (FLM) [FLM]  Success!
2026-08-16 20:10:58.508 [Info] (FLM) [FLM]  Checking file: chat_template.jinja...
2026-08-16 20:10:58.508 [Info] (FLM) [FLM]  Success!
2026-08-16 20:10:58.508 [Info] (FLM) [FLM]  All required files are present.
2026-08-16 20:10:58.508 [Info] (FLM) [FLM]  Present files (6):
2026-08-16 20:10:58.508 [Info] (FLM)   - config.json
2026-08-16 20:10:58.508 [Info] (FLM)   - model.q4nx
2026-08-16 20:10:58.508 [Info] (FLM)   - tokenizer.json
2026-08-16 20:10:58.508 [Info] (FLM)   - tokenizer_config.json
2026-08-16 20:10:58.508 [Info] (FLM)   - vision_weight.q4nx
2026-08-16 20:10:58.508 [Info] (FLM)   - chat_template.jinja
2026-08-16 20:10:58.689 [Info] (FLM) [FLM]  No files to download for model: qwen3.5:9b
2026-08-16 20:10:58.689 [Info] (ModelManager) FLM model pull completed successfully
2026-08-16 20:10:58.689 [Info] (ModelManager) Invalidated model cache after download for 'qwen3.5-9b-FLM' (backend rebuilds its model list)
2026-08-16 20:10:58.689 [Info] (ModelManager) Building models cache...
2026-08-16 20:10:58.691 [Info] (ModelManager) FLM binary found at: /var/lib/lemonade/.cache/lemonade/bin/flm/npu/flm
2026-08-16 20:10:59.863 [Info] (ModelManager) Cache built: 171 total, 23 downloaded
2026-08-16 20:10:59.864 [Debug] (Router) Loading model: qwen3.5-9b-FLM (checkpoint: qwen3.5:9b, recipe: flm, type: llm, device: npu, residency: standard)
2026-08-16 20:10:59.864 [Debug] (Router) Effective settings: ctx_size=32768, flm_args=(none), merge_args=true, auto_evict=(none), evict_idle_timeout=300, downsize_idle_timeout=60, evict_weight_factor=1.000000, pinned=false
2026-08-16 20:10:59.864 [Debug] (Router) Created backend for recipe 'flm' via registry
2026-08-16 20:10:59.864 [Debug] (Router) Starting backend (this may take a moment)...
2026-08-16 20:10:59.864 [Info] (FastFlowLM) Loading model: qwen3.5-9b-FLM
2026-08-16 20:10:59.864 [Debug] (BackendManager) Installing flm:npu
2026-08-16 20:10:59.918 [Debug] (flm Server) Found executable at: /var/lib/lemonade/.cache/lemonade/bin/flm/npu/flm
2026-08-16 20:10:59.918 [Info] (FastFlowLM) Found flm at: /var/lib/lemonade/.cache/lemonade/bin/flm/npu/flm
2026-08-16 20:11:00.072 [Info] (FastFlowLM) Pulling model with FLM: qwen3.5:9b
2026-08-16 20:11:00.073 [Info] (FastFlowLM) Found flm at: /var/lib/lemonade/.cache/lemonade/bin/flm/npu/flm
2026-08-16 20:11:00.073 [Info] (ProcessManager) Starting process: "/var/lib/lemonade/.cache/lemonade/bin/flm/npu/flm" "pull" "qwen3.5:9b"
2026-08-16 20:11:00.073 [Debug] (ProcessManager) Starting process with inherited output: /var/lib/lemonade/.cache/lemonade/bin/flm/npu/flm pull qwen3.5:9b
2026-08-16 20:11:00.075 [Info] (ProcessManager) Process started successfully, PID: 5228
2026-08-16 20:11:00.075 [Info] (FastFlowLM) Waiting for model download to complete...
2026-08-16 20:11:00.175 [Info] (FastFlowLM) Model pull completed successfully
2026-08-16 20:11:00.175 [Debug] (WrappedServer) FastFlowLM will use port: 8001
2026-08-16 20:11:00.176 [Info] (FastFlowLM) Starting flm-server...
2026-08-16 20:11:00.176 [Info] (ProcessManager) Starting process: "/var/lib/lemonade/.cache/lemonade/bin/flm/npu/flm" "serve" "qwen3.5:9b" "--ctx-len" "32768" "--port" "8001" "--host" "127.0.0.1" "--quiet"
2026-08-16 20:11:00.176 [Debug] (ProcessManager) Starting process with filtered output: /var/lib/lemonade/.cache/lemonade/bin/flm/npu/flm serve qwen3.5:9b --ctx-len 32768 --port 8001 --host 127.0.0.1 --quiet
2026-08-16 20:11:00.180 [Info] (ProcessManager) Process started successfully, PID: 5231
2026-08-16 20:11:00.180 [Info] (ProcessManager) Process started successfully
2026-08-16 20:11:00.180 [Info] (FastFlowLM) Waiting for FastFlowLM to be ready...
2026-08-16 20:11:00.699 [Info] (Process) [FLM]  New version detected! (current v0.9.46, latest v1.0.1)
2026-08-16 20:11:00.699 [Info] (Process) [FLM]  Download link: https://github.com/FastFlowLM/FastFlowLM/releases/latest/download/flm-setup.exe
2026-08-16 20:11:00.699 [Info] (Process) [FLM]  Using user-specified port: 8001
2026-08-16 20:11:01.217 [Info] (Process) [31m[FLM]  Qwen3.5 pre-resize image height to 720 pixels if larger than that[0m
2026-08-16 20:11:01.217 [Info] (Process) [FLM]  Loading model: /var/lib/lemonade/.config/flm/models/Qwen3.5-9B-NPU2
2026-08-16 20:11:06.982 [Info] (Process) [FLM]  Starting server on port 8001...
2026-08-16 20:11:06.982 [Info] (Process) [🔗 ]  TCP connection established - Remote: 127.0.0.1:60924
2026-08-16 20:11:06.982 [Info] (Process) [🔗 ]  TCP connection established - Remote: 127.0.0.1:46260
2026-08-16 20:11:06.982 [Info] (Process) [🔗 ]  TCP connection established - Remote: 127.0.0.1:46268
2026-08-16 20:11:06.982 [Info] (Process) [FLM]  WebServer started on port 8001 with 10 I/O threads
2026-08-16 20:11:06.982 [Info] (Process) [FLM]  Press Ctrl+C to stop.
2026-08-16 20:11:06.982 [Info] (Process) [TCP]  Read 88 bytes from socket
2026-08-16 20:11:06.982 [Info] (Process) ================================================
2026-08-16 20:11:06.982 [Info] (Process) [⬇️ ]  Incoming Request: GET
2026-08-16 20:11:06.982 [Info] (Process) [TCP]  Read 88 bytes from socket
2026-08-16 20:11:06.982 [Info] (Process) ================================================
2026-08-16 20:11:06.982 [Info] (Process) [⬇️ ]  Incoming Request: GET
2026-08-16 20:11:06.982 [Info] (Process) [LOG]  Time stamp: 20:11:06 08:16:2026
2026-08-16 20:11:06.982 [Info] (Process) [LOG]  Target: /api/tags
2026-08-16 20:11:06.982 [Info] (Process) [LOG]  Version: 11
2026-08-16 20:11:06.982 [Info] (Process) [LOG]  Keep-Alive: 1
2026-08-16 20:11:06.982 [Info] (Process) [LOG]  Time stamp: 20:11:06 08:16:2026
2026-08-16 20:11:06.982 [Info] (Process) [LOG]  Target: /api/tags
2026-08-16 20:11:06.982 [Info] (Process) [LOG]  Version: 11
2026-08-16 20:11:06.982 [Info] (Process) [LOG]  Keep-Alive: 1
2026-08-16 20:11:06.982 [Info] (Process) [TCP]  Read 88 bytes from socket
2026-08-16 20:11:06.982 [Info] (Process) ================================================
2026-08-16 20:11:06.982 [Info] (Process) [⬇️ ]  Incoming Request: GET
2026-08-16 20:11:06.982 [Info] (Process) [LOG]  Time stamp: 20:11:06 08:16:2026
2026-08-16 20:11:06.982 [Info] (Process) [LOG]  Target: /api/tags
2026-08-16 20:11:06.982 [Info] (Process) [LOG]  Version: 11
2026-08-16 20:11:06.982 [Info] (Process) [LOG]  Keep-Alive: 1
2026-08-16 20:11:06.982 [Info] (Process) [🔴 ]  Client disconnected; cancelling active request
2026-08-16 20:11:06.982 [Info] (Process) [🔴 ]  Client disconnected; cancelling active request
2026-08-16 20:11:06.982 [Info] (Process) [🔴 ]  Client disconnected; cancelling active request
2026-08-16 20:11:06.982 [Info] (Process) ================================================
2026-08-16 20:11:06.982 [Info] (Process) ================================================
2026-08-16 20:11:06.982 [Info] (Process) ================================================
2026-08-16 20:11:06.982 [Info] (Process) [🔒 ]  TCP connection closed - Remote endpoint unavailable
2026-08-16 20:11:06.982 [Info] (Process) [🔒 ]  TCP connection closed - Remote endpoint unavailable
2026-08-16 20:11:06.982 [Info] (Process) [🔒 ]  TCP connection closed - Remote endpoint unavailable
2026-08-16 20:11:07.185 [Info] (Process) [🔗 ]  TCP connection established - Remote: 127.0.0.1:46278
2026-08-16 20:11:07.185 [Info] (Process) [TCP]  Read 88 bytes from socket
2026-08-16 20:11:07.185 [Info] (Process) ================================================
2026-08-16 20:11:07.185 [Info] (Process) [⬇️ ]  Incoming Request: GET
2026-08-16 20:11:07.185 [Info] (Process) [LOG]  Time stamp: 20:11:07 08:16:2026
2026-08-16 20:11:07.185 [Info] (Process) [LOG]  Target: /api/tags
2026-08-16 20:11:07.185 [Info] (Process) [LOG]  Version: 11
2026-08-16 20:11:07.185 [Info] (Process) [LOG]  Keep-Alive: 1
2026-08-16 20:11:07.185 [Info] (Process) ================================================
2026-08-16 20:11:07.185 [Info] (Process) [🔒 ]  TCP connection closed - Remote: 127.0.0.1:46278
2026-08-16 20:11:07.186 [Info] (FastFlowLM) FastFlowLM is ready!
2026-08-16 20:11:07.187 [Info] (BackendWatchdog) Started watchdog for FastFlowLM using http://127.0.0.1:8001/api/tags (streaming=on, non_streaming=on)
2026-08-16 20:11:07.187 [Info] (FastFlowLM) Model loaded on port 8001
2026-08-16 20:11:07.187 [Debug] (Router) Backend started successfully in 7322ms
2026-08-16 20:11:07.187 [Info] (Router) Model loaded successfully. Total loaded: 1
2026-08-16 20:11:07.187 [Debug] (Server) POST /api/v1/load - 200
2026-08-16 20:11:07.292 [Debug] (Server) GET /api/v1/models
```
</details>

### After

`is_model_downloaded()` correctly reports `true`. No `Model not downloaded, downloading...` log, no `download_registered_model()` call. Only the backend's own `load()` pulls, once, without `--force`:

<details>
<summary>after.log</summary>

```
2026-08-16 20:13:08.050 [Debug] (Server) GET /api/v1/system-info
2026-08-16 20:13:08.100 [Debug] (Server) POST /api/v1/load
2026-08-16 20:13:08.100 [Debug] (Server) ===== LOAD ENDPOINT ENTERED (Thread: 137113928455872) =====
2026-08-16 20:13:08.100 [Info] (Server) Ensuring model loaded: qwen3.5-9b-FLM 
2026-08-16 20:13:08.100 [Debug] (Router) Loading model: qwen3.5-9b-FLM (checkpoint: qwen3.5:9b, recipe: flm, type: llm, device: npu, residency: standard)
2026-08-16 20:13:08.100 [Debug] (Router) Effective settings: ctx_size=32768, flm_args=(none), merge_args=true, auto_evict=(none), evict_idle_timeout=300, downsize_idle_timeout=60, evict_weight_factor=1.000000, pinned=false
2026-08-16 20:13:08.100 [Debug] (Router) Created backend for recipe 'flm' via registry
2026-08-16 20:13:08.100 [Debug] (Router) Starting backend (this may take a moment)...
2026-08-16 20:13:08.100 [Info] (FastFlowLM) Loading model: qwen3.5-9b-FLM
2026-08-16 20:13:08.100 [Debug] (BackendManager) Installing flm:npu
2026-08-16 20:13:08.152 [Debug] (flm Server) Found executable at: /var/lib/lemonade/.cache/lemonade/bin/flm/npu/flm
2026-08-16 20:13:08.152 [Info] (FastFlowLM) Found flm at: /var/lib/lemonade/.cache/lemonade/bin/flm/npu/flm
2026-08-16 20:13:08.168 [Info] (FastFlowLM) Pulling model with FLM: qwen3.5:9b
2026-08-16 20:13:08.168 [Info] (FastFlowLM) Found flm at: /var/lib/lemonade/.cache/lemonade/bin/flm/npu/flm
2026-08-16 20:13:08.168 [Info] (ProcessManager) Starting process: "/var/lib/lemonade/.cache/lemonade/bin/flm/npu/flm" "pull" "qwen3.5:9b"
2026-08-16 20:13:08.168 [Debug] (ProcessManager) Starting process with inherited output: /var/lib/lemonade/.cache/lemonade/bin/flm/npu/flm pull qwen3.5:9b
2026-08-16 20:13:08.169 [Info] (ProcessManager) Process started successfully, PID: 5434
2026-08-16 20:13:08.169 [Info] (FastFlowLM) Waiting for model download to complete...
2026-08-16 20:13:08.269 [Info] (FastFlowLM) Model pull completed successfully
2026-08-16 20:13:08.269 [Debug] (WrappedServer) FastFlowLM will use port: 8002
2026-08-16 20:13:08.269 [Info] (FastFlowLM) Starting flm-server...
2026-08-16 20:13:08.269 [Info] (ProcessManager) Starting process: "/var/lib/lemonade/.cache/lemonade/bin/flm/npu/flm" "serve" "qwen3.5:9b" "--ctx-len" "32768" "--port" "8002" "--host" "127.0.0.1" "--quiet"
2026-08-16 20:13:08.269 [Debug] (ProcessManager) Starting process with filtered output: /var/lib/lemonade/.cache/lemonade/bin/flm/npu/flm serve qwen3.5:9b --ctx-len 32768 --port 8002 --host 127.0.0.1 --quiet
2026-08-16 20:13:08.271 [Info] (ProcessManager) Process started successfully, PID: 5437
2026-08-16 20:13:08.271 [Info] (ProcessManager) Process started successfully
2026-08-16 20:13:08.271 [Info] (FastFlowLM) Waiting for FastFlowLM to be ready...
2026-08-16 20:13:08.346 [Info] (Process) [FLM]  New version detected! (current v0.9.46, latest v1.0.1)
2026-08-16 20:13:08.346 [Info] (Process) [FLM]  Download link: https://github.com/FastFlowLM/FastFlowLM/releases/latest/download/flm-setup.exe
2026-08-16 20:13:08.346 [Info] (Process) [FLM]  Using user-specified port: 8002
2026-08-16 20:13:08.861 [Info] (Process) [FLM]  Loading model: /var/lib/lemonade/.config/flm/models/Qwen3.5-9B-NPU2
2026-08-16 20:13:08.861 [Info] (Process) [31m[FLM]  Qwen3.5 pre-resize image height to 720 pixels if larger than that[0m
2026-08-16 20:13:14.367 [Info] (Process) [FLM]  Starting server on port 8002...
2026-08-16 20:13:14.368 [Info] (Process) [🔗 ]  TCP connection established - Remote: 127.0.0.1:35870
2026-08-16 20:13:14.368 [Info] (Process) [FLM]  WebServer started on port 8002 with 10 I/O threads
2026-08-16 20:13:14.368 [Info] (Process) [FLM]  Press Ctrl+C to stop.
2026-08-16 20:13:14.368 [Info] (Process) [🔗 ]  TCP connection established - Remote: 127.0.0.1:35872
2026-08-16 20:13:14.368 [Info] (Process) [TCP]  Read 88 bytes from socket
2026-08-16 20:13:14.368 [Info] (Process) ================================================
2026-08-16 20:13:14.368 [Info] (Process) [⬇️ ]  [🔗 ]  Incoming Request: GETTCP connection established - Remote: 127.0.0.1:53992
2026-08-16 20:13:14.368 [Info] (Process) [TCP]  Read 88 bytes from socket
2026-08-16 20:13:14.368 [Info] (Process) ================================================
2026-08-16 20:13:14.368 [Info] (Process) [⬇️ ]  Incoming Request: GET
2026-08-16 20:13:14.368 [Info] (Process) [TCP]  Read 88 bytes from socket
2026-08-16 20:13:14.368 [Info] (Process) ================================================
2026-08-16 20:13:14.368 [Info] (Process) [⬇️ ]  Incoming Request: GET
2026-08-16 20:13:14.368 [Info] (Process) [LOG]  Time stamp: 20:13:14 08:16:2026[
2026-08-16 20:13:14.368 [Info] (Process) LOG]  [LOG]  Target: /api/tags
2026-08-16 20:13:14.368 [Info] (Process) Time stamp: 20:13:14 08:16:2026
2026-08-16 20:13:14.368 [Info] (Process) [LOG]  [Version: 11LOG
2026-08-16 20:13:14.368 [Info] (Process) ]  Target: /api/tags
2026-08-16 20:13:14.368 [Info] (Process) [LOG]  Version: 11
2026-08-16 20:13:14.368 [Info] (Process) [LOG[]  LOG]  Keep-Alive: 1
2026-08-16 20:13:14.368 [Info] (Process) Keep-Alive: 1
2026-08-16 20:13:14.368 [Info] (Process) [LOG]  Time stamp: 20:13:14 08:16:2026
2026-08-16 20:13:14.368 [Info] (Process) [LOG]  Target: /api/tags
2026-08-16 20:13:14.368 [Info] (Process) [LOG]  Version: 11
2026-08-16 20:13:14.368 [Info] (Process) [LOG]  Keep-Alive: 1
2026-08-16 20:13:14.368 [Info] (Process) [🔴 ]  Client disconnected; cancelling active request
2026-08-16 20:13:14.368 [Info] (Process) [🔴 ]  Client disconnected; cancelling active request
2026-08-16 20:13:14.368 [Info] (Process) [🔴 ]  Client disconnected; cancelling active request
2026-08-16 20:13:14.368 [Info] (Process) ================================================
2026-08-16 20:13:14.368 [Info] (Process) ================================================
2026-08-16 20:13:14.368 [Info] (Process) ================================================
2026-08-16 20:13:14.368 [Info] (Process) [🔒 ]  TCP connection closed - Remote endpoint unavailable
2026-08-16 20:13:14.368 [Info] (Process) [🔒 ]  TCP connection closed - Remote endpoint unavailable
2026-08-16 20:13:14.368 [Info] (Process) [🔒 ]  TCP connection closed - Remote endpoint unavailable
2026-08-16 20:13:15.277 [Info] (Process) [🔗 ]  TCP connection established - Remote: 127.0.0.1:54002
2026-08-16 20:13:15.277 [Info] (Process) [TCP]  Read 88 bytes from socket
2026-08-16 20:13:15.277 [Info] (Process) ================================================
2026-08-16 20:13:15.277 [Info] (Process) [⬇️ ]  Incoming Request: GET
2026-08-16 20:13:15.277 [Info] (Process) [LOG]  Time stamp: 20:13:15 08:16:2026
2026-08-16 20:13:15.277 [Info] (Process) [LOG]  Target: /api/tags
2026-08-16 20:13:15.277 [Info] (Process) [LOG]  Version: 11
2026-08-16 20:13:15.277 [Info] (Process) [LOG]  Keep-Alive: 1
2026-08-16 20:13:15.277 [Info] (Process) ================================================
2026-08-16 20:13:15.277 [Info] (Process) [🔒 ]  TCP connection closed - Remote: 127.0.0.1:54002
2026-08-16 20:13:15.277 [Info] (FastFlowLM) FastFlowLM is ready!
2026-08-16 20:13:15.277 [Info] (BackendWatchdog) Started watchdog for FastFlowLM using http://127.0.0.1:8002/api/tags (streaming=on, non_streaming=on)
2026-08-16 20:13:15.277 [Info] (FastFlowLM) Model loaded on port 8002
2026-08-16 20:13:15.277 [Debug] (Router) Backend started successfully in 7177ms
2026-08-16 20:13:15.277 [Info] (Router) Model loaded successfully. Total loaded: 1
2026-08-16 20:13:15.278 [Debug] (Server) POST /api/v1/load - 200
2026-08-16 20:13:15.331 [Debug] (Server) GET /api/v1/models
```
</details>
