### PR TITLE
feat(server): support transient null overrides on load

### DIFF
--- a/docs/api/lemonade.md
+++ b/docs/api/lemonade.md
@@ -967,6 +967,8 @@ Explicitly load a registered model into memory. This is useful to ensure that th
 
 > Note: loading a collection (`recipe: "collection.omni"`) loads each of its components in turn. Per-model options like `ctx_size` or `llamacpp_backend` are not forwarded to components — set them on each component's own `recipe_options.json` entry instead.
 
+Recipe option fields on `/v1/load` have three-state semantics. Omitting a field keeps using its saved per-model value. Passing explicit `null` ignores only that saved key for this load and falls through to the lower default layers without changing `recipe_options.json`. Passing a concrete value overrides the saved value. `ctx_size: -1` is a concrete value meaning automatic context sizing, not a tombstone. With `save_options: true`, concrete values are persisted as usual while a `null` tombstone preserves the existing saved value for that key.
+
 ### Parameters
 
 | Parameter | Required | Applies to | Description |

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -5793,10 +5793,18 @@ void Server::handle_load(const httplib::Request& req, httplib::Response& res) {
 
         auto info = model_manager_->get_model_info(model_name);
 
-        // Extract optional per-model settings. An omitted or empty option falls
-        // through to the Router defaults; an explicit ctx_size of -1 requests
-        // automatic sizing for this load.
+        // Extract optional per-model settings. Omitted options keep using the
+        // saved per-model layer. Explicit null is a transient tombstone: skip
+        // only that saved key for this load, then fall through to lower layers.
+        // ctx_size=-1 remains an explicit request for automatic sizing.
         RecipeOptions options = RecipeOptions(info.recipe, request_json);
+        std::set<std::string> transient_saved_option_tombstones;
+        for (const auto& key : RecipeOptions::keys_for_recipe(info.recipe)) {
+            if (request_json.contains(key) && request_json[key].is_null()) {
+                transient_saved_option_tombstones.insert(key);
+            }
+        }
+
         bool save_options = request_json.value("save_options", false);
         std::optional<bool> pinned_opt = std::nullopt;
         if (request_json.contains("pinned") && request_json["pinned"].is_boolean()) {
@@ -5807,12 +5815,38 @@ void Server::handle_load(const httplib::Request& req, httplib::Response& res) {
         LOG(INFO, "Server") << " " << options.to_log_string(false);
         LOG(INFO, "Server") << std::endl;
 
-        // Persist request options to model info if requested. Re-read so this
-        // load still sees the model's own registry-level options rather than
-        // just the request's.
+        // Persist concrete request options if requested. A null tombstone is
+        // load-scoped, so preserve the existing saved value for that key.
         if (save_options) {
-            model_manager_->set_saved_model_options(model_name, options.to_json());
+            json saved_for_write = options.to_json();
+            if (!transient_saved_option_tombstones.empty()) {
+                const json existing_saved = model_manager_->get_saved_model_options(model_name);
+                for (const auto& key : transient_saved_option_tombstones) {
+                    auto it = existing_saved.find(key);
+                    if (it != existing_saved.end()) {
+                        saved_for_write[key] = *it;
+                    }
+                }
+            }
+            model_manager_->set_saved_model_options(model_name, saved_for_write);
             info = model_manager_->get_model_info(model_name);
+        }
+
+        // ModelInfo::recipe_options contains the model-level defaults plus the
+        // recipe_options.json overlay. Rebuild that local copy with only the
+        // explicitly tombstoned saved keys removed. This changes this load only;
+        // the persistent recipe_options.json entry remains untouched.
+        if (!transient_saved_option_tombstones.empty()) {
+            json per_model_options = model_manager_->get_model_default_options(info).to_json();
+            const json saved = model_manager_->get_saved_model_options(model_name);
+            if (saved.is_object()) {
+                for (const auto& [key, value] : saved.items()) {
+                    if (transient_saved_option_tombstones.count(key) == 0) {
+                        per_model_options[key] = value;
+                    }
+                }
+            }
+            info.recipe_options = RecipeOptions(info.recipe, per_model_options);
         }
 
         // Download model if needed (first-time use or missing files). Collections have no

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -5832,6 +5832,12 @@ void Server::handle_load(const httplib::Request& req, httplib::Response& res) {
             info = model_manager_->get_model_info(model_name);
         }
 
+        if (!model_manager_->is_model_downloaded(model_name) && !is_model_collection_recipe(info.recipe)) {
+            LOG(INFO, "Server") << "Model not downloaded, downloading..." << std::endl;
+            model_manager_->download_registered_model(info);
+            info = model_manager_->get_model_info(model_name);
+        }
+
         // ModelInfo::recipe_options contains the model-level defaults plus the
         // recipe_options.json overlay. Rebuild that local copy with only the
         // explicitly tombstoned saved keys removed. This changes this load only;
@@ -5849,14 +5855,6 @@ void Server::handle_load(const httplib::Request& req, httplib::Response& res) {
             info.recipe_options = RecipeOptions(info.recipe, per_model_options);
         }
 
-        // Download model if needed (first-time use or missing files). Collections have no
-        // checkpoint of their own, so skip the generic HF download path here
-        // and let the per-component branch below cascade any missing pieces.
-        if (!model_manager_->is_model_downloaded(model_name) && !is_model_collection_recipe(info.recipe)) {
-            LOG(INFO, "Server") << "Model not downloaded, downloading..." << std::endl;
-            model_manager_->download_registered_model(info);
-            info = model_manager_->get_model_info(model_name);
-        }
 
         // Collection models: load each component instead
         if (is_omni_collection_recipe(info.recipe) && !info.components.empty()) {

--- a/test/server_endpoints.py
+++ b/test/server_endpoints.py
@@ -1109,6 +1109,170 @@ class EndpointTests(ServerTestBase):
         )
         self.assertEqual(response.status_code, 200, response.text)
 
+    def test_012la_load_null_transiently_clears_saved_args(self):
+        """Explicit null skips a saved *_args value for one load only."""
+        self._snapshot_options()
+        self.addCleanup(
+            requests.post,
+            f"{self.base_url}/unload",
+            json={"model_name": ENDPOINT_TEST_MODEL},
+            timeout=TIMEOUT_DEFAULT,
+        )
+        requests.post(
+            f"{self.base_url}/unload",
+            json={"model_name": ENDPOINT_TEST_MODEL},
+            timeout=TIMEOUT_DEFAULT,
+        )
+        self._reset_options()
+
+        response = requests.post(
+            self._options_url(),
+            json={"llamacpp_args": "--threads 1"},
+            timeout=TIMEOUT_DEFAULT,
+        )
+        self.assertEqual(response.status_code, 200, response.text)
+
+        response = requests.post(
+            f"{self.base_url}/load",
+            json={
+                "model_name": ENDPOINT_TEST_MODEL,
+                "llamacpp_args": None,
+                "save_options": True,
+            },
+            timeout=TIMEOUT_MODEL_OPERATION,
+        )
+        self.assertEqual(response.status_code, 200, response.text)
+
+        loaded = self._get_loaded_model_info(ENDPOINT_TEST_MODEL)
+        self.assertIsNotNone(loaded)
+        loaded_args = loaded.get("recipe_options", {}).get("llamacpp_args", "")
+        self.assertNotIn("--threads 1", loaded_args)
+
+        saved = requests.get(self._options_url(), timeout=TIMEOUT_DEFAULT).json()["saved"]
+        self.assertEqual(saved.get("llamacpp_args"), "--threads 1")
+
+    def test_012lb_load_null_keeps_other_saved_keys(self):
+        """A tombstone masks only its key; unrelated saved settings still apply."""
+        self._snapshot_options()
+        self.addCleanup(
+            requests.post,
+            f"{self.base_url}/unload",
+            json={"model_name": ENDPOINT_TEST_MODEL},
+            timeout=TIMEOUT_DEFAULT,
+        )
+        requests.post(
+            f"{self.base_url}/unload",
+            json={"model_name": ENDPOINT_TEST_MODEL},
+            timeout=TIMEOUT_DEFAULT,
+        )
+        self._reset_options()
+
+        response = requests.post(
+            self._options_url(),
+            json={"llamacpp_args": "--threads 1", "ctx_size": 3072},
+            timeout=TIMEOUT_DEFAULT,
+        )
+        self.assertEqual(response.status_code, 200, response.text)
+
+        response = requests.post(
+            f"{self.base_url}/load",
+            json={"model_name": ENDPOINT_TEST_MODEL, "llamacpp_args": None},
+            timeout=TIMEOUT_MODEL_OPERATION,
+        )
+        self.assertEqual(response.status_code, 200, response.text)
+
+        loaded = self._get_loaded_model_info(ENDPOINT_TEST_MODEL)
+        self.assertIsNotNone(loaded)
+        recipe_options = loaded.get("recipe_options", {})
+        self.assertNotIn("--threads 1", recipe_options.get("llamacpp_args", ""))
+        self.assertEqual(recipe_options.get("ctx_size"), 3072)
+
+        saved = requests.get(self._options_url(), timeout=TIMEOUT_DEFAULT).json()["saved"]
+        self.assertEqual(saved.get("llamacpp_args"), "--threads 1")
+        self.assertEqual(saved.get("ctx_size"), 3072)
+
+    def test_012lc_load_merge_args_still_merges_saved_and_request_args(self):
+        """Concrete *_args requests keep the existing merge_args behavior."""
+        self._snapshot_options()
+        self.addCleanup(
+            requests.post,
+            f"{self.base_url}/unload",
+            json={"model_name": ENDPOINT_TEST_MODEL},
+            timeout=TIMEOUT_DEFAULT,
+        )
+        requests.post(
+            f"{self.base_url}/unload",
+            json={"model_name": ENDPOINT_TEST_MODEL},
+            timeout=TIMEOUT_DEFAULT,
+        )
+        self._reset_options()
+
+        response = requests.post(
+            self._options_url(),
+            json={
+                "llamacpp_args": "--threads 1 --threads-batch 1",
+                "merge_args": True,
+            },
+            timeout=TIMEOUT_DEFAULT,
+        )
+        self.assertEqual(response.status_code, 200, response.text)
+
+        response = requests.post(
+            f"{self.base_url}/load",
+            json={
+                "model_name": ENDPOINT_TEST_MODEL,
+                "llamacpp_args": "--threads 2",
+                "merge_args": True,
+            },
+            timeout=TIMEOUT_MODEL_OPERATION,
+        )
+        self.assertEqual(response.status_code, 200, response.text)
+
+        loaded = self._get_loaded_model_info(ENDPOINT_TEST_MODEL)
+        self.assertIsNotNone(loaded)
+        loaded_args = loaded.get("recipe_options", {}).get("llamacpp_args", "")
+        self.assertIn("--threads 2", loaded_args)
+        self.assertIn("--threads-batch 1", loaded_args)
+        self.assertNotIn("--threads 1 ", loaded_args + " ")
+
+    def test_012ld_load_ctx_size_minus_one_remains_explicit_auto(self):
+        """ctx_size=-1 is a concrete auto value, not a transient tombstone."""
+        self._snapshot_options()
+        self.addCleanup(
+            requests.post,
+            f"{self.base_url}/unload",
+            json={"model_name": ENDPOINT_TEST_MODEL},
+            timeout=TIMEOUT_DEFAULT,
+        )
+        requests.post(
+            f"{self.base_url}/unload",
+            json={"model_name": ENDPOINT_TEST_MODEL},
+            timeout=TIMEOUT_DEFAULT,
+        )
+        self._reset_options()
+
+        response = requests.post(
+            self._options_url(),
+            json={"ctx_size": 3072},
+            timeout=TIMEOUT_DEFAULT,
+        )
+        self.assertEqual(response.status_code, 200, response.text)
+
+        response = requests.post(
+            f"{self.base_url}/load",
+            json={
+                "model_name": ENDPOINT_TEST_MODEL,
+                "ctx_size": -1,
+                "save_options": True,
+            },
+            timeout=TIMEOUT_MODEL_OPERATION,
+        )
+        self.assertEqual(response.status_code, 200, response.text)
+
+        options = requests.get(self._options_url(), timeout=TIMEOUT_DEFAULT).json()
+        self.assertEqual(options["saved"].get("ctx_size"), -1)
+        self.assertEqual(options["effective"].get("ctx_size"), -1)
+
     def test_012m_model_options_save_without_loading(self):
         """POST /models/{id}/options persists options without loading the model."""
         requests.post(


### PR DESCRIPTION
### Summary

Add transient per-option clearing semantics to `POST /v1/load`.

An explicitly provided `null` now means: ignore the saved per-model value for this load only and fall through to the lower server/default layers.

This gives `/v1/load` three distinct states for recipe options:

* omitted: keep using the saved per-model value
* `null`: ignore the saved per-model value for this load only
* concrete value: override it for this load

`ctx_size: -1` remains the explicit auto-sizing value and is not treated as a clear.

### Why

This lets clients clear individual saved options without mutating `recipe_options.json`.

For example, a client can temporarily clear saved `llamacpp_args` without also losing unrelated saved settings. This is more precise than a global `ignore_saved_options` flag.


### Tests

Added coverage for:

* saved args → transient `null` clear
* another saved option remains active
* `merge_args` behavior
* explicit `ctx_size: -1`
