### PR TITLE
Remove some MTP default flags

### DIFF
--- a/src/cpp/server/backends/llamacpp/llamacpp_server.cpp
+++ b/src/cpp/server/backends/llamacpp/llamacpp_server.cpp
@@ -406,8 +406,6 @@ void LlamaCppServer::load(const std::string& model_name,
     } else if (uses_mtp) {
         LOG(INFO, "LlamaCpp") << "Model uses MTP, adding draft decoding defaults" << std::endl;
         push_overridable_arg(args, llamacpp_args, "--spec-type", "draft-mtp");
-        push_overridable_arg(args, llamacpp_args, "--spec-draft-n-max", "3");
-        push_overridable_arg(args, llamacpp_args, "--spec-draft-p-min", "0.75");
     }
 
     // Disable llamacpp webui by default


### PR DESCRIPTION

## Summary

Stops passing `--spec-draft-n-max 3` (this matches the default so is not really necessary) and `--spec-draft-p-min 0.75` when an MTP model is detected, aligning the behavior with that of DFlash.

The reason is that `--spec-draft-p-min 0.75` doesn't seem to be universally better and harms performance in some configurations, with results worse than llamacpp's defaults across the board.

Fixes #3175

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

run an MTP model that doesn't override the abovementioned flags => they do not get added by default anymore

## Documentation

- [x] Documentation is not affected by this change.
- [ ] Documentation is affected and has been updated.
- [ ] Documentation is affected but will be handled in a separate PR or issue.

## Breaking Changes

- [ ] This PR introduces breaking changes.
- [x] This PR does not introduce breaking changes.

<!-- If breaking changes, describe them and migration path -->

## AI-assisted contribution

Please select one:

- [ ] I used AI tools for this PR.
- [x] I did not use AI tools for this PR.

If AI tools were used:

- [ ] I verified that I understand the changes.
- [ ] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.
