### PR TITLE
feat(server): enable cross-platform tcp keepalive socket options

### DIFF
--- a/src/cpp/include/lemon/upgradable_http_server.h
+++ b/src/cpp/include/lemon/upgradable_http_server.h
@@ -34,6 +34,9 @@
 #include <string>
 #include <thread>
 
+#include "lemon/utils/aixlog.hpp"
+#include "lemon/utils/network_utils.h"
+
 namespace lemon {
 
 bool is_websocket_endpoint(const std::string& path);
@@ -139,6 +142,9 @@ public:
 
 private:
     bool process_and_close_socket(socket_t sock) override {
+        if (!lemon::utils::configure_tcp_keepalive(sock)) {
+            LOG(DEBUG, "Server") << "Failed to configure TCP keep-alive on accepted socket" << std::endl;
+        }
         if (upgrade_handler_ && detail::peek_websocket_upgrade(sock)) {
             if (upgrade_handler_(sock)) {
                 return true;  // ownership transferred to the WebSocket server

--- a/src/cpp/include/lemon/utils/network_utils.h
+++ b/src/cpp/include/lemon/utils/network_utils.h
@@ -4,6 +4,13 @@
 #include <cstddef>
 #include <string>
 
+#ifdef _WIN32
+#include <winsock2.h>
+using socket_t = SOCKET;
+#else
+using socket_t = int;
+#endif
+
 namespace lemon::utils {
 
 bool is_tcp_listener_active(int family, const std::string& host_ip, int port);
@@ -39,5 +46,13 @@ private:
     std::atomic<std::size_t> completed_bind_attempts_{0};
     std::atomic<bool> failed_{false};
 };
+
+// Enable TCP keepalive probes with 15s initial idle, 5s retry interval, and
+// 3 probe attempts (~30s total dead-peer detection) to prevent stateful L4
+// firewalls, NAT gateways, and intermediate routers from silently dropping
+// idle TCP connections during prolonged inactivity (e.g. prompt evaluation).
+// Note: application-layer idle timeouts (e.g. nginx proxy_read_timeout or ALB
+// idle timeout) require periodic application data / SSE heartbeats.
+bool configure_tcp_keepalive(socket_t sock);
 
 } // namespace lemon::utils

--- a/src/cpp/server/utils/platform/network_unix.cpp
+++ b/src/cpp/server/utils/platform/network_unix.cpp
@@ -1,15 +1,55 @@
+#include "lemon/utils/aixlog.hpp"
 #include "lemon/utils/network_utils.h"
 
 #include <arpa/inet.h>
+#include <cstring>
 #include <errno.h>
 #include <fcntl.h>
 #include <netinet/in.h>
+#include <netinet/tcp.h>
 #include <sys/select.h>
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <unistd.h>
 
+#if defined(__APPLE__)
+#define LEMON_TCP_KEEPIDLE TCP_KEEPALIVE
+#elif defined(TCP_KEEPIDLE)
+#define LEMON_TCP_KEEPIDLE TCP_KEEPIDLE
+#endif
+
 namespace lemon::utils {
+
+bool configure_tcp_keepalive(socket_t sock) {
+    int opt = 1;
+    bool ok = true;
+    if (setsockopt(sock, SOL_SOCKET, SO_KEEPALIVE, &opt, sizeof(opt)) != 0) {
+        LOG(DEBUG, "Server") << "setsockopt(SO_KEEPALIVE) failed: " << std::strerror(errno) << " (" << errno << ")" << std::endl;
+        ok = false;
+    }
+#ifdef LEMON_TCP_KEEPIDLE
+    int idle = 15;
+    if (setsockopt(sock, IPPROTO_TCP, LEMON_TCP_KEEPIDLE, &idle, sizeof(idle)) != 0) {
+        LOG(DEBUG, "Server") << "setsockopt(LEMON_TCP_KEEPIDLE) failed: " << std::strerror(errno) << " (" << errno << ")" << std::endl;
+        ok = false;
+    }
+#endif
+#ifdef TCP_KEEPINTVL
+    int interval = 5;
+    if (setsockopt(sock, IPPROTO_TCP, TCP_KEEPINTVL, &interval, sizeof(interval)) != 0) {
+        LOG(DEBUG, "Server") << "setsockopt(TCP_KEEPINTVL) failed: " << std::strerror(errno) << " (" << errno << ")" << std::endl;
+        ok = false;
+    }
+#endif
+#ifdef TCP_KEEPCNT
+    int count = 3;
+    if (setsockopt(sock, IPPROTO_TCP, TCP_KEEPCNT, &count, sizeof(count)) != 0) {
+        LOG(DEBUG, "Server") << "setsockopt(TCP_KEEPCNT) failed: " << std::strerror(errno) << " (" << errno << ")" << std::endl;
+        ok = false;
+    }
+#endif
+    return ok;
+}
 
 bool is_tcp_listener_active(int family, const std::string& host_ip, int port) {
     int sock = socket(family, SOCK_STREAM, IPPROTO_TCP);

--- a/src/cpp/server/utils/platform/network_windows.cpp
+++ b/src/cpp/server/utils/platform/network_windows.cpp
@@ -1,9 +1,55 @@
-#include "lemon/utils/network_utils.h"
-
+// Windows header discipline — must precede all other includes.
+#ifdef _WIN32
+#ifndef _WINSOCKAPI_
+#define _WINSOCKAPI_
+#endif
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
 #include <winsock2.h>
 #include <ws2tcpip.h>
+#include <mstcpip.h>
+#include <windows.h>
+#pragma comment(lib, "ws2_32.lib")
+#ifdef ERROR
+#undef ERROR
+#endif
+#endif
+
+#include "lemon/utils/network_utils.h"
+#include "lemon/utils/aixlog.hpp"
 
 namespace lemon::utils {
+
+bool configure_tcp_keepalive(socket_t sock) {
+    int opt = 1;
+    bool ok = true;
+    if (setsockopt(sock, SOL_SOCKET, SO_KEEPALIVE, reinterpret_cast<const char*>(&opt), sizeof(opt)) != 0) {
+        LOG(DEBUG, "Server") << "setsockopt(SO_KEEPALIVE) failed: WSA error " << WSAGetLastError() << std::endl;
+        ok = false;
+    }
+#ifdef TCP_KEEPIDLE
+    int idle = 15;
+    if (setsockopt(sock, IPPROTO_TCP, TCP_KEEPIDLE, reinterpret_cast<const char*>(&idle), sizeof(idle)) != 0) {
+        LOG(DEBUG, "Server") << "setsockopt(TCP_KEEPIDLE) failed: WSA error " << WSAGetLastError() << std::endl;
+        ok = false;
+    }
+#endif
+#ifdef TCP_KEEPINTVL
+    int interval = 5;
+    if (setsockopt(sock, IPPROTO_TCP, TCP_KEEPINTVL, reinterpret_cast<const char*>(&interval), sizeof(interval)) != 0) {
+        LOG(DEBUG, "Server") << "setsockopt(TCP_KEEPINTVL) failed: WSA error " << WSAGetLastError() << std::endl;
+        ok = false;
+    }
+#endif
+#ifdef TCP_KEEPCNT
+    int count = 3;
+    if (setsockopt(sock, IPPROTO_TCP, TCP_KEEPCNT, reinterpret_cast<const char*>(&count), sizeof(count)) != 0) {
+        LOG(DEBUG, "Server") << "setsockopt(TCP_KEEPCNT) failed: WSA error " << WSAGetLastError() << std::endl;
+        ok = false;
+    }
+#endif
+    return ok;
+}
 
 bool is_tcp_listener_active(int family, const std::string& host_ip, int port) {
     SOCKET sock = socket(family, SOCK_STREAM, IPPROTO_TCP);

--- a/src/cpp/server/websocket_server.cpp
+++ b/src/cpp/server/websocket_server.cpp
@@ -1,5 +1,6 @@
 #include "lemon/router.h"
 #include "lemon/utils/json_utils.h"
+#include "lemon/utils/network_utils.h"
 #include "lemon/utils/origin_utils.h"
 #include "lemon/utils/process_manager.h"
 #include "lemon/websocket_server.h"
@@ -101,7 +102,16 @@ int WebSocketServer::ws_callback(struct lws* wsi,
         }
 
         case LWS_CALLBACK_ESTABLISHED: {
-            std::snprintf(pss->connection_id, sizeof(pss->connection_id), "%d", static_cast<int>(lws_get_socket_fd(wsi)));
+            auto sock = static_cast<socket_t>(lws_get_socket_fd(wsi));
+#ifdef _WIN32
+            if (sock != INVALID_SOCKET) {
+#else
+            if (sock >= 0) {
+#endif
+                lemon::utils::configure_tcp_keepalive(sock);
+            }
+
+            std::snprintf(pss->connection_id, sizeof(pss->connection_id), "%d", static_cast<int>(sock));
 
             char ip[128] = {0};
             lws_get_peer_simple(wsi, ip, sizeof(ip));

--- a/test/cpp/test_network_utils.cpp
+++ b/test/cpp/test_network_utils.cpp
@@ -1,3 +1,20 @@
+// Windows header discipline — must precede all other includes.
+#ifdef _WIN32
+#ifndef _WINSOCKAPI_
+#define _WINSOCKAPI_
+#endif
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#include <mstcpip.h>
+#include <windows.h>
+#pragma comment(lib, "ws2_32.lib")
+#ifdef ERROR
+#undef ERROR
+#endif
+#endif
+
 #include "lemon/utils/network_utils.h"
 
 #include <cassert>
@@ -5,14 +22,12 @@
 #include <string>
 #include <thread>
 
-#ifdef _WIN32
-    #include <winsock2.h>
-    #include <ws2tcpip.h>
-#else
-    #include <arpa/inet.h>
-    #include <netinet/in.h>
-    #include <sys/socket.h>
-    #include <unistd.h>
+#ifndef _WIN32
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <sys/socket.h>
+#include <unistd.h>
 #endif
 
 struct TestResult {
@@ -260,6 +275,169 @@ static void test_listener_startup_state(TestResult& r) {
     }
 }
 
+static void test_configure_tcp_keepalive(TestResult& r) {
+#ifdef _WIN32
+    SOCKET listener = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+    assert(listener != INVALID_SOCKET);
+#else
+    int listener = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+    assert(listener >= 0);
+#endif
+
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = inet_addr("127.0.0.1");
+    addr.sin_port = 0;
+
+    int bind_res = bind(listener, reinterpret_cast<sockaddr*>(&addr), sizeof(addr));
+    assert(bind_res == 0);
+    int listen_res = listen(listener, 1);
+    assert(listen_res == 0);
+
+    sockaddr_in bound_addr{};
+    socklen_t addr_len = sizeof(bound_addr);
+    int name_res = getsockname(listener, reinterpret_cast<sockaddr*>(&bound_addr), &addr_len);
+    assert(name_res == 0);
+
+#ifdef _WIN32
+    SOCKET client = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+    assert(client != INVALID_SOCKET);
+#else
+    int client = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+    assert(client >= 0);
+#endif
+
+    int conn_res = connect(client, reinterpret_cast<sockaddr*>(&bound_addr), sizeof(bound_addr));
+    assert(conn_res == 0);
+
+#ifdef _WIN32
+    SOCKET accepted = accept(listener, nullptr, nullptr);
+    if (accepted == INVALID_SOCKET) {
+        r.fail("configure_tcp_keepalive: accept socket");
+        closesocket(client);
+        closesocket(listener);
+        return;
+    }
+#else
+    int accepted = accept(listener, nullptr, nullptr);
+    if (accepted < 0) {
+        r.fail("configure_tcp_keepalive: accept socket");
+        close(client);
+        close(listener);
+        return;
+    }
+#endif
+
+    bool config_res = lemon::utils::configure_tcp_keepalive(accepted);
+    if (config_res) {
+        r.ok("configure_tcp_keepalive returns true on accepted socket");
+    } else {
+        r.fail("configure_tcp_keepalive returned false on accepted socket");
+    }
+
+    int opt = 0;
+    socklen_t optlen = sizeof(opt);
+#ifdef _WIN32
+    int res = getsockopt(accepted, SOL_SOCKET, SO_KEEPALIVE, reinterpret_cast<char*>(&opt), &optlen);
+#else
+    int res = getsockopt(accepted, SOL_SOCKET, SO_KEEPALIVE, &opt, &optlen);
+#endif
+
+    if (res == 0 && opt != 0) {
+        r.ok("SO_KEEPALIVE enabled on accepted socket");
+    } else {
+        r.fail("SO_KEEPALIVE not enabled on accepted socket");
+    }
+
+#ifdef __linux__
+    int idle = 0;
+    optlen = sizeof(idle);
+    if (getsockopt(accepted, IPPROTO_TCP, TCP_KEEPIDLE, &idle, &optlen) == 0 && idle == 15) {
+        r.ok("TCP_KEEPIDLE == 15 on accepted socket");
+    } else {
+        r.fail("TCP_KEEPIDLE check failed");
+    }
+
+    int interval = 0;
+    optlen = sizeof(interval);
+    if (getsockopt(accepted, IPPROTO_TCP, TCP_KEEPINTVL, &interval, &optlen) == 0 && interval == 5) {
+        r.ok("TCP_KEEPINTVL == 5 on accepted socket");
+    } else {
+        r.fail("TCP_KEEPINTVL check failed");
+    }
+
+    int count = 0;
+    optlen = sizeof(count);
+    if (getsockopt(accepted, IPPROTO_TCP, TCP_KEEPCNT, &count, &optlen) == 0 && count == 3) {
+        r.ok("TCP_KEEPCNT == 3 on accepted socket");
+    } else {
+        r.fail("TCP_KEEPCNT check failed");
+    }
+#elif defined(__APPLE__)
+    int idle = 0;
+    optlen = sizeof(idle);
+    if (getsockopt(accepted, IPPROTO_TCP, TCP_KEEPALIVE, &idle, &optlen) == 0 && idle == 15) {
+        r.ok("TCP_KEEPALIVE == 15 on accepted socket");
+    } else {
+        r.fail("TCP_KEEPALIVE check failed");
+    }
+
+    int interval = 0;
+    optlen = sizeof(interval);
+    if (getsockopt(accepted, IPPROTO_TCP, TCP_KEEPINTVL, &interval, &optlen) == 0 && interval == 5) {
+        r.ok("TCP_KEEPINTVL == 5 on accepted socket");
+    } else {
+        r.fail("TCP_KEEPINTVL check failed");
+    }
+
+    int count = 0;
+    optlen = sizeof(count);
+    if (getsockopt(accepted, IPPROTO_TCP, TCP_KEEPCNT, &count, &optlen) == 0 && count == 3) {
+        r.ok("TCP_KEEPCNT == 3 on accepted socket");
+    } else {
+        r.fail("TCP_KEEPCNT check failed");
+    }
+#elif defined(_WIN32)
+#ifdef TCP_KEEPIDLE
+    int idle = 0;
+    optlen = sizeof(idle);
+    if (getsockopt(accepted, IPPROTO_TCP, TCP_KEEPIDLE, reinterpret_cast<char*>(&idle), &optlen) == 0 && idle == 15) {
+        r.ok("TCP_KEEPIDLE == 15 on accepted socket");
+    } else {
+        r.fail("TCP_KEEPIDLE check failed");
+    }
+#endif
+#ifdef TCP_KEEPINTVL
+    int interval = 0;
+    optlen = sizeof(interval);
+    if (getsockopt(accepted, IPPROTO_TCP, TCP_KEEPINTVL, reinterpret_cast<char*>(&interval), &optlen) == 0 && interval == 5) {
+        r.ok("TCP_KEEPINTVL == 5 on accepted socket");
+    } else {
+        r.fail("TCP_KEEPINTVL check failed");
+    }
+#endif
+#ifdef TCP_KEEPCNT
+    int count = 0;
+    optlen = sizeof(count);
+    if (getsockopt(accepted, IPPROTO_TCP, TCP_KEEPCNT, reinterpret_cast<char*>(&count), &optlen) == 0 && count == 3) {
+        r.ok("TCP_KEEPCNT == 3 on accepted socket");
+    } else {
+        r.fail("TCP_KEEPCNT check failed");
+    }
+#endif
+#endif
+
+#ifdef _WIN32
+    closesocket(accepted);
+    closesocket(client);
+    closesocket(listener);
+#else
+    close(accepted);
+    close(client);
+    close(listener);
+#endif
+}
+
 int main() {
 #ifdef _WIN32
     WSADATA wsaData;
@@ -273,6 +451,7 @@ int main() {
     test_inactive_port(r);
     test_active_port(r);
     test_listener_startup_state(r);
+    test_configure_tcp_keepalive(r);
 
     printf("\n%d/%d tests passed\n", r.passed, r.passed + r.failed);
 


### PR DESCRIPTION
### Summary

Enable OS-level TCP Keep-Alive socket options across `lemond`'s HTTP front server (`UpgradableFrontServer`) and WebSocket server (`WebSocketServer`) on Linux, macOS, and Windows.

### Rationale

Stateful L4 firewalls, NAT gateways, and intermediate routers often silently drop idle TCP connections after inactivity windows (often 60s or lower). For LLM inference workflows involving long time-to-first-token (TTFT) prefill or idle client connections between turns, silent drops cause broken connections without proper TCP RST or FIN notification.

*(Note: application-layer idle timeouts, such as nginx `proxy_read_timeout` or ALB idle timeout, require application data / SSE heartbeats.)*

### Changes

- **Cross-Platform Helper (`network_utils`)**: Implemented `lemon::utils::configure_tcp_keepalive(socket_t sock)` in `network_unix.cpp` and `network_windows.cpp`:
  - `SO_KEEPALIVE`: enabled
  - Idle time before probe: 15s (`TCP_KEEPIDLE` on Linux/Windows, `TCP_KEEPALIVE` on macOS)
  - Probe interval: 5s (`TCP_KEEPINTVL`)
  - Probe count: 3 probes (`TCP_KEEPCNT`)
- **HTTP Server (`UpgradableFrontServer`)**: Configures client sockets upon accept in `process_and_close_socket` before HTTP parsing.
- **WebSocket Server (`WebSocketServer`)**: Invokes `configure_tcp_keepalive()` on newly established client sockets (`LWS_CALLBACK_ESTABLISHED` via `lws_get_socket_fd`) as well as upgrade sockets adopted from the HTTP server.
- **Platform Separation**: Keeps server headers clean and free of OS-specific headers / `#ifdef`s.
- **Diagnostic Logging**: Emits debug logs identifying failed options with `errno` / `WSAGetLastError`.
- **Tests**: Consolidated loopback accepted-socket verification into `test/cpp/test_network_utils.cpp` running under `NetworkUtilsTest`.

### Verification

- `cmake --build build --preset default` (0 errors)
- `ctest --test-dir build -L cpp-ci --output-on-failure` (passed)
- `python3 docs/tools/gen_backend_boilerplate.py --check` (clean, 0 drift)

Relates-to: #2898