### PR TITLE
fix(gui3): pin storage meter to the bottom of the models rail

### DIFF
--- a/src/app/src/components/ModelNavRail.tsx
+++ b/src/app/src/components/ModelNavRail.tsx
@@ -524,7 +524,9 @@ export const ModelNavRail: React.FC<ModelNavRailProps> = ({
         )}
       </section>
 
-      {/* 5. Storage meter */}
+      </div>
+
+      {/* 5. Storage meter — pinned footer (stays at the bottom of the rail) */}
       <div className="model-nav-rail__storage">
         <div className="model-nav-rail__storage-row">
           <span className="model-nav-rail__storage-label">Storage{storage.real ? '' : ' (est.)'}</span>
@@ -541,7 +543,6 @@ export const ModelNavRail: React.FC<ModelNavRailProps> = ({
         >
           <span className="model-nav-rail__storage-fill" style={{ width: `${storage.pct}%` }} aria-hidden="true" />
         </div>
-      </div>
       </div>
     </nav>
   );

--- a/src/app/src/styles/styles.css
+++ b/src/app/src/styles/styles.css
@@ -6702,6 +6702,7 @@ optgroup {
 }
 
 .model-nav-rail__scroll {
+  flex: 1;
   min-height: 0;
   overflow-y: auto;
   display: flex;
@@ -6946,11 +6947,11 @@ optgroup {
 
 /* 6. Storage meter */
 .model-nav-rail__storage {
-  margin-top: auto;
+  flex-shrink: 0;
   display: flex;
   flex-direction: column;
   gap: var(--space-1);
-  padding: var(--space-2) var(--space-2) 0;
+  padding: var(--space-2);
   border-top: 1px solid var(--border-subtle);
 }
 


### PR DESCRIPTION
## Summary

Pin the storage meter in the Models rail so it stays fixed at the bottom of the rail instead of moving when the filter sections expand or collapse.

The meter was rendered inside `.model-nav-rail__scroll`, so toggling the Task / Backends / Tags sections shifted its position (and it could scroll out of view). This moves it out of the scroll container into a pinned footer, and gives the scroll area `flex: 1` so the filters scroll independently above it. The meter stays hidden when the rail is collapsed (the existing `.workspace-rail.is-collapsed` rule covers it).

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

Built the web-app from source (`cmake --build build --config Release --target web-app`) and verified in the browser that the storage meter stays pinned at the bottom of the rail while the filter sections scroll independently. Also rebuilt the Tauri desktop app and confirmed it compiles and launches.

## Documentation

- [x] Documentation is not affected by this change.

## Breaking Changes

- [x] This PR does not introduce breaking changes.

## AI-assisted contribution

- [x] I used AI tools for this PR.

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.
