### PR TITLE
fix(gui): omni model bug

### DIFF
--- a/src/app/src/components/ChatView.tsx
+++ b/src/app/src/components/ChatView.tsx
@@ -46,7 +46,7 @@ import {
 import { storageKey } from '../storage';
 import { CHAT_HISTORY_PREFERENCE_EVENT, loadChatHistoryPreference } from '../features/chatHistory/historySettings';
 import type { DownloadListItem } from '../features/downloadManager/downloadStore';
-import { findModelInfoByName, getAudioTranscriptionComponent, getPrimaryChatComponent, getVisionChatComponent, isCollectionModel } from '../features/collections/collectionModels';
+import { findModelInfoByName, getAudioTranscriptionComponent, getPrimaryChatComponent, getVisionChatComponent, isCollectionModel, virtualLoadedCollection } from '../features/collections/collectionModels';
 import { LEMONADE_MCP_SERVER_ID, LEMONADE_MCP_TOOL_COUNT, MAX_MCP_SERVER_SELECTION, type McpServerToolOption } from '../tools/mcpMetadata';
 import { TTS_SETTINGS_EVENT, loadTtsPlaybackSettings, ttsVoiceFromRecipeOptions } from '../features/audio/ttsSettings';
 import {
@@ -1792,9 +1792,11 @@ const ChatView: React.FC<ChatViewProps> = ({ currentModel: selectedModel, loaded
     convoId: string,
   ): Promise<ModelSnapshot> => {
     const [{ downloadStore }, api] = await Promise.all([getDownloadStoreModule(), getApiClient()]);
-    const loadedFrom = (models: LoadedModel[]) => models.find(
-      model => model.model_name.toLowerCase() === modelName.toLowerCase(),
-    ) || null;
+    const loadedFrom = (models: LoadedModel[], info: ModelInfo | null = initialInfo) => (
+      models.find(
+        model => model.model_name.toLowerCase() === modelName.toLowerCase(),
+      ) || (info && isCollectionModel(info) ? virtualLoadedCollection(info, models) : null)
+    );
 
     let health = await api.health();
     let loaded = loadedFrom(health.all_models_loaded || []);
@@ -1860,7 +1862,7 @@ const ChatView: React.FC<ChatViewProps> = ({ currentModel: selectedModel, loaded
     await loadModelWithPolicy(modelName, info || initialInfo);
     await Promise.resolve(onRefresh());
     health = await api.health();
-    loaded = loadedFrom(health.all_models_loaded || []);
+    loaded = loadedFrom(health.all_models_loaded || [], info);
     if (!loaded) throw new Error(`${modelName} was downloaded but did not become ready for chat.`);
 
     saveLastReadyModelName(loaded.model_name);


### PR DESCRIPTION
## Summary

Fixes a GUI3 regression where Omni collections can be downloaded and loaded successfully, but the chat view still reports that the collection "did not become ready for chat."

Omni collections are virtual models: the server loads their component models rather than adding the collection name itself to `all_models_loaded`.

The chat readiness check now uses the existing virtual collection logic so a fully loaded Omni collection is correctly recognized as ready for chat.

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_

Reproduction target: `LMX-Omni-5.5B-Lite`.

Before the fix, the model downloads and its components load, but sending a chat message fails with:

`LMX-Omni-5.5B-Lite was downloaded but did not become ready for chat.`

Test:
- Load `LMX-Omni-5.5B-Lite` and send a normal chat message, also asked for an image, worked both.

## Documentation

- [x] Documentation is not affected by this change.

## Breaking Changes

- [x] This PR does not introduce breaking changes.

## AI-assisted contribution

Please select one:

- [x] I used AI tools for this PR.

If AI tools were used:

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.