### PR TITLE
fix(rocm): only stage amdhip64_7.dll when TheRock runtime is newer than System32

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2956,6 +2956,13 @@ if(BUILD_TESTING AND EXISTS "${_GPU_ENV_TEST_SRC}")
     add_cpp_ci_test(BackendUtilsGpuEnvTest CI ON COMMAND test_backend_utils_gpu_env)
 endif()
 
+set(_DLL_VERSION_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_backend_utils_dll_version.cpp")
+if(BUILD_TESTING AND EXISTS "${_DLL_VERSION_TEST_SRC}")
+    add_executable(test_backend_utils_dll_version test/cpp/test_backend_utils_dll_version.cpp)
+    target_link_libraries(test_backend_utils_dll_version PRIVATE lemonade-server-core)
+    add_cpp_ci_test(BackendUtilsDllVersionTest CI ON COMMAND test_backend_utils_dll_version)
+endif()
+
 set(_PIP_DL_PARSER_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_pip_download_parser.cpp")
 if(BUILD_TESTING AND EXISTS "${_PIP_DL_PARSER_TEST_SRC}")
     add_executable(test_pip_download_parser test/cpp/test_pip_download_parser.cpp)

--- a/src/cpp/include/lemon/backends/backend_utils.h
+++ b/src/cpp/include/lemon/backends/backend_utils.h
@@ -192,6 +192,16 @@ namespace lemon::backends {
          *  get_therock_lib_paths). Returns "" for empty input. */
         static std::string join_runtime_dirs(const std::vector<std::string>& dirs);
 
+        /** Stage TheRock's amdhip64_7.dll next to a ROCm backend exe, unless
+         *  System32 already ships a newer runtime. No-op off Windows. */
+        static bool stage_therock_hip_runtime(const std::string& rocm_arch,
+                                              const fs::path& target_dir);
+
+        /** Read a DLL's VS_FIXEDFILEINFO version (packed MS<<32|LS). Windows
+         *  only; returns 0 elsewhere. GetFileVersionInfoW returns stale data
+         *  for system32 paths, so callers read versions from plain paths. */
+        static uint64_t read_dll_version(const fs::path& dll);
+
         /** Get the path to the backend's binary. Gives precedence to the path set through environment variables, if set. Throws if not found. */
         static std::string get_backend_binary_path(const BackendSpec& spec, const std::string& backend);
 

--- a/src/cpp/server/backends/backend_utils.cpp
+++ b/src/cpp/server/backends/backend_utils.cpp
@@ -27,6 +27,8 @@
 
 #ifdef _WIN32
     #include <windows.h>
+    #include <winver.h>
+    #pragma comment(lib, "version.lib")
 #else
     #include <unistd.h>
     #include <sys/stat.h>
@@ -1918,6 +1920,120 @@ namespace lemon::backends {
             add(utils::path_from_utf8(d));
         }
         return out;
+#endif
+    }
+
+#ifdef _WIN32
+    // GetFileVersionInfoW can return stale cached data for system32 paths (it
+    // reported 6.2 for a file that actually contains 10.0). Callers read
+    // versions from plain paths (TheRock dir, staged copies) where it is
+    // reliable.
+    uint64_t BackendUtils::read_dll_version(const fs::path& dll) {
+        const std::wstring wpath = dll.wstring();
+        DWORD handle = 0;
+        DWORD size = GetFileVersionInfoSizeW(wpath.c_str(), &handle);
+        if (size == 0) {
+            return 0;
+        }
+        std::vector<BYTE> data(size);
+        if (!GetFileVersionInfoW(wpath.c_str(), handle, size, data.data())) {
+            return 0;
+        }
+        VS_FIXEDFILEINFO* ffi = nullptr;
+        UINT len = 0;
+        if (!VerQueryValueW(data.data(), L"\\", reinterpret_cast<void**>(&ffi), &len) || ffi == nullptr) {
+            return 0;
+        }
+        return (static_cast<uint64_t>(ffi->dwFileVersionMS) << 32) | ffi->dwFileVersionLS;
+    }
+#else
+    uint64_t BackendUtils::read_dll_version(const fs::path& dll) {
+        (void)dll;
+        return 0;
+    }
+#endif
+
+    bool BackendUtils::stage_therock_hip_runtime(const std::string& rocm_arch,
+                                                 const fs::path& target_dir) {
+#ifndef _WIN32
+        (void)rocm_arch;
+        (void)target_dir;
+        return false;
+#else
+        if (rocm_arch.empty()) {
+            return false;
+        }
+
+        std::vector<std::string> therock_dirs = get_therock_lib_paths(rocm_arch);
+        if (therock_dirs.empty()) {
+            return false;
+        }
+
+        const fs::path therock_dll = utils::path_from_utf8(therock_dirs.front()) / "amdhip64_7.dll";
+        if (!fs::exists(therock_dll)) {
+            return false;
+        }
+
+        const fs::path target_dll = target_dir / "amdhip64_7.dll";
+
+        wchar_t sysdir[MAX_PATH] = {};
+        if (GetSystemDirectoryW(sysdir, MAX_PATH) == 0) {
+            return false;
+        }
+        const fs::path system_dll = fs::path(sysdir) / "amdhip64_7.dll";
+
+        const uint64_t therock_ver = read_dll_version(therock_dll);
+
+        // A previously staged copy may be locked by a running backend process
+        // (Windows blocks overwriting a loaded DLL), so leave it untouched when
+        // it is already at least as new as TheRock's.
+        const uint64_t staged_ver = read_dll_version(target_dll);
+        if (staged_ver != 0 && staged_ver >= therock_ver) {
+            LOG(INFO, "BackendUtils")
+                << "Existing amdhip64_7.dll at " << utils::path_to_utf8(target_dll)
+                << " is at least as new as TheRock's; leaving it in place" << std::endl;
+            return false;
+        }
+
+        // Windows loads DLLs from the exe dir before System32, so the staged
+        // copy wins over System32. Stage System32's runtime first (a plain
+        // path, where GetFileVersionInfoW is reliable) and only overwrite it
+        // with TheRock's when TheRock is newer.
+        std::error_code ec;
+        if (fs::exists(system_dll)) {
+            fs::copy_file(system_dll, target_dll, fs::copy_options::overwrite_existing, ec);
+            if (!ec) {
+                const uint64_t system_ver = read_dll_version(target_dll);
+                if (system_ver != 0 && system_ver >= therock_ver) {
+                    LOG(INFO, "BackendUtils")
+                        << "System32 amdhip64_7.dll is at least as new as TheRock's; staged it at "
+                        << utils::path_to_utf8(target_dll) << std::endl;
+                    return false;
+                }
+                fs::copy_file(therock_dll, target_dll, fs::copy_options::overwrite_existing, ec);
+                if (!ec) {
+                    LOG(INFO, "BackendUtils")
+                        << "TheRock's amdhip64_7.dll is newer than System32's; staged it at "
+                        << utils::path_to_utf8(target_dll) << std::endl;
+                    return true;
+                }
+                LOG(ERROR, "BackendUtils")
+                    << "Failed to copy amdhip64_7.dll from TheRock: " << ec.message() << std::endl;
+                return false;
+            }
+            LOG(WARNING, "BackendUtils")
+                << "Failed to stage System32 amdhip64_7.dll: " << ec.message() << std::endl;
+        }
+
+        fs::copy_file(therock_dll, target_dll, fs::copy_options::overwrite_existing, ec);
+        if (!ec) {
+            LOG(INFO, "BackendUtils")
+                << "Copied amdhip64_7.dll from TheRock to " << utils::path_to_utf8(target_dll)
+                << std::endl;
+            return true;
+        }
+        LOG(ERROR, "BackendUtils") << "Failed to copy amdhip64_7.dll: " << ec.message() << std::endl;
+        return false;
 #endif
     }
     void BackendUtils::apply_cuda_env_vars(

--- a/src/cpp/server/backends/llamacpp/llamacpp_server.cpp
+++ b/src/cpp/server/backends/llamacpp/llamacpp_server.cpp
@@ -506,29 +506,13 @@ void LlamaCppServer::load(const std::string& model_name,
         }
 
         // Windows DLL search order checks System32 BEFORE PATH, so a stale
-        // System32 amdhip64_7.dll crashes the runtime even when PATH points at
-        // TheRock. Copying to the exe directory overrides both.
+        // System32 amdhip64_7.dll shadows the TheRock runtime on PATH. Copying
+        // to the exe directory overrides both.
         if (llamacpp_backend == "rocm-stable") {
             std::string rocm_arch = SystemInfo::get_rocm_arch();
             if (!rocm_arch.empty()) {
-                std::vector<std::string> therock_dirs =
-                    BackendUtils::get_therock_lib_paths(rocm_arch);
-                std::string therock_bin = therock_dirs.empty() ? std::string() : therock_dirs.front();
-                if (!therock_bin.empty()) {
-                    fs::path therock_dll = fs::path(therock_bin) / "amdhip64_7.dll";
-                    fs::path target_dll = fs::path(executable).parent_path() / "amdhip64_7.dll";
-                    if (fs::exists(therock_dll)) {
-                        std::error_code ec;
-                        fs::copy_file(therock_dll, target_dll, fs::copy_options::overwrite_existing, ec);
-                        if (!ec) {
-                            LOG(INFO, "LlamaCpp") << "Copied amdhip64_7.dll from TheRock to "
-                                << path_to_utf8(target_dll) << std::endl;
-                        } else {
-                            LOG(ERROR, "LlamaCpp") << "Failed to copy amdhip64_7.dll: "
-                                << ec.message() << std::endl;
-                        }
-                    }
-                }
+                BackendUtils::stage_therock_hip_runtime(
+                    rocm_arch, fs::path(executable).parent_path());
             }
         }
 

--- a/test/cpp/test_backend_utils_dll_version.cpp
+++ b/test/cpp/test_backend_utils_dll_version.cpp
@@ -1,0 +1,125 @@
+// Unit tests for BackendUtils::read_dll_version().
+//
+// GetFileVersionInfoW returns stale cached data for system32 paths (it
+// reported 6.2 for a file that actually contains 10.0). stage_therock_hip_runtime
+// works around this by staging System32's amdhip64_7.dll into the backend exe
+// directory first and reading the version from that plain path, where the API
+// is reliable. These tests verify read_dll_version returns the same value as
+// the direct API for a plain path, and that it degrades gracefully.
+
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+
+#include <lemon/backends/backend_utils.h>
+
+#ifdef _WIN32
+#include <windows.h>
+#include <winver.h>
+#endif
+
+using lemon::backends::BackendUtils;
+
+namespace {
+
+int g_failures = 0;
+
+void check(bool cond, const char* msg) {
+    if (cond) {
+        std::cout << "[ok] " << msg << std::endl;
+    } else {
+        std::cerr << "[FAIL] " << msg << std::endl;
+        ++g_failures;
+    }
+}
+
+#ifdef _WIN32
+// Reference implementation: direct GetFileVersionInfoW read of a plain path.
+uint64_t read_version_direct(const fs::path& path) {
+    const std::wstring wpath = path.wstring();
+    DWORD handle = 0;
+    DWORD size = GetFileVersionInfoSizeW(wpath.c_str(), &handle);
+    if (size == 0) {
+        return 0;
+    }
+    std::vector<BYTE> data(size);
+    if (!GetFileVersionInfoW(wpath.c_str(), handle, size, data.data())) {
+        return 0;
+    }
+    VS_FIXEDFILEINFO* ffi = nullptr;
+    UINT len = 0;
+    if (!VerQueryValueW(data.data(), L"\\", reinterpret_cast<void**>(&ffi), &len) || ffi == nullptr) {
+        return 0;
+    }
+    return (static_cast<uint64_t>(ffi->dwFileVersionMS) << 32) | ffi->dwFileVersionLS;
+}
+#endif
+
+}  // namespace
+
+int main() {
+#ifdef _WIN32
+    // Test 1: read_dll_version on a plain path matches a direct API read.
+    {
+        const fs::path sys32 = fs::path("C:\\Windows\\System32\\kernel32.dll");
+        if (!fs::exists(sys32)) {
+            check(false, "kernel32.dll exists on the test host");
+            return 1;
+        }
+
+        // A plain-path copy is what stage_therock_hip_runtime reads versions
+        // from; the API must agree with read_dll_version there.
+        const fs::path copy = fs::temp_directory_path() / "lemonade_test_kernel32_copy.dll";
+        std::error_code ec;
+        fs::copy_file(sys32, copy, fs::copy_options::overwrite_existing, ec);
+        if (ec) {
+            check(false, "kernel32.dll can be copied to a temp path");
+            return 1;
+        }
+
+        const uint64_t via_helper = BackendUtils::read_dll_version(copy);
+        const uint64_t direct = read_version_direct(copy);
+        check(via_helper != 0, "read_dll_version returns a non-zero version for kernel32.dll");
+        check(via_helper == direct,
+              "read_dll_version matches the direct API on a plain path");
+
+        fs::remove(copy, ec);
+    }
+
+    // Test 2: the System32 kernel32.dll itself must also read through the
+    // helper (the API may cache system32 paths, but kernel32 is a stable
+    // reference file that read_dll_version should still handle).
+    {
+        const fs::path sys32 = fs::path("C:\\Windows\\System32\\kernel32.dll");
+        if (fs::exists(sys32)) {
+            const uint64_t v = BackendUtils::read_dll_version(sys32);
+            check(v != 0, "read_dll_version reads kernel32.dll from System32");
+        }
+    }
+
+    // Test 3: missing file yields 0.
+    {
+        const fs::path missing = fs::temp_directory_path() / "lemonade_does_not_exist.dll";
+        fs::remove(missing);
+        const uint64_t v = BackendUtils::read_dll_version(missing);
+        check(v == 0, "read_dll_version returns 0 for a missing file");
+    }
+#else
+    // Off Windows the helper is a no-op stub.
+    {
+        const fs::path missing = fs::temp_directory_path() / "lemonade_does_not_exist.dll";
+        const uint64_t v = BackendUtils::read_dll_version(missing);
+        check(v == 0, "read_dll_version returns 0 on non-Windows platforms");
+    }
+#endif
+
+    if (g_failures > 0) {
+        std::cerr << "Total failures: " << g_failures << std::endl;
+        return 1;
+    }
+
+    std::cout << "All DLL version reading tests passed!" << std::endl;
+    return 0;
+}


### PR DESCRIPTION
<!--
Before submitting this PR, please read:
- docs/dev/contribute.md
- docs/dev/philosophy.md
- AGENTS.md if you used an AI coding agent or AI-assisted workflow
- docs/dev/documentation.md if this PR changes user-facing or developer-facing documentation
-->

## Summary

PR #2768 force-copies TheRock's `amdhip64_7.dll` into the backend exe directory unconditionally. When the AMD driver ships a newer HIP runtime in System32 (e.g. 10.0.3679 vs TheRock's 10.0.3581), the stale copy shadows it: Windows loads DLLs from the exe dir before System32, so llama-server's `hipGetDeviceCount()` returns 0 and ROCm reports "no ROCm-capable device is detected".
This PR makes staging version-aware: it copies System32's `amdhip64_7.dll` into the exe dir first, reads its version from that plain path (GetFileVersionInfoW returns stale cached data for System32 paths), and only overwrites it with TheRock's when TheRock is newer. The exe dir always ends up with the correct runtime, so the loaded DLL is always known.

Fixes #3213

The staging is only applied to llama.cpp.

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

<!-- Describe what you tested, commands run, and results -->
Testing details:
- Built with `cmake --build build --preset vs18 --target wix_installer_minimal` — MSI built successfully.
- New unit test `BackendUtilsDllVersionTest` passes via `ctest --test-dir build -C Release -R BackendUtils` (verifies `read_dll_version` matches the direct API on a plain path and handles missing files).
- On Strix Halo (gfx1151): with System32 HIP runtime 10.0.3679 (newer than TheRock's 10.0.3581), the staged System32 copy is used and ROCm detects the GPU — inference at ~47.4 t/s (matches ROCm benchmark; Vulkan was ~50.4 t/s).

## Documentation

<!-- Select ONE of the following -->

- [x] Documentation is not affected by this change.
- [ ] Documentation is affected and has been updated.
- [ ] Documentation is affected but will be handled in a separate PR or issue.

## Breaking Changes

- [ ] This PR introduces breaking changes.
- [x] This PR does not introduce breaking changes.

<!-- If breaking changes, describe them and migration path -->

## AI-assisted contribution

Please select one:

- [x] I used AI tools for this PR.
- [ ] I did not use AI tools for this PR.

If AI tools were used:

<!-- Only complete this section if you checked "I used AI tools for this PR" above -->

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.
