### PR TITLE
fix(pre-commit): make comment-slop runnable on Windows

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,8 +30,8 @@ repos:
     hooks:
       - id: comment-slop
         name: comment slop (repeated explanations, oversized blocks)
-        entry: tools/check_comment_slop.py
-        language: script
+        entry: python tools/check_comment_slop.py
+        language: python
         pass_filenames: false
         require_serial: true
         types_or: [c, c++, python]


### PR DESCRIPTION
`comment-slop` uses `language: script`, which on Windows can't launch a `.py` via `CreateProcess` (no shebang, no assoc) → hook exits `9009`. Switch to `language: python` so pre-commit provisions an interpreter and runs `python tools/check_comment_slop.py`.