### PR TITLE
fix(gui3): derive recipe configuration from system-info

### DIFF
--- a/src/app/src/components/BackendManager.tsx
+++ b/src/app/src/components/BackendManager.tsx
@@ -1,12 +1,10 @@
 import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import api, { friendlyErrorMessage } from '../api';
-import {
-  BackendTuning,
-  backendSupportsArgs,
-} from '../modelConfiguration';
+import { BackendTuning } from '../modelConfiguration';
 import { Icon, type IconName } from './Icon';
 import { WorkspaceCatalogLayout, WorkspaceCatalogSection } from './WorkspaceCatalogLayout';
 import { useFocusTrap } from '../hooks/useFocusTrap';
+import { recipeCapability } from '../features/backends/recipeMetadata';
 import { DownloadListItem, downloadStore, isDownloadActive } from '../features/downloadManager/downloadStore';
 import { WorkspaceActionButton, WorkspaceActionGroup, WorkspacePaneHeader } from './WorkspacePanels';
 
@@ -41,6 +39,7 @@ interface RecipeInfo {
   experimental?: boolean;
   display_name?: string;
   web_display_name?: string;
+  modality?: string;
 }
 
 interface SystemInfoData {
@@ -115,22 +114,6 @@ const BACKEND_LABELS: Record<string, string> = {
   dml:      'DirectML',
 };
 
-/** Recipe → capability column for the matrix */
-const RECIPE_CAPABILITY: Record<string, string> = {
-  llamacpp:       'LLM',
-  whispercpp:     'Audio',
-  moonshine:      'Audio',
-  'sd-cpp':       'Image',
-  kokoro:         'TTS',
-  flm:            'LLM',
-  'ryzenai-llm':  'LLM',
-  vllm:           'LLM',
-  acestep:         'Audio',
-  thinksound:      'Audio',
-  openmoss:        'TTS',
-  trellis:         '3D',
-};
-
 // Older lemond builds did not expose descriptor.experimental through
 // /system-info yet. Keep a compatibility fallback for the recipes that are
 // declared experimental in the backend descriptor registry. Newer servers
@@ -184,7 +167,7 @@ const BACKEND_DEVICE: Record<string, DeviceKey> = {
 };
 
 /** Capability columns */
-const CAPABILITY_COLS = ['LLM', 'Audio', 'Image', 'TTS', '3D'] as const;
+const CAPABILITY_COLS = ['LLM', 'Audio', 'Image', 'TTS', '3D', 'Other'] as const;
 
 type CapabilityCol = typeof CAPABILITY_COLS[number];
 type CellEntry = { recipe: string; backend: string; info: BackendInfo };
@@ -203,6 +186,7 @@ const CAPABILITY_LABELS: Record<CapabilityCol, string> = {
   Image: 'Image generation',
   TTS: 'Text to speech',
   '3D': '3D generation',
+  Other: 'Other runtimes',
 };
 
 const CAPABILITY_DESCRIPTIONS: Record<CapabilityCol, string> = {
@@ -211,6 +195,7 @@ const CAPABILITY_DESCRIPTIONS: Record<CapabilityCol, string> = {
   Image: 'Image generation and editing runtimes.',
   TTS: 'Text-to-speech runtimes.',
   '3D': '3D asset generation runtimes.',
+  Other: 'Runtimes with a server-defined modality this GUI has not seen before.',
 };
 
 const BACKEND_VIEW_FILTERS: Array<[BackendViewFilter, string, string, IconName]> = [
@@ -1059,7 +1044,7 @@ const BackendManager: React.FC<BackendManagerProps> = ({ isActive = true }) => {
     const cells = new Map<string, CellEntry[]>();
 
     for (const [recipe, recipeInfo] of Object.entries(sysInfo.recipes)) {
-      const cap = (RECIPE_CAPABILITY[recipe] || 'LLM') as CapabilityCol;
+      const cap = recipeCapability(sysInfo, recipe) as CapabilityCol;
       for (const [backend, backendInfo] of Object.entries(recipeInfo.backends)) {
         const effectiveInfo: BackendInfo = {
           ...backendInfo,
@@ -1126,7 +1111,6 @@ const BackendManager: React.FC<BackendManagerProps> = ({ isActive = true }) => {
 
   const renderBackendCard = useCallback(({ recipe, variants }: BackendCatalogEntry) => {
     const engineName = RECIPE_LABELS[recipe] || recipe;
-    const supportsArgs = backendSupportsArgs(recipe);
     const logo = ENGINE_LOGOS[recipe];
 
     return (
@@ -1163,6 +1147,7 @@ const BackendManager: React.FC<BackendManagerProps> = ({ isActive = true }) => {
           {variants.map(({ backend, info }) => {
             const badge = stateBadge(info.state);
             const cellKey = backendKey(recipe, backend);
+            const canEditArgs = backendArgsTarget(runtimeConfig, cellKey) !== null;
             const isInstalling = installing === cellKey;
             const backendDownload = downloadItems.find(download => backendDownloadMatches(download, recipe, backend));
             const showBackendProgress = Boolean(backendDownload && (isDownloadActive(backendDownload) || backendDownload.status === 'paused'));
@@ -1285,7 +1270,7 @@ const BackendManager: React.FC<BackendManagerProps> = ({ isActive = true }) => {
                         {isInstalling ? 'Working…' : 'Uninstall'}
                       </WorkspaceActionButton>
                     )}
-                    {supportsArgs && info.state !== 'unsupported' && (
+                    {canEditArgs && info.state !== 'unsupported' && (
                       <WorkspaceActionButton
                         type="button"
                         size="toolbar"
@@ -1324,7 +1309,7 @@ const BackendManager: React.FC<BackendManagerProps> = ({ isActive = true }) => {
         </div>
       </article>
     );
-  }, [backendTunings, downloadItems, handleAction, handleInstall, handleUninstall, installing, showLogos, showTech]);
+  }, [backendTunings, downloadItems, handleAction, handleInstall, handleUninstall, installing, runtimeConfig, showLogos, showTech, sysInfo]);
 
 
   const isUpdatesView = viewFilter === 'updates';

--- a/src/app/src/components/ModelDetailPanel.tsx
+++ b/src/app/src/components/ModelDetailPanel.tsx
@@ -10,6 +10,17 @@ import DOMPurify from 'dompurify';
 import type { ModelInfo, LoadedModel, ModelFileInfo, HFModelResult, ModelRegistryProvider, PullVariantsResult, CloudProviderRow } from '../api';
 import api from '../api';
 import { copyTextToClipboard } from '../clipboard';
+import {
+  recipeBackendOptionName,
+  recipeOptionHint,
+  recipeOptionIsArgs,
+  recipeOptionIsBackend,
+  recipeOptionIsBoolean,
+  recipeOptionIsDevice,
+  recipeOptionIsNumeric,
+  recipeOptionLabel,
+  recipeOptionNames,
+} from '../features/backends/recipeMetadata';
 import { capabilityFromModelInfo, capabilityLabel, identityFromModelInfo } from '../modelCapabilities';
 import {
   modelBaseTuningForModel, loadModelTuning, saveModelTuning, resetModelTuning,
@@ -268,82 +279,28 @@ const TUNING_FIELD_HINTS: Partial<Record<keyof RecipeOptions, string>> = {
   flm_args: 'Raw backend args for this model only.',
 };
 
-const NUMERIC_TUNING_KEYS = new Set<keyof RecipeOptions>(['steps', 'cfg_scale', 'width', 'height', 'flow_shift', 'speed']);
-const BOOLEAN_TUNING_KEYS = new Set<keyof RecipeOptions>();
-const BACKEND_TUNING_KEYS = new Set<keyof RecipeOptions>(['llamacpp_backend', 'vllm_backend', 'sd-cpp_backend', 'whispercpp_backend', 'moonshine_backend', 'acestep_backend', 'thinksound_backend', 'openmoss_backend', 'trellis_backend']);
-const DEVICE_TUNING_KEYS = new Set<keyof RecipeOptions>(['llamacpp_device']);
-const ARGS_TUNING_KEYS = new Set<keyof RecipeOptions>(['llamacpp_args', 'sdcpp_args', 'whispercpp_args', 'moonshine_args', 'vllm_args', 'flm_args']);
-const BACKEND_ARGS_KEY: Partial<Record<keyof RecipeOptions, keyof RecipeOptions>> = {
-  llamacpp_backend: 'llamacpp_args',
-  vllm_backend: 'vllm_args',
-  'sd-cpp_backend': 'sdcpp_args',
-  whispercpp_backend: 'whispercpp_args',
-  moonshine_backend: 'moonshine_args',
-};
-
-const LLAMACPP_RECIPE_KEYS: Array<keyof RecipeOptions> = ['llamacpp_backend', 'llamacpp_device', 'llamacpp_args'];
-const VLLM_RECIPE_KEYS: Array<keyof RecipeOptions> = ['vllm_backend', 'vllm_args'];
-const FLM_RECIPE_KEYS: Array<keyof RecipeOptions> = ['flm_args'];
-const RYZENAI_RECIPE_KEYS: Array<keyof RecipeOptions> = [];
-const IMAGE_RECIPE_KEYS: Array<keyof RecipeOptions> = ['sd-cpp_backend', 'steps', 'cfg_scale', 'width', 'height', 'sampling_method', 'flow_shift', 'sdcpp_args'];
-const WHISPER_RECIPE_KEYS: Array<keyof RecipeOptions> = ['whispercpp_backend', 'whispercpp_args'];
-const MOONSHINE_RECIPE_KEYS: Array<keyof RecipeOptions> = ['moonshine_backend', 'moonshine_args'];
-const TTS_RECIPE_KEYS: Array<keyof RecipeOptions> = ['voice', 'speed'];
-const ACESTEP_RECIPE_KEYS: Array<keyof RecipeOptions> = ['acestep_backend'];
-const THINKSOUND_RECIPE_KEYS: Array<keyof RecipeOptions> = ['thinksound_backend'];
-const OPENMOSS_RECIPE_KEYS: Array<keyof RecipeOptions> = ['openmoss_backend', 'voice', 'speed'];
-const TRELLIS_RECIPE_KEYS: Array<keyof RecipeOptions> = ['trellis_backend'];
-
-
-
 function formatContextSize(value: number): string {
   if (!Number.isFinite(value) || value <= 0) return 'auto';
   if (value >= 1024 && value % 1024 === 0) return `${Math.round(value / 1024)}K`;
   return value.toLocaleString();
 }
 
-function recipeKeysForRecipe(recipe: string): Array<keyof RecipeOptions> | null {
-  switch (recipe) {
-    case 'llamacpp': return LLAMACPP_RECIPE_KEYS;
-    case 'vllm': return VLLM_RECIPE_KEYS;
-    case 'flm': return FLM_RECIPE_KEYS;
-    case 'ryzenai-llm': return RYZENAI_RECIPE_KEYS;
-    case 'sd-cpp': return IMAGE_RECIPE_KEYS;
-    case 'whispercpp': return WHISPER_RECIPE_KEYS;
-    case 'moonshine': return MOONSHINE_RECIPE_KEYS;
-    case 'kokoro': return TTS_RECIPE_KEYS;
-    case 'acestep': return ACESTEP_RECIPE_KEYS;
-    case 'thinksound': return THINKSOUND_RECIPE_KEYS;
-    case 'openmoss': return OPENMOSS_RECIPE_KEYS;
-    case 'trellis': return TRELLIS_RECIPE_KEYS;
-    default: return null;
+function tuningKeysForModel(
+  model: ModelInfo,
+  info: SystemInfoLike,
+): Array<keyof RecipeOptions> {
+  const recipe = activeRecipeForModel(model);
+  const keys = recipeOptionNames(info, recipe)
+    .map(key => key as keyof RecipeOptions);
+
+  // voice/speed are model sampling fields rather than backend descriptor
+  // options, so keep this small non-recipe-specific residue for TTS models.
+  if (capabilityFromModelInfo(model) === 'tts') {
+    if (!keys.includes('voice')) keys.push('voice');
+    if (!keys.includes('speed')) keys.push('speed');
   }
-}
 
-function tuningKeysForModel(model: ModelInfo): Array<keyof RecipeOptions> {
-  const cap = capabilityFromModelInfo(model);
-  const recipes = recipesForDisplay(model);
-  const activeRecipe = activeRecipeForModel(model);
-  const set = new Set<keyof RecipeOptions>();
-  const add = (keys: Array<keyof RecipeOptions>) => keys.forEach(key => set.add(key));
-
-  const activeKeys = recipeKeysForRecipe(activeRecipe);
-  if (activeKeys) add(activeKeys);
-  else if (cap === 'chat') add(LLAMACPP_RECIPE_KEYS);
-  else if (cap === 'image') add(IMAGE_RECIPE_KEYS);
-  else if (cap === 'audio') add(recipes.includes('moonshine') ? MOONSHINE_RECIPE_KEYS : WHISPER_RECIPE_KEYS);
-  else if (cap === 'audio-generation') add(recipes.includes('acestep') ? ACESTEP_RECIPE_KEYS : THINKSOUND_RECIPE_KEYS);
-  else if (cap === 'tts') add(recipes.includes('openmoss') ? OPENMOSS_RECIPE_KEYS : TTS_RECIPE_KEYS);
-  else if (cap === 'model3d') add(TRELLIS_RECIPE_KEYS);
-
-  const base = modelBaseTuningForModel(model).recipe_options;
-  Object.keys(base).forEach(key => {
-    if (key !== 'ctx_size' && key !== 'merge_args' && key !== 'mmproj_enabled') set.add(key as keyof RecipeOptions);
-  });
-  set.delete('ctx_size');
-  set.delete('merge_args');
-  set.delete('mmproj_enabled');
-  return [...set];
+  return keys.filter(key => key !== 'ctx_size' && key !== 'merge_args' && key !== 'mmproj_enabled');
 }
 
 type SystemInfoLike = Record<string, unknown> | null | undefined;
@@ -370,60 +327,25 @@ function backendIsSelectable(recipe: string, backend: string, info: unknown): bo
   return true;
 }
 
-function activeRecipeForBackendKey(key: keyof RecipeOptions, model: ModelInfo): string {
-  switch (key) {
-    case 'llamacpp_backend': return 'llamacpp';
-    case 'vllm_backend': return 'vllm';
-    case 'sd-cpp_backend': return 'sd-cpp';
-    case 'whispercpp_backend': return 'whispercpp';
-    case 'moonshine_backend': return 'moonshine';
-    case 'acestep_backend': return 'acestep';
-    case 'thinksound_backend': return 'thinksound';
-    case 'openmoss_backend': return 'openmoss';
-    case 'trellis_backend': return 'trellis';
-    default: return activeRecipeForModel(model);
-  }
-}
-
-function fallbackBackendsForRecipe(recipe: string): string[] {
-  switch (recipe) {
-    case 'vllm': return ['cpu', 'cuda', 'rocm'];
-    case 'whispercpp': return ['cpu', 'cuda', 'vulkan', 'opencl'];
-    case 'moonshine': return ['cpu', 'cuda'];
-    case 'sd-cpp': return ['cpu', 'cuda', 'vulkan', 'rocm'];
-    case 'kokoro': return ['cpu'];
-    case 'acestep':
-    case 'thinksound':
-    case 'openmoss':
-    case 'trellis': return ['cuda', 'rocm', 'vulkan'];
-    case 'llamacpp':
-    default:
-      // Keep fallback conservative: no Metal/NPU unless the server explicitly reports them as selectable.
-      return ['cpu', 'cuda', 'vulkan', 'opencl', 'rocm'];
-  }
-}
-
 function recipeDefaultBackend(info: SystemInfoLike, recipe: string): string {
   return optionalDisplayValue(systemRecipes(info)?.[recipe]?.default_backend);
 }
 
 function backendOptionsForKey(key: keyof RecipeOptions, current: string | undefined, model: ModelInfo, info: SystemInfoLike): string[] {
-  const recipe = activeRecipeForBackendKey(key, model);
+  const recipe = activeRecipeForModel(model);
   const fromServer = Object.entries(backendMapForRecipe(info, recipe) || {})
     .filter(([backend, backendInfo]) => backendIsSelectable(recipe, backend, backendInfo) && backendMatchesDetectedHardware(backend, info))
     .map(([backend]) => backend);
-  const rawBase = fromServer.length ? fromServer : fallbackBackendsForRecipe(recipe);
-  const base = rawBase.filter(backend => backendMatchesDetectedHardware(backend, info));
-  const safeBase = Array.from(new Set(['auto', ...(base.length ? base : ['cpu'])]));
   const normalizedCurrent = optionalDisplayValue(current);
-  const options = normalizedCurrent && !safeBase.includes(normalizedCurrent) ? [normalizedCurrent, ...safeBase] : safeBase;
+  const base = fromServer.length ? ['auto', ...fromServer] : [normalizedCurrent || 'auto'];
+  const options = normalizedCurrent && !base.includes(normalizedCurrent) ? [normalizedCurrent, ...base] : base;
   return Array.from(new Set(options.filter(Boolean)));
 }
 
 function activeBackendValue(key: keyof RecipeOptions, baseValue: unknown, model: ModelInfo, info: SystemInfoLike): string {
   const fromModel = optionalDisplayValue(baseValue);
   if (fromModel) return fromModel;
-  const recipe = activeRecipeForBackendKey(key, model);
+  const recipe = activeRecipeForModel(model);
   return recipeDefaultBackend(info, recipe) || 'auto';
 }
 
@@ -1076,7 +998,8 @@ const ModelConfigurationTab: React.FC<{
     [model, serverDefaultCtxSize],
   );
   const supportsContextSize = modelSupportsContextSize(model);
-  const recipeKeys = useMemo(() => tuningKeysForModel(model), [model]);
+  const activeRecipe = activeRecipeForModel(model);
+  const recipeKeys = useMemo(() => tuningKeysForModel(model, systemInfo), [model, systemInfo]);
   const knownVoiceOptions = useMemo(() => knownVoiceOptionsForModel(model), [model]);
   const knownVoiceIds = useMemo(() => new Set(knownVoiceOptions.map(option => option.id.toLowerCase())), [knownVoiceOptions]);
 
@@ -1186,17 +1109,20 @@ const ModelConfigurationTab: React.FC<{
     );
     setCtxSizeDraft(String(nextValue));
   };
-  const selectorKeys = recipeKeys.filter(key => BACKEND_TUNING_KEYS.has(key) || DEVICE_TUNING_KEYS.has(key));
-  const argsKeys = recipeKeys.filter(key => ARGS_TUNING_KEYS.has(key));
+  const selectorKeys = recipeKeys.filter(key =>
+    recipeOptionIsBackend(systemInfo, activeRecipe, String(key))
+    || recipeOptionIsDevice(systemInfo, activeRecipe, String(key))
+  );
+  const argsKeys = recipeKeys.filter(key => recipeOptionIsArgs(systemInfo, activeRecipe, String(key)));
   const otherRecipeKeys = recipeKeys.filter(key => !selectorKeys.includes(key) && !argsKeys.includes(key));
 
   const buildConfigOptions = (): RecipeOptions => {
     const raw: Partial<RecipeOptions> = {};
     for (const [key, value] of Object.entries(recipeDraft) as Array<[keyof RecipeOptions, string]>) {
       if (!value.trim()) continue;
-      if (BOOLEAN_TUNING_KEYS.has(key)) {
+      if (recipeOptionIsBoolean(systemInfo, activeRecipe, String(key))) {
         (raw as Record<string, unknown>)[key] = value === 'true';
-      } else if (NUMERIC_TUNING_KEYS.has(key)) {
+      } else if (recipeOptionIsNumeric(systemInfo, activeRecipe, String(key))) {
         const n = parseNumberOrUndefined(value);
         if (n !== undefined) (raw as Record<string, unknown>)[key] = n;
       } else {
@@ -1307,11 +1233,12 @@ const ModelConfigurationTab: React.FC<{
 
   const renderConfigRecipeField = (key: keyof RecipeOptions) => {
     const fieldId = `config-${name}-${String(key)}`.replace(/[^a-zA-Z0-9_-]/g, '-');
-    const label = TUNING_FIELD_LABELS[key] || String(key);
+    const label = TUNING_FIELD_LABELS[key] || recipeOptionLabel(systemInfo, activeRecipe, String(key));
+    const hint = TUNING_FIELD_HINTS[key] || recipeOptionHint(systemInfo, activeRecipe, String(key));
     const draftValue = recipeDraft[String(key)] || '';
     const baseValue = serverEffectiveRecipeOptions[key] ?? baseTuning.recipe_options[key];
 
-    if (BACKEND_TUNING_KEYS.has(key)) {
+    if (recipeOptionIsBackend(systemInfo, activeRecipe, String(key))) {
       const activeBackend = activeBackendValue(key, baseValue, model, info);
       const options = backendOptionsForKey(key, draftValue || undefined, model, info).filter(opt => opt !== activeBackend);
       return (
@@ -1330,9 +1257,11 @@ const ModelConfigurationTab: React.FC<{
       );
     }
 
-    if (DEVICE_TUNING_KEYS.has(key)) {
-      const backendKey: keyof RecipeOptions = 'llamacpp_backend';
-      const selectedBackend = recipeDraft[String(backendKey)] || activeBackendValue(backendKey, baseTuning.recipe_options[backendKey], model, info);
+    if (recipeOptionIsDevice(systemInfo, activeRecipe, String(key))) {
+      const backendKey = recipeBackendOptionName(systemInfo, activeRecipe) as keyof RecipeOptions | null;
+      const selectedBackend = backendKey
+        ? recipeDraft[String(backendKey)] || activeBackendValue(backendKey, baseTuning.recipe_options[backendKey], model, info)
+        : 'auto';
       const activeDevice = optionalDisplayValue(baseValue) || 'auto';
       const options = deviceOptionsForKey(key, draftValue || undefined, selectedBackend, model, info).filter(opt => opt !== activeDevice);
       return (
@@ -1402,8 +1331,7 @@ const ModelConfigurationTab: React.FC<{
       );
     }
 
-    if (ARGS_TUNING_KEYS.has(key)) {
-      const hint = TUNING_FIELD_HINTS[key];
+    if (recipeOptionIsArgs(systemInfo, activeRecipe, String(key))) {
       const defaultPlaceholders: Partial<Record<keyof RecipeOptions, string>> = {
         llamacpp_args: '--gpu-layers 35 --threads 8 --batch-size 512',
         vllm_args: '--tensor-parallel-size 1 --max-model-len 8192',
@@ -1436,7 +1364,27 @@ const ModelConfigurationTab: React.FC<{
       );
     }
 
-    if (NUMERIC_TUNING_KEYS.has(key)) {
+    if (recipeOptionIsBoolean(systemInfo, activeRecipe, String(key))) {
+      return (
+        <div key={String(key)} className="detail-tuning__field detail-configuration__field">
+          <span id={`${fieldId}-label`}>{label}</span>
+          <select
+            id={fieldId}
+            className="select detail-configuration__select"
+            value={draftValue}
+            aria-labelledby={`${fieldId}-label`}
+            onChange={e => setRecipeDraft(prev => ({ ...prev, [String(key)]: e.target.value }))}
+          >
+            <option value="">{baseValue === undefined ? 'Model default' : `Model default (${baseValue ? 'on' : 'off'})`}</option>
+            <option value="true">On</option>
+            <option value="false">Off</option>
+          </select>
+          {hint && <small>{hint}</small>}
+        </div>
+      );
+    }
+
+    if (recipeOptionIsNumeric(systemInfo, activeRecipe, String(key))) {
       const stepNumericInput = (direction: -1 | 1) => {
         const input = document.getElementById(fieldId);
         if (!(input instanceof HTMLInputElement)) return;
@@ -1467,6 +1415,7 @@ const ModelConfigurationTab: React.FC<{
               </button>
             </span>
           </div>
+          {hint && <small>{hint}</small>}
         </div>
       );
     }
@@ -1482,6 +1431,7 @@ const ModelConfigurationTab: React.FC<{
           placeholder={optionalDisplayValue(baseValue) || ''}
           onChange={e => setRecipeDraft(prev => ({ ...prev, [String(key)]: e.target.value }))}
         />
+        {hint && <small>{hint}</small>}
       </label>
     );
   };

--- a/src/app/src/components/ModelListPanel.tsx
+++ b/src/app/src/components/ModelListPanel.tsx
@@ -27,6 +27,7 @@ import {
   type WorkspaceListRowStatus,
 } from './WorkspacePanels';
 import { backendCompactLabel, backendLabel } from '../modelPresentation';
+import { recipeBackendOptionName } from '../features/backends/recipeMetadata';
 
 /* ── Helpers ─────────────────────────────────────────────────── */
 
@@ -60,32 +61,9 @@ export interface ModelBackendReadiness {
   state?: string;
 }
 
-const BACKEND_MANAGED_RECIPES = new Set([
-  'llamacpp',
-  'vllm',
-  'flm',
-  'ryzenai-llm',
-  'sd-cpp',
-  'whispercpp',
-  'moonshine',
-  'kokoro',
-  'acestep',
-  'thinksound',
-  'openmoss',
-  'trellis',
-]);
-
-const BACKEND_OPTION_FIELD: Record<string, string> = {
-  llamacpp: 'llamacpp_backend',
-  vllm: 'vllm_backend',
-  'sd-cpp': 'sd-cpp_backend',
-  whispercpp: 'whispercpp_backend',
-  moonshine: 'moonshine_backend',
-  acestep: 'acestep_backend',
-  thinksound: 'thinksound_backend',
-  openmoss: 'openmoss_backend',
-  trellis: 'trellis_backend',
-};
+function needsLocalBackend(recipe: string): boolean {
+  return !recipe.startsWith('cloud') && !recipe.startsWith('collection');
+}
 
 function asRecord(value: unknown): Record<string, any> | null {
   return value && typeof value === 'object' && !Array.isArray(value)
@@ -97,11 +75,16 @@ function normalizedBackend(value: unknown): string {
   return typeof value === 'string' ? value.trim().toLowerCase() : '';
 }
 
-function configuredBackendForModel(model: ModelInfo, recipe: string, recipeInfo: Record<string, any>): string {
+function configuredBackendForModel(
+  model: ModelInfo,
+  recipe: string,
+  recipeInfo: Record<string, any>,
+  systemInfo?: Record<string, unknown> | null,
+): string {
   const raw = model as any;
   const recipeOptions = asRecord(raw.recipe_options);
   const options = asRecord(raw.options);
-  const field = BACKEND_OPTION_FIELD[recipe];
+  const field = recipeBackendOptionName(systemInfo, recipe);
   const configured = normalizedBackend(
     (field ? recipeOptions?.[field] : undefined)
       ?? recipeOptions?.backend
@@ -136,7 +119,7 @@ export function modelBackendReadiness(
   }
 
   const recipeInfo = asRecord(recipes[recipe]);
-  if (!recipeInfo && !BACKEND_MANAGED_RECIPES.has(recipe)) {
+  if (!recipeInfo && !needsLocalBackend(recipe)) {
     return { tone: 'ready', label: 'Model downloaded and ready.' };
   }
   if (!recipeInfo) {
@@ -156,7 +139,7 @@ export function modelBackendReadiness(
     };
   }
 
-  const configuredBackend = configuredBackendForModel(model, recipe, recipeInfo);
+  const configuredBackend = configuredBackendForModel(model, recipe, recipeInfo, systemInfo);
   let backend = configuredBackend;
   let backendInfo: Record<string, any> | null = null;
 

--- a/src/app/src/features/backends/recipeMetadata.ts
+++ b/src/app/src/features/backends/recipeMetadata.ts
@@ -1,0 +1,128 @@
+/**
+ * Small, read-only view over lemond's /v1/system-info recipe metadata.
+ *
+ * Recipe ids are an open server-owned set. Descriptor metadata is authoritative:
+ * this module intentionally has no per-recipe fallback tables. Presentation and
+ * branding remain in the existing UI presentation helpers.
+ */
+
+export type RecipeCapability = 'LLM' | 'Audio' | 'Image' | 'TTS' | '3D' | 'Other';
+
+export interface RecipeOptionMetadata {
+  name: string;
+  cliFlag: string;
+  defaultValue: unknown;
+  typeName: string;
+  help: string;
+  group: string;
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {};
+}
+
+function asString(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function normalizedRecipeKey(recipe: string): string {
+  return String(recipe || '').trim().toLowerCase();
+}
+
+function recipeRecord(systemInfo: unknown, recipe: string): Record<string, unknown> {
+  const recipes = asRecord(asRecord(systemInfo).recipes);
+  return asRecord(recipes[normalizedRecipeKey(recipe)]);
+}
+
+export function recipeCapability(systemInfo: unknown, recipe: string): RecipeCapability {
+  const modality = asString(recipeRecord(systemInfo, recipe).modality).toLowerCase();
+  switch (modality) {
+    case 'text generation':
+    case 'embeddings':
+    case 'reranking':
+    case 'text classification': return 'LLM';
+    case 'speech-to-text':
+    case 'audio generation': return 'Audio';
+    case 'image generation': return 'Image';
+    case 'text-to-speech': return 'TTS';
+    case '3d generation': return '3D';
+    default: return 'Other';
+  }
+}
+
+export function recipeOptions(systemInfo: unknown, recipe: string): RecipeOptionMetadata[] {
+  const raw = recipeRecord(systemInfo, recipe).options;
+  if (!Array.isArray(raw)) return [];
+  return raw.map(entry => {
+    const option = asRecord(entry);
+    return {
+      name: asString(option.name),
+      cliFlag: asString(option.cli_flag),
+      defaultValue: option.default,
+      typeName: asString(option.type_name),
+      help: asString(option.help),
+      group: asString(option.group),
+    };
+  }).filter(option => option.name !== '');
+}
+
+export function recipeOptionNames(systemInfo: unknown, recipe: string): string[] {
+  const names = recipeOptions(systemInfo, recipe).map(option => option.name);
+  const backend = recipeBackendOptionName(systemInfo, recipe);
+  if (backend && !names.includes(backend)) names.unshift(backend);
+  return names;
+}
+
+export function recipeOption(
+  systemInfo: unknown,
+  recipe: string,
+  key: string,
+): RecipeOptionMetadata | undefined {
+  return recipeOptions(systemInfo, recipe).find(option => option.name === key);
+}
+
+export function recipeBackendOptionName(systemInfo: unknown, recipe: string): string | null {
+  const explicit = recipeOptions(systemInfo, recipe).find(option => option.typeName === 'BACKEND')?.name;
+  if (explicit) return explicit;
+  return recipeRecord(systemInfo, recipe).selectable_backend === true
+    ? `${normalizedRecipeKey(recipe)}_backend`
+    : null;
+}
+
+export function recipeOptionLabel(systemInfo: unknown, recipe: string, key: string): string {
+  const typeName = recipeOption(systemInfo, recipe, key)?.typeName;
+  if (recipeOptionIsBackend(systemInfo, recipe, key)) return 'Backend';
+  if (typeName === 'DEVICES') return 'Device';
+  if (recipeOptionIsArgs(systemInfo, recipe, key)) return 'Backend args';
+  return key.charAt(0).toUpperCase() + key.slice(1).replace(/_/g, ' ');
+}
+
+export function recipeOptionHint(systemInfo: unknown, recipe: string, key: string): string | undefined {
+  const help = recipeOption(systemInfo, recipe, key)?.help;
+  if (help) return help;
+  if (recipeOptionIsArgs(systemInfo, recipe, key)) return 'Raw backend args for this model only.';
+  return undefined;
+}
+
+export function recipeOptionIsBackend(systemInfo: unknown, recipe: string, key: string): boolean {
+  return recipeBackendOptionName(systemInfo, recipe) === key;
+}
+
+export function recipeOptionIsDevice(systemInfo: unknown, recipe: string, key: string): boolean {
+  return recipeOption(systemInfo, recipe, key)?.typeName === 'DEVICES';
+}
+
+export function recipeOptionIsArgs(systemInfo: unknown, recipe: string, key: string): boolean {
+  const option = recipeOption(systemInfo, recipe, key);
+  return Boolean(option && option.typeName === 'ARGS' && option.name.endsWith('_args'));
+}
+
+export function recipeOptionIsNumeric(systemInfo: unknown, recipe: string, key: string): boolean {
+  return recipeOption(systemInfo, recipe, key)?.typeName === 'SIZE' || key === 'speed';
+}
+
+export function recipeOptionIsBoolean(systemInfo: unknown, recipe: string, key: string): boolean {
+  return recipeOption(systemInfo, recipe, key)?.typeName === 'BOOL';
+}

--- a/src/app/src/modelConfiguration.ts
+++ b/src/app/src/modelConfiguration.ts
@@ -2,20 +2,7 @@ import type { ModelInfo } from './api';
 import { capabilityFromModelInfo, type ModelCapability } from './modelCapabilities';
 import { storageKey } from './storage';
 
-export type RecipeName =
-  | 'llamacpp'
-  | 'sd-cpp'
-  | 'whispercpp'
-  | 'moonshine'
-  | 'flm'
-  | 'ryzenai-llm'
-  | 'vllm'
-  | 'kokoro'
-  | 'acestep'
-  | 'thinksound'
-  | 'openmoss'
-  | 'trellis'
-  | 'auto';
+export type RecipeName = string;
 
 export type ThinkingMode = 'none' | 'normal' | 'smart' | 'smart_extra';
 export type TuningValueSource = 'custom' | 'built_in' | 'generic' | 'optimized';
@@ -94,26 +81,6 @@ export const MODEL_CONFIGURATION_EVENT = 'lemonade:model-configuration-changed';
 
 const LS_MODEL_TUNINGS = 'model_tunings';
 
-const BACKEND_ARGS_FIELD_BY_RECIPE: Partial<Record<RecipeName, keyof RecipeOptions>> = {
-  llamacpp: 'llamacpp_args',
-  'sd-cpp': 'sdcpp_args',
-  whispercpp: 'whispercpp_args',
-  moonshine: 'moonshine_args',
-  flm: 'flm_args',
-  vllm: 'vllm_args',
-};
-
-const BACKEND_FIELD_BY_RECIPE: Record<string, keyof RecipeOptions> = {
-  llamacpp: 'llamacpp_backend',
-  vllm: 'vllm_backend',
-  whispercpp: 'whispercpp_backend',
-  moonshine: 'moonshine_backend',
-  acestep: 'acestep_backend',
-  thinksound: 'thinksound_backend',
-  openmoss: 'openmoss_backend',
-  trellis: 'trellis_backend',
-};
-
 export const THINKING_MODE_LABELS: Record<ThinkingMode, string> = {
   none: 'None',
   normal: 'Normal',
@@ -131,13 +98,43 @@ function emitModelConfigurationEvent(): void {
   } catch {}
 }
 
-export function backendArgsFieldForRecipe(recipe: string): keyof RecipeOptions | null {
-  const recipeName = normalizeRecipeName(recipe);
-  return recipeName ? BACKEND_ARGS_FIELD_BY_RECIPE[recipeName] || null : null;
+function recipeOptionFieldFromSystemInfo(
+  systemInfo: Record<string, unknown> | null | undefined,
+  recipe: string,
+  predicate: (option: Record<string, unknown>) => boolean,
+): keyof RecipeOptions | undefined {
+  const recipes = (systemInfo?.recipes ?? null) as Record<string, { options?: unknown }> | null;
+  const options = recipes?.[String(recipe || '').trim().toLowerCase()]?.options;
+  if (!Array.isArray(options)) return undefined;
+  for (const entry of options) {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) continue;
+    const option = entry as Record<string, unknown>;
+    if (!predicate(option)) continue;
+    if (typeof option.name === 'string' && option.name.trim()) {
+      return option.name.trim() as keyof RecipeOptions;
+    }
+  }
+  return undefined;
 }
 
-export function backendSupportsArgs(recipe: string): boolean {
-  return backendArgsFieldForRecipe(recipe) !== null;
+export function backendArgsFieldForRecipe(
+  recipe: string,
+  systemInfo?: Record<string, unknown> | null,
+): keyof RecipeOptions | null {
+  return recipeOptionFieldFromSystemInfo(
+    systemInfo,
+    recipe,
+    option => option.type_name === 'ARGS'
+      && typeof option.name === 'string'
+      && option.name.endsWith('_args'),
+  ) ?? null;
+}
+
+export function backendSupportsArgs(
+  recipe: string,
+  systemInfo?: Record<string, unknown> | null,
+): boolean {
+  return backendArgsFieldForRecipe(recipe, systemInfo) !== null;
 }
 
 export interface SessionArgsOverride {
@@ -246,10 +243,7 @@ function sanitizeTuningValues(raw: TuningValues | null | undefined): TuningValue
 function normalizeRecipeName(value: unknown): RecipeName | undefined {
   const rawName = String(value || '').trim().toLowerCase();
   const name = rawName === 'sd_cpp' ? 'sd-cpp' : rawName === 'ryzenai_llm' ? 'ryzenai-llm' : rawName;
-  return [
-    'auto', 'llamacpp', 'sd-cpp', 'whispercpp', 'moonshine', 'flm',
-    'ryzenai-llm', 'vllm', 'kokoro', 'acestep', 'thinksound', 'openmoss', 'trellis',
-  ].includes(name) ? name as RecipeName : undefined;
+  return name || undefined;
 }
 
 export function sanitizeModelTuning(raw: Partial<ModelTuning> | null | undefined): ModelTuning {
@@ -544,43 +538,44 @@ export function modelDefaultRecipeOptions(model: ModelInfo | null | undefined, f
   }
   if (recipe === 'ryzenai-llm') out.ctx_size = ctx;
 
-  if (capability === 'image' || recipe === 'sd-cpp') {
-    out['sd-cpp_backend'] = readStringFromModelOrRecipe(model, [
-      ['recipe_options', 'sd-cpp_backend'], ['options', 'sd-cpp_backend'], ['sd-cpp_backend'],
-    ]) ?? backend;
+  if (capability === 'image') {
     out.steps = readNumberFromModelOrRecipe(model, [['recipe_options', 'steps'], ['sample_params', 'steps'], ['sample_steps'], ['steps']]);
     out.cfg_scale = readNumberFromModelOrRecipe(model, [['recipe_options', 'cfg_scale'], ['sample_params', 'cfg_scale'], ['sample_params', 'guidance', 'txt_cfg'], ['txt_cfg'], ['cfg_scale']]);
     out.width = readNumberFromModelOrRecipe(model, [['recipe_options', 'width'], ['sample_params', 'width'], ['width']]);
     out.height = readNumberFromModelOrRecipe(model, [['recipe_options', 'height'], ['sample_params', 'height'], ['height']]);
+  }
+  if (recipe === 'sd-cpp') {
+    out['sd-cpp_backend'] = readStringFromModelOrRecipe(model, [
+      ['recipe_options', 'sd-cpp_backend'], ['options', 'sd-cpp_backend'], ['sd-cpp_backend'],
+    ]) ?? backend;
     out.sampling_method = readStringFromModelOrRecipe(model, [['recipe_options', 'sampling_method'], ['sample_params', 'sampling_method'], ['sampling_method']]);
     out.flow_shift = readNumberFromModelOrRecipe(model, [['recipe_options', 'flow_shift'], ['sample_params', 'flow_shift'], ['flow_shift']]);
     out.sdcpp_args = readStringFromModelOrRecipe(model, [['recipe_options', 'sdcpp_args'], ['options', 'sdcpp_args'], ['sdcpp_args'], ['args']]);
   }
 
-  if (capability === 'audio' || recipe === 'whispercpp' || recipe === 'moonshine') {
-    if (recipe === 'moonshine') {
-      out.moonshine_backend = readStringFromModelOrRecipe(model, [
-        ['recipe_options', 'moonshine_backend'], ['options', 'moonshine_backend'], ['moonshine_backend'],
-      ]) ?? backend;
-      out.moonshine_args = readStringFromModelOrRecipe(model, [
-        ['recipe_options', 'moonshine_args'], ['options', 'moonshine_args'], ['moonshine_args'], ['args'],
-      ]);
-    } else {
-      out.whispercpp_backend = readStringFromModelOrRecipe(model, [
-        ['recipe_options', 'whispercpp_backend'], ['options', 'whispercpp_backend'], ['whispercpp_backend'],
-      ]) ?? backend;
-      out.whispercpp_args = readStringFromModelOrRecipe(model, [
-        ['recipe_options', 'whispercpp_args'], ['options', 'whispercpp_args'], ['whispercpp_args'], ['args'],
-      ]);
-    }
+  if (recipe === 'moonshine') {
+    out.moonshine_backend = readStringFromModelOrRecipe(model, [
+      ['recipe_options', 'moonshine_backend'], ['options', 'moonshine_backend'], ['moonshine_backend'],
+    ]) ?? backend;
+    out.moonshine_args = readStringFromModelOrRecipe(model, [
+      ['recipe_options', 'moonshine_args'], ['options', 'moonshine_args'], ['moonshine_args'], ['args'],
+    ]);
+  }
+  if (recipe === 'whispercpp') {
+    out.whispercpp_backend = readStringFromModelOrRecipe(model, [
+      ['recipe_options', 'whispercpp_backend'], ['options', 'whispercpp_backend'], ['whispercpp_backend'],
+    ]) ?? backend;
+    out.whispercpp_args = readStringFromModelOrRecipe(model, [
+      ['recipe_options', 'whispercpp_args'], ['options', 'whispercpp_args'], ['whispercpp_args'], ['args'],
+    ]);
   }
 
-  if (capability === 'audio-generation' || recipe === 'acestep' || recipe === 'thinksound') {
+  if (recipe === 'acestep' || recipe === 'thinksound') {
     if (recipe === 'acestep') out.acestep_backend = readStringFromModelOrRecipe(model, [['recipe_options', 'acestep_backend'], ['options', 'acestep_backend'], ['acestep_backend']]) ?? backend;
     if (recipe === 'thinksound') out.thinksound_backend = readStringFromModelOrRecipe(model, [['recipe_options', 'thinksound_backend'], ['options', 'thinksound_backend'], ['thinksound_backend']]) ?? backend;
   }
 
-  if (capability === 'model3d' || recipe === 'trellis') {
+  if (recipe === 'trellis') {
     out.trellis_backend = readStringFromModelOrRecipe(model, [['recipe_options', 'trellis_backend'], ['options', 'trellis_backend'], ['trellis_backend']]) ?? backend;
   }
 
@@ -735,13 +730,30 @@ function recipeDefaultBackend(systemInfo: Record<string, unknown> | null | undef
   return normalizeBackendValue(recipes?.[recipe]?.default_backend);
 }
 
+function backendFieldFromSystemInfo(
+  systemInfo: Record<string, unknown> | null | undefined,
+  recipe: string,
+): keyof RecipeOptions | undefined {
+  const explicit = recipeOptionFieldFromSystemInfo(
+    systemInfo,
+    recipe,
+    option => option.type_name === 'BACKEND',
+  );
+  if (explicit) return explicit;
+  const recipes = (systemInfo?.recipes ?? null) as Record<string, { selectable_backend?: unknown }> | null;
+  const normalizedRecipe = String(recipe || '').trim().toLowerCase();
+  return recipes?.[normalizedRecipe]?.selectable_backend === true
+    ? `${normalizedRecipe}_backend` as keyof RecipeOptions
+    : undefined;
+}
+
 function concreteBackendForRecipe(
   recipe: string,
   explicitOptions: RecipeOptions | null | undefined,
   modelOptions: RecipeOptions | null | undefined,
   systemInfo: Record<string, unknown> | null | undefined,
 ): string | undefined {
-  const field = BACKEND_FIELD_BY_RECIPE[recipe];
+  const field = backendFieldFromSystemInfo(systemInfo, recipe);
   return (field ? normalizeBackendValue(explicitOptions?.[field]) : undefined)
     ?? (field ? normalizeBackendValue(modelOptions?.[field]) : undefined)
     ?? recipeDefaultBackend(systemInfo, recipe);
@@ -764,7 +776,7 @@ export function activeBackendTuningForModel(
   }
 
   for (const recipe of recipes) {
-    if (!backendSupportsArgs(recipe)) continue;
+    if (!backendSupportsArgs(recipe, ctx?.systemInfo)) continue;
     const backend = concreteBackendForRecipe(recipe, ctx?.explicitOptions, ctx?.modelOptions, ctx?.systemInfo);
     if (!backend) continue;
     const key = `${recipe}:${backend}`;
@@ -792,14 +804,14 @@ export function recipeOptionsForModel(
   });
   const backendOptions: RecipeOptions = {};
   if (backendTuning) {
-    const field = backendArgsFieldForRecipe(backendTuning.recipe);
+    const field = backendArgsFieldForRecipe(backendTuning.recipe, systemInfo);
     if (field) (backendOptions as Record<string, unknown>)[field] = backendTuning.tuning.args;
   }
 
   const merged: RecipeOptions = { ...backendOptions, ...modelOptions };
   const sessionOverride = getSessionArgsOverride(modelName);
   if (sessionOverride) {
-    const field = backendArgsFieldForRecipe(sessionOverride.recipe);
+    const field = backendArgsFieldForRecipe(sessionOverride.recipe, systemInfo);
     if (field) {
       (merged as Record<string, unknown>)[field] = sessionOverride.args;
       merged.merge_args = false;

--- a/src/app/tests/configuration-consistency.runtime.cjs
+++ b/src/app/tests/configuration-consistency.runtime.cjs
@@ -8,6 +8,10 @@ const appPath = path.join(root, 'src/App.tsx');
 const chatPath = path.join(root, 'src/components/ChatView.tsx');
 const effectivePath = path.join(root, 'src/components/EffectiveSettingsModal.tsx');
 const detailPath = path.join(root, 'src/components/ModelDetailPanel.tsx');
+const backendManagerPath = path.join(root, 'src/components/BackendManager.tsx');
+const modelListPath = path.join(root, 'src/components/ModelListPanel.tsx');
+const modelConfigurationPath = path.join(root, 'src/modelConfiguration.ts');
+const recipeMetadataPath = path.join(root, 'src/features/backends/recipeMetadata.ts');
 const apiPath = path.join(root, 'src/api.ts');
 const stylesPath = path.join(root, 'src/styles/styles.css');
 
@@ -16,6 +20,10 @@ const sources = new Map([
   [chatPath, fs.readFileSync(chatPath, 'utf8')],
   [effectivePath, fs.readFileSync(effectivePath, 'utf8')],
   [detailPath, fs.readFileSync(detailPath, 'utf8')],
+  [backendManagerPath, fs.readFileSync(backendManagerPath, 'utf8')],
+  [modelListPath, fs.readFileSync(modelListPath, 'utf8')],
+  [modelConfigurationPath, fs.readFileSync(modelConfigurationPath, 'utf8')],
+  [recipeMetadataPath, fs.readFileSync(recipeMetadataPath, 'utf8')],
   [apiPath, fs.readFileSync(apiPath, 'utf8')],
 ]);
 const styles = fs.readFileSync(stylesPath, 'utf8');
@@ -44,6 +52,10 @@ const appSource = sources.get(appPath);
 const chatSource = sources.get(chatPath);
 const effectiveSource = sources.get(effectivePath);
 const detailSource = sources.get(detailPath);
+const backendManagerSource = sources.get(backendManagerPath);
+const modelListSource = sources.get(modelListPath);
+const modelConfigurationSource = sources.get(modelConfigurationPath);
+const recipeMetadataSource = sources.get(recipeMetadataPath);
 const apiSource = sources.get(apiPath);
 
 assert.match(appSource, /<header className="titlebar" data-tauri-drag-region>/);
@@ -98,5 +110,221 @@ assert.match(chatSource, /api\.getModelOptions\(currentModel\)/, 'chat generatio
 assert.match(chatSource, /api\.getModelOptions\(modelName\)/, 'pinned TTS must use server-owned model options');
 assert.match(chatSource, /api\.getModelOptions\(model\.name\)/, 'capability TTS must use server-owned model options');
 assert.doesNotMatch(chatSource, /loadModelTuning\s*\([^)]*\)[^;\n]*recipe_options/, 'chat must not read recipe options from browser model tuning state');
+
+
+
+
+// GUI3 server-defined recipe metadata contract v3.
+assert.doesNotMatch(backendManagerSource, /RECIPE_CAPABILITY/, 'backend sections must not enumerate recipes');
+assert.doesNotMatch(backendManagerSource, /backendSupportsArgs/, 'backend Args availability must not use a recipe allowlist');
+assert.match(backendManagerSource, /llamacpp:\s+'llama\.cpp'/,
+  'functional recipe metadata refactor must preserve existing backend presentation labels');
+assert.match(backendManagerSource, /const label = `\$\{RECIPE_LABELS\[recipe\] \|\| recipe\} · \$\{backend \|\| 'default'\}`;/,
+  'backend Args dialog must preserve the established accessible recipe label');
+assert.match(backendManagerSource, /const engineName = RECIPE_LABELS\[recipe\] \|\| recipe;/,
+  'backend Args trigger must preserve the established accessible recipe label');
+assert.match(backendManagerSource, /const canEditArgs = backendArgsTarget\(runtimeConfig, cellKey\) !== null;/,
+  'backend Args availability must require the concrete writable runtime-config target');
+assert.match(backendManagerSource,
+  /const hasPerBackendArgs = Object\.keys\(section\)\.some\(key => key\.endsWith\('_args'\)\);[\s\S]*else if \(!hasPerBackendArgs && Object\.prototype\.hasOwnProperty\.call\(section, 'args'\)\)/,
+  'final #3183 per-backend args safety rule must remain intact');
+assert.doesNotMatch(detailSource, /IMAGE_RECIPE_KEYS|recipeKeysForRecipe\(|fallbackBackendsForRecipe\(/,
+  'Model Configuration must not map an unknown recipe onto a frontend recipe table');
+assert.match(detailSource, /recipeOptionNames\(info, recipe\)/,
+  'Model Configuration fields must come from recipes[].options[]');
+assert.match(detailSource, /recipeBackendOptionName\(systemInfo, activeRecipe\)/,
+  'device options must resolve their owning backend field from recipe metadata');
+assert.match(detailSource, /api\.getModelOptions\(name\)/,
+  'Model Configuration must keep reading model-specific defaults from lemond');
+assert.match(detailSource, /const baseValue = serverEffectiveRecipeOptions\[key\] \?\? baseTuning\.recipe_options\[key\];/,
+  'server-effective model defaults must win over frontend fallback values');
+
+assert.doesNotMatch(modelListSource, /BACKEND_MANAGED_RECIPES|BACKEND_OPTION_FIELD/,
+  'model readiness must not enumerate recipe ids or backend option names');
+assert.match(modelListSource, /recipeBackendOptionName\(systemInfo, recipe\)/,
+  'model readiness must discover the backend field from system-info');
+assert.match(modelConfigurationSource, /export type RecipeName = string;/,
+  'recipe ids must be an open server-owned set');
+assert.doesNotMatch(modelConfigurationSource, /BACKEND_ARGS_FIELD_BY_RECIPE|BACKEND_FIELD_BY_RECIPE/,
+  'backend option resolution must not keep per-recipe compatibility maps');
+assert.match(modelConfigurationSource, /backendArgsFieldForRecipe\(backendTuning\.recipe, systemInfo\)/,
+  'model backend args must resolve their option name from system-info');
+
+const metadataCompiled = ts.transpileModule(recipeMetadataSource, {
+  compilerOptions: { target: ts.ScriptTarget.ES2022, module: ts.ModuleKind.CommonJS },
+  fileName: recipeMetadataPath,
+  reportDiagnostics: true,
+});
+const metadataErrors = (metadataCompiled.diagnostics || []).filter(
+  diagnostic => diagnostic.category === ts.DiagnosticCategory.Error,
+);
+assert.equal(metadataErrors.length, 0,
+  metadataErrors.map(diagnostic => ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n')).join('\n'));
+const metadataModule = { exports: {} };
+new Function('module', 'exports', metadataCompiled.outputText)(metadataModule, metadataModule.exports);
+const metadata = metadataModule.exports;
+
+const recipeFixture = {
+  recipes: {
+    thenoise: {
+      modality: 'Image generation',
+      options: [
+        { name: 'thenoise_backend', type_name: 'BACKEND', help: 'TheNoise backend to use' },
+        { name: 'steps', type_name: 'SIZE', help: 'Number of denoising steps' },
+        { name: 'cfg_scale', type_name: 'SIZE', help: 'CFG scale' },
+        { name: 'width', type_name: 'SIZE', help: 'Output image width' },
+        { name: 'height', type_name: 'SIZE', help: 'Output image height' },
+        { name: 'sampler', type_name: 'ARGS', help: 'Denoising solver' },
+        { name: 'negative_prompt', type_name: 'ARGS', help: 'Negative prompt' },
+        { name: 'qwen_vae_enhance', type_name: 'BOOL', help: 'Nyquist notch post-filter' },
+        { name: 'film_grain', type_name: 'SIZE', help: 'Film grain strength' },
+        { name: 'sharpening', type_name: 'SIZE', help: 'RCAS sharpening strength' },
+        { name: 'lora_specs', type_name: 'ARGS', help: 'Comma-separated LoRA specs' },
+      ],
+    },
+    futurellm: {
+      modality: 'Text generation',
+      options: [
+        { name: 'futurellm_backend', type_name: 'BACKEND' },
+        { name: 'futurellm_args', type_name: 'ARGS' },
+      ],
+    },
+  },
+};
+assert.equal(metadata.recipeCapability(recipeFixture, 'thenoise'), 'Image');
+assert.deepEqual(metadata.recipeOptionNames(recipeFixture, 'thenoise'),
+  ['thenoise_backend', 'steps', 'cfg_scale', 'width', 'height', 'sampler', 'negative_prompt',
+    'qwen_vae_enhance', 'film_grain', 'sharpening', 'lora_specs']);
+assert.equal(metadata.recipeOptionIsBackend(recipeFixture, 'thenoise', 'thenoise_backend'), true);
+assert.equal(metadata.recipeOptionIsBoolean(recipeFixture, 'thenoise', 'qwen_vae_enhance'), true);
+assert.equal(metadata.recipeOptionIsNumeric(recipeFixture, 'thenoise', 'film_grain'), true);
+assert.equal(metadata.recipeOptionIsNumeric(recipeFixture, 'thenoise', 'sharpening'), true);
+assert.equal(metadata.recipeOptionIsArgs(recipeFixture, 'thenoise', 'lora_specs'), false,
+  'generic ARGS-valued recipe options are not backend argv fields');
+assert.equal(metadata.recipeOptionIsArgs(recipeFixture, 'futurellm', 'futurellm_args'), true,
+  'a future backend *_args field is discovered without a frontend recipe entry');
+assert.equal(metadata.recipeCapability({ recipes: { llamacpp: { backends: {} } } }, 'llamacpp'), 'Other',
+  'missing descriptor modality must not be hidden by a frontend recipe fallback');
+assert.deepEqual(metadata.recipeOptionNames({ recipes: { llamacpp: { backends: {} } } }, 'llamacpp'), [],
+  'missing descriptor options must not be hidden by a frontend recipe fallback');
+assert.equal(metadata.recipeCapability({ recipes: { strange: { modality: 'New modality' } } }, 'strange'), 'Other',
+  'unknown server modalities must not silently fall back to LLM');
+
+
+// GUI3 server-defined recipe metadata contract v4.
+assert.doesNotMatch(backendManagerSource, /RECIPE_CAPABILITY/, 'backend sections must not enumerate recipes');
+assert.doesNotMatch(backendManagerSource, /backendSupportsArgs/, 'backend Args availability must not use a recipe allowlist');
+assert.match(backendManagerSource, /llamacpp:\s+'llama\.cpp'/,
+  'functional recipe metadata refactor must preserve existing backend presentation labels');
+assert.match(backendManagerSource, /const label = `\$\{RECIPE_LABELS\[recipe\] \|\| recipe\} · \$\{backend \|\| 'default'\}`;/,
+  'backend Args dialog must preserve the established accessible recipe label');
+assert.match(backendManagerSource, /const engineName = RECIPE_LABELS\[recipe\] \|\| recipe;/,
+  'backend Args trigger must preserve the established accessible recipe label');
+assert.match(backendManagerSource, /const canEditArgs = backendArgsTarget\(runtimeConfig, cellKey\) !== null;/,
+  'backend Args availability must require the concrete writable runtime-config target');
+assert.match(backendManagerSource,
+  /const hasPerBackendArgs = Object\.keys\(section\)\.some\(key => key\.endsWith\('_args'\)\);[\s\S]*else if \(!hasPerBackendArgs && Object\.prototype\.hasOwnProperty\.call\(section, 'args'\)\)/,
+  'final #3183 per-backend args safety rule must remain intact');
+assert.doesNotMatch(detailSource, /IMAGE_RECIPE_KEYS|recipeKeysForRecipe\(|fallbackBackendsForRecipe\(/,
+  'Model Configuration must not map an unknown recipe onto a frontend recipe table');
+assert.match(detailSource, /recipeOptionNames\(info, recipe\)/,
+  'Model Configuration fields must come from recipes[].options[]');
+assert.match(detailSource, /recipeBackendOptionName\(systemInfo, activeRecipe\)/,
+  'device options must resolve their owning backend field from recipe metadata');
+assert.match(detailSource, /const TUNING_FIELD_LABELS:/,
+  'known field labels remain presentation overrides, not functional recipe discovery');
+assert.match(detailSource, /const TUNING_FIELD_HINTS:/,
+  'known field help remains presentation-only while new fields use server metadata');
+assert.match(detailSource, /TUNING_FIELD_LABELS\[key\] \|\| recipeOptionLabel\(systemInfo, activeRecipe, String\(key\)\)/,
+  'known labels must win while unknown fields still render from server metadata');
+assert.match(detailSource, /api\.getModelOptions\(name\)/,
+  'Model Configuration must keep reading model-specific defaults from lemond');
+assert.match(detailSource, /const baseValue = serverEffectiveRecipeOptions\[key\] \?\? baseTuning\.recipe_options\[key\];/,
+  'server-effective model defaults must win over frontend fallback values');
+
+assert.doesNotMatch(modelListSource, /BACKEND_MANAGED_RECIPES|BACKEND_OPTION_FIELD/,
+  'model readiness must not enumerate recipe ids or backend option names');
+assert.match(modelListSource, /recipeBackendOptionName\(systemInfo, recipe\)/,
+  'model readiness must discover the backend field from system-info');
+assert.match(modelConfigurationSource, /export type RecipeName = string;/,
+  'recipe ids must be an open server-owned set');
+assert.doesNotMatch(modelConfigurationSource, /BACKEND_ARGS_FIELD_BY_RECIPE|BACKEND_FIELD_BY_RECIPE/,
+  'backend option resolution must not keep per-recipe compatibility maps');
+assert.match(modelConfigurationSource, /backendArgsFieldForRecipe\(backendTuning\.recipe, systemInfo\)/,
+  'model backend args must resolve their option name from system-info');
+assert.match(modelConfigurationSource, /selectable_backend === true/,
+  'backend field discovery may derive <recipe>_backend only from the server selectable_backend contract');
+assert.doesNotMatch(modelConfigurationSource, /capability === 'image' \|\| recipe === 'sd-cpp'/,
+  'an unknown image recipe must never inherit sd-cpp-only fields');
+assert.doesNotMatch(modelConfigurationSource, /capability === 'audio' \|\| recipe === 'whispercpp'/,
+  'an unknown audio recipe must never inherit whispercpp-only fields');
+
+const metadataCompiled = ts.transpileModule(recipeMetadataSource, {
+  compilerOptions: { target: ts.ScriptTarget.ES2022, module: ts.ModuleKind.CommonJS },
+  fileName: recipeMetadataPath,
+  reportDiagnostics: true,
+});
+const metadataErrors = (metadataCompiled.diagnostics || []).filter(
+  diagnostic => diagnostic.category === ts.DiagnosticCategory.Error,
+);
+assert.equal(metadataErrors.length, 0,
+  metadataErrors.map(diagnostic => ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n')).join('\n'));
+const metadataModule = { exports: {} };
+new Function('module', 'exports', metadataCompiled.outputText)(metadataModule, metadataModule.exports);
+const metadata = metadataModule.exports;
+
+const recipeFixture = {
+  recipes: {
+    thenoise: {
+      modality: 'Image generation',
+      options: [
+        { name: 'thenoise_backend', type_name: 'BACKEND', help: 'TheNoise backend to use' },
+        { name: 'steps', type_name: 'SIZE', help: 'Number of denoising steps' },
+        { name: 'cfg_scale', type_name: 'SIZE', help: 'CFG scale' },
+        { name: 'width', type_name: 'SIZE', help: 'Output image width' },
+        { name: 'height', type_name: 'SIZE', help: 'Output image height' },
+        { name: 'sampler', type_name: 'ARGS', help: 'Denoising solver' },
+        { name: 'negative_prompt', type_name: 'ARGS', help: 'Negative prompt' },
+        { name: 'qwen_vae_enhance', type_name: 'BOOL', help: 'Nyquist notch post-filter' },
+        { name: 'film_grain', type_name: 'SIZE', help: 'Film grain strength' },
+        { name: 'sharpening', type_name: 'SIZE', help: 'RCAS sharpening strength' },
+        { name: 'lora_specs', type_name: 'ARGS', help: 'Comma-separated LoRA specs' },
+      ],
+    },
+    futurellm: {
+      modality: 'Text generation',
+      options: [
+        { name: 'futurellm_backend', type_name: 'BACKEND' },
+        { name: 'futurellm_args', type_name: 'ARGS' },
+      ],
+    },
+    derivedbackend: {
+      modality: 'Text generation',
+      selectable_backend: true,
+      options: [],
+    },
+  },
+};
+assert.equal(metadata.recipeCapability(recipeFixture, 'thenoise'), 'Image');
+assert.deepEqual(metadata.recipeOptionNames(recipeFixture, 'thenoise'),
+  ['thenoise_backend', 'steps', 'cfg_scale', 'width', 'height', 'sampler', 'negative_prompt',
+    'qwen_vae_enhance', 'film_grain', 'sharpening', 'lora_specs']);
+assert.equal(metadata.recipeOptionIsBackend(recipeFixture, 'thenoise', 'thenoise_backend'), true);
+assert.equal(metadata.recipeOptionIsBoolean(recipeFixture, 'thenoise', 'qwen_vae_enhance'), true);
+assert.equal(metadata.recipeOptionIsNumeric(recipeFixture, 'thenoise', 'film_grain'), true);
+assert.equal(metadata.recipeOptionIsNumeric(recipeFixture, 'thenoise', 'sharpening'), true);
+assert.equal(metadata.recipeOptionIsArgs(recipeFixture, 'thenoise', 'lora_specs'), false,
+  'generic ARGS-valued recipe options are not backend argv fields');
+assert.equal(metadata.recipeOptionIsArgs(recipeFixture, 'futurellm', 'futurellm_args'), true,
+  'a future backend *_args field is discovered without a frontend recipe entry');
+assert.equal(metadata.recipeBackendOptionName(recipeFixture, 'derivedbackend'), 'derivedbackend_backend',
+  'selectable_backend derives the conventional backend option without a recipe table');
+assert.deepEqual(metadata.recipeOptionNames(recipeFixture, 'derivedbackend'), ['derivedbackend_backend']);
+assert.equal(metadata.recipeCapability({ recipes: { llamacpp: { backends: {} } } }, 'llamacpp'), 'Other',
+  'missing descriptor modality must not be hidden by a frontend recipe fallback');
+assert.deepEqual(metadata.recipeOptionNames({ recipes: { llamacpp: { backends: {} } } }, 'llamacpp'), [],
+  'missing descriptor options must not be hidden by a frontend recipe fallback');
+assert.equal(metadata.recipeCapability({ recipes: { strange: { modality: 'New modality' } } }, 'strange'), 'Other',
+  'unknown server modalities must not silently fall back to LLM');
 
 console.log('GUI3 configuration consistency contract checks passed.');

--- a/src/app/tests/features.spec.ts
+++ b/src/app/tests/features.spec.ts
@@ -762,6 +762,35 @@ test.describe('Lemonade UI — Feature Parity', () => {
         recipes: {
           llamacpp: {
             default_backend: 'cpu',
+            selectable_backend: true,
+            uses_ctx_size: true,
+            modality: 'Text generation',
+            options: [
+              {
+                name: 'llamacpp_backend',
+                cli_flag: '--llamacpp',
+                default: '',
+                type_name: 'BACKEND',
+                help: 'LlamaCpp backend to use',
+                group: 'Llama.cpp Backend Options',
+              },
+              {
+                name: 'llamacpp_device',
+                cli_flag: '--llamacpp-device',
+                default: '',
+                type_name: 'DEVICES',
+                help: 'Comma-separated list of accelerator devices to use (e.g. Vulkan0)',
+                group: 'Llama.cpp Backend Options',
+              },
+              {
+                name: 'llamacpp_args',
+                cli_flag: '--llamacpp-args',
+                default: '',
+                type_name: 'ARGS',
+                help: 'Custom arguments to pass to llama-server',
+                group: 'Llama.cpp Backend Options',
+              },
+            ],
             backends: { cpu: { state: 'installed', version: 'test' } },
           },
         },
@@ -1502,6 +1531,35 @@ test.describe('Lemonade UI — Feature Parity', () => {
         recipes: {
           llamacpp: {
             default_backend: 'cpu',
+            selectable_backend: true,
+            uses_ctx_size: true,
+            modality: 'Text generation',
+            options: [
+              {
+                name: 'llamacpp_backend',
+                cli_flag: '--llamacpp',
+                default: '',
+                type_name: 'BACKEND',
+                help: 'LlamaCpp backend to use',
+                group: 'Llama.cpp Backend Options',
+              },
+              {
+                name: 'llamacpp_device',
+                cli_flag: '--llamacpp-device',
+                default: '',
+                type_name: 'DEVICES',
+                help: 'Comma-separated list of accelerator devices to use (e.g. Vulkan0)',
+                group: 'Llama.cpp Backend Options',
+              },
+              {
+                name: 'llamacpp_args',
+                cli_flag: '--llamacpp-args',
+                default: '',
+                type_name: 'ARGS',
+                help: 'Custom arguments to pass to llama-server',
+                group: 'Llama.cpp Backend Options',
+              },
+            ],
             backends: { cpu: { state: 'installed', version: 'test' } },
           },
         },


### PR DESCRIPTION
## Summary

Derive GUI3 recipe configuration from the recipe metadata already exposed by `/system-info` instead of maintaining separate frontend recipe tables.

This fixes the recipe coupling uncovered during #3142, where a new recipe such as `thenoise` could be classified incorrectly or inherit configuration fields from another recipe such as `sd-cpp`.

The Model Configuration tab now uses the server-provided recipe option schema for field discovery and field types, while keeping existing GUI labels and presentation overrides. Backend selection is also resolved from the recipe metadata rather than a frontend recipe allowlist.

As a follow-up to #3183, the Backends page now only exposes the backend arguments action when the selected backend variant has a concrete writable runtime-config target. This keeps the existing per-backend args safety behavior while allowing future backends to expose args without adding another GUI recipe allowlist.

No server API or C++ changes are required.

Related to #3161.
Follow-up to #3142 and #3183.

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_

- npm run typecheck
- npm test
- manual UI tresting and inference

Regression coverage includes:
- server-defined recipes such as `thenoise` use their own option schema instead of `sd-cpp` fields
- unknown recipes are not silently classified as LLM
- backend selector fields are discovered from server recipe metadata
- future `*_args` fields can be discovered without adding a frontend recipe entry
- backend args actions require a concrete writable runtime-config target
- existing `llama.cpp` accessible labels remain unchanged
- model-specific defaults continue to come from lemond

## Documentation

- [x] Documentation is not affected by this change.

## Breaking Changes

- [x] This PR does not introduce breaking changes.

## AI-assisted contribution

Please select one:

- [x] I used AI tools for this PR.

If AI tools were used:

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.