### PR TITLE
feat(server): record the backend launch command in /health

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3078,3 +3078,12 @@ if(BUILD_TESTING AND EXISTS "${_ROUTING_HELPER_RECONCILE_TEST_SRC}")
     target_link_libraries(test_routing_helper_reconcile PRIVATE lemonade-server-core)
     add_cpp_ci_test(RoutingHelperReconcileTest CI ON COMMAND test_routing_helper_reconcile)
 endif()
+
+# Launch command bookkeeping: the command recorded at spawn must keep describing
+# the process currently held, so a restart replaces it and cleanup erases it.
+set(_LAUNCH_COMMAND_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_launch_command.cpp")
+if(BUILD_TESTING AND EXISTS "${_LAUNCH_COMMAND_TEST_SRC}")
+    add_executable(test_launch_command test/cpp/test_launch_command.cpp)
+    target_link_libraries(test_launch_command PRIVATE lemonade-server-core)
+    add_cpp_ci_test(LaunchCommandTest CI ON COMMAND test_launch_command)
+endif()

--- a/docs/api/lemonade.md
+++ b/docs/api/lemonade.md
@@ -1270,6 +1270,12 @@ curl http://localhost:13305/v1/health
       "pinned": true,
       "recipe": "ryzenai-llm",
       "pid": 12345,
+      "launch_command": [
+        "~/.cache/lemonade/bin/ryzenai/npu/ryzenai-server.exe",
+        "-m", "~/.cache/lemonade/models/Llama-3.2-1B-Instruct-Hybrid",
+        "--port", "8001",
+        "--ctx-size", "4096"
+      ],
       "recipe_options": {
         "ctx_size": 4096
       },
@@ -1339,7 +1345,7 @@ curl http://localhost:13305/v1/health
   - `is_streaming` - Boolean indicating if the model is actively generating output tokens (true after first chunk arrives, false when all streaming requests complete)
   - `backend_url` - URL of the backend server process handling this model (useful for debugging)
   - `pid` - The Process ID (PID) of the backend engine handling this model
-  - `launch_command` - *(optional)* Command the backend engine was started with, as an array with the executable at index 0. Absent for cloud models.
+  - `launch_command` - *(optional)* The command used to start the backend engine, as an array with the program first and its arguments after it. Every local backend has one. Cloud models don't, because they don't start a program. The values shown are the ones actually used, so a `ctx_size` of `auto` appears here as a real number, and any flags Lemonade added on its own are included.
   - `recipe` - Backend/device recipe used to load the model (e.g., `"ryzenai-llm"`, `"llamacpp"`, `"flm"`)
   - `recipe_options` - Options used to load the model (e.g., `"ctx_size"`, `"llamacpp_backend"`, `"llamacpp_args"`, `"whispercpp_args"`)
 - `pinned_models` - Counts of pinned models currently loaded in memory per model type (e.g., `llm`, `embedding`, etc.)

--- a/docs/api/lemonade.md
+++ b/docs/api/lemonade.md
@@ -1284,6 +1284,13 @@ curl http://localhost:13305/v1/health
       "pinned": false,
       "recipe": "llamacpp",
       "pid": 12346,
+      "launch_command": [
+        "~/.cache/lemonade/bin/llamacpp/rocm-stable/llama-server.exe",
+        "-m", "~/.cache/huggingface/hub/models--nomic-ai--nomic-embed-text-v1-GGUF/.../nomic-embed-text-v1.Q4_K_S.gguf",
+        "--ctx-size", "8192",
+        "--port", "8002",
+        "--no-mmap"
+      ],
       "recipe_options": {
         "ctx_size": 8192,
         "llamacpp_args": "--no-mmap",
@@ -1332,6 +1339,7 @@ curl http://localhost:13305/v1/health
   - `is_streaming` - Boolean indicating if the model is actively generating output tokens (true after first chunk arrives, false when all streaming requests complete)
   - `backend_url` - URL of the backend server process handling this model (useful for debugging)
   - `pid` - The Process ID (PID) of the backend engine handling this model
+  - `launch_command` - *(optional)* Command the backend engine was started with, as an array with the executable at index 0. Absent for cloud models.
   - `recipe` - Backend/device recipe used to load the model (e.g., `"ryzenai-llm"`, `"llamacpp"`, `"flm"`)
   - `recipe_options` - Options used to load the model (e.g., `"ctx_size"`, `"llamacpp_backend"`, `"llamacpp_args"`, `"whispercpp_args"`)
 - `pinned_models` - Counts of pinned models currently loaded in memory per model type (e.g., `llm`, `embedding`, etc.)

--- a/src/cpp/include/lemon/wrapped_server.h
+++ b/src/cpp/include/lemon/wrapped_server.h
@@ -406,6 +406,7 @@ public:
         return ctx_size_auto_;
     }
     int get_process_id() const { return get_process_handle_snapshot().pid; }
+    std::vector<std::string> get_launch_command() const;
     int get_backend_port() const;
 
     // Cheap liveness gate used by the router. On POSIX this relies on
@@ -570,7 +571,9 @@ protected:
 
     static bool has_process_handle(const ProcessHandle& handle);
     ProcessHandle get_process_handle_snapshot() const;
-    void set_process_handle(ProcessHandle handle);
+    void set_process_handle(ProcessHandle handle,
+                            const std::string& executable,
+                            const std::vector<std::string>& args);
     ProcessHandle consume_process_handle_for_cleanup();
 
     // Choose an available port
@@ -610,6 +613,7 @@ protected:
     std::string server_name_;
     int port_;
     ProcessHandle process_handle_;
+    std::vector<std::string> launch_command_;
     mutable std::mutex process_mutex_;
     Telemetry telemetry_;
     std::string log_level_;

--- a/src/cpp/include/lemon/wrapped_server.h
+++ b/src/cpp/include/lemon/wrapped_server.h
@@ -409,6 +409,12 @@ public:
     std::vector<std::string> get_launch_command() const;
     int get_backend_port() const;
 
+    struct ProcessInfo {
+        int pid = 0;
+        std::vector<std::string> launch_command;
+    };
+    ProcessInfo get_process_info() const;
+
     // Cheap liveness gate used by the router. On POSIX this relies on
     // ProcessManager::is_running(), which intentionally checks without reaping.
     virtual bool is_backend_alive() const;

--- a/src/cpp/server/backends/acestep/acestep_server.cpp
+++ b/src/cpp/server/backends/acestep/acestep_server.cpp
@@ -156,7 +156,7 @@ void AceStepServer::load(const std::string& model_name,
     LOG(INFO, "acestep-server") << "Starting " << exe_path << " on port " << port_ << std::endl;
     ProcessHandle started_handle = utils::ProcessManager::start_process(
         exe_path, args, "", is_debug(), false, env_vars);
-    set_process_handle(started_handle);
+    set_process_handle(started_handle, exe_path, args);
     if (!has_process_handle(started_handle)) {
         throw std::runtime_error("Failed to start acestep-server process");
     }

--- a/src/cpp/server/backends/fastflowlm/fastflowlm_server.cpp
+++ b/src/cpp/server/backends/fastflowlm/fastflowlm_server.cpp
@@ -216,7 +216,8 @@ void FastFlowLMServer::load(const std::string& model_name,
     }
     LOG(INFO, "ProcessManager") << std::endl;
 
-    set_process_handle(utils::ProcessManager::start_process(flm_path, args, "", is_debug(), true));
+    set_process_handle(utils::ProcessManager::start_process(flm_path, args, "", is_debug(), true),
+                       flm_path, args);
     LOG(INFO, "ProcessManager") << "Process started successfully" << std::endl;
 
     bool ready = wait_for_ready();

--- a/src/cpp/server/backends/kokoro/kokoro_server.cpp
+++ b/src/cpp/server/backends/kokoro/kokoro_server.cpp
@@ -133,7 +133,7 @@ void KokoroServer::load(const std::string& model_name, const ModelInfo& model_in
         false,
         env_vars
     );
-    set_process_handle(started_handle);
+    set_process_handle(started_handle, exe_path, args);
 
     if (!has_process_handle(started_handle)) {
         throw std::runtime_error("Failed to start koko process");

--- a/src/cpp/server/backends/llamacpp/llamacpp_server.cpp
+++ b/src/cpp/server/backends/llamacpp/llamacpp_server.cpp
@@ -617,7 +617,8 @@ void LlamaCppServer::load(const std::string& model_name,
 
     bool inherit_llama_output = (log_level_ == "info") || is_debug();
     set_process_handle(ProcessManager::start_process(
-        process_executable, args, working_dir, inherit_llama_output, true, env_vars));
+        process_executable, args, working_dir, inherit_llama_output, true, env_vars),
+        process_executable, args);
 
     if (!wait_for_ready("/health")) {
         const ProcessHandle handle = consume_process_handle_for_cleanup();

--- a/src/cpp/server/backends/moonshine/moonshine_server.cpp
+++ b/src/cpp/server/backends/moonshine/moonshine_server.cpp
@@ -169,7 +169,7 @@ void MoonshineServer::load(const std::string& model_name,
         false,  // filter_health_logs
         env_vars
     );
-    set_process_handle(started_handle);
+    set_process_handle(started_handle, executable, args);
 
     if (!has_process_handle(started_handle)) {
         throw std::runtime_error("Failed to start moonshine-server process");

--- a/src/cpp/server/backends/onnxruntime/onnxruntime_server.cpp
+++ b/src/cpp/server/backends/onnxruntime/onnxruntime_server.cpp
@@ -206,7 +206,7 @@ void OnnxRuntimeServer::load(const std::string& model_name,
     bool inherit_output = (log_level_ == "info") || is_debug();
     ProcessHandle started_handle = utils::ProcessManager::start_process(
         executable, args, "", inherit_output, false, {});
-    set_process_handle(started_handle);
+    set_process_handle(started_handle, executable, args);
 
     if (!has_process_handle(started_handle)) {
         throw std::runtime_error("Failed to start ort-server process");

--- a/src/cpp/server/backends/openmoss/openmoss_server.cpp
+++ b/src/cpp/server/backends/openmoss/openmoss_server.cpp
@@ -117,7 +117,7 @@ void OpenMossServer::load(const std::string& model_name,
     LOG(INFO, "openmoss-server") << "Starting " << exe_path << " on port " << port_ << std::endl;
     ProcessHandle started_handle = utils::ProcessManager::start_process(
         exe_path, args, "", is_debug(), false, env_vars);
-    set_process_handle(started_handle);
+    set_process_handle(started_handle, exe_path, args);
     if (!has_process_handle(started_handle)) {
         throw std::runtime_error("Failed to start openmoss-server process");
     }

--- a/src/cpp/server/backends/ryzenai/ryzenai_server.cpp
+++ b/src/cpp/server/backends/ryzenai/ryzenai_server.cpp
@@ -104,7 +104,7 @@ void RyzenAIServer::load(const std::string& model_name,
         is_debug(),
         true
     );
-    set_process_handle(started_handle);
+    set_process_handle(started_handle, ryzenai_server_path, args);
 
     if (!utils::ProcessManager::is_running(started_handle)) {
         throw std::runtime_error("Failed to start ryzenai-server process");

--- a/src/cpp/server/backends/sdcpp/sdcpp_server.cpp
+++ b/src/cpp/server/backends/sdcpp/sdcpp_server.cpp
@@ -392,7 +392,7 @@ void SDServer::load(const std::string& model_name,
         false,  // filter_health_logs
         env_vars
     );
-    set_process_handle(started_handle);
+    set_process_handle(started_handle, process_exe_path, args);
 
     if (!has_process_handle(started_handle)) {
         throw std::runtime_error("Failed to start sd-server process");

--- a/src/cpp/server/backends/thenoise/thenoise_server.cpp
+++ b/src/cpp/server/backends/thenoise/thenoise_server.cpp
@@ -153,7 +153,7 @@ void TheNoiseServer::load(const std::string& model_name,
         false,  // filter_health_logs
         env_vars
     );
-    set_process_handle(started_handle);
+    set_process_handle(started_handle, exe_path, args);
 
     if (!has_process_handle(started_handle)) {
         throw std::runtime_error("Failed to start thenoise process");

--- a/src/cpp/server/backends/thinksound/thinksound_server.cpp
+++ b/src/cpp/server/backends/thinksound/thinksound_server.cpp
@@ -125,7 +125,7 @@ void ThinkSoundServer::load(const std::string& model_name,
     LOG(INFO, "thinksound-server") << "Starting " << exe_path << " on port " << port_ << std::endl;
     ProcessHandle started_handle = utils::ProcessManager::start_process(
         exe_path, args, "", is_debug(), false, env_vars);
-    set_process_handle(started_handle);
+    set_process_handle(started_handle, exe_path, args);
     if (!has_process_handle(started_handle)) {
         throw std::runtime_error("Failed to start thinksound-server process");
     }

--- a/src/cpp/server/backends/trellis/trellis_server.cpp
+++ b/src/cpp/server/backends/trellis/trellis_server.cpp
@@ -141,7 +141,7 @@ void TrellisServer::load(const std::string& model_name,
     LOG(INFO, "trellis-server") << "Starting " << exe_path << " on port " << port_ << std::endl;
     ProcessHandle started_handle = utils::ProcessManager::start_process(
         exe_path, args, "", is_debug(), true, env_vars);
-    set_process_handle(started_handle);
+    set_process_handle(started_handle, exe_path, args);
     if (!has_process_handle(started_handle)) {
         throw std::runtime_error("Failed to start trellis-server process");
     }

--- a/src/cpp/server/backends/vllm/vllm_server.cpp
+++ b/src/cpp/server/backends/vllm/vllm_server.cpp
@@ -501,7 +501,8 @@ void VLLMServer::load(const std::string& model_name,
     env_vars.push_back({"PYTHONNOUSERSITE", "1"});
 
     bool inherit_output = (log_level_ == "info") || is_debug();
-    set_process_handle(ProcessManager::start_process(executable, args, "", inherit_output, true, env_vars));
+    set_process_handle(ProcessManager::start_process(executable, args, "", inherit_output, true, env_vars),
+                       executable, args);
 
     // vLLM can take longer to start (loading model, compiling kernels)
     if (!wait_for_ready("/health", HttpClient::get_default_timeout())) {

--- a/src/cpp/server/backends/whispercpp/whispercpp_server.cpp
+++ b/src/cpp/server/backends/whispercpp/whispercpp_server.cpp
@@ -330,7 +330,7 @@ void WhisperServer::load(const std::string& model_name,
         false,  // filter_health_logs
         env_vars
     );
-    set_process_handle(started_handle);
+    set_process_handle(started_handle, exe_path, args);
 
     if (!has_process_handle(started_handle)) {
         throw std::runtime_error("Failed to start whisper-server process");

--- a/src/cpp/server/router.cpp
+++ b/src/cpp/server/router.cpp
@@ -1304,10 +1304,10 @@ json Router::get_all_loaded_models() const {
                   server->get_model_type(), server->get_residency_class());
         model_info["device"] = device_type_to_string(server->get_device_type());
         model_info["backend_url"] = server->get_address();  // For debugging port issues
-        model_info["pid"] = server->get_process_id();
-        std::vector<std::string> launch_command = server->get_launch_command();
-        if (!launch_command.empty()) {
-            model_info["launch_command"] = launch_command;
+        const WrappedServer::ProcessInfo process_info = server->get_process_info();
+        model_info["pid"] = process_info.pid;
+        if (!process_info.launch_command.empty()) {
+            model_info["launch_command"] = process_info.launch_command;
         }
         model_info["status"] = model_state_to_string(server->get_state());
         model_info["backend_alive"] = true;

--- a/src/cpp/server/router.cpp
+++ b/src/cpp/server/router.cpp
@@ -1305,6 +1305,10 @@ json Router::get_all_loaded_models() const {
         model_info["device"] = device_type_to_string(server->get_device_type());
         model_info["backend_url"] = server->get_address();  // For debugging port issues
         model_info["pid"] = server->get_process_id();
+        std::vector<std::string> launch_command = server->get_launch_command();
+        if (!launch_command.empty()) {
+            model_info["launch_command"] = launch_command;
+        }
         model_info["status"] = model_state_to_string(server->get_state());
         model_info["backend_alive"] = true;
         model_info["backend_health"] = server->get_backend_health_state();

--- a/src/cpp/server/wrapped_server.cpp
+++ b/src/cpp/server/wrapped_server.cpp
@@ -177,9 +177,19 @@ ProcessHandle WrappedServer::get_process_handle_snapshot() const {
     return process_handle_;
 }
 
-void WrappedServer::set_process_handle(ProcessHandle handle) {
+void WrappedServer::set_process_handle(ProcessHandle handle,
+                                       const std::string& executable,
+                                       const std::vector<std::string>& args) {
     std::lock_guard<std::mutex> lock(process_mutex_);
     process_handle_ = handle;
+    launch_command_.clear();
+    launch_command_.push_back(executable);
+    launch_command_.insert(launch_command_.end(), args.begin(), args.end());
+}
+
+std::vector<std::string> WrappedServer::get_launch_command() const {
+    std::lock_guard<std::mutex> lock(process_mutex_);
+    return launch_command_;
 }
 
 int WrappedServer::get_backend_port() const {
@@ -192,6 +202,7 @@ ProcessHandle WrappedServer::consume_process_handle_for_cleanup() {
     ProcessHandle handle = process_handle_;
     process_handle_ = {nullptr, 0};
     port_ = 0;
+    launch_command_.clear();
     return handle;
 }
 

--- a/src/cpp/server/wrapped_server.cpp
+++ b/src/cpp/server/wrapped_server.cpp
@@ -192,6 +192,11 @@ std::vector<std::string> WrappedServer::get_launch_command() const {
     return launch_command_;
 }
 
+WrappedServer::ProcessInfo WrappedServer::get_process_info() const {
+    std::lock_guard<std::mutex> lock(process_mutex_);
+    return {process_handle_.pid, launch_command_};
+}
+
 int WrappedServer::get_backend_port() const {
     std::lock_guard<std::mutex> lock(process_mutex_);
     return port_;

--- a/test/cpp/test_launch_command.cpp
+++ b/test/cpp/test_launch_command.cpp
@@ -1,0 +1,80 @@
+// Proves the recorded launch command always describes the process currently in
+// process_handle_. Neither half is reachable from /health: a restart replacing
+// the previous command needs a backend to be started twice (in production, a
+// watchdog reset), and cleanup erasing it is invisible because
+// Router::get_all_loaded_models() drops dead backends before it builds any JSON.
+
+#include "lemon/wrapped_server.h"
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+namespace {
+
+int failures = 0;
+
+void check(const std::string& what, bool ok) {
+    std::printf("%s %s\n", ok ? "PASS" : "FAIL", what.c_str());
+    if (!ok) ++failures;
+}
+
+}  // namespace
+
+namespace lemon {
+
+// Minimal WrappedServer that never spawns a subprocess. Only load()/unload() are
+// pure virtual; set_process_handle() and the cleanup consumer are protected, so
+// the stub republishes them for the test.
+class StubWrappedServer : public WrappedServer {
+public:
+    StubWrappedServer() : WrappedServer("stub", "error", nullptr, nullptr) {}
+
+    void load(const std::string&, const ModelInfo&, const RecipeOptions&, bool) override {}
+
+    void unload() override {}
+
+    using WrappedServer::consume_process_handle_for_cleanup;
+    using WrappedServer::set_process_handle;
+};
+
+}  // namespace lemon
+
+int main() {
+    lemon::StubWrappedServer server;
+
+    // No real child process is started, so the handle stays empty on every
+    // platform: has_process_handle() is false for both {nullptr} and {pid 0}.
+    const lemon::ProcessHandle handle{nullptr, 0};
+
+    check("a server that never started reports no command",
+          server.get_launch_command().empty());
+
+    server.set_process_handle(handle, "llama-server.exe",
+                              {"-m", "model.gguf", "--ctx-size", "8192"});
+    const std::vector<std::string> first = server.get_launch_command();
+    check("executable lands at index 0",
+          !first.empty() && first[0] == "llama-server.exe");
+    check("arguments follow the executable in order",
+          first == std::vector<std::string>({"llama-server.exe", "-m", "model.gguf",
+                                             "--ctx-size", "8192"}));
+
+    // What a watchdog reset does: same object, second process, new port.
+    server.set_process_handle(handle, "llama-server.exe",
+                              {"-m", "model.gguf", "--port", "8082"});
+    check("a restart replaces the previous command instead of appending",
+          server.get_launch_command() ==
+              std::vector<std::string>({"llama-server.exe", "-m", "model.gguf",
+                                        "--port", "8082"}));
+
+    server.consume_process_handle_for_cleanup();
+    check("cleanup erases the command along with the handle",
+          server.get_launch_command().empty());
+
+    if (failures == 0) {
+        std::printf("\nAll launch command checks passed.\n");
+        return 0;
+    }
+    std::printf("\n%d launch command check(s) failed.\n", failures);
+    return 1;
+}

--- a/test/cpp/test_launch_command.cpp
+++ b/test/cpp/test_launch_command.cpp
@@ -1,7 +1,8 @@
 // Proves the recorded launch command always describes the process currently in
-// process_handle_. Neither half is reachable from /health: a restart replacing
-// the previous command needs a backend to be started twice (in production, a
-// watchdog reset), and cleanup erasing it is invisible because
+// process_handle_, and that /health reads both halves as one snapshot rather
+// than two independently locked reads. Neither half is reachable from /health:
+// a restart replacing the previous command needs a backend to be started twice
+// (in production, a watchdog reset), and cleanup erasing it is invisible because
 // Router::get_all_loaded_models() drops dead backends before it builds any JSON.
 
 #include "lemon/wrapped_server.h"
@@ -48,28 +49,32 @@ int main() {
     const lemon::ProcessHandle handle{nullptr, 0};
 
     check("a server that never started reports no command",
-          server.get_launch_command().empty());
+          server.get_process_info().launch_command.empty());
 
     server.set_process_handle(handle, "llama-server.exe",
                               {"-m", "model.gguf", "--ctx-size", "8192"});
-    const std::vector<std::string> first = server.get_launch_command();
+    const std::vector<std::string> first = server.get_process_info().launch_command;
     check("executable lands at index 0",
           !first.empty() && first[0] == "llama-server.exe");
     check("arguments follow the executable in order",
           first == std::vector<std::string>({"llama-server.exe", "-m", "model.gguf",
                                              "--ctx-size", "8192"}));
+    check("the standalone accessor agrees with the snapshot",
+          server.get_launch_command() == first &&
+              server.get_process_id() == server.get_process_info().pid);
 
     // What a watchdog reset does: same object, second process, new port.
     server.set_process_handle(handle, "llama-server.exe",
                               {"-m", "model.gguf", "--port", "8082"});
     check("a restart replaces the previous command instead of appending",
-          server.get_launch_command() ==
+          server.get_process_info().launch_command ==
               std::vector<std::string>({"llama-server.exe", "-m", "model.gguf",
                                         "--port", "8082"}));
 
     server.consume_process_handle_for_cleanup();
-    check("cleanup erases the command along with the handle",
-          server.get_launch_command().empty());
+    const lemon::WrappedServer::ProcessInfo cleaned = server.get_process_info();
+    check("cleanup erases pid and command in the same snapshot",
+          cleaned.pid == 0 && cleaned.launch_command.empty());
 
     if (failures == 0) {
         std::printf("\nAll launch command checks passed.\n");

--- a/test/server_endpoints.py
+++ b/test/server_endpoints.py
@@ -147,6 +147,25 @@ class EndpointTests(ServerTestBase):
         self.assertIsInstance(model_info["pid"], int)
         self.assertGreater(model_info["pid"], 0)
 
+    def _assert_loaded_model_launch_command(self, model_info):
+        """Assert /health exposes the command the wrapped backend was started with."""
+        self.assertIsNotNone(model_info, "Model should appear in /health")
+        self.assertIn("launch_command", model_info)
+        command = model_info["launch_command"]
+        self.assertIsInstance(command, list)
+        self.assertGreater(len(command), 1)
+        self.assertTrue(all(isinstance(part, str) for part in command))
+        self.assertTrue(command[0], "Executable belongs at index 0")
+
+        # The backend is started with a resolved on-disk path, so the checkpoint
+        # file name has to appear somewhere in the arguments.
+        checkpoint_file = model_info.get("checkpoint", "").split(":")[-1]
+        if checkpoint_file:
+            self.assertTrue(
+                any(checkpoint_file in part for part in command),
+                f"Checkpoint {checkpoint_file} missing from {command}",
+            )
+
     def _parse_prometheus_text(self, body):
         """Validate Prometheus text format and return sample labels by metric name."""
         samples = {}
@@ -811,6 +830,7 @@ class EndpointTests(ServerTestBase):
         # Verify model is loaded via health endpoint and exposes backend PID
         loaded_model = self._get_loaded_model_info(ENDPOINT_TEST_MODEL)
         self._assert_loaded_model_pid(loaded_model)
+        self._assert_loaded_model_launch_command(loaded_model)
 
         print(f"[OK] Loaded model: {ENDPOINT_TEST_MODEL}")
 


### PR DESCRIPTION
## Summary

Fixes #3192.

Before this change, backends ran as subprocesses and `/health` only showed the process ID. The command itself was never recorded, even though options get resolved at load time: `ctx_size: auto` becomes a number, and the server adds flags of its own for llama.cpp.

`WrappedServer` now keeps the executable and args with the process handle. The 14 backends pass them at spawn, and the router publishes them in `/health` as `launch_command`. Replaced on restart, cleared on stop. Cloud models spawn nothing, so they have no field.

`/metrics` is left out on purpose. Prometheus, the monitoring system that scrapes it, stores one time series per unique label value, so a command line as a label would grow the series count without bound.

```json
"pid": 30320,
"launch_command": [
  "~/.cache/lemonade/bin/llamacpp/vulkan/llama-server.exe",
  "-m", "~/.cache/huggingface/hub/.../gemma-3-270m-it-UD-IQ2_M.gguf",
  "--ctx-size", "2048",
  "--port", "8001",
  "--jinja", "--metrics",
  "--reasoning-format", "auto",
  "--no-ui"
]
```

The caller supplied the ctx size and the server filled in the rest, which is now visible.

## Testing

Built on Windows with the `vs18` preset.

Added `test/cpp/test_launch_command.cpp` for the parts `/health` can't reach. The router skips dead backends, so a restart replacing the old command, and cleanup wiping it, are only checkable in process.

Ran a server on llama.cpp/Vulkan with `Tiny-Test-Model-GGUF`. The JSON above is what came back. Reloading with `ctx_size: 4096` gave 12 entries with the new value instead of 24. `test_009_load_model_basic` passes.

Notes:

- No user interface changes, out of scope, but the data is available if it should be displayed.

No cloud provider is configured locally, so I couldn't exercise that path, and I didn't run the full endpoint suite.

## Documentation

Updated `docs/api/lemonade.md`.

## AI-assisted contribution

Used AI tools. Reviewed to make sure only the changes needed were made.

