### PR TITLE
refactor(server): drop load_command from the options endpoint

### DIFF
--- a/docs/api/lemonade.md
+++ b/docs/api/lemonade.md
@@ -272,22 +272,9 @@ curl http://localhost:13305/v1/models/Qwen3-0.6B-GGUF/options
     "merge_args": true,
     "model_name": "Qwen3-0.6B-GGUF"
   },
-  "resolved_ctx_size": 32768,
-  "load_command": "curl -X POST $LEMONADE_BASE_URL/v1/load -H \"Content-Type: application/json\" -d '{\"ctx_size\":-1, ...}'"
+  "resolved_ctx_size": 32768
 }
 ```
-
-`load_command` is `effective` posted to [`/v1/load`](#post-v1load): the exact load the model would get right now, as a command.
-
-The base URL is left as `$LEMONADE_BASE_URL`, and the API key, when the server requires one, as `$LEMONADE_API_KEY`. The server cannot fill either in: it always listens over plain HTTP, so a client that reached it through a TLS-terminating proxy is on `https` without the server ever knowing, and the `Host` header is only the caller's own claim about where it sent the request. Export the variables to run the command as-is:
-
-```bash
-export LEMONADE_BASE_URL=http://localhost:13305
-```
-
-A client that already knows its base URL — every GUI and CLI does — can substitute the two tokens before displaying the command.
-
-The quoting is for POSIX shells: bash, zsh, and PowerShell 7.3 and newer, which is where PowerShell began passing arguments to native commands unchanged. `cmd.exe` does not treat `'` as a quote character at all. In either of those, build the request from `effective` rather than pasting the command.
 
 | Field | Description |
 |-------|-------------|
@@ -297,7 +284,6 @@ The quoting is for POSIX shells: bash, zsh, and PowerShell 7.3 and newer, which 
 | `effective` | The `/v1/load` body shown above. Posting it back whole to this endpoint saves every resolved value as an override, so send only the options the user changed. |
 | `defaults` | What `effective` becomes if `saved` is erased, in the same shape. A `ctx_size` of `-1` means the server picks the context size automatically. |
 | `resolved_ctx_size` | The context size a load right now would use: the effective `ctx_size`, or the automatically computed size when that is `-1`. |
-| `load_command` | The curl command that reproduces the load: `effective` posted to `/v1/load`, with `$LEMONADE_BASE_URL` (and `$LEMONADE_API_KEY` on a key-protected server) left for the caller to fill in. |
 
 > Note: per-architecture defaults come from the model's GGUF metadata. For a model that has not been downloaded yet, every key is still present but carries the value it has before those defaults apply.
 
@@ -308,7 +294,7 @@ Save recipe options for a model without loading it. The request body is a flat o
 
 The request merges into the model's saved entry, so keys you don't mention are left alone. `null` removes an option, and the model falls back to the next layer of the [priority chain](#post-v1load). [`DELETE`](#delete-v1modelsidoptions) removes every saved option at once.
 
-`dry_run: true` validates and resolves the request identically but persists nothing: `effective`, `resolved_ctx_size`, and `load_command` describe the state the save would produce, while `saved` keeps reporting the entry on disk. Use it to preview a change before committing it.
+`dry_run: true` validates and resolves the request identically but persists nothing: `effective` and `resolved_ctx_size` describe the state the save would produce, while `saved` keeps reporting the entry on disk. Use it to preview a change before committing it.
 
 `ctx_size` takes a positive whole number, or `-1` to pin the model to automatic sizing even when the server-wide `ctx_size` is a specific number.
 

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -3022,18 +3022,6 @@ static bool is_live_process_option(const std::string& key) {
     return key == "pinned";
 }
 
-static std::string shell_single_quote(const std::string& s) {
-    std::string quoted = "'";
-    for (char c : s) {
-        if (c == '\'') {
-            quoted += "'\\''";
-        } else {
-            quoted += c;
-        }
-    }
-    return quoted + "'";
-}
-
 // Fill in every option the recipe accepts, resolving unset keys through the
 // default chain, so a client can render a complete form from one response.
 static nlohmann::json resolve_all_recipe_options(const RecipeOptions& options) {
@@ -3128,26 +3116,13 @@ void Server::respond_with_model_options(
         const int64_t resolved_ctx = auto_ctx != -2 ? auto_ctx
             : (effective_ctx.is_number() ? effective_ctx.get<int64_t>() : -1);
 
-        // The load command, with the two things only the caller knows left as
-        // environment references. lemond always listens in the clear, so a
-        // client that reached it through a TLS-terminating proxy is on https
-        // and this process cannot tell; the Host header is a guess of the same
-        // kind, supplied by the caller.
-        std::string load_command =
-            "curl -X POST $LEMONADE_BASE_URL/v1/load -H \"Content-Type: application/json\"";
-        if (!api_key_.empty()) {
-            load_command += " -H \"Authorization: Bearer $LEMONADE_API_KEY\"";
-        }
-        load_command += " -d " + shell_single_quote(effective_json.dump());
-
         nlohmann::json response = {
             {"model_name", model_id},
             {"recipe", info.recipe},
             {"saved", model_manager_->get_saved_model_options(model_key)},
             {"effective", effective_json},
             {"defaults", defaults_json},
-            {"resolved_ctx_size", resolved_ctx},
-            {"load_command", load_command}
+            {"resolved_ctx_size", resolved_ctx}
         };
         res.set_content(response.dump(), "application/json");
     } catch (const std::exception& e) {

--- a/test/server_endpoints.py
+++ b/test/server_endpoints.py
@@ -1148,7 +1148,9 @@ class EndpointTests(ServerTestBase):
         loaded_args = loaded.get("recipe_options", {}).get("llamacpp_args", "")
         self.assertNotIn("--threads 1", loaded_args)
 
-        saved = requests.get(self._options_url(), timeout=TIMEOUT_DEFAULT).json()["saved"]
+        saved = requests.get(self._options_url(), timeout=TIMEOUT_DEFAULT).json()[
+            "saved"
+        ]
         self.assertEqual(saved.get("llamacpp_args"), "--threads 1")
 
     def test_012lb_load_null_keeps_other_saved_keys(self):
@@ -1187,7 +1189,9 @@ class EndpointTests(ServerTestBase):
         self.assertNotIn("--threads 1", recipe_options.get("llamacpp_args", ""))
         self.assertEqual(recipe_options.get("ctx_size"), 3072)
 
-        saved = requests.get(self._options_url(), timeout=TIMEOUT_DEFAULT).json()["saved"]
+        saved = requests.get(self._options_url(), timeout=TIMEOUT_DEFAULT).json()[
+            "saved"
+        ]
         self.assertEqual(saved.get("llamacpp_args"), "--threads 1")
         self.assertEqual(saved.get("ctx_size"), 3072)
 
@@ -1547,16 +1551,6 @@ class EndpointTests(ServerTestBase):
         self.assertEqual(data["resolved_ctx_size"], 4096)
         self.assertEqual(data["saved"], {}, "dry_run must not persist anything")
 
-        # load_command is effective posted to /v1/load, with the base URL left
-        # to the caller: lemond only ever listens over plain HTTP, so it cannot
-        # know the scheme a client reached it through.
-        command = data["load_command"]
-        self.assertTrue(
-            command.startswith("curl -X POST $LEMONADE_BASE_URL/v1/load"), command
-        )
-        self.assertIn('"ctx_size":4096', command)
-        self.assertIn(f'"model_name":"{ENDPOINT_TEST_MODEL}"', command)
-
         after = requests.get(self._options_url(), timeout=TIMEOUT_DEFAULT).json()
         self.assertEqual(after["saved"], {}, "dry_run must not persist anything")
         self.assertGreater(
@@ -1573,96 +1567,6 @@ class EndpointTests(ServerTestBase):
         self.assertEqual(rejected.status_code, 400, "dry_run still validates")
 
         print("[OK] resolved_ctx_size is concrete and dry_run persists nothing")
-
-    def test_012v_load_command_omits_client_supplied_host(self):
-        """The command is built from what the server knows, not what it is told.
-
-        `Host` is the caller's own claim about where it sent the request, and
-        the command is meant to be run, so none of it may reach the string.
-        """
-        forged = "evil.example.com; touch /tmp/lemonade-load-command"
-        response = requests.get(
-            self._options_url(),
-            headers={"Host": forged},
-            timeout=TIMEOUT_DEFAULT,
-        )
-        self.assertEqual(response.status_code, 200, response.text)
-
-        command = response.json()["load_command"]
-        self.assertIn("$LEMONADE_BASE_URL/v1/load", command)
-        self.assertNotIn("evil.example.com", command)
-        self.assertNotIn("touch", command)
-
-        print("[OK] load_command never repeats the caller's Host header")
-
-    def test_012w_load_command_carries_auth_when_a_key_is_required(self):
-        """A key-protected server renders the header its own /v1/load demands.
-
-        Without it the command reports a load that would come back 401. The key
-        itself stays out of the response: only the variable holding it is named.
-        """
-        lemond_binary = _resolve_lemond_binary()
-        if not lemond_binary:
-            self.skipTest("lemond binary not found (build it or add it to PATH)")
-
-        api_key = "options-load-command-key"
-        headers = {"Authorization": f"Bearer {api_key}"}
-        port = _pick_free_port()
-        cache_dir = tempfile.mkdtemp(prefix="lemond_optauth_")
-        log_path = os.path.join(cache_dir, "lemond.log")
-        env = os.environ.copy()
-        env["LEMONADE_API_KEY"] = api_key
-        env.pop("LEMONADE_ADMIN_API_KEY", None)
-
-        server = None
-        try:
-            with open(log_path, "w", encoding="utf-8") as log_file:
-                server = subprocess.Popen(
-                    [lemond_binary, cache_dir, "--port", str(port)],
-                    stdout=log_file,
-                    stderr=subprocess.STDOUT,
-                    env=env,
-                )
-
-            deadline = time.time() + 60
-            healthy = False
-            while time.time() < deadline:
-                if server.poll() is not None:
-                    break  # exited early; surface the log below
-                if _lemond_health_ok(port, headers):
-                    healthy = True
-                    break
-                time.sleep(1)
-
-            if not healthy:
-                with open(log_path, "r", encoding="utf-8", errors="replace") as f:
-                    log = f.read()
-                self.fail(
-                    f"lemond never became healthy on port {port}.\n"
-                    f"=== lemond log ===\n{log}"
-                )
-
-            response = requests.get(
-                f"http://localhost:{port}/api/v1/models/{ENDPOINT_TEST_MODEL}/options",
-                headers=headers,
-                timeout=TIMEOUT_DEFAULT,
-            )
-            self.assertEqual(response.status_code, 200, response.text)
-
-            command = response.json()["load_command"]
-            self.assertIn('-H "Authorization: Bearer $LEMONADE_API_KEY"', command)
-            self.assertNotIn(api_key, command)
-
-            print("[OK] load_command carries the Authorization header /load requires")
-        finally:
-            if server is not None and server.poll() is None:
-                server.terminate()
-                try:
-                    server.wait(timeout=10)
-                except subprocess.TimeoutExpired:
-                    server.kill()
-                    server.wait(timeout=10)
-            shutil.rmtree(cache_dir, ignore_errors=True)
 
     def test_013_auto_load_forwards_only_allowlisted_options(self):
         """Regression for #2663 / PR #2664 review: request-scoped params must NOT leak


### PR DESCRIPTION
Context: we realized that the design of this field was based on a misunderstanding. It was introduced after v11.6.0 released, so if remove before vNext we can avoid supporting it forever as a published API. FYI @superm1 this should be in the vNext release this week.

## Summary

Removes the `load_command` field from `/v1/models/{id}/options` before it ships, along with the shell-quoting helper that existed only to build it, its documentation, and the two tests that covered it. Clients that need the command can build it from `effective`, which is already the exact `/v1/load` body.

Closes #3191

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

Note: the two 4-line Black reformats in `test/server_endpoints.py` are pre-existing on `main` (Black 26.1.0 flags them there too); the pre-commit hook applied them because it formats the whole file.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_ Built `lemond` (Ninja/Release) and ran it against an isolated cache dir and port. `GET` and `POST {"dry_run": true}` on `/api/v1/models/Qwen3-0.6B-GGUF/options` both return `model_name`, `recipe`, `saved`, `effective`, `defaults`, and `resolved_ctx_size` with no `load_command`.

## Documentation

- [x] Documentation is affected and has been updated.

## Breaking Changes

- [x] This PR does not introduce breaking changes.

The field was never in a release.

## AI-assisted contribution

- [x] I used AI tools for this PR.

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.
