### PR TITLE
add lemonade version to benchmark results

### DIFF
--- a/src/cpp/cli/bench.cpp
+++ b/src/cpp/cli/bench.cpp
@@ -974,6 +974,18 @@ int handle_bench_command(lemonade::LemonadeClient& client, const BenchConfig& co
         return 1;
     }
 
+    // Fetch version from /health (not present in system-info)
+    std::string lemonade_version;
+    try {
+        std::string resp = client.make_request("/api/v1/health", "GET", "", "", 5000, 5000);
+        json health = json::parse(resp);
+        if (health.contains("version") && health["version"].is_string()) {
+            lemonade_version = health["version"].get<std::string>();
+        }
+    } catch (const std::exception& e) {
+        std::cerr << "Warning: Failed to fetch lemonade version from /health: " << e.what() << std::endl;
+    }
+
     std::unordered_set<std::string> test_recipes, test_backends;
     std::map<std::string, std::vector<BackendDiscovery>> backends_by_model;
     for (const auto& model : unique_models) {
@@ -989,7 +1001,8 @@ int handle_bench_command(lemonade::LemonadeClient& client, const BenchConfig& co
     json hardware_profile = build_hardware_profile(
         sys_info,
         {test_recipes.begin(), test_recipes.end()},
-        {test_backends.begin(), test_backends.end()});
+        {test_backends.begin(), test_backends.end()},
+        lemonade_version);
 
     // Execute benchmarks for each model
     struct ModelBenchResult {

--- a/src/cpp/cli/bench_sysinfo.cpp
+++ b/src/cpp/cli/bench_sysinfo.cpp
@@ -26,8 +26,13 @@ static double parse_gb_string(const std::string& s) {
 
 json build_hardware_profile(const json& sys_info,
                             const std::vector<std::string>& recipes,
-                            const std::vector<std::string>& backends) {
+                            const std::vector<std::string>& backends,
+                            const std::string& lemonade_version) {
     json profile;
+
+    if (!lemonade_version.empty()) {
+        profile["lemonade_version"] = lemonade_version;
+    }
 
     try {
         std::string os_version = sys_info.value("OS Version", "unknown");

--- a/src/cpp/include/lemon_cli/bench_sysinfo.h
+++ b/src/cpp/include/lemon_cli/bench_sysinfo.h
@@ -17,6 +17,7 @@ using json = nlohmann::json;
 // `recipes` and `backends` filter which backend versions to include (empty = all).
 json build_hardware_profile(const json& sys_info,
                             const std::vector<std::string>& recipes,
-                            const std::vector<std::string>& backends);
+                            const std::vector<std::string>& backends,
+                            const std::string& lemonade_version);
 
 } // namespace lemon_cli


### PR DESCRIPTION
as discussed with @sofiageo, we want to add lemonade's version into benchmark results