### PR TITLE
docs: add latest release and Lemonade AI YouTube videos to news feed

### DIFF
--- a/docs/assets/news-data.js
+++ b/docs/assets/news-data.js
@@ -4,7 +4,7 @@ const newsData = [
         title: "The easiest free local coding setup with Pi and Qwen3.8 27B!",
         url: "https://www.youtube.com/watch?v=AT10gUUgTrE",
         date: "August 19, 2026",
-        description: "Install the Pi coding agent, connect it to Lemonade, and let Qwen3.8 27B build this video's title card in HTML and CSS—all running locally for free.",
+        description: "Install the Pi coding agent, connect it to Lemonade, and let Qwen3.8 27B build this video's title card in HTML and CSS, all running locally for free.",
         image: "https://img.youtube.com/vi/AT10gUUgTrE/maxresdefault.jpg",
         imageStyle: "width: 100%; height: 100%; object-position: center top; ",
         type: "video"
@@ -13,7 +13,7 @@ const newsData = [
         title: "Make images and audio in Claude Code with the local AI skill!",
         url: "https://www.youtube.com/watch?v=OmteZN1Wtes",
         date: "August 17, 2026",
-        description: "See how AMD's local-ai-use skill lets Claude Code—or Codex or Cursor—generate images and audio with local AI through Lemonade.",
+        description: "See how AMD's local-ai-use skill lets Claude Code, Codex, or Cursor generate images and audio with local AI through Lemonade.",
         image: "https://img.youtube.com/vi/OmteZN1Wtes/maxresdefault.jpg",
         imageStyle: "width: 100%; height: 100%; object-position: center top; ",
         type: "video"

--- a/docs/assets/news-data.js
+++ b/docs/assets/news-data.js
@@ -1,6 +1,24 @@
 // News content data - easy to add new entries
 const newsData = [
     {
+        title: "Make images and audio in Claude Code with the local AI skill!",
+        url: "https://www.youtube.com/watch?v=OmteZN1Wtes",
+        date: "August 17, 2026",
+        description: "See how AMD's local-ai-use skill lets Claude Code—or Codex or Cursor—generate images and audio with local AI through Lemonade.",
+        image: "https://img.youtube.com/vi/OmteZN1Wtes/maxresdefault.jpg",
+        imageStyle: "width: 100%; height: 100%; object-position: center top; ",
+        type: "video"
+        },
+    {
+        title: "Run day0 LLMs locally with Lemonade, feat. Muse Glimmer 30B",
+        url: "https://www.youtube.com/watch?v=0RVUGOHtp6k",
+        date: "August 10, 2026",
+        description: "A walkthrough of running day-0 open-weights models locally with Lemonade, using Meta's Muse Glimmer 30B as the example.",
+        image: "https://img.youtube.com/vi/0RVUGOHtp6k/maxresdefault.jpg",
+        imageStyle: "width: 100%; height: 100%; object-position: center top; ",
+        type: "video"
+        },
+    {
         title: "Run Meta's Muse Glimmer 30B locally with Lemonade",
         url: "https://lemonade-server.ai/news/muse-glimmer.html",
         date: "August 10, 2026",

--- a/docs/assets/news-data.js
+++ b/docs/assets/news-data.js
@@ -1,6 +1,15 @@
 // News content data - easy to add new entries
 const newsData = [
     {
+        title: "The easiest free local coding setup with Pi and Qwen3.8 27B!",
+        url: "https://www.youtube.com/watch?v=AT10gUUgTrE",
+        date: "August 19, 2026",
+        description: "Install the Pi coding agent, connect it to Lemonade, and let Qwen3.8 27B build this video's title card in HTML and CSS—all running locally for free.",
+        image: "https://img.youtube.com/vi/AT10gUUgTrE/maxresdefault.jpg",
+        imageStyle: "width: 100%; height: 100%; object-position: center top; ",
+        type: "video"
+        },
+    {
         title: "Make images and audio in Claude Code with the local AI skill!",
         url: "https://www.youtube.com/watch?v=OmteZN1Wtes",
         date: "August 17, 2026",

--- a/docs/assets/news-data.js
+++ b/docs/assets/news-data.js
@@ -19,6 +19,15 @@ const newsData = [
         type: "video"
         },
     {
+        title: "Lemonade 11.6 Integrates Muse-Glimmer 30B, Experimental TheNoise ROCm Image Generation",
+        url: "https://www.phoronix.com/news/Lemonade-SDK-11.6",
+        date: "August 14, 2026",
+        description: "Phoronix covers the Lemonade 11.6 release: Muse Glimmer 30B in the llama.cpp catalog, an experimental TheNoise ROCm image-generation backend for Strix Halo and Strix Point, and out-of-the-box support for older AMD Instinct GPUs.",
+        image: "https://raw.githubusercontent.com/lemonade-sdk/assets/refs/heads/main/partner_logos/phoronix.svg",
+        imageStyle: "width: 100%; height: 100%; object-position: center top; ",
+        type: "blog"
+        },
+    {
         title: "Run day0 LLMs locally with Lemonade, feat. Muse Glimmer 30B",
         url: "https://www.youtube.com/watch?v=0RVUGOHtp6k",
         date: "August 10, 2026",
@@ -86,7 +95,7 @@ const newsData = [
         url: "https://www.phoronix.com/news/Lemonade-SDK-10.2-Released",
         date: "April 9, 2026",
         description: "Phoronix covers the Lemonade SDK 10.2 release, which publishes embeddable artifacts so developers can bundle Lemonade's local AI stack into their own apps.",
-        image: "https://raw.githubusercontent.com/lemonade-sdk/assets/refs/heads/main/docs/banner.png",
+        image: "https://raw.githubusercontent.com/lemonade-sdk/assets/refs/heads/main/partner_logos/phoronix.svg",
         imageStyle: "width: 100%; height: 100%; object-position: center top; ",
         type: "blog"
         },
@@ -95,7 +104,7 @@ const newsData = [
         url: "https://www.phoronix.com/news/Lemonade-10.1-Released",
         date: "April 7, 2026",
         description: "Phoronix highlights Lemonade 10.1, featuring a revamped CLI, async model loading, super resolution upscaling, and Gemma 4 GPU support.",
-        image: "https://raw.githubusercontent.com/lemonade-sdk/assets/refs/heads/main/docs/banner.png",
+        image: "https://raw.githubusercontent.com/lemonade-sdk/assets/refs/heads/main/partner_logos/phoronix.svg",
         imageStyle: "width: 100%; height: 100%; object-position: center top; ",
         type: "blog"
         },


### PR DESCRIPTION

<img width="2440" height="1310" alt="image" src="https://github.com/user-attachments/assets/dfc93dd1-73dd-4257-ad77-44d271e2c968" />

## Summary

Adds four missing news items to `docs/assets/news-data.js` and gives Phoronix articles their own thumbnail.

The three most recent uploads from the [Lemonade AI YouTube channel](https://youtube.com/@lemonadeai):

- **The easiest free local coding setup with Pi and Qwen3.8 27B!** (Aug 19, 2026)
- **Make images and audio in Claude Code with the local AI skill!** (Aug 17, 2026)
- **Run day0 LLMs locally with Lemonade, feat. Muse Glimmer 30B** (Aug 10, 2026)

Plus the Phoronix writeup of the 11.6 release, [Lemonade 11.6 Integrates Muse-Glimmer 30B, Experimental TheNoise ROCm Image Generation](https://www.phoronix.com/news/Lemonade-SDK-11.6) (Aug 14, 2026).

All three Phoronix entries now use [`partner_logos/phoronix.svg`](https://github.com/lemonade-sdk/assets/blob/main/partner_logos/phoronix.svg) from the assets repo instead of the generic Lemonade banner, so press coverage is identifiable at a glance. It is a 1.8 KB 16:9 card in Phoronix's own palette (`#348755` on near-black), with the wordmark drawn as vector paths whose metrics were measured off the site logo; a pixel overlay against their published raster matches within ~1px.

This PR itself touches only `news-data.js`.

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_ Data-only change (no C++ build affected). Validated `news-data.js` with `node --check`, then parsed the data and confirmed 48 entries, no missing fields, no duplicate URLs, and correct placement of the four new entries. (The 7 pre-existing ordering violations among the 2025 entries are unchanged from `main`.) Video titles, IDs, and dates come from the channel's RSS feed; the article title and date come from the Phoronix page itself. Rendered `/news/` in Chromium both from `file://` and from a local server: all three Phoronix cards fetch the SVG from `raw.githubusercontent.com` and render at its natural 1200x675. The newest video's `maxresdefault.jpg` returns 200 (95 KB); the two older thumbnails follow the same convention but were not fetched.

## Documentation

- [x] Documentation is affected and has been updated.

## Breaking Changes

- [x] This PR does not introduce breaking changes.

## AI-assisted contribution

- [x] I used AI tools for this PR.

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HHDD3aiRTUFbWgjYgZp4Th)_


