### PR TITLE
update TheNoise v0.2.1

### DIFF
--- a/docs/dev/backends-reference.md
+++ b/docs/dev/backends-reference.md
@@ -146,12 +146,10 @@ the generator instead. Prose outside the markers is preserved. -->
 | `height` | — | SIZE | 512 | Output image height |
 | `sampler` | — | ARGS | "" | Denoising solver (euler \| er_sde) |
 | `negative_prompt` | — | ARGS | "" | Negative prompt |
-| `upscale` | — | BOOL | false | 2x latent upscale with refine denoise |
 | `qwen_vae_enhance` | — | BOOL | false | Nyquist notch post-filter (removes 2px grid artifacts) |
 | `film_grain` | — | SIZE | 0.0 | Film grain strength (0.0-10.0) |
 | `sharpening` | — | SIZE | 0.0 | RCAS sharpening strength (0.0-1.0) |
 | `lora_specs` | — | ARGS | "" | Comma-separated LoRA specs, e.g. "style:0.8,sub/detail:0.5" |
-| `lora_dir` | — | ARGS | "" | Directory containing LoRA .safetensors files (subdirectories allowed) |
 
 #### `thinksound` — ThinkSound
 

--- a/docs/guide/configuration/README.md
+++ b/docs/guide/configuration/README.md
@@ -137,7 +137,8 @@ Values set in the user's `config.json` always take precedence over these seeded 
   },
   "thenoise": {
     "backend": "auto",
-    "lora_dir": ""
+    "lora_dir": "",
+    "upscaler_dir": ""
   },
   "thinksound": {
     "backend": "auto",

--- a/src/cpp/include/lemon/backends/thenoise/thenoise.h
+++ b/src/cpp/include/lemon/backends/thenoise/thenoise.h
@@ -28,12 +28,10 @@ inline const BackendDescriptor descriptor = {
         {"height", "", 512, "SIZE", "Output image height", "TheNoise Options"},
         {"sampler", "", "", "ARGS", "Denoising solver (euler | er_sde)", "TheNoise Options"},
         {"negative_prompt", "", "", "ARGS", "Negative prompt", "TheNoise Options"},
-        {"upscale", "", false, "BOOL", "2x latent upscale with refine denoise", "TheNoise Options"},
         {"qwen_vae_enhance", "", false, "BOOL", "Nyquist notch post-filter (removes 2px grid artifacts)", "TheNoise Options"},
         {"film_grain", "", 0.0, "SIZE", "Film grain strength (0.0-10.0)", "TheNoise Options"},
         {"sharpening", "", 0.0, "SIZE", "RCAS sharpening strength (0.0-1.0)", "TheNoise Options"},
         {"lora_specs", "", "", "ARGS", "Comma-separated LoRA specs, e.g. \"style:0.8,sub/detail:0.5\"", "TheNoise Options"},
-        {"lora_dir", "", "", "ARGS", "Directory containing LoRA .safetensors files (subdirectories allowed)", "TheNoise Options"},
     },
     /*support*/ {
         {"rocm", {"linux"}, {{"amd_gpu", {"gfx1150", "gfx1151", "gfx1152"}}}, "Supported AMD ROCm iGPU families"},
@@ -51,7 +49,7 @@ inline const BackendDescriptor descriptor = {
     /*takes_args*/      false,
     /*arg_variants*/    {},
     /*bin_variants*/    {},
-    /*config_extra*/    {{"lora_dir", ""}},
+    /*config_extra*/    {{"lora_dir", ""}, {"upscaler_dir", ""}},
 };
 
 }  // namespace thenoise

--- a/src/cpp/resources/backend_versions.json
+++ b/src/cpp/resources/backend_versions.json
@@ -146,7 +146,7 @@
   },
   "thenoise": {
     "comment": "TheNoise release tag. The portable bundle publishes per-GPU-target archives (<tag>-gfxNNNN-x64.tar.gz) under this tag; the host arch picks the matching archive.",
-    "rocm": "thenoise-0.1.2-rocm7.14.0"
+    "rocm": "thenoise-0.2.1-rocm7.14.0"
   },
   "rocm_asset_families": {
     "comment": "Maps a concrete ROCm ISA (as detected on the device) to the family target name the GitHub release repos publish assets under. ISAs not listed here (e.g. gfx908, gfx90a, which ship as individual assets) are used verbatim. Add a new GPU's ISA here when its release asset is published under a family name.",

--- a/src/cpp/resources/defaults.json
+++ b/src/cpp/resources/defaults.json
@@ -102,7 +102,8 @@
   },
   "thenoise": {
     "backend": "auto",
-    "lora_dir": ""
+    "lora_dir": "",
+    "upscaler_dir": ""
   },
   "thinksound": {
     "backend": "auto",

--- a/src/cpp/resources/server_models.json
+++ b/src/cpp/resources/server_models.json
@@ -2166,6 +2166,25 @@
             "height": 1024
         }
     },
+    "Z-Image-Turbo-TheNoise": {
+        "checkpoints": {
+            "main": "Comfy-Org/z_image_turbo:split_files/diffusion_models/z_image_turbo_bf16.safetensors",
+            "text_encoder": "Comfy-Org/z_image_turbo:split_files/text_encoders/qwen_3_4b.safetensors",
+            "vae": "Comfy-Org/z_image_turbo:split_files/vae/ae.safetensors"
+        },
+        "recipe": "thenoise",
+        "suggested": true,
+        "labels": [
+            "image"
+        ],
+        "size": 20.7,
+        "image_defaults": {
+            "steps": 8,
+            "cfg_scale": 1.0,
+            "width": 1024,
+            "height": 1024
+        }
+    },
     "RealESRGAN-x4plus": {
         "checkpoint": "amd/realesrgan-x4plus:RealESRGAN_x4plus.pth",
         "recipe": "sd-cpp",

--- a/src/cpp/server/backends/thenoise/thenoise_server.cpp
+++ b/src/cpp/server/backends/thenoise/thenoise_server.cpp
@@ -11,6 +11,7 @@
 #include <ctime>
 #include <filesystem>
 #include <random>
+#include <set>
 #include <sstream>
 #include <string>
 
@@ -331,12 +332,20 @@ json TheNoiseServer::build_request(const json& request) const {
     }
 
     // Pass through any request parameters this adapter does not map so they
-    // reach the backend untouched. Skip keys already folded into the body and
-    // the ones consumed/transformed above (model, n, size, cfg_scale) so they
-    // are not forwarded in their raw form.
+    // reach the backend untouched. Skip every key the adapter handles (derived
+    // from the descriptor options) plus the ones it consumes/transforms that
+    // are not descriptor options, so raw forms are never re-forwarded.
+    std::set<std::string> handled;
+    for (const auto& opt : thenoise::descriptor.options) {
+        handled.insert(opt.name);
+    }
+    for (const char* key : {
+        "prompt", "seed", "size", "model", "n"
+    }) {
+        handled.insert(key);
+    }
     for (auto& [key, value] : request.items()) {
-        if (body.contains(key)) continue;
-        if (key == "model" || key == "n" || key == "size" || key == "cfg_scale") continue;
+        if (handled.count(key)) continue;
         body[key] = value;
     }
 

--- a/src/cpp/server/backends/thenoise/thenoise_server.cpp
+++ b/src/cpp/server/backends/thenoise/thenoise_server.cpp
@@ -124,10 +124,21 @@ void TheNoiseServer::load(const std::string& model_name,
         "--port", std::to_string(port_)
     };
 
-    std::string lora_dir = options.get_option("lora_dir");
+    // lora_dir / upscaler_dir are server-wide config (config.json
+    // "thenoise" section) and are not overridable per model.
+    std::string lora_dir;
+    std::string upscaler_dir;
+    if (auto* cfg = RuntimeConfig::global()) {
+        lora_dir = cfg->backend_string("thenoise", "lora_dir");
+        upscaler_dir = cfg->backend_string("thenoise", "upscaler_dir");
+    }
     if (!lora_dir.empty()) {
         args.push_back("--lora-dir");
         args.push_back(lora_dir);
+    }
+    if (!upscaler_dir.empty()) {
+        args.push_back("--upscaler-dir");
+        args.push_back(upscaler_dir);
     }
 
     // The portable thenoise launcher sets up LD_LIBRARY_PATH / CC / ROCm env itself.
@@ -285,12 +296,6 @@ json TheNoiseServer::build_request(const json& request) const {
         body["sampler"] = sampler;
     }
 
-    // upscale
-    bool upscale = resolve_bool("upscale", recipe_options_.get_option("upscale"));
-    if (upscale) {
-        body["upscale"] = true;
-    }
-
     // qwen_vae_enhance
     bool qwen_vae_enhance = resolve_bool("qwen_vae_enhance",
         recipe_options_.get_option("qwen_vae_enhance"));
@@ -323,6 +328,16 @@ json TheNoiseServer::build_request(const json& request) const {
         const json opt = recipe_options_.get_option("lora_specs");
         std::string specs = opt.is_string() ? opt.get<std::string>() : "";
         if (!specs.empty()) body["lora_specs"] = split_lora_specs(specs);
+    }
+
+    // Pass through any request parameters this adapter does not map so they
+    // reach the backend untouched. Skip keys already folded into the body and
+    // the ones consumed/transformed above (model, n, size, cfg_scale) so they
+    // are not forwarded in their raw form.
+    for (auto& [key, value] : request.items()) {
+        if (body.contains(key)) continue;
+        if (key == "model" || key == "n" || key == "size" || key == "cfg_scale") continue;
+        body[key] = value;
     }
 
     return body;

--- a/src/cpp/server/runtime_config.cpp
+++ b/src/cpp/server/runtime_config.cpp
@@ -903,7 +903,7 @@ void RuntimeConfig::validate_backend(const std::string& backend, const std::stri
             throw std::invalid_argument("'" + backend + "." + key + "' must be positive");
         }
     }
-    else if (key == "lora_dir") {
+    else if (key == "lora_dir" || key == "upscaler_dir") {
         if (!value.is_string()) {
             throw std::invalid_argument("'" + backend + "." + key + "' must be a string");
         }


### PR DESCRIPTION
update TheNoise to version v0.2.1:

- add support for Z-Image-Turbo
- forward non-mapped request parameter to the backend as-is
- add upscaler_dir backend config to support additional upscaler models
- remove upscale boolean as from recipe option and keep it as request parameter
- remove lora_dir from recipe options and keep it as backend config (better security)
