### PR TITLE
Fix stale gfx90X-dcgpu TheRock URL mapping for gfx908/gfx90a

### DIFF
--- a/src/cpp/resources/backend_versions.json
+++ b/src/cpp/resources/backend_versions.json
@@ -98,8 +98,6 @@
       "gfx120X"
     ],
     "url_mapping": {
-      "gfx908": "gfx90X-dcgpu",
-      "gfx90a": "gfx90X-dcgpu",
       "gfx942": "gfx94X-dcgpu",
       "gfx950": "gfx950-dcgpu",
       "gfx103X": "gfx103X-all",


### PR DESCRIPTION
## Summary

Fixes ROCm backend download failures (HTTP 403) for gfx908/gfx90a GPUs. AMD's TheRock tarball repo split the combined `gfx90X-dcgpu` package into separate per-arch `gfx908` and `gfx90a` tarballs starting with version 7.12.0; the combined asset no longer exists at the pinned 7.13.0 version. Removes the stale `url_mapping` entries so the download falls back to using the arch name directly, matching the new upstream filenames.

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_
- Validated `src/cpp/resources/backend_versions.json` parses as valid JSON after the edit.
- Verified via `curl` that `https://repo.amd.com/rocm/tarball/therock-dist-linux-gfx908-7.13.0.tar.gz` and `.../therock-dist-linux-gfx90a-7.13.0.tar.gz` both return HTTP 200, while the old combined `.../therock-dist-linux-gfx90X-dcgpu-7.13.0.tar.gz` returns HTTP 403 (confirming the split happened upstream and this mapping was stale).
- Tested with a MI-100 card

## Documentation

- [x] Documentation is not affected by this change.

## Breaking Changes

- [x] This PR does not introduce breaking changes.

## AI-assisted contribution

- [x] I used AI tools for this PR.

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.