### PR TITLE
fix(gui3): make pinned models server-owned

### DIFF
--- a/src/app/src/api.ts
+++ b/src/app/src/api.ts
@@ -134,6 +134,7 @@ function normalizeLoadedModel(model: unknown): LoadedModel | null {
     input_modalities: Array.isArray(model.input_modalities) ? model.input_modalities.filter((value): value is string => typeof value === 'string') : undefined,
     output_modalities: Array.isArray(model.output_modalities) ? model.output_modalities.filter((value): value is string => typeof value === 'string') : undefined,
     recipe_options: isObject(model.recipe_options) ? model.recipe_options : undefined,
+    pinned: typeof model.pinned === 'boolean' ? model.pinned : undefined,
   };
 }
 
@@ -226,6 +227,7 @@ export interface LoadedModel {
   input_modalities?: string[];
   output_modalities?: string[];
   recipe_options?: Record<string, unknown>;
+  pinned?: boolean;
 }
 
 /** Response shape of GET/POST/DELETE /api/v1/models/{id}/options. */
@@ -1468,6 +1470,18 @@ class LemonadeAPI {
     }
     const body = modelName ? { model_name: modelName } : {};
     const result = await this._json('/api/v1/unload', { method: 'POST', body });
+    this._notifyModelsChanged();
+    return result;
+  }
+
+  async setModelPinned(
+    modelName: string,
+    pinned: boolean,
+  ): Promise<{ status: string; model_name: string; pinned: boolean }> {
+    const result = await this._json<{ status: string; model_name: string; pinned: boolean }>(
+      '/internal/pin',
+      { method: 'POST', body: { model_name: modelName, pinned } },
+    );
     this._notifyModelsChanged();
     return result;
   }

--- a/src/app/src/components/ChatView.tsx
+++ b/src/app/src/components/ChatView.tsx
@@ -65,7 +65,6 @@ import {
 import {
   GLOBAL_MODEL_SETTINGS_EVENT,
   loadGlobalModelSettings,
-  loadPinnedModelNames,
   loadWithGlobalModelPolicy,
   savePinnedModelNames,
 } from '../features/modelSettings/globalModelSettings';
@@ -1789,7 +1788,9 @@ const ChatView: React.FC<ChatViewProps> = ({
       loadedModels: currentLoaded,
       allModels: knownModelInfos,
       target,
-      pinnedNames: loadPinnedModelNames(),
+      pinnedNames: currentLoaded
+        .filter(model => model.pinned === true)
+        .map(model => model.model_name),
       settings: globalModelSettings,
       unload: name => api.unloadModel(name),
       load: () => api.loadModel(modelName, recipeOptions, target),

--- a/src/app/src/components/ChatView.tsx
+++ b/src/app/src/components/ChatView.tsx
@@ -66,7 +66,6 @@ import {
   GLOBAL_MODEL_SETTINGS_EVENT,
   loadGlobalModelSettings,
   loadWithGlobalModelPolicy,
-  savePinnedModelNames,
 } from '../features/modelSettings/globalModelSettings';
 
 interface Message {
@@ -3530,6 +3529,7 @@ ${finalText}`
               unloadingModel={modelPickerUnloading}
               onChipClick={startLemonadeToolPrompt}
               modelInfos={knownModelInfos}
+              onRefresh={onRefresh}
             />
           ) : (
             <div className="thread">
@@ -4473,6 +4473,7 @@ interface EmptyStateProps {
   unloadingModel: string | null;
   onChipClick: (text: string) => void;
   modelInfos: ModelInfo[];
+  onRefresh: () => void | Promise<void>;
 }
 
 const EmptyState: React.FC<EmptyStateProps> = ({
@@ -4485,27 +4486,12 @@ const EmptyState: React.FC<EmptyStateProps> = ({
   unloadingModel,
   onChipClick,
   modelInfos,
+  onRefresh,
 }) => {
-  const [pinnedModels, setPinnedModels] = useState<string[]>(() => loadPinnedModelNames());
-  const pinnedNameSet = useMemo(
-    () => new Set(pinnedModels.map(name => name.toLowerCase())),
-    [pinnedModels],
-  );
-
-  useEffect(() => {
-    const reloadPinnedModels = () => setPinnedModels(loadPinnedModelNames());
-    window.addEventListener(GLOBAL_MODEL_SETTINGS_EVENT, reloadPinnedModels);
-    return () => window.removeEventListener(GLOBAL_MODEL_SETTINGS_EVENT, reloadPinnedModels);
-  }, []);
-
-  const togglePinnedModel = (modelName: string) => {
-    const key = modelName.toLowerCase();
-    const exists = pinnedModels.some(name => name.toLowerCase() === key);
-    const next = exists
-      ? pinnedModels.filter(name => name.toLowerCase() !== key)
-      : [modelName, ...pinnedModels];
-    setPinnedModels(next);
-    savePinnedModelNames(next);
+  const togglePinnedModel = async (model: LoadedModel) => {
+    const api = await getApiClient();
+    await api.setModelPinned(model.model_name, model.pinned !== true);
+    await Promise.resolve(onRefresh());
   };
 
   return (
@@ -4559,7 +4545,7 @@ const EmptyState: React.FC<EmptyStateProps> = ({
               const selectable = canSelectInComposer(model) || isComposerSelectableCapability(capability);
               const isActive = currentModel === model.model_name;
               const isUnloading = unloadingModel === model.model_name;
-              const isPinned = pinnedNameSet.has(model.model_name.toLowerCase());
+              const isPinned = model.pinned === true;
               const sizeLabel = loadedOverviewSizeLabel(modelInfo);
               const deviceLabel = loadedOverviewDeviceLabel(model);
 
@@ -4623,7 +4609,7 @@ const EmptyState: React.FC<EmptyStateProps> = ({
                     className={`loaded-overview__pin${isPinned ? ' loaded-overview__pin--active' : ''}`}
                     onClick={event => {
                       event.stopPropagation();
-                      togglePinnedModel(model.model_name);
+                      void togglePinnedModel(model);
                     }}
                     aria-label={isPinned ? `Unpin ${model.model_name}` : `Pin ${model.model_name}`}
                     aria-pressed={isPinned}

--- a/src/app/src/components/ModelDetailPanel.tsx
+++ b/src/app/src/components/ModelDetailPanel.tsx
@@ -2435,7 +2435,7 @@ export interface ModelDetailPanelProps {
   onDelete: (model: ModelInfo) => void;
   onCancelPull: (name: string) => void;
   serverDefaultCtxSize: number;
-  /** Whether this model is currently pinned in the client-local model list. */
+  /** Whether this loaded model is currently pinned by lemond. */
   isPinned?: boolean;
   /** Toggle this model's pinned state. Receives the model name. */
   onTogglePin?: (name: string) => void;
@@ -2729,7 +2729,7 @@ export const ModelDetailPanel: React.FC<ModelDetailPanelProps> = ({
           </WorkspaceActionButton>
         </>
       )}
-      {onTogglePin && (
+      {isLoaded && onTogglePin && (
         <WorkspaceActionButton
           className={`model-detail-panel__fav-btn${isPinned ? ' model-detail-panel__fav-btn--on' : ''}`}
           appearance="quiet"

--- a/src/app/src/components/ModelListPanel.tsx
+++ b/src/app/src/components/ModelListPanel.tsx
@@ -439,12 +439,12 @@ export interface ModelListPanelProps {
   onOpenCustomModels?: () => void;
   onOpenRouter?: () => void;
   onUpdateAllModels?: () => void;
-  /** Lowercased set of pinned model names. Pinned rows float to the top. Client-local. */
+  /** Lowercased server-owned pin state. Pinned running rows stay grouped at the top. */
   pinnedNames?: Set<string>;
-  /** Toggle a model's pinned state. Receives the model name. */
-  onTogglePin?: (name: string) => void;
   /** Lowercased set of favorited model names (distinct from pinned). Client-local. */
   favoriteNames?: Set<string>;
+  /** Toggle a model's favorite state. Receives the model name. */
+  onToggleFavorite?: (name: string) => void;
   /** Optional remote-provider results rendered below the local model list. */
   registryZone?: React.ReactNode;
   /** Elevated remote-provider results rendered above the list when no local results match. */
@@ -474,8 +474,8 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
   onOpenRouter,
   onUpdateAllModels,
   pinnedNames,
-  onTogglePin,
   favoriteNames,
+  onToggleFavorite,
   registryZone,
   registryZoneTop,
   systemInfo = null,
@@ -587,10 +587,10 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
   }, [flatList]);
 
   // Arrow/Home/End and Enter/Space live in WorkspaceList; the catalog only adds
-  // its own pin shortcut.
+  // its own Favorite shortcut for the row-scoped secondary action.
   const handleItemKeyDown = useCallback((e: React.KeyboardEvent<HTMLElement>, modelId: string) => {
-    if ((e.key === 'p' || e.key === 'P') && onTogglePin) { e.preventDefault(); onTogglePin(modelId); }
-  }, [onTogglePin]);
+    if ((e.key === 'f' || e.key === 'F') && onToggleFavorite) { e.preventDefault(); onToggleFavorite(modelId); }
+  }, [onToggleFavorite]);
 
   /* One catalog row. Hoisted out of the section map so the body reads at its
      own indentation rather than three levels in. */
@@ -634,6 +634,7 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
           : undefined;
     const meta = model.size != null && model.size > 0 ? listFmtSize(model.size) : undefined;
     const secondaryTags = capTags.filter(tag => tag !== (primaryCapability as string));
+    const favorited = favoriteNames?.has(mId.toLowerCase()) ?? false;
 
     return (
       <WorkspaceListRow
@@ -653,19 +654,16 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
         tabIndex={isSelected ? 0 : -1}
         dataAttributes={{ 'data-model-id': mId }}
         className={pinned ? 'workspace-list-row--pinned' : undefined}
-        ariaKeyShortcuts={onTogglePin ? 'P' : undefined}
-        ariaLabel={`${displayName}${pinned ? ', pinned' : ''}${status === 'running' ? ', running' : status === 'downloading' ? ', downloading' : ''}${displayedBackend ? `, ${displayedBackend}` : ''}${readinessLabel ? `, ${readinessLabel}` : ''}`}
+        ariaKeyShortcuts={onToggleFavorite ? 'F' : undefined}
+        ariaLabel={`${displayName}${pinned ? ', pinned' : ''}${favorited ? ', favorite' : ''}${status === 'running' ? ', running' : status === 'downloading' ? ', downloading' : ''}${displayedBackend ? `, ${displayedBackend}` : ''}${readinessLabel ? `, ${readinessLabel}` : ''}`}
         onClick={() => onSelectModel(mId)}
-        onKeyDown={e => handleItemKeyDown(e, mId)}
-        action={onTogglePin ? {
-          icon: 'pin',
-          label: pinned ? `Unpin ${displayName} (P)` : `Pin ${displayName} (P)`,
-          onClick: () => onTogglePin(mId),
-          // A pinned model's pin outranks its engine as the fact worth showing,
-          // and keeps the row's state visible without hovering. The row owns the
-          // advertised P keyboard shortcut, so the nested affordance is pointer-only.
+        onKeyDown={onToggleFavorite ? e => handleItemKeyDown(e, mId) : undefined}
+        action={onToggleFavorite ? {
+          icon: 'star',
+          label: favorited ? `Remove ${displayName} from favorites (F)` : `Add ${displayName} to favorites (F)`,
+          onClick: () => onToggleFavorite(mId),
           pointerOnly: true,
-          latched: pinned,
+          active: favorited,
         } : undefined}
       />
     );

--- a/src/app/src/components/ModelListPanel.tsx
+++ b/src/app/src/components/ModelListPanel.tsx
@@ -641,7 +641,19 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
         key={mId}
         rowId={mId}
         capability={primaryCapability}
-        title={displayName}
+        title={(
+          <span className="model-list-panel__row-title">
+            <span className="model-list-panel__row-title-text">{displayName}</span>
+            {favorited && (
+              <Icon
+                name="star"
+                size={10}
+                className="model-list-panel__favorite-indicator"
+                aria-hidden="true"
+              />
+            )}
+          </span>
+        )}
         meta={meta}
         glyphs={secondaryTags.map(capabilityTagIconTarget)}
         anchor={recipe && !neutralCollectionGuide ? displayedBackend : undefined}

--- a/src/app/src/components/ModelManager.tsx
+++ b/src/app/src/components/ModelManager.tsx
@@ -30,10 +30,8 @@ import {
   GLOBAL_MODEL_SETTINGS_EVENT,
   automaticUpdateIsDue,
   loadGlobalModelSettings,
-  loadPinnedModelNames,
   loadWithGlobalModelPolicy,
   saveGlobalModelSettings,
-  savePinnedModelNames,
   type GlobalModelSettings,
 } from '../features/modelSettings/globalModelSettings';
 import { backendLabel } from '../modelPresentation';
@@ -1127,7 +1125,10 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
   const [dynamicRecipeOptions, setDynamicRecipeOptions] = useState<Partial<Record<CustomModelCapability, CustomRecipeOption[]>>>({});
   const [customRecipeAvailabilityLoaded, setCustomRecipeAvailabilityLoaded] = useState(false);
   const [systemInfo, setSystemInfo] = useState<Record<string, unknown> | null>(() => api.systemInfoData);
-  const [pinnedModels, setPinnedModels] = useState<string[]>(() => loadPinnedModelNames());
+  const pinnedModels = useMemo(
+    () => loadedModels.filter(model => model.pinned === true).map(model => model.model_name),
+    [loadedModels],
+  );
   const [favoriteModels, setFavoriteModels] = useState<string[]>(() => loadFavoriteModels());
   // Real disk usage for the storage meter (null until/unless lemond exposes it).
   const [storageInfo, setStorageInfo] = useState<import('../api').StorageInfo | null>(null);
@@ -1164,7 +1165,6 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
 
 
   useEffect(() => {
-    setPinnedModels(loadPinnedModelNames());
     setFavoriteModels(loadFavoriteModels());
   }, []);
 
@@ -2098,13 +2098,16 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
     }
   };
 
-  const togglePinnedModel = (name: string) => {
-    setPinnedModels(prev => {
-      const exists = prev.some(item => item.toLowerCase() === name.toLowerCase());
-      const next = exists ? prev.filter(item => item.toLowerCase() !== name.toLowerCase()) : [name, ...prev];
-      savePinnedModelNames(next);
-      return next;
-    });
+  const togglePinnedModel = async (name: string) => {
+    const loaded = loadedModels.find(model => model.model_name.toLowerCase() === name.toLowerCase());
+    if (!loaded) return;
+
+    try {
+      setLoadError(null);
+      await api.setModelPinned(name, loaded.pinned !== true);
+    } catch (error) {
+      setLoadError({ modelName: name, message: friendlyErrorMessage(error) });
+    }
   };
 
   const toggleFavoriteModel = (name: string) => {
@@ -2804,8 +2807,8 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
         onUpdateAllModels={() => { void handleUpdateAllModels(); }}
         onOpenCustomModels={() => openCustomForm('model')}
         pinnedNames={pinnedNameSet}
-        onTogglePin={togglePinnedModel}
         favoriteNames={favoriteNameSet}
+        onToggleFavorite={toggleFavoriteModel}
         registryZoneTop={hasRemoteActivity && !hasLocalMatches ? renderRegistryZones() : undefined}
         registryZone={hasRemoteActivity && hasLocalMatches ? renderRegistryZones() : undefined}
         systemInfo={systemInfo}
@@ -3176,7 +3179,7 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
           onCancelPull={handleCancelPull}
           serverDefaultCtxSize={serverDefaultCtxSize}
           isPinned={selectedDetailModelId ? pinnedNameSet.has(selectedDetailModelId.toLowerCase()) : false}
-          onTogglePin={togglePinnedModel}
+          onTogglePin={selectedDetailModelId && displayLoadedModels.some(m => m.model_name === selectedDetailModelId) ? togglePinnedModel : undefined}
           isFavorite={selectedDetailModelId ? favoriteNameSet.has(selectedDetailModelId.toLowerCase()) : false}
           onToggleFavorite={toggleFavoriteModel}
           onEditCustomCollection={(model) => {

--- a/src/app/src/components/ModelManager.tsx
+++ b/src/app/src/components/ModelManager.tsx
@@ -1182,7 +1182,6 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
   useEffect(() => {
     const reloadGlobalSettings = () => {
       setGlobalModelSettings(loadGlobalModelSettings());
-      setPinnedModels(loadPinnedModelNames());
     };
     automaticUpdateStartedRef.current = false;
     reloadGlobalSettings();

--- a/src/app/src/components/ModelManager.tsx
+++ b/src/app/src/components/ModelManager.tsx
@@ -2062,7 +2062,13 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
 
   const togglePinnedModel = async (name: string) => {
     const loaded = loadedModels.find(model => model.model_name.toLowerCase() === name.toLowerCase());
-    if (!loaded) return;
+    if (!loaded) {
+      setLoadError({
+        modelName: name,
+        message: `Cannot change pin state for ${name}: the model is no longer loaded.`,
+      });
+      return;
+    }
 
     try {
       setLoadError(null);
@@ -3128,7 +3134,7 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
           onCancelPull={handleCancelPull}
           serverDefaultCtxSize={serverDefaultCtxSize}
           isPinned={selectedDetailModelId ? pinnedNameSet.has(selectedDetailModelId.toLowerCase()) : false}
-          onTogglePin={selectedDetailModelId && displayLoadedModels.some(m => m.model_name === selectedDetailModelId) ? togglePinnedModel : undefined}
+          onTogglePin={selectedDetailModelId && loadedModels.some(m => m.model_name.toLowerCase() === selectedDetailModelId.toLowerCase()) ? togglePinnedModel : undefined}
           isFavorite={selectedDetailModelId ? favoriteNameSet.has(selectedDetailModelId.toLowerCase()) : false}
           onToggleFavorite={toggleFavoriteModel}
           onEditCustomCollection={(model) => {

--- a/src/app/src/components/WorkspacePanels.tsx
+++ b/src/app/src/components/WorkspacePanels.tsx
@@ -357,8 +357,8 @@ function joinMeta(parts: React.ReactNode[]): React.ReactNode[] {
  * instead means the anchor reaches the row's true right edge and the control
  * appears only when it is relevant — at a size worth aiming at.
  *
- * `latched` makes the swap permanent — a pinned model shows its pin instead of
- * its engine, because the pin is now the more useful fact about that row.
+ * `latched` makes the swap permanent when a caller intentionally wants the
+ * row-scoped action to remain visible after hover/focus.
  * Otherwise the anchor holds the slot and the control takes it on hover.
  */
 export interface WorkspaceListRowAction {
@@ -367,6 +367,8 @@ export interface WorkspaceListRowAction {
   onClick: () => void;
   /** Hold the slot permanently, replacing the anchor. */
   latched?: boolean;
+  /** Use active-state styling without forcing the action to stay visible. */
+  active?: boolean;
   /** Render a pointer-only affordance when the owning option provides keyboard access. */
   pointerOnly?: boolean;
 }
@@ -404,7 +406,7 @@ export const WorkspaceList: React.FC<WorkspaceListProps> = ({
   onRowFocus, onRowActivate, wrap = false, activateOnMove = false, selectable = true,
 }) => {
   const handleKeyDown = (event: React.KeyboardEvent<HTMLUListElement>) => {
-    // A row may claim a key first — the catalog's pin shortcut does.
+    // A row may claim a key first — the catalog's Favorite shortcut does.
     if (event.defaultPrevented) return;
 
     const options = Array.from(
@@ -637,7 +639,7 @@ export const WorkspaceListRow: React.FC<WorkspaceListRowProps> = ({
       aria-label={ariaLabel}
       aria-keyshortcuts={ariaKeyShortcuts}
       tabIndex={tabIndex}
-      className={`workspace-list-row${selected ? ' workspace-list-row--selected' : ''}${disabled ? ' workspace-list-row--disabled' : ''}${className ? ` ${className}` : ''}`}
+      className={`workspace-list-row${selected ? ' workspace-list-row--selected' : ''}${disabled ? ' workspace-list-row--disabled' : ''}${action?.pointerOnly ? ' workspace-list-row--pointer-action' : ''}${className ? ` ${className}` : ''}`}
       onClick={disabled ? undefined : onClick}
       onKeyDown={onKeyDown}
       onFocus={onFocus}
@@ -667,10 +669,10 @@ export const WorkspaceListRow: React.FC<WorkspaceListRowProps> = ({
 
       {action && (action.pointerOnly ? (
         // A listbox option cannot legally contain another interactive control.
-        // Use this only when the option itself owns the keyboard command (the model
-        // pin advertises and handles P); pointer behaviour and visuals stay intact.
+        // Use this only when the option itself owns the keyboard command; pointer
+        // behaviour and visuals stay intact without nesting a second interactive control.
         <span
-          className={`workspace-list-row__action${action.latched ? ' workspace-list-row__action--latched' : ''}`}
+          className={`workspace-list-row__action${action.latched ? ' workspace-list-row__action--latched' : ''}${action.active ? ' workspace-list-row__action--active' : ''}`}
           onClick={event => { event.stopPropagation(); action.onClick(); }}
           aria-hidden="true"
           title={action.label}
@@ -680,7 +682,7 @@ export const WorkspaceListRow: React.FC<WorkspaceListRowProps> = ({
       ) : (
         <button
           type="button"
-          className={`workspace-list-row__action${action.latched ? ' workspace-list-row__action--latched' : ''}`}
+          className={`workspace-list-row__action${action.latched ? ' workspace-list-row__action--latched' : ''}${action.active ? ' workspace-list-row__action--active' : ''}`}
           onClick={event => { event.stopPropagation(); action.onClick(); }}
           aria-label={action.label}
           title={action.label}

--- a/src/app/src/features/modelSettings/globalModelSettings.ts
+++ b/src/app/src/features/modelSettings/globalModelSettings.ts
@@ -35,10 +35,6 @@ function settingsKey(): string {
   return storageKey('global_model_settings');
 }
 
-function pinnedModelsKey(): string {
-  return storageKey('pinned_models');
-}
-
 function finiteBudget(value: unknown): number {
   const parsed = Number(value);
   if (!Number.isFinite(parsed)) return DEFAULT_GLOBAL_MODEL_SETTINGS.resourceBudgetGb;
@@ -84,27 +80,6 @@ export function saveGlobalModelSettings(settings: GlobalModelSettings): GlobalMo
     window.dispatchEvent(new CustomEvent(GLOBAL_MODEL_SETTINGS_EVENT, { detail: { settings: sanitized } }));
   } catch { /* best effort */ }
   return sanitized;
-}
-
-export function loadPinnedModelNames(): string[] {
-  try {
-    const raw = localStorage.getItem(pinnedModelsKey());
-    const parsed = raw ? JSON.parse(raw) : [];
-    return Array.isArray(parsed)
-      ? Array.from(new Set(parsed.map(value => String(value).trim()).filter(Boolean)))
-      : [];
-  } catch {
-    return [];
-  }
-}
-
-export function savePinnedModelNames(names: Iterable<string>): string[] {
-  const normalized = Array.from(new Set([...names].map(name => String(name).trim()).filter(Boolean)));
-  try { localStorage.setItem(pinnedModelsKey(), JSON.stringify(normalized)); } catch { /* best effort */ }
-  try {
-    window.dispatchEvent(new CustomEvent(GLOBAL_MODEL_SETTINGS_EVENT, { detail: { pinnedModelNames: normalized } }));
-  } catch { /* best effort */ }
-  return normalized;
 }
 
 export function automaticUpdateIsDue(settings: GlobalModelSettings, now = Date.now(), intervalMs = 24 * 60 * 60 * 1000): boolean {

--- a/src/app/src/storage.ts
+++ b/src/app/src/storage.ts
@@ -18,6 +18,7 @@ const OBSOLETE_LEGACY_CONFIGURATION_KEYS = [
   `${STORAGE_PREFIX}applied_presets`,
   `${STORAGE_PREFIX}backend_presets`,
   `${STORAGE_PREFIX}running_presets`,
+  `${STORAGE_PREFIX}pinned_models`,
 ] as const;
 
 let migrationComplete = false;

--- a/src/app/src/styles/styles.css
+++ b/src/app/src/styles/styles.css
@@ -14330,7 +14330,7 @@ a.backend-card__version:focus-visible {
 /* Hovering hands the right edge to the action. Visibility rather than display,
    so the anchor keeps reserving its own width and the meta line cannot reflow. */
 .workspace-list-row:hover .workspace-list-row__anchor,
-.workspace-list-row:focus-within .workspace-list-row__anchor { visibility: hidden; }
+.workspace-list-row:focus-within:not(.workspace-list-row--pointer-action) .workspace-list-row__anchor { visibility: hidden; }
 
 /* Dot and words are one unit. Split across the grid — dot in the trailing
    column, words in the meta line — the mark sat diagonally away from the thing
@@ -14399,7 +14399,7 @@ a.backend-card__version:focus-visible {
 }
 
 .workspace-list-row:hover .workspace-list-row__action,
-.workspace-list-row:focus-within .workspace-list-row__action,
+.workspace-list-row:focus-within:not(.workspace-list-row--pointer-action) .workspace-list-row__action,
 .workspace-list-row__action--latched { visibility: visible; }
 
 .workspace-list-row__action:hover {
@@ -14407,8 +14407,17 @@ a.backend-card__version:focus-visible {
   background: color-mix(in srgb, var(--text-primary) 8%, transparent);
 }
 
-/* A latched action is the row's standing fact, not a transient affordance. */
-.workspace-list-row__action--latched { color: var(--accent-fg); }
+/* Active state may be transient; only `latched` also controls visibility. */
+.workspace-list-row__action--latched,
+.workspace-list-row__action--active { color: var(--accent-fg); }
+/* A favorited row keeps the normal hover-only affordance, but the visible star
+   uses the same active treatment as the Favorite control in ModelDetailPanel. */
+.workspace-list-row__action--active .app-icon[data-icon='star'] {
+  color: var(--accent-fg);
+}
+.workspace-list-row__action--active .app-icon[data-icon='star'] path {
+  fill: currentColor;
+}
 
 .workspace-list-row__progress {
   position: absolute;

--- a/src/app/src/styles/styles.css
+++ b/src/app/src/styles/styles.css
@@ -15562,6 +15562,45 @@ button.workspace-metadata-chip:hover {
   grid-template-columns: 26px minmax(min-content, 1fr);
 }
 
+/* Compact at-rest Favorite indicator for model rows. */
+.model-list-panel__row-title {
+  position: relative;
+  display: block;
+  width: 100%;
+  min-width: 0;
+}
+
+.model-list-panel__row-title-text {
+  display: block;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Fixed at the title row's right edge so model-name length never moves it. */
+.model-list-panel__favorite-indicator {
+  position: absolute;
+  inset-inline-end:
+    calc(var(--space-1) - var(--workspace-list-row-action));
+  top: 50%;
+  transform: translateY(-50%);
+  width: 10px;
+  height: 10px;
+  color: var(--accent-fg);
+  pointer-events: none;
+}
+
+.model-list-panel__favorite-indicator path {
+  fill: none;
+}
+
+/* The full-size Favorite affordance owns the hover state. Keep only one star
+   visible while it temporarily replaces the backend anchor. */
+.workspace-list-row:hover .model-list-panel__favorite-indicator {
+  visibility: hidden;
+}
+
 /* PR3141 V2: loaded models responsive */
 @media (max-width: 768px) {
   .loaded-overview__header { align-items: flex-start; flex-direction: column; gap: var(--space-1); }

--- a/src/app/tests/a11y.spec.ts
+++ b/src/app/tests/a11y.spec.ts
@@ -2158,20 +2158,29 @@ test.describe('Accessibility — model README raw-HTML rendering (#2355)', () =>
 
 // ─── 26. #2355 left-rail parity — pin / favorite (client-local) ───────────────
 //
-// fl0rianr feedback (2026-06-25): the master-detail rail dropped the original
-// rail's pin/favorite affordance. Re-wired the existing client-local pin store
-// (localStorage `pinned_models`, no lemond) into ModelListPanel. Pinned models
-// float to the top; the affordance is a non-button span (so it does not nest an
-// interactive control inside role="option"), and keyboard/AT users toggle via
-// the "P" shortcut on the focused row, with pinned state in the row aria-label.
-// Range: A118–A123.
+// Model-list secondary action: Favorite is client-local UI state. Runtime Pin is
+// server-owned and intentionally not the list row action. The obsolete
+// lemonade:pinned_models key must still be removed by storage migration.
+// Range: A118-A123.
 
 test.describe('Accessibility — left-rail pin/favorite parity (#2355)', () => {
-  async function goToModelsWithMock(page: Page): Promise<void> {
+  async function goToModelsWithMock(page: Page, serverPinned = false): Promise<void> {
     await page.route('**/api/v1/health', async route =>
       route.fulfill({
         contentType: 'application/json',
-        body: JSON.stringify({ status: 'ok', version: 'test', all_models_loaded: [] }),
+        body: JSON.stringify({
+          status: 'ok',
+          version: 'test',
+          all_models_loaded: [
+            {
+              model_name: 'Llama-3.1-8B',
+              recipe: 'llamacpp',
+              pid: 123,
+              last_use: 1,
+              pinned: serverPinned,
+            },
+          ],
+        }),
       }),
     );
     await page.route('**/api/v1/models**', async route =>
@@ -2193,95 +2202,97 @@ test.describe('Accessibility — left-rail pin/favorite parity (#2355)', () => {
     await page.waitForTimeout(200);
   }
 
-  test('A118 — each model row exposes a pin affordance with an accessible title', async ({ page }) => {
+  function modelRow(page: Page, name: string) {
+    return page.locator('.model-list-panel__list .workspace-list-row').filter({ hasText: name }).first();
+  }
+
+  test('A118 — every local model row exposes Favorite as its secondary action', async ({ page }) => {
     await goToModelsWithMock(page);
-    const pins = page.locator('.model-list-panel__list .workspace-list-row__action');
-    const count = await pins.count();
-    expect(count).toBeGreaterThan(0);
-    // Title communicates the pin action to pointer users.
-    const title = await pins.first().getAttribute('title');
-    expect((title ?? '').toLowerCase()).toContain('pin');
+    for (const name of ['Llama-3.1-8B', 'Qwen2.5-7B']) {
+      const action = modelRow(page, name).locator('.workspace-list-row__action');
+      await expect(action).toHaveCount(1);
+      const title = await action.getAttribute('title');
+      expect((title ?? '').toLowerCase()).toContain('favorite');
+    }
   });
 
-  test('A119 — pin affordance is NOT a nested interactive button inside role="option"', async ({ page }) => {
+  test('A119 — Favorite affordance is not a nested interactive button inside role="option"', async ({ page }) => {
     await goToModelsWithMock(page);
-    const pin = page.locator('.model-list-panel__list .workspace-list-row__action').first();
-    // It must be a span (not a button/anchor/input) so role=option does not nest
-    // an interactive control (axe nested-interactive).
-    const tag = await pin.evaluate(el => el.tagName.toLowerCase());
+    const action = modelRow(page, 'Llama-3.1-8B').locator('.workspace-list-row__action');
+    const tag = await action.evaluate(el => el.tagName.toLowerCase());
     expect(tag).toBe('span');
-    // No button inside any option row.
     expect(await page.locator('[role="option"] button').count()).toBe(0);
   });
 
-  test('A120 — clicking the pin toggles the row pinned state and aria-label', async ({ page }) => {
-    await goToModelsWithMock(page);
-    const row = page.locator('.model-list-panel__list .workspace-list-row').first();
-    const pin = row.locator('.workspace-list-row__action');
+  test('A120 — Favorite only replaces backend info while the row is hovered', async ({ page }) => {
+    await goToModelsWithMock(page, true);
+    const row = modelRow(page, 'Llama-3.1-8B');
+    await expect(row).toHaveClass(/workspace-list-row--pinned/);
+    const action = row.locator('.workspace-list-row__action');
+    const anchor = row.locator('.workspace-list-row__anchor');
+    await expect(anchor).toBeVisible();
+    await expect(action).toBeHidden();
     await row.hover();
-    await expect(pin).toBeVisible();
-    await pin.click();
-    await page.waitForTimeout(100);
-    // The (now-pinned) model floats to the top; assert the first row is pinned.
-    const firstRow = page.locator('.model-list-panel__list .workspace-list-row').first();
-    await expect(firstRow).toHaveClass(/workspace-list-row--pinned/);
-    const label = await firstRow.getAttribute('aria-label');
-    expect((label ?? '').toLowerCase()).toContain('pinned');
-    // Unpin and verify the pinned class is removed.
-    await firstRow.hover();
-    const unpin = firstRow.locator('.workspace-list-row__action');
-    await expect(unpin).toBeVisible();
-    await unpin.click();
-    await page.waitForTimeout(100);
-    expect(await page.locator('.model-list-panel__list .workspace-list-row--pinned').count()).toBe(0);
+    await expect(anchor).toBeHidden();
+    await expect(action).toBeVisible();
+    await action.click();
+    await expect(action).not.toHaveClass(/workspace-list-row__action--latched/);
+    await expect(action).toHaveClass(/workspace-list-row__action--active/);
+    await expect(row).toHaveClass(/workspace-list-row--pinned/);
+    await expect(row).toHaveAttribute('aria-label', /favorite/i);
+    await page.locator('.model-list-panel__search-input').hover();
+    await expect(action).toBeHidden();
+    await expect(anchor).toBeVisible();
   });
 
-  test('A121 — selected row is keyboard-operable: "P" toggles pin (aria-keyshortcuts)', async ({ page }) => {
+  test('A121 — selected model row is keyboard-operable: "F" toggles Favorite', async ({ page }) => {
     await goToModelsWithMock(page);
-    // Select a model (focus moves to the detail panel in master-detail), then
-    // return focus to the now-focusable selected row (tabIndex 0) — the path a
-    // keyboard user takes via Shift+Tab — and press the advertised "P" shortcut.
-    await page.locator('.model-list-panel__list .workspace-list-row').first().click();
+    const row = modelRow(page, 'Llama-3.1-8B');
+    await row.click();
     await page.waitForTimeout(150);
-    const selected = page.locator('.model-list-panel__list .workspace-list-row--selected');
-    // The shortcut must be advertised to assistive tech.
-    expect(await selected.getAttribute('aria-keyshortcuts')).toBe('P');
+    const selected = modelRow(page, 'Llama-3.1-8B');
+    expect(await selected.getAttribute('aria-keyshortcuts')).toBe('F');
     await selected.focus();
-    await page.keyboard.press('p');
-    await page.waitForTimeout(100);
-    const pinnedCount = await page.locator('.model-list-panel__list .workspace-list-row--pinned').count();
-    expect(pinnedCount).toBe(1);
-    const label = await page.locator('.model-list-panel__list .workspace-list-row--pinned').first().getAttribute('aria-label');
-    expect((label ?? '').toLowerCase()).toContain('pinned');
+    await page.keyboard.press('f');
+    await expect(selected.locator('.workspace-list-row__action')).not.toHaveClass(/workspace-list-row__action--latched/);
+    // The click that selected this row leaves the pointer over it. Move away before
+    // checking the at-rest state; while hovered the Favorite action should be visible.
+    await page.locator('.model-list-panel__search-input').hover();
+    await expect(selected.locator('.workspace-list-row__action')).toBeHidden();
+    await expect(selected).toHaveAttribute('aria-label', /favorite/i);
   });
 
-  test('A122 — pinned state persists client-locally to localStorage (no lemond)', async ({ page }) => {
-    await goToModelsWithMock(page);
-    const pinRow = page.locator('.model-list-panel__list .workspace-list-row').first();
-    await pinRow.hover();
-    const pin = pinRow.locator('.workspace-list-row__action');
-    await expect(pin).toBeVisible();
-    await pin.click();
-    await page.waitForTimeout(100);
-    const persisted = await page.evaluate(() => {
-      for (let i = 0; i < localStorage.length; i++) {
-        const key = localStorage.key(i);
-        if (key && key.endsWith('pinned_models')) return localStorage.getItem(key);
-      }
-      return null;
+  test('A122 — Favorite persists client-locally while obsolete Pin storage is removed', async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem('lemonade:pinned_models', JSON.stringify(['Qwen2.5-7B']));
     });
-    expect(persisted, 'a *pinned_models localStorage key should exist').toBeTruthy();
-    expect((persisted ?? '').length).toBeGreaterThan(2); // non-empty JSON array
+    await goToModelsWithMock(page);
+    expect(await page.evaluate(() => localStorage.getItem('lemonade:pinned_models'))).toBeNull();
+
+    const row = modelRow(page, 'Qwen2.5-7B');
+    await row.hover();
+    await row.locator('.workspace-list-row__action').click();
+    expect(await page.evaluate(() => localStorage.getItem('lemonade:favorite_models'))).toContain('Qwen2.5-7B');
+
+    await page.reload();
+    await page.waitForSelector('.model-list-panel__list .workspace-list-row');
+    const reloadedRow = modelRow(page, 'Qwen2.5-7B');
+    await expect(reloadedRow).toHaveAttribute('aria-label', /favorite/i);
+    // Reload preserves the pointer position, which may still be over this row.
+    // Move away before asserting the non-hover state.
+    await page.locator('.model-list-panel__search-input').hover();
+    await expect(reloadedRow.locator('.workspace-list-row__action')).toBeHidden();
+    await reloadedRow.hover();
+    await expect(reloadedRow.locator('.workspace-list-row__action')).toHaveAttribute('title', /remove .* from favorites/i);
+    await expect(reloadedRow.locator('.workspace-list-row__action')).toHaveClass(/workspace-list-row__action--active/);
+    expect(await page.evaluate(() => localStorage.getItem('lemonade:pinned_models'))).toBeNull();
   });
 
-  test('A123 — model list with a pinned row passes WCAG 2.1 AA axe-core scan', async ({ page }) => {
-    await goToModelsWithMock(page);
-    const pinRow = page.locator('.model-list-panel__list .workspace-list-row').first();
-    await pinRow.hover();
-    const pin = pinRow.locator('.workspace-list-row__action');
-    await expect(pin).toBeVisible();
-    await pin.click();
-    await page.waitForTimeout(150);
+  test('A123 — model list with server Pin state and Favorite action passes WCAG 2.1 AA axe-core scan', async ({ page }) => {
+    await goToModelsWithMock(page, true);
+    const row = modelRow(page, 'Llama-3.1-8B');
+    await row.hover();
+    await row.locator('.workspace-list-row__action').click();
     const results = await new AxeBuilder({ page })
       .withTags([...WCAG_TAGS])
       .analyze();

--- a/src/app/tests/a11y.spec.ts
+++ b/src/app/tests/a11y.spec.ts
@@ -2238,11 +2238,13 @@ test.describe('Accessibility — left-rail pin/favorite parity (#2355)', () => {
     await action.click();
     await expect(action).not.toHaveClass(/workspace-list-row__action--latched/);
     await expect(action).toHaveClass(/workspace-list-row__action--active/);
+    await expect(row.locator('.model-list-panel__favorite-indicator')).toBeHidden();
     await expect(row).toHaveClass(/workspace-list-row--pinned/);
     await expect(row).toHaveAttribute('aria-label', /favorite/i);
     await page.locator('.model-list-panel__search-input').hover();
     await expect(action).toBeHidden();
     await expect(anchor).toBeVisible();
+    await expect(row.locator('.model-list-panel__favorite-indicator')).toBeVisible();
   });
 
   test('A121 — selected model row is keyboard-operable: "F" toggles Favorite', async ({ page }) => {
@@ -2282,7 +2284,9 @@ test.describe('Accessibility — left-rail pin/favorite parity (#2355)', () => {
     // Move away before asserting the non-hover state.
     await page.locator('.model-list-panel__search-input').hover();
     await expect(reloadedRow.locator('.workspace-list-row__action')).toBeHidden();
+    await expect(reloadedRow.locator('.model-list-panel__favorite-indicator')).toBeVisible();
     await reloadedRow.hover();
+    await expect(reloadedRow.locator('.model-list-panel__favorite-indicator')).toBeHidden();
     await expect(reloadedRow.locator('.workspace-list-row__action')).toHaveAttribute('title', /remove .* from favorites/i);
     await expect(reloadedRow.locator('.workspace-list-row__action')).toHaveClass(/workspace-list-row__action--active/);
     expect(await page.evaluate(() => localStorage.getItem('lemonade:pinned_models'))).toBeNull();

--- a/src/app/tests/configuration-consistency.runtime.cjs
+++ b/src/app/tests/configuration-consistency.runtime.cjs
@@ -14,6 +14,9 @@ const modelConfigurationPath = path.join(root, 'src/modelConfiguration.ts');
 const recipeMetadataPath = path.join(root, 'src/features/backends/recipeMetadata.ts');
 const apiPath = path.join(root, 'src/api.ts');
 const samplerPath = path.join(root, 'src/samplerArgs.ts');
+const managerPath = path.join(root, 'src/components/ModelManager.tsx');
+const globalSettingsPath = path.join(root, 'src/features/modelSettings/globalModelSettings.ts');
+const storagePath = path.join(root, 'src/storage.ts');
 const stylesPath = path.join(root, 'src/styles/styles.css');
 
 const sources = new Map([
@@ -27,6 +30,9 @@ const sources = new Map([
   [recipeMetadataPath, fs.readFileSync(recipeMetadataPath, 'utf8')],
   [apiPath, fs.readFileSync(apiPath, 'utf8')],
   [samplerPath, fs.readFileSync(samplerPath, 'utf8')],
+  [managerPath, fs.readFileSync(managerPath, 'utf8')],
+  [globalSettingsPath, fs.readFileSync(globalSettingsPath, 'utf8')],
+  [storagePath, fs.readFileSync(storagePath, 'utf8')],
 ]);
 const styles = fs.readFileSync(stylesPath, 'utf8');
 const samplerSource = sources.get(samplerPath);
@@ -60,6 +66,9 @@ const modelListSource = sources.get(modelListPath);
 const modelConfigurationSource = sources.get(modelConfigurationPath);
 const recipeMetadataSource = sources.get(recipeMetadataPath);
 const apiSource = sources.get(apiPath);
+const managerSource = sources.get(managerPath);
+const globalSettingsSource = sources.get(globalSettingsPath);
+const storageSource = sources.get(storagePath);
 
 assert.match(appSource, /<header className="titlebar" data-tauri-drag-region>/);
 assert.doesNotMatch(appSource, /titlebar--chat/);
@@ -372,5 +381,24 @@ assert.deepEqual(metadata.recipeOptionNames({ recipes: { llamacpp: { backends: {
   'missing descriptor options must not be hidden by a frontend recipe fallback');
 assert.equal(metadata.recipeCapability({ recipes: { strange: { modality: 'New modality' } } }, 'strange'), 'Other',
   'unknown server modalities must not silently fall back to LLM');
+// server-owned pin contract
+assert.match(apiSource, /pinned: typeof model\.pinned === 'boolean'/, 'health normalization must preserve server pin state');
+assert.match(apiSource, /'\/internal\/pin'/, 'pin mutations must use the server endpoint');
+assert.match(managerSource, /loadedModels\.filter\(model => model\.pinned === true\)/, 'GUI pin state must derive from loaded server models');
+assert.match(managerSource, /api\.setModelPinned\(name, loaded\.pinned !== true\)/, 'GUI pin toggles must mutate server state');
+assert.match(managerSource, /onToggleFavorite=\{toggleFavoriteModel\}/, 'model list secondary action must be Favorite');
+assert.match(managerSource, /onTogglePin=\{selectedDetailModelId && displayLoadedModels\.some/, 'detail Pin handler must only be supplied for loaded models');
+assert.match(modelListSource, /ariaKeyShortcuts=\{onToggleFavorite \? 'F'/, 'model list must expose Favorite as its row shortcut');
+assert.match(modelListSource, /icon: 'star'/, 'model list secondary action must render Favorite');
+assert.doesNotMatch(modelListSource, /onTogglePin\?:/, 'model list must not own runtime Pin mutation');
+assert.doesNotMatch(managerSource, /loadPinnedModelNames|savePinnedModelNames/, 'ModelManager must not use browser pin persistence');
+assert.doesNotMatch(globalSettingsSource, /pinnedModelsKey|loadPinnedModelNames|savePinnedModelNames|pinned_models/, 'global model settings must not own pin persistence');
+assert.match(storageSource, /`\$\{STORAGE_PREFIX\}pinned_models`/, 'obsolete client pin storage must be cleaned up');
+
+// favorite hover-only row-action contract
+assert.doesNotMatch(modelListSource, /latched:\s*favorited/, 'Favorite must remain hover-only so backend info is visible at rest');
+assert.match(modelListSource, /active:\s*favorited/, 'favorited row action must keep active-state styling while hovered');
+assert.match(styles, /focus-within:not\(\.workspace-list-row--pointer-action\)\s+\.workspace-list-row__action/, 'pointer-only row action must not remain visible from row focus alone');
+assert.match(styles, /workspace-list-row__action--latched,\s*\n\.workspace-list-row__action--active\s*\{[^}]*color:\s*var\(--accent-fg\)/s, 'active row action must use the accent color without latching visibility');
 
 console.log('GUI3 configuration consistency contract checks passed.');

--- a/src/app/tests/configuration-consistency.runtime.cjs
+++ b/src/app/tests/configuration-consistency.runtime.cjs
@@ -387,7 +387,9 @@ assert.match(apiSource, /'\/internal\/pin'/, 'pin mutations must use the server 
 assert.match(managerSource, /loadedModels\.filter\(model => model\.pinned === true\)/, 'GUI pin state must derive from loaded server models');
 assert.match(managerSource, /api\.setModelPinned\(name, loaded\.pinned !== true\)/, 'GUI pin toggles must mutate server state');
 assert.match(managerSource, /onToggleFavorite=\{toggleFavoriteModel\}/, 'model list secondary action must be Favorite');
-assert.match(managerSource, /onTogglePin=\{selectedDetailModelId && displayLoadedModels\.some/, 'detail Pin handler must only be supplied for loaded models');
+assert.match(managerSource, /onTogglePin=\{selectedDetailModelId && loadedModels\.some/, 'detail Pin handler must only be supplied for server-loaded models');
+assert.doesNotMatch(managerSource, /onTogglePin=\{selectedDetailModelId && displayLoadedModels\.some/, 'virtual collection entries must not expose the server Pin action');
+assert.doesNotMatch(managerSource, /if \(!loaded\) return;/, 'Pin handler must not silently no-op if loaded state races the click');
 assert.match(modelListSource, /ariaKeyShortcuts=\{onToggleFavorite \? 'F'/, 'model list must expose Favorite as its row shortcut');
 assert.match(modelListSource, /icon: 'star'/, 'model list secondary action must render Favorite');
 assert.doesNotMatch(modelListSource, /onTogglePin\?:/, 'model list must not own runtime Pin mutation');

--- a/src/app/tests/features.spec.ts
+++ b/src/app/tests/features.spec.ts
@@ -901,10 +901,13 @@ test.describe('Lemonade UI — Feature Parity', () => {
     await expect(panel.locator('[id$="llamacpp_backend"]')).toBeVisible();
     await expect(panel.getByRole('button', { name: 'Reset' })).toBeVisible();
 
-    const pin = page.getByRole('button', { name: 'Pin config-beta-model' });
-    await expect(pin).toBeVisible();
-    await pin.click();
-    await expect(page.getByRole('button', { name: 'Unpin config-beta-model' }))
+    // Pin is a server runtime action and must not be offered until the model is loaded.
+    await expect(page.getByRole('button', { name: 'Pin config-beta-model' })).toHaveCount(0);
+    await expect(page.getByRole('button', { name: 'Unpin config-beta-model' })).toHaveCount(0);
+    const favorite = page.getByRole('button', { name: 'Add config-beta-model to favorites' });
+    await expect(favorite).toBeVisible();
+    await favorite.click();
+    await expect(page.getByRole('button', { name: 'Remove config-beta-model from favorites' }))
       .toHaveClass(/model-detail-panel__fav-btn--on/);
     await expect(page.getByRole('button', { name: 'Delete downloaded files for config-beta-model' }))
       .toHaveClass(/workspace-action-button--secondary/);

--- a/src/app/tests/storage.runtime.cjs
+++ b/src/app/tests/storage.runtime.cjs
@@ -66,6 +66,7 @@ values.set('lemonade:user:b:mcp_server_ids', JSON.stringify(['b']));
   'lemonade:applied_presets',
   'lemonade:backend_presets',
   'lemonade:running_presets',
+  'lemonade:pinned_models',
 ].forEach(key => values.set(key, 'obsolete'));
 
 const storageModule = loadStorageModule();
@@ -96,6 +97,7 @@ assert.equal(values.get('lemonade_storage_migrated_v2'), 'true');
   'lemonade:applied_presets',
   'lemonade:backend_presets',
   'lemonade:running_presets',
+  'lemonade:pinned_models',
 ].forEach(key => assert.equal(localStorage.getItem(key), null));
 
 [
@@ -105,6 +107,7 @@ assert.equal(values.get('lemonade_storage_migrated_v2'), 'true');
   'lemonade:applied_presets',
   'lemonade:backend_presets',
   'lemonade:running_presets',
+  'lemonade:pinned_models',
 ].forEach(key => values.set(key, 'obsolete-again'));
 const rerunStorageModule = loadStorageModule();
 assert.equal(rerunStorageModule.storageKey('rerun_probe'), 'lemonade:rerun_probe');
@@ -115,6 +118,7 @@ assert.equal(rerunStorageModule.storageKey('rerun_probe'), 'lemonade:rerun_probe
   'lemonade:applied_presets',
   'lemonade:backend_presets',
   'lemonade:running_presets',
+  'lemonade:pinned_models',
 ].forEach(key => assert.equal(localStorage.getItem(key), null));
 
 console.log('Client storage migration preserves scoped conversations and merges compatible settings.');


### PR DESCRIPTION
## Summary

Make runtime model pinning server-owned in GUI3.

- read the current pin state from lemond instead of maintaining a second `pinned_models` state in localStorage
- update pin state through `/internal/pin`
- remove the obsolete localStorage pin ownership and clean up the stale key
- keep Pin available in model details **only when the model is actually loaded**
- use **Favorite as the model-list secondary action**
- keep favorite state visible in the list with a small indicator when the hover action is not shown (seperate commit)
- update the affected storage, feature and accessibility tests

Related to #3161.

### Why the model-list action changes

This looks slightly wider than a storage fix, but it follows from making Pin reflect the server's runtime state.

A pin only applies to a loaded model. In practice that is normally one or two models, while the catalog can easily contain 100+ or more models and e.g. 15 favorites are likely numbers. Keeping Pin as the shared right-side action in the model list would therefore make that action unavailable for most rows.

The list row also intentionally has one shared secondary-action slot. Special-casing that slot so Pin only exists for loaded rows would break the interaction pattern used by the other lists (chat, telemetry etc.).

Favorite fits that slot better because it can be applied to every model in the catalog. It is also useful as the lightweight way to keep a small set of models easy to find, especially with the separate **My models** navigation planned to go away and **Favorite** seems to fit much better . Keeping Favorite only in the detail card would make that workflow unnecessarily slow for a larger catalog.

Pin state is not hidden by this change: pinned models still have their dedicated `Pinned` section in the model list and the state remains visible and controllable from model details.

There is one remaining workflow gap: loading a model takes the user into Chat, while Pin currently lives in the Models view. I plan to add the Pin control to the loaded-model UI in #3141, where it matches the server semantics well because that view only contains models that are actually loaded.

I hope in the light of this change make sense to you @jeremyfowers 

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_

- npm test
- verify Pin is only offered for loaded models
- verify pin/unpin updates the server-owned state and the Pinned section
- verify Favorite can be toggled from any catalog row
- verify favorited rows show the small stationary star, replace it with the Favorite action on hover, and restore the backend label after hover
- verify favorite state persists across reload

## Documentation

- [x] Documentation is not affected by this change.

## Breaking Changes

- [x] This PR does not introduce breaking changes.

## AI-assisted contribution

Please select one:

- [x] I used AI tools for this PR.

If AI tools were used:

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.