### PR TITLE
fix(server): let load args override saved args

### DIFF
--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -5793,15 +5793,27 @@ void Server::handle_load(const httplib::Request& req, httplib::Response& res) {
 
         auto info = model_manager_->get_model_info(model_name);
 
-        // Extract optional per-model settings. Omitted options keep using the
-        // saved per-model layer. Explicit null is a transient tombstone: skip
-        // only that saved key for this load, then fall through to lower layers.
+        // Extract optional per-model settings. Omitted options keep saved values;
+        // explicit *_args keys mask them for this load, and null acts as a tombstone.
+        // ctx_size=-1 explicitly requests automatic sizing.
         // ctx_size=-1 remains an explicit request for automatic sizing.
         RecipeOptions options = RecipeOptions(info.recipe, request_json);
         std::set<std::string> transient_saved_option_tombstones;
+        std::set<std::string> transient_saved_option_masks;
         for (const auto& key : RecipeOptions::keys_for_recipe(info.recipe)) {
-            if (request_json.contains(key) && request_json[key].is_null()) {
+            if (!request_json.contains(key)) {
+                continue;
+            }
+
+            if (request_json[key].is_null()) {
                 transient_saved_option_tombstones.insert(key);
+                transient_saved_option_masks.insert(key);
+                continue;
+            }
+
+            if (key.size() >= 5 &&
+                key.compare(key.size() - 5, 5, "_args") == 0) {
+                transient_saved_option_masks.insert(key);
             }
         }
 
@@ -5839,15 +5851,17 @@ void Server::handle_load(const httplib::Request& req, httplib::Response& res) {
         }
 
         // ModelInfo::recipe_options contains the model-level defaults plus the
-        // recipe_options.json overlay. Rebuild that local copy with only the
-        // explicitly tombstoned saved keys removed. This changes this load only;
-        // the persistent recipe_options.json entry remains untouched.
-        if (!transient_saved_option_tombstones.empty()) {
+        // recipe_options.json overlay. Rebuild that local copy with request-masked
+        // saved keys removed. Concrete *_args then override the saved same-key
+        // layer while merge_args can still combine model defaults and the lower
+        // architecture/backend/global layers. This load does not alter the
+        // persistent recipe_options.json entry.
+        if (!transient_saved_option_masks.empty()) {
             json per_model_options = model_manager_->get_model_default_options(info).to_json();
             const json saved = model_manager_->get_saved_model_options(model_name);
             if (saved.is_object()) {
                 for (const auto& [key, value] : saved.items()) {
-                    if (transient_saved_option_tombstones.count(key) == 0) {
+                    if (transient_saved_option_masks.count(key) == 0) {
                         per_model_options[key] = value;
                     }
                 }

--- a/test/server_endpoints.py
+++ b/test/server_endpoints.py
@@ -1109,6 +1109,15 @@ class EndpointTests(ServerTestBase):
         )
         self.assertEqual(response.status_code, 200, response.text)
 
+    def _set_global_llamacpp_args(self, args):
+        """Set the server-wide llama.cpp custom arguments."""
+        response = requests.post(
+            f"{self.internal_url}/set",
+            json={"llamacpp_args": args},
+            timeout=TIMEOUT_DEFAULT,
+        )
+        self.assertEqual(response.status_code, 200, response.text)
+
     def test_012la_load_null_transiently_clears_saved_args(self):
         """Explicit null skips a saved *_args value for one load only."""
         self._snapshot_options()
@@ -1148,7 +1157,9 @@ class EndpointTests(ServerTestBase):
         loaded_args = loaded.get("recipe_options", {}).get("llamacpp_args", "")
         self.assertNotIn("--threads 1", loaded_args)
 
-        saved = requests.get(self._options_url(), timeout=TIMEOUT_DEFAULT).json()["saved"]
+        saved = requests.get(self._options_url(), timeout=TIMEOUT_DEFAULT).json()[
+            "saved"
+        ]
         self.assertEqual(saved.get("llamacpp_args"), "--threads 1")
 
     def test_012lb_load_null_keeps_other_saved_keys(self):
@@ -1187,13 +1198,20 @@ class EndpointTests(ServerTestBase):
         self.assertNotIn("--threads 1", recipe_options.get("llamacpp_args", ""))
         self.assertEqual(recipe_options.get("ctx_size"), 3072)
 
-        saved = requests.get(self._options_url(), timeout=TIMEOUT_DEFAULT).json()["saved"]
+        saved = requests.get(self._options_url(), timeout=TIMEOUT_DEFAULT).json()[
+            "saved"
+        ]
         self.assertEqual(saved.get("llamacpp_args"), "--threads 1")
         self.assertEqual(saved.get("ctx_size"), 3072)
 
-    def test_012lc_load_merge_args_still_merges_saved_and_request_args(self):
-        """Concrete *_args requests keep the existing merge_args behavior."""
+    def test_012lc_load_request_args_replace_saved_args_layer(self):
+        """Concrete *_args requests replace the saved same-key layer."""
         self._snapshot_options()
+        config = requests.get(
+            f"{self.internal_url}/config", timeout=TIMEOUT_DEFAULT
+        ).json()
+        original_global_args = config.get("llamacpp", {}).get("args", "")
+        self.addCleanup(self._set_global_llamacpp_args, original_global_args)
         self.addCleanup(
             requests.post,
             f"{self.base_url}/unload",
@@ -1206,6 +1224,7 @@ class EndpointTests(ServerTestBase):
             timeout=TIMEOUT_DEFAULT,
         )
         self._reset_options()
+        self._set_global_llamacpp_args("")
 
         response = requests.post(
             self._options_url(),
@@ -1232,8 +1251,17 @@ class EndpointTests(ServerTestBase):
         self.assertIsNotNone(loaded)
         loaded_args = loaded.get("recipe_options", {}).get("llamacpp_args", "")
         self.assertIn("--threads 2", loaded_args)
-        self.assertIn("--threads-batch 1", loaded_args)
+        self.assertNotIn("--threads-batch 1", loaded_args)
         self.assertNotIn("--threads 1 ", loaded_args + " ")
+
+        saved = requests.get(self._options_url(), timeout=TIMEOUT_DEFAULT).json()[
+            "saved"
+        ]
+        self.assertEqual(
+            saved.get("llamacpp_args"),
+            "--threads 1 --threads-batch 1",
+            "Transient /load must not rewrite the saved args layer",
+        )
 
     def test_012ld_load_ctx_size_minus_one_remains_explicit_auto(self):
         """ctx_size=-1 is a concrete auto value, not a transient tombstone."""
@@ -1272,6 +1300,57 @@ class EndpointTests(ServerTestBase):
         options = requests.get(self._options_url(), timeout=TIMEOUT_DEFAULT).json()
         self.assertEqual(options["saved"].get("ctx_size"), -1)
         self.assertEqual(options["effective"].get("ctx_size"), -1)
+
+    def test_012le_load_request_args_still_merge_global_args(self):
+        """Request *_args skips saved same-key but still merges lower global args."""
+        self._snapshot_options()
+        config = requests.get(
+            f"{self.internal_url}/config", timeout=TIMEOUT_DEFAULT
+        ).json()
+        original_global_args = config.get("llamacpp", {}).get("args", "")
+        self.addCleanup(self._set_global_llamacpp_args, original_global_args)
+        self.addCleanup(
+            requests.post,
+            f"{self.base_url}/unload",
+            json={"model_name": ENDPOINT_TEST_MODEL},
+            timeout=TIMEOUT_DEFAULT,
+        )
+        requests.post(
+            f"{self.base_url}/unload",
+            json={"model_name": ENDPOINT_TEST_MODEL},
+            timeout=TIMEOUT_DEFAULT,
+        )
+        self._reset_options()
+        self._set_global_llamacpp_args("--no-mmap --threads 1")
+
+        response = requests.post(
+            self._options_url(),
+            json={
+                "llamacpp_args": "--threads-batch 1",
+                "merge_args": True,
+            },
+            timeout=TIMEOUT_DEFAULT,
+        )
+        self.assertEqual(response.status_code, 200, response.text)
+
+        response = requests.post(
+            f"{self.base_url}/load",
+            json={
+                "model_name": ENDPOINT_TEST_MODEL,
+                "llamacpp_args": "--threads 2",
+                "merge_args": True,
+            },
+            timeout=TIMEOUT_MODEL_OPERATION,
+        )
+        self.assertEqual(response.status_code, 200, response.text)
+
+        loaded = self._get_loaded_model_info(ENDPOINT_TEST_MODEL)
+        self.assertIsNotNone(loaded)
+        loaded_args = loaded.get("recipe_options", {}).get("llamacpp_args", "")
+        self.assertIn("--threads 2", loaded_args)
+        self.assertIn("--no-mmap", loaded_args)
+        self.assertNotIn("--threads-batch 1", loaded_args)
+        self.assertNotIn("--threads 1 ", loaded_args + " ")
 
     def test_012m_model_options_save_without_loading(self):
         """POST /models/{id}/options persists options without loading the model."""


### PR DESCRIPTION
## Summary

Make explicitly provided `*_args` in `/load` replace the saved value for the same key before `merge_args` is applied. Lower-priority architecture, backend, and global args can still be merged normally.

Follow-up/related to #3082.

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I described the testing performed below.

_Testing details:_

- Updated `test_012lc` to verify request `llamacpp_args` replace the saved same-key layer without modifying the saved value.
- Added `test_012le` to verify request args still merge with lower-priority global args and win on conflicting flags.

## Documentation

- [x] Documentation is not affected by this change.

## Breaking Changes

- [x] This PR does not introduce breaking changes.

## AI-assisted contribution

Please select one:

- [x] I used AI tools for this PR.

If AI tools were used:

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.