### PR TITLE
Fail startup when one resolved address cannot bind

### DIFF
--- a/src/cpp/include/lemon/utils/network_utils.h
+++ b/src/cpp/include/lemon/utils/network_utils.h
@@ -1,9 +1,43 @@
 #pragma once
 
+#include <atomic>
+#include <cstddef>
 #include <string>
 
 namespace lemon::utils {
 
 bool is_tcp_listener_active(int family, const std::string& host_ip, int port);
+
+class ListenerStartupState {
+public:
+    explicit ListenerStartupState(std::size_t expected_bind_attempts)
+        : expected_bind_attempts_(expected_bind_attempts) {}
+
+    void record_bind_success() {
+        completed_bind_attempts_.fetch_add(1);
+    }
+
+    void record_bind_failure() {
+        failed_.store(true);
+        completed_bind_attempts_.fetch_add(1);
+    }
+
+    void record_listen_failure() {
+        failed_.store(true);
+    }
+
+    bool bind_attempts_complete() const {
+        return completed_bind_attempts_.load() == expected_bind_attempts_;
+    }
+
+    bool failed() const {
+        return failed_.load();
+    }
+
+private:
+    const std::size_t expected_bind_attempts_;
+    std::atomic<std::size_t> completed_bind_attempts_{0};
+    std::atomic<bool> failed_{false};
+};
 
 } // namespace lemon::utils

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -2048,8 +2048,8 @@ void Server::run() {
         }
 
         if (listener_startup.failed()) {
-            LOG(ERROR, "Server") << "Could not bind every address resolved for host '"
-                                 << host << "'. Server startup aborted." << std::endl;
+            LOG(ERROR, "Server") << "Could not start HTTP listeners for every address resolved for host '"
+                                 << host << "' (bind or listen failure). Server startup aborted." << std::endl;
             stop();
             if (http_v4_thread_.joinable())
                 http_v4_thread_.join();

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -1994,50 +1994,69 @@ void Server::run() {
             break;
         }
 
-        std::atomic<bool> listener_started(false);
-        std::atomic<bool> listener_start_failed(false);
+        const std::size_t listener_count =
+            static_cast<std::size_t>(!ipv4.empty()) +
+            static_cast<std::size_t>(!ipv6.empty());
+        utils::ListenerStartupState listener_startup(listener_count);
 
         if (!ipv4.empty()) {
             // setup ipv4 thread
             setup_http_logger(*http_server_);
-            http_v4_thread_ = std::thread([this, ipv4, &listener_started, &listener_start_failed]() {
+            http_v4_thread_ = std::thread([this, ipv4, &listener_startup]() {
                 LOG(INFO, "Server") << "Binding IPv4 HTTP server to " << ipv4 << ":" << port_ << "..." << std::endl;
                 int result = http_front_->bind_to_port(ipv4, port_);
                 if (result <= 0) {
                     LOG(ERROR, "Server") << "Failed to bind IPv4 HTTP server to " << ipv4 << ":" << port_ << std::endl;
-                    listener_start_failed = true;
+                    listener_startup.record_bind_failure();
                     return;
                 }
                 // The routed server's keep-alive loop runs only while it sees
                 // a valid listen socket
                 http_server_->set_listen_socket(http_front_->listen_socket());
                 LOG(INFO, "Server") << "IPv4 HTTP server listening on " << ipv4 << ":" << port_ << std::endl;
-                listener_started = true;
+                listener_startup.record_bind_success();
                 if (!http_front_->listen_after_bind()) {
                     LOG(ERROR, "Server") << "IPv4 HTTP server listen_after_bind() failed" << std::endl;
-                    listener_start_failed = true;
+                    listener_startup.record_listen_failure();
                 }
             });
         }
         if (!ipv6.empty()) {
             // setup ipv6 thread
             setup_http_logger(*http_server_v6_);
-            http_v6_thread_ = std::thread([this, ipv6, &listener_started, &listener_start_failed]() {
+            http_v6_thread_ = std::thread([this, ipv6, &listener_startup]() {
                 LOG(INFO, "Server") << "Binding IPv6 HTTP server to [" << ipv6 << "]:" << port_ << "..." << std::endl;
                 int result = http_front_v6_->bind_to_port(ipv6, port_);
                 if (result <= 0) {
                     LOG(ERROR, "Server") << "Failed to bind IPv6 HTTP server to [" << ipv6 << "]:" << port_ << std::endl;
-                    listener_start_failed = true;
+                    listener_startup.record_bind_failure();
                     return;
                 }
                 http_server_v6_->set_listen_socket(http_front_v6_->listen_socket());
                 LOG(INFO, "Server") << "IPv6 HTTP server listening on [" << ipv6 << "]:" << port_ << std::endl;
-                listener_started = true;
+                listener_startup.record_bind_success();
                 if (!http_front_v6_->listen_after_bind()) {
                     LOG(ERROR, "Server") << "IPv6 HTTP server listen_after_bind() failed" << std::endl;
-                    listener_start_failed = true;
+                    listener_startup.record_listen_failure();
                 }
             });
+        }
+
+        while (!listener_startup.bind_attempts_complete() &&
+               !shutdown_requested_.load() && !rebind_requested_.load()) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        }
+
+        if (listener_startup.failed()) {
+            LOG(ERROR, "Server") << "Could not bind every address resolved for host '"
+                                 << host << "'. Server startup aborted." << std::endl;
+            stop();
+            if (http_v4_thread_.joinable())
+                http_v4_thread_.join();
+            if (http_v6_thread_.joinable())
+                http_v6_thread_.join();
+            startup_failed_ = true;
+            break;
         }
 
         // Enumerate all RFC1918 interfaces to determine if we can broadcast.
@@ -2067,7 +2086,8 @@ void Server::run() {
         // The threads are blocked in listen_after_bind(), which only returns when
         // the server is stopped or an error occurs.
         while ((http_v4_thread_.joinable() || http_v6_thread_.joinable()) &&
-               !shutdown_requested_.load() && !rebind_requested_.load()) {
+               !shutdown_requested_.load() && !rebind_requested_.load() &&
+               !listener_startup.failed()) {
             std::this_thread::sleep_for(std::chrono::milliseconds(100));
         }
 
@@ -2082,6 +2102,17 @@ void Server::run() {
             if (http_v6_thread_.joinable())
                 http_v6_thread_.join();
             break;  // Exit the main loop
+        }
+
+        if (listener_startup.failed()) {
+            LOG(ERROR, "Server") << "An HTTP listener stopped unexpectedly. Server exiting." << std::endl;
+            stop();
+            if (http_v4_thread_.joinable())
+                http_v4_thread_.join();
+            if (http_v6_thread_.joinable())
+                http_v6_thread_.join();
+            startup_failed_ = true;
+            break;
         }
 
         // If rebind was requested, stop() has already been called by apply_config_side_effects().
@@ -2100,20 +2131,6 @@ void Server::run() {
                 http_v4_thread_.join();
             if (http_v6_thread_.joinable())
                 http_v6_thread_.join();
-        }
-
-        if (!listener_started && listener_start_failed) {
-            if (rebind_requested_) {
-                // Port rebind failed (e.g. port in use) — restore old port and retry
-                LOG(ERROR, "Server") << "Failed to bind to new port " << port_
-                            << ", will not retry" << std::endl;
-                rebind_requested_ = false;
-                break;
-            }
-            std::cerr << "[Server] Another Lemonade router/server instance is already running on "
-                      << config_->host() << ":" << port_ << ". Duplicate instance now exiting." << std::endl;
-            stop();
-            break;
         }
 
         if (!rebind_requested_) {

--- a/test/cpp/test_network_utils.cpp
+++ b/test/cpp/test_network_utils.cpp
@@ -3,6 +3,7 @@
 #include <cassert>
 #include <cstdio>
 #include <string>
+#include <thread>
 
 #ifdef _WIN32
     #include <winsock2.h>
@@ -185,6 +186,80 @@ static void test_active_port(TestResult& r) {
     }
 }
 
+static void test_listener_startup_state(TestResult& r) {
+    {
+        lemon::utils::ListenerStartupState state(1);
+        if (!state.bind_attempts_complete() && !state.failed()) {
+            r.ok("single listener starts pending");
+        } else {
+            r.fail("single listener starts pending");
+        }
+        state.record_bind_success();
+        if (state.bind_attempts_complete() && !state.failed()) {
+            r.ok("single listener bind succeeds");
+        } else {
+            r.fail("single listener bind succeeds");
+        }
+    }
+
+    {
+        lemon::utils::ListenerStartupState state(1);
+        state.record_bind_failure();
+        if (state.bind_attempts_complete() && state.failed()) {
+            r.ok("single listener bind fails");
+        } else {
+            r.fail("single listener bind fails");
+        }
+    }
+
+    {
+        lemon::utils::ListenerStartupState state(2);
+        state.record_bind_success();
+        state.record_bind_failure();
+        if (state.bind_attempts_complete() && state.failed()) {
+            r.ok("dual listener success then failure is fatal");
+        } else {
+            r.fail("dual listener success then failure is fatal");
+        }
+    }
+
+    {
+        lemon::utils::ListenerStartupState state(2);
+        state.record_bind_failure();
+        state.record_bind_success();
+        if (state.bind_attempts_complete() && state.failed()) {
+            r.ok("dual listener failure then success is fatal");
+        } else {
+            r.fail("dual listener failure then success is fatal");
+        }
+    }
+
+    {
+        lemon::utils::ListenerStartupState state(2);
+        std::thread first([&state]() { state.record_bind_success(); });
+        std::thread second([&state]() { state.record_bind_failure(); });
+        first.join();
+        second.join();
+        if (state.bind_attempts_complete() && state.failed()) {
+            r.ok("concurrent listener results are recorded");
+        } else {
+            r.fail("concurrent listener results are recorded");
+        }
+    }
+
+    {
+        lemon::utils::ListenerStartupState state(2);
+        state.record_bind_success();
+        state.record_bind_success();
+        state.record_listen_failure();
+        if (state.bind_attempts_complete() && state.failed()) {
+            r.ok("listen failure after successful binds is fatal");
+        } else {
+            r.fail("listen failure after successful binds is fatal");
+        }
+    }
+}
+
 int main() {
 #ifdef _WIN32
     WSADATA wsaData;
@@ -197,6 +272,7 @@ int main() {
 
     test_inactive_port(r);
     test_active_port(r);
+    test_listener_startup_state(r);
 
     printf("\n%d/%d tests passed\n", r.passed, r.passed + r.failed);
 


### PR DESCRIPTION
Fixes #2917.

When a host resolves to both IPv4 and IPv6, wait for every requested bind attempt and abort startup if either one fails. This prevents `lemond` from remaining healthy on only one address family after a bind race.

Tests:

- Built `lemond` and passed all 39 `cpp-ci` tests on Ubuntu 24.04.
- Built natively on an M1 Mac and reproduced the reported IPv4-fails/IPv6-succeeds case; the patched process exited with status 1 and closed the IPv6 listener.
- Confirmed normal dual-stack startup remained healthy over both IPv4 and IPv6 on macOS.
