### PR TITLE
feat(server): hide backends with no runnable models on this host

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2805,6 +2805,18 @@ if(BUILD_TESTING AND EXISTS "${_MODEL_MANAGER_COLLECTION_VALIDATION_TEST_SRC}")
     add_cpp_ci_test(ModelManagerCollectionValidationTest CI ON COMMAND test_model_manager_collection_validation)
 endif()
 
+# Recipe hiding: a backend with every built-in model dropped by the system-memory
+# heuristic (and no user model left) is hidden from the recipe/backends listing.
+set(_RECIPE_HIDING_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_recipe_hiding.cpp")
+if(BUILD_TESTING AND EXISTS "${_RECIPE_HIDING_TEST_SRC}")
+    add_executable(test_recipe_hiding test/cpp/test_recipe_hiding.cpp)
+    target_link_libraries(test_recipe_hiding PRIVATE lemonade-server-core)
+    add_dependencies(test_recipe_hiding copy_resources)
+
+    include(CTest)
+    add_cpp_ci_test(RecipeHidingTest CI ON COMMAND test_recipe_hiding)
+endif()
+
 # Remote model registry source parsing, cache namespaces, snapshot fingerprints,
 # and persistence of ModelScope provenance in ModelInfo.
 set(_MODEL_REGISTRY_TEST_SRC

--- a/src/app/src/renderer/BackendManager.tsx
+++ b/src/app/src/renderer/BackendManager.tsx
@@ -141,9 +141,18 @@ const BackendManager: React.FC<BackendManagerProps> = ({ searchQuery, showError,
     window.open(url, '_blank', 'noopener,noreferrer');
   }, []);
 
+  // Mirrors BackendRow's `isInstalledLike`: something is on disk here, so this
+  // panel must keep showing it. It is the only place that offers uninstall
+  // (ModelManager renders the 'banner' variant, which has no uninstall action),
+  // so hiding an unavailable-but-installed backend would strand it.
+  const isInstalledLike = (info: BackendInfo) =>
+    info.state === 'installed' || info.state === 'update_available';
+
   const groupedBackends: Array<[string, Array<[string, BackendInfo]>]> = recipes
     ? Object.entries(recipes)
-      .filter(([recipeName]) => !unavailableRecipes.has(recipeName))
+      .filter(([recipeName, recipe]: [string, Recipe]) =>
+        !unavailableRecipes.has(recipeName) ||
+        Object.values(recipe.backends).some(isInstalledLike))
       .map(([recipeName, recipe]: [string, Recipe]) => {
         const backends = Object.entries(recipe.backends).filter(([, info]) => info.state !== 'unsupported');
         return [recipeName, backends] as [string, Array<[string, BackendInfo]>];

--- a/src/app/src/renderer/BackendManager.tsx
+++ b/src/app/src/renderer/BackendManager.tsx
@@ -47,6 +47,10 @@ const BackendManager: React.FC<BackendManagerProps> = ({ searchQuery, showError,
   }, [refresh]);
 
   const recipes = systemInfo?.recipes;
+  // `recipes` is canonical (docs are generated from it), so host-specific
+  // availability arrives separately: these have no model that fits this
+  // machine's memory, so there is nothing to install them for.
+  const unavailableRecipes = new Set(systemInfo?.unavailable_recipes ?? []);
 
   // Fetch asset sizes from GitHub Releases API
   useEffect(() => {
@@ -139,6 +143,7 @@ const BackendManager: React.FC<BackendManagerProps> = ({ searchQuery, showError,
 
   const groupedBackends: Array<[string, Array<[string, BackendInfo]>]> = recipes
     ? Object.entries(recipes)
+      .filter(([recipeName]) => !unavailableRecipes.has(recipeName))
       .map(([recipeName, recipe]: [string, Recipe]) => {
         const backends = Object.entries(recipe.backends).filter(([, info]) => info.state !== 'unsupported');
         return [recipeName, backends] as [string, Array<[string, BackendInfo]>];

--- a/src/app/src/renderer/BackendManager.tsx
+++ b/src/app/src/renderer/BackendManager.tsx
@@ -141,20 +141,29 @@ const BackendManager: React.FC<BackendManagerProps> = ({ searchQuery, showError,
     window.open(url, '_blank', 'noopener,noreferrer');
   }, []);
 
-  // Mirrors BackendRow's `isInstalledLike`: something is on disk here, so this
-  // panel must keep showing it. It is the only place that offers uninstall
-  // (ModelManager renders the 'banner' variant, which has no uninstall action),
-  // so hiding an unavailable-but-installed backend would strand it.
-  const isInstalledLike = (info: BackendInfo) =>
-    info.state === 'installed' || info.state === 'update_available';
+  // Matches the server's own `locally_installed` (system_info.cpp): these three
+  // states all mean the backend is on disk, `update_required` included.
+  const isLocallyInstalled = (info: BackendInfo) =>
+    info.state === 'installed' ||
+    info.state === 'update_available' ||
+    info.state === 'update_required';
+
+  // An unavailable recipe has no built-in model that fits this host, so it keeps
+  // only rows for an existing installation: this panel is the only one offering
+  // uninstall (ModelManager renders the 'banner' variant, which has none), so
+  // hiding those would strand them. `installable` and `action_required` are
+  // dropped — nothing is on disk yet, and setting one up would buy the user
+  // nothing. A recipe left with no rows falls out via the length check below.
+  const keepBackend = (recipeName: string) =>
+    unavailableRecipes.has(recipeName)
+      ? isLocallyInstalled
+      : (info: BackendInfo) => info.state !== 'unsupported';
 
   const groupedBackends: Array<[string, Array<[string, BackendInfo]>]> = recipes
     ? Object.entries(recipes)
-      .filter(([recipeName, recipe]: [string, Recipe]) =>
-        !unavailableRecipes.has(recipeName) ||
-        Object.values(recipe.backends).some(isInstalledLike))
       .map(([recipeName, recipe]: [string, Recipe]) => {
-        const backends = Object.entries(recipe.backends).filter(([, info]) => info.state !== 'unsupported');
+        const keep = keepBackend(recipeName);
+        const backends = Object.entries(recipe.backends).filter(([, info]) => keep(info));
         return [recipeName, backends] as [string, Array<[string, BackendInfo]>];
       })
       .filter(([, backends]) => backends.length > 0)

--- a/src/app/src/renderer/utils/systemData.ts
+++ b/src/app/src/renderer/utils/systemData.ts
@@ -4,6 +4,10 @@ export interface SystemInfo {
   processor: string;
   devices: Devices;
   recipes?: Recipes;
+  // Recipes with nothing runnable on this host: every built-in model was
+  // dropped by the system-memory heuristic. `recipes` stays canonical, so
+  // listings that reflect this host must subtract this set themselves.
+  unavailable_recipes?: string[];
 }
 
 interface Devices {

--- a/src/cpp/cli/lemonade_client.cpp
+++ b/src/cpp/cli/lemonade_client.cpp
@@ -968,7 +968,20 @@ int LemonadeClient::list_recipes(bool show_all) const {
             return 0;
         }
 
+        // Hidden unless --all (see /system-info's unavailable_recipes).
+        std::set<std::string> unavailable_recipes;
+        if (json_response.contains("unavailable_recipes") &&
+            json_response["unavailable_recipes"].is_array()) {
+            for (const auto& r : json_response["unavailable_recipes"]) {
+                if (r.is_string()) unavailable_recipes.insert(r.get<std::string>());
+            }
+        }
+
         for (const auto& [recipe_name, recipe_data] : json_response["recipes"].items()) {
+            if (!show_all && unavailable_recipes.count(recipe_name)) {
+                continue;
+            }
+
             RecipeStatus status;
             status.name = recipe_name;
 

--- a/src/cpp/include/lemon/model_manager.h
+++ b/src/cpp/include/lemon/model_manager.h
@@ -214,9 +214,12 @@ public:
     // Get downloaded models
     std::map<std::string, ModelInfo> get_downloaded_models();
 
-    // Filter models by available backends
+    // Filter models by available backends. Set track_recipe_availability only on
+    // the full-cache build: the single-model temp maps used by incremental
+    // updates must not overwrite the whole-registry availability side table.
     std::map<std::string, ModelInfo> filter_models_by_backend(
-        const std::map<std::string, ModelInfo>& models);
+        const std::map<std::string, ModelInfo>& models,
+        bool track_recipe_availability = false);
 
     // Register a user model
     void register_user_model(const std::string& model_name,
@@ -294,6 +297,10 @@ public:
     static std::set<std::string> recipes_missing_all_models(
         const std::set<std::string>& size_filtered_recipes,
         const std::set<std::string>& visible_recipes);
+
+    // Test-only raw view of the side table without a cache rebuild; prefer
+    // recipes_with_all_models_filtered() everywhere else.
+    std::set<std::string> recipes_all_models_filtered_snapshot() const;
 
     // Check if model is downloaded
     bool is_model_downloaded(const std::string& model_name);

--- a/src/cpp/include/lemon/model_manager.h
+++ b/src/cpp/include/lemon/model_manager.h
@@ -280,6 +280,21 @@ public:
     // Returns a user-friendly message explaining why the model is not available
     std::string get_model_filter_reason(const std::string& model_name);
 
+    // Real-backend recipes with nothing runnable on this system because every
+    // one of their built-in models was filtered out by the system-memory
+    // heuristic (and no user model fills the gap). Callers use this to hide such
+    // backends from the recipe/backends listing. Recipes filtered for
+    // hardware/OS reasons are excluded (they keep their "unsupported" display).
+    // Builds the cache if needed.
+    std::set<std::string> recipes_with_all_models_filtered();
+
+    // The set difference behind the above: recipes that had a model dropped by
+    // the memory heuristic and kept none visible. Pure and hardware-independent
+    // so it can be unit-tested directly.
+    static std::set<std::string> recipes_missing_all_models(
+        const std::set<std::string>& size_filtered_recipes,
+        const std::set<std::string>& visible_recipes);
+
     // Check if model is downloaded
     bool is_model_downloaded(const std::string& model_name);
 
@@ -478,6 +493,9 @@ private:
     mutable std::map<std::string, std::string> public_model_aliases_;  // public name -> canonical name
     mutable std::map<std::string, std::string> canonical_public_names_;  // canonical name -> public name
     mutable std::map<std::string, std::string> filtered_out_models_;  // model_name -> filter reason
+    // Real-backend recipes whose entire built-in model set was size-filtered
+    // with no model left visible. Populated alongside filtered_out_models_.
+    mutable std::set<std::string> recipes_all_models_filtered_;
     mutable bool cache_valid_ = false;
 
     // Refresh user_models.json on-demand when a user.* lookup misses the cache.

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -2481,8 +2481,10 @@ void ModelManager::build_cache() {
         info.recipe_options = build_recipe_options(info, jro, cache_key_to_canonical_id(name), recipe_options_);
     }
 
-    // Step 2: Filter by backend availability
-    all_models = filter_models_by_backend(all_models);
+    // Step 2: Filter by backend availability. This is the full-registry pass, so
+    // it also refreshes the recipe availability side table used to hide backends
+    // that have nothing runnable on this host.
+    all_models = filter_models_by_backend(all_models, /*track_recipe_availability=*/true);
 
     // Step 3: Check download status for all models. Dynamic-discovery backends
     // (flm, cloud) already set downloaded during discovery; everyone else asks
@@ -2858,7 +2860,8 @@ bool parse_TF_env_var(const char* env_var_name) {
 }
 
 std::map<std::string, ModelInfo> ModelManager::filter_models_by_backend(
-    const std::map<std::string, ModelInfo>& models) {
+    const std::map<std::string, ModelInfo>& models,
+    bool track_recipe_availability) {
 
     // Check if model filtering is disabled via config.json
     bool disable_filtering = false;
@@ -2871,6 +2874,9 @@ std::map<std::string, ModelInfo> ModelManager::filter_models_by_backend(
 
     if (disable_filtering) {
         filtered_out_models_.clear();
+        if (track_recipe_availability) {
+            recipes_all_models_filtered_.clear();
+        }
         return models;
     }
 
@@ -2884,11 +2890,7 @@ std::map<std::string, ModelInfo> ModelManager::filter_models_by_backend(
     std::map<std::string, ModelInfo> filtered;
 
     filtered_out_models_.clear();
-    recipes_all_models_filtered_.clear();
 
-    // Recipes whose models were dropped by the system-memory heuristic vs.
-    // recipes that kept at least one runnable (built-in or user) model. A recipe
-    // in the first set but not the second has nothing runnable on this host.
     std::set<std::string> size_filtered_recipes;
     std::set<std::string> visible_recipes;
 
@@ -3045,10 +3047,19 @@ std::map<std::string, ModelInfo> ModelManager::filter_models_by_backend(
         filtered[name] = info;
     }
 
-    recipes_all_models_filtered_ =
-        recipes_missing_all_models(size_filtered_recipes, visible_recipes);
+    // Only the full-registry pass may commit the availability side table;
+    // incremental single-model passes would otherwise reduce it to one model.
+    if (track_recipe_availability) {
+        recipes_all_models_filtered_ =
+            recipes_missing_all_models(size_filtered_recipes, visible_recipes);
+    }
 
     return filtered;
+}
+
+std::set<std::string> ModelManager::recipes_all_models_filtered_snapshot() const {
+    std::lock_guard<std::mutex> lock(models_cache_mutex_);
+    return recipes_all_models_filtered_;
 }
 
 std::set<std::string> ModelManager::recipes_missing_all_models(
@@ -5698,7 +5709,6 @@ std::string ModelManager::get_model_filter_reason(const std::string& model_name)
 }
 
 std::set<std::string> ModelManager::recipes_with_all_models_filtered() {
-    // Ensure cache is built (this populates recipes_all_models_filtered_).
     build_cache();
     std::lock_guard<std::mutex> lock(models_cache_mutex_);
     return recipes_all_models_filtered_;

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -2884,6 +2884,13 @@ std::map<std::string, ModelInfo> ModelManager::filter_models_by_backend(
     std::map<std::string, ModelInfo> filtered;
 
     filtered_out_models_.clear();
+    recipes_all_models_filtered_.clear();
+
+    // Recipes whose models were dropped by the system-memory heuristic vs.
+    // recipes that kept at least one runnable (built-in or user) model. A recipe
+    // in the first set but not the second has nothing runnable on this host.
+    std::set<std::string> size_filtered_recipes;
+    std::set<std::string> visible_recipes;
 
     json system_info = SystemInfoCache::get_system_info_with_cache();
     json hardware = system_info.contains("devices") ? system_info["devices"] : json::object();
@@ -3005,6 +3012,7 @@ std::map<std::string, ModelInfo> ModelManager::filter_models_by_backend(
         if (!filter_out && !user_controlled_model && system_ram_gb > 0.0 && info.size > 0.0) {
             if (info.size > max_model_size_gb) {
                 filter_out = true;
+                size_filtered_recipes.insert(recipe);
                 std::ostringstream oss;
                 oss << std::fixed << std::setprecision(1);
                 oss << "This model requires approximately " << info.size << " GB of memory, "
@@ -3033,10 +3041,26 @@ std::map<std::string, ModelInfo> ModelManager::filter_models_by_backend(
         }
 
         // Model passes all filters
+        visible_recipes.insert(info.recipe);
         filtered[name] = info;
     }
 
+    recipes_all_models_filtered_ =
+        recipes_missing_all_models(size_filtered_recipes, visible_recipes);
+
     return filtered;
+}
+
+std::set<std::string> ModelManager::recipes_missing_all_models(
+    const std::set<std::string>& size_filtered_recipes,
+    const std::set<std::string>& visible_recipes) {
+    std::set<std::string> hidden;
+    for (const auto& recipe : size_filtered_recipes) {
+        if (visible_recipes.find(recipe) == visible_recipes.end()) {
+            hidden.insert(recipe);
+        }
+    }
+    return hidden;
 }
 
 void ModelManager::set_cloud_registry(CloudProviderRegistry* registry) {
@@ -5671,6 +5695,13 @@ std::string ModelManager::get_model_filter_reason(const std::string& model_name)
 
     // Model wasn't filtered out (either it's available or doesn't exist)
     return "";
+}
+
+std::set<std::string> ModelManager::recipes_with_all_models_filtered() {
+    // Ensure cache is built (this populates recipes_all_models_filtered_).
+    build_cache();
+    std::lock_guard<std::mutex> lock(models_cache_mutex_);
+    return recipes_all_models_filtered_;
 }
 
 // Must be called with models_cache_mutex_ held.

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -15,6 +15,7 @@
 #include "lemon/mcp_server.h"
 #include "lemon/mcp_client.h"
 #include "lemon/ollama_api.h"
+#include "lemon/backends/backend_descriptor_registry.h"
 #include "lemon/backends/cloud/cloud_server.h"
 #include "lemon/backends/sdcpp/sdcpp_server.h"
 #include "lemon/backends/backend_utils.h"
@@ -6620,6 +6621,20 @@ void Server::handle_system_info(const httplib::Request& req, httplib::Response& 
     // Enrich with release_url, download_filename, version from BackendManager config
     if (system_info.contains("recipes")) {
         enrich_recipes(system_info["recipes"]);
+    }
+
+    // Hide backends that have nothing runnable on this host because every one of
+    // their built-in models was filtered out for lack of system memory. Listing
+    // them as installed/available would be misleading. Dynamic-model backends
+    // (cloud, flm) supply models at runtime, so they are never hidden this way.
+    if (system_info.contains("recipes") && model_manager_) {
+        for (const std::string& recipe : model_manager_->recipes_with_all_models_filtered()) {
+            const BackendDescriptor* desc = backends::descriptor_for(recipe);
+            if (desc && desc->dynamic_models) {
+                continue;
+            }
+            system_info["recipes"].erase(recipe);
+        }
     }
 
     // Surface runtime config flags that affect client-side install/download UX.

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -6623,18 +6623,20 @@ void Server::handle_system_info(const httplib::Request& req, httplib::Response& 
         enrich_recipes(system_info["recipes"]);
     }
 
-    // Hide backends that have nothing runnable on this host because every one of
-    // their built-in models was filtered out for lack of system memory. Listing
-    // them as installed/available would be misleading. Dynamic-model backends
-    // (cloud, flm) supply models at runtime, so they are never hidden this way.
-    if (system_info.contains("recipes") && model_manager_) {
+    // Surfaced as a separate host-specific field rather than by pruning
+    // `recipes`, which must stay canonical: the docs generator renders
+    // README/models.js from it and would otherwise drift with the generating
+    // machine's memory. Dynamic-model backends (cloud, flm) are never listed.
+    if (model_manager_) {
+        nlohmann::json unavailable = nlohmann::json::array();
         for (const std::string& recipe : model_manager_->recipes_with_all_models_filtered()) {
             const BackendDescriptor* desc = backends::descriptor_for(recipe);
             if (desc && desc->dynamic_models) {
                 continue;
             }
-            system_info["recipes"].erase(recipe);
+            unavailable.push_back(recipe);
         }
+        system_info["unavailable_recipes"] = std::move(unavailable);
     }
 
     // Surface runtime config flags that affect client-side install/download UX.

--- a/test/cpp/test_recipe_hiding.cpp
+++ b/test/cpp/test_recipe_hiding.cpp
@@ -1,16 +1,22 @@
-// Tests for the rule that hides a backend from the recipe/backends listing
-// when every one of its built-in models was dropped by the system-memory
-// heuristic. The set-difference at the heart of the rule is pure and
-// hardware-independent, so it is exercised directly here; the end-to-end wiring
-// (size filtering -> recipes_with_all_models_filtered() -> handle_system_info
-// erase, with dynamic-model backends exempt) is covered by manual server runs.
+// Tests for the rule that reports a backend as unavailable (so clients hide it
+// from the recipe/backends listing) when every one of its built-in models was
+// dropped by the system-memory heuristic. Two layers are covered:
+//   * the pure set-difference at the heart of the rule, and
+//   * the stateful contract that only a full-registry filter pass may commit the
+//     availability side table, so incremental single-model updates cannot
+//     clobber it.
 
 #include "lemon/model_manager.h"
+#include "lemon/utils/path_utils.h"
 
 #include <cstdio>
+#include <filesystem>
+#include <map>
 #include <set>
 #include <string>
 
+namespace fs = std::filesystem;
+using lemon::ModelInfo;
 using lemon::ModelManager;
 
 static int g_failures = 0;
@@ -20,41 +26,92 @@ static void check(const std::string& name, bool ok) {
     if (!ok) ++g_failures;
 }
 
-static bool eq(const std::set<std::string>& a, const std::set<std::string>& b) {
-    return a == b;
+static ModelInfo model(const std::string& recipe, double size_gb) {
+    ModelInfo info;
+    info.recipe = recipe;
+    info.size = size_gb;
+    return info;
+}
+
+static void test_pure_set_difference() {
+    using S = std::set<std::string>;
+
+    check("all built-ins filtered -> recipe reported",
+          ModelManager::recipes_missing_all_models({"ds4"}, {}) == S{"ds4"});
+
+    check("partial filtering -> recipe kept",
+          ModelManager::recipes_missing_all_models({"llamacpp"}, {"llamacpp"}) == S{});
+
+    check("no filtered models -> nothing reported",
+          ModelManager::recipes_missing_all_models({}, {"llamacpp", "kokoro"}) == S{});
+
+    check("mixed recipes resolve independently",
+          ModelManager::recipes_missing_all_models({"ds4", "vllm"}, {"vllm", "llamacpp"})
+              == S{"ds4"});
+
+    check("recipe not size-filtered is never reported",
+          ModelManager::recipes_missing_all_models({"ds4"}, {"ds4", "llamacpp"}) == S{});
+}
+
+// A size so large no real machine can hold it, so the model is always
+// memory-filtered regardless of where the test runs.
+static constexpr double HUGE_GB = 1.0e6;
+
+static void test_full_pass_commits_and_recomputes(ModelManager& manager) {
+    // Full pass over a registry where whispercpp's only model is unfillable and
+    // kokoro's fits: whispercpp is reported (if supported on this host), kokoro
+    // is not.
+    std::map<std::string, ModelInfo> full = {
+        {"HugeWhisper", model("whispercpp", HUGE_GB)},
+        {"TinyKokoro", model("kokoro", 0.01)},
+    };
+    manager.filter_models_by_backend(full, /*track_recipe_availability=*/true);
+    std::set<std::string> after_huge = manager.recipes_all_models_filtered_snapshot();
+    check("full pass never reports a recipe that kept a visible model",
+          after_huge.count("kokoro") == 0);
+
+    // A subsequent full pass where whispercpp now has a fitting model must
+    // recompute from scratch, not accumulate: whispercpp is no longer reported.
+    std::map<std::string, ModelInfo> full_fits = {
+        {"TinyWhisper", model("whispercpp", 0.01)},
+        {"TinyKokoro", model("kokoro", 0.01)},
+    };
+    manager.filter_models_by_backend(full_fits, /*track_recipe_availability=*/true);
+    std::set<std::string> after_fits = manager.recipes_all_models_filtered_snapshot();
+    check("full pass recomputes: a now-fitting recipe is dropped",
+          after_fits.count("whispercpp") == 0);
+}
+
+static void test_incremental_pass_does_not_clobber(ModelManager& manager) {
+    // Seed the side table with a full pass, then run an incremental single-model
+    // pass (as add_model_to_cache does). The incremental pass must leave the
+    // side table untouched.
+    std::map<std::string, ModelInfo> full = {
+        {"HugeWhisper", model("whispercpp", HUGE_GB)},
+    };
+    manager.filter_models_by_backend(full, /*track_recipe_availability=*/true);
+    std::set<std::string> seeded = manager.recipes_all_models_filtered_snapshot();
+
+    std::map<std::string, ModelInfo> one = {{"TinyKokoro", model("kokoro", 0.01)}};
+    manager.filter_models_by_backend(one, /*track_recipe_availability=*/false);
+    std::set<std::string> after_incremental = manager.recipes_all_models_filtered_snapshot();
+
+    check("incremental pass leaves the availability side table unchanged",
+          after_incremental == seeded);
 }
 
 int main() {
-    using S = std::set<std::string>;
+    fs::path temp = fs::temp_directory_path() / "lemonade-recipe-hiding-test";
+    fs::create_directories(temp);
+    lemon::utils::set_cache_dir(temp.string());
 
-    // A recipe whose only models were all size-filtered, with nothing visible,
-    // is hidden.
-    check("all built-ins filtered -> recipe hidden",
-          eq(ModelManager::recipes_missing_all_models({"ds4"}, {}),
-             S{"ds4"}));
+    test_pure_set_difference();
 
-    // A recipe with at least one model still visible is kept, even if some of
-    // its models were filtered (partial filtering).
-    check("partial filtering -> recipe kept",
-          eq(ModelManager::recipes_missing_all_models({"llamacpp"}, {"llamacpp"}),
-             S{}));
+    ModelManager manager;
+    test_full_pass_commits_and_recomputes(manager);
+    test_incremental_pass_does_not_clobber(manager);
 
-    // A recipe that never had a model filtered is not a hide candidate.
-    check("no filtered models -> nothing hidden",
-          eq(ModelManager::recipes_missing_all_models({}, {"llamacpp", "kokoro"}),
-             S{}));
-
-    // Mixed: one recipe fully filtered, another partially, a third untouched.
-    check("mixed recipes resolve independently",
-          eq(ModelManager::recipes_missing_all_models(
-                 {"ds4", "vllm"}, {"vllm", "llamacpp"}),
-             S{"ds4"}));
-
-    // Only the size-filtered set drives hiding: a recipe absent from it is never
-    // hidden regardless of visibility.
-    check("recipe not size-filtered is never hidden",
-          eq(ModelManager::recipes_missing_all_models({"ds4"}, {"ds4", "llamacpp"}),
-             S{}));
+    fs::remove_all(temp);
 
     if (g_failures == 0) {
         std::printf("All recipe hiding tests passed.\n");

--- a/test/cpp/test_recipe_hiding.cpp
+++ b/test/cpp/test_recipe_hiding.cpp
@@ -1,0 +1,65 @@
+// Tests for the rule that hides a backend from the recipe/backends listing
+// when every one of its built-in models was dropped by the system-memory
+// heuristic. The set-difference at the heart of the rule is pure and
+// hardware-independent, so it is exercised directly here; the end-to-end wiring
+// (size filtering -> recipes_with_all_models_filtered() -> handle_system_info
+// erase, with dynamic-model backends exempt) is covered by manual server runs.
+
+#include "lemon/model_manager.h"
+
+#include <cstdio>
+#include <set>
+#include <string>
+
+using lemon::ModelManager;
+
+static int g_failures = 0;
+
+static void check(const std::string& name, bool ok) {
+    std::printf("%s %s\n", ok ? "PASS" : "FAIL", name.c_str());
+    if (!ok) ++g_failures;
+}
+
+static bool eq(const std::set<std::string>& a, const std::set<std::string>& b) {
+    return a == b;
+}
+
+int main() {
+    using S = std::set<std::string>;
+
+    // A recipe whose only models were all size-filtered, with nothing visible,
+    // is hidden.
+    check("all built-ins filtered -> recipe hidden",
+          eq(ModelManager::recipes_missing_all_models({"ds4"}, {}),
+             S{"ds4"}));
+
+    // A recipe with at least one model still visible is kept, even if some of
+    // its models were filtered (partial filtering).
+    check("partial filtering -> recipe kept",
+          eq(ModelManager::recipes_missing_all_models({"llamacpp"}, {"llamacpp"}),
+             S{}));
+
+    // A recipe that never had a model filtered is not a hide candidate.
+    check("no filtered models -> nothing hidden",
+          eq(ModelManager::recipes_missing_all_models({}, {"llamacpp", "kokoro"}),
+             S{}));
+
+    // Mixed: one recipe fully filtered, another partially, a third untouched.
+    check("mixed recipes resolve independently",
+          eq(ModelManager::recipes_missing_all_models(
+                 {"ds4", "vllm"}, {"vllm", "llamacpp"}),
+             S{"ds4"}));
+
+    // Only the size-filtered set drives hiding: a recipe absent from it is never
+    // hidden regardless of visibility.
+    check("recipe not size-filtered is never hidden",
+          eq(ModelManager::recipes_missing_all_models({"ds4"}, {"ds4", "llamacpp"}),
+             S{}));
+
+    if (g_failures == 0) {
+        std::printf("All recipe hiding tests passed.\n");
+    } else {
+        std::printf("%d recipe hiding test(s) failed.\n", g_failures);
+    }
+    return g_failures == 0 ? 0 : 1;
+}

--- a/test/cpp/test_recipe_hiding.cpp
+++ b/test/cpp/test_recipe_hiding.cpp
@@ -57,47 +57,72 @@ static void test_pure_set_difference() {
 // memory-filtered regardless of where the test runs.
 static constexpr double HUGE_GB = 1.0e6;
 
-static void test_full_pass_commits_and_recomputes(ModelManager& manager) {
-    // Full pass over a registry where whispercpp's only model is unfillable and
-    // kokoro's fits: whispercpp is reported (if supported on this host), kokoro
-    // is not.
-    std::map<std::string, ModelInfo> full = {
-        {"HugeWhisper", model("whispercpp", HUGE_GB)},
-        {"TinyKokoro", model("kokoro", 0.01)},
-    };
-    manager.filter_models_by_backend(full, /*track_recipe_availability=*/true);
-    std::set<std::string> after_huge = manager.recipes_all_models_filtered_snapshot();
-    check("full pass never reports a recipe that kept a visible model",
-          after_huge.count("kokoro") == 0);
+// The memory heuristic only sees models that already cleared the hardware/OS
+// gate (check_recipe_supported) and only runs when system RAM is readable, so
+// the stateful tests cannot assume any particular recipe reaches it. Probe for
+// one that does: a tiny model must survive (recipe supported here) and a huge
+// one must not (size filter actually active). Probes pass
+// track_recipe_availability=false, so they never disturb the side table.
+static std::string find_probe_recipe(ModelManager& manager) {
+    for (const char* candidate : {"llamacpp", "whispercpp", "kokoro", "sd-cpp"}) {
+        std::map<std::string, ModelInfo> tiny = {{"ProbeTiny", model(candidate, 0.01)}};
+        if (manager.filter_models_by_backend(tiny, false).empty()) continue;
 
-    // A subsequent full pass where whispercpp now has a fitting model must
-    // recompute from scratch, not accumulate: whispercpp is no longer reported.
-    std::map<std::string, ModelInfo> full_fits = {
-        {"TinyWhisper", model("whispercpp", 0.01)},
-        {"TinyKokoro", model("kokoro", 0.01)},
-    };
-    manager.filter_models_by_backend(full_fits, /*track_recipe_availability=*/true);
-    std::set<std::string> after_fits = manager.recipes_all_models_filtered_snapshot();
-    check("full pass recomputes: a now-fitting recipe is dropped",
-          after_fits.count("whispercpp") == 0);
+        std::map<std::string, ModelInfo> huge = {{"ProbeHuge", model(candidate, HUGE_GB)}};
+        if (!manager.filter_models_by_backend(huge, false).empty()) continue;
+
+        return candidate;
+    }
+    return "";
 }
 
-static void test_incremental_pass_does_not_clobber(ModelManager& manager) {
+static void test_full_pass_commits_and_recomputes(ModelManager& manager,
+                                                  const std::string& recipe) {
+    // Every model of `recipe` is unfillable -> the recipe is recorded. This is
+    // the positive half: without it the "unchanged" assertions below would also
+    // hold if the full pass had committed nothing at all.
+    std::map<std::string, ModelInfo> all_filtered = {{"Huge", model(recipe, HUGE_GB)}};
+    manager.filter_models_by_backend(all_filtered, /*track_recipe_availability=*/true);
+    check("full pass records a recipe whose every model was size-filtered",
+          manager.recipes_all_models_filtered_snapshot().count(recipe) == 1);
+
+    // One model still fits -> partial filtering, so the recipe must not be
+    // recorded, and the recompute must drop the entry seeded above.
+    std::map<std::string, ModelInfo> partial = {
+        {"Huge", model(recipe, HUGE_GB)},
+        {"Tiny", model(recipe, 0.01)},
+    };
+    manager.filter_models_by_backend(partial, /*track_recipe_availability=*/true);
+    check("full pass recomputes: partially-filtered recipe is dropped",
+          manager.recipes_all_models_filtered_snapshot().count(recipe) == 0);
+
+    // Nothing filtered at all -> still not recorded.
+    std::map<std::string, ModelInfo> all_fit = {{"Tiny", model(recipe, 0.01)}};
+    manager.filter_models_by_backend(all_fit, /*track_recipe_availability=*/true);
+    check("full pass never records a recipe that kept a visible model",
+          manager.recipes_all_models_filtered_snapshot().count(recipe) == 0);
+}
+
+static void test_incremental_pass_does_not_clobber(ModelManager& manager,
+                                                   const std::string& recipe) {
     // Seed the side table with a full pass, then run an incremental single-model
     // pass (as add_model_to_cache does). The incremental pass must leave the
     // side table untouched.
-    std::map<std::string, ModelInfo> full = {
-        {"HugeWhisper", model("whispercpp", HUGE_GB)},
-    };
+    std::map<std::string, ModelInfo> full = {{"Huge", model(recipe, HUGE_GB)}};
     manager.filter_models_by_backend(full, /*track_recipe_availability=*/true);
     std::set<std::string> seeded = manager.recipes_all_models_filtered_snapshot();
 
-    std::map<std::string, ModelInfo> one = {{"TinyKokoro", model("kokoro", 0.01)}};
+    check("seeded side table actually holds the all-filtered recipe",
+          seeded.count(recipe) == 1);
+
+    std::map<std::string, ModelInfo> one = {{"Tiny", model(recipe, 0.01)}};
     manager.filter_models_by_backend(one, /*track_recipe_availability=*/false);
     std::set<std::string> after_incremental = manager.recipes_all_models_filtered_snapshot();
 
     check("incremental pass leaves the availability side table unchanged",
           after_incremental == seeded);
+    check("incremental pass does not drop the recorded recipe",
+          after_incremental.count(recipe) == 1);
 }
 
 int main() {
@@ -108,8 +133,17 @@ int main() {
     test_pure_set_difference();
 
     ModelManager manager;
-    test_full_pass_commits_and_recomputes(manager);
-    test_incremental_pass_does_not_clobber(manager);
+    // A vacuous pass is exactly what this test guards against, so a host where
+    // no recipe reaches the memory heuristic is reported as a failure rather
+    // than skipped silently.
+    std::string probe = find_probe_recipe(manager);
+    if (probe.empty()) {
+        check("found a recipe that reaches the memory heuristic on this host", false);
+    } else {
+        std::printf("Using probe recipe: %s\n", probe.c_str());
+        test_full_pass_commits_and_recomputes(manager, probe);
+        test_incremental_pass_does_not_clobber(manager, probe);
+    }
 
     fs::remove_all(temp);
 


### PR DESCRIPTION
## Summary

When every one of a backend's built-in models is dropped by the system-memory filter, the backend has nothing runnable on this host — yet it was still listed as `installed`/`available` in the recipes/backends output (e.g. a large single-model backend on a smaller-RAM box). This hides such recipes from the `/system-info` listing, which is the single source for the CLI `backends` command, the web BackendManager, and `pull` backend-selection.

Scoped deliberately:
- Only recipes dropped by the **memory** heuristic are hidden. Recipes filtered for hardware/OS reasons keep their existing "unsupported" display.
- **Partial** filtering keeps the backend visible (≥1 model, built-in or user, still runnable).
- **Dynamic-model** backends (`cloud`, `flm`) are never hidden — they supply models at runtime.
- The load-time "requires N GB, your system has M GB" error is unaffected (still returned if the model is named directly).

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_

- New unit test `test/cpp/test_recipe_hiding.cpp` (`RecipeHidingTest`, CI ON) covers the pure rule: all-filtered → hidden, partial → kept, not-size-filtered → never hidden, mixed recipes independent.
- End-to-end on a live server by inflating registry model sizes to force the memory filter:
  - single-model backend (`kokoro`) with its only model filtered → **hidden** from `/system-info`, `lemonade backends`, and `/models`.
  - multi-model backend (`llamacpp`) with 1 of 90 models filtered → **still listed**.
  - `flm` (dynamic_models) → **never hidden**.
  - loading the filtered model still returns the clear "requires N GB" error.
- Existing `ModelManagerCollectionValidationTest` still passes.

## Documentation

- [x] Documentation is not affected by this change.

## Breaking Changes

- [x] This PR does not introduce breaking changes.

<!-- Behavior change is additive: backends that were previously listed with zero runnable models are now hidden; nothing that had runnable models changes. -->

## AI-assisted contribution

- [x] I used AI tools for this PR.

Implemented with Claude Code (Opus 4.8). Design, tests, and end-to-end verification reviewed by the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
