### PR TITLE
fix(gui3): make download state server-owned

### DIFF
--- a/src/app/src/components/BackendManager.tsx
+++ b/src/app/src/components/BackendManager.tsx
@@ -323,11 +323,19 @@ type BackendSyncResult = {
 };
 
 const BACKEND_STATUS_RETRY_DELAYS_MS = [0, 250, 500, 1000, 2000, 4000, 8000] as const;
+const BACKEND_DOWNLOAD_REGISTRATION_TIMEOUT_MS = 15_000;
 
 class BackendDownloadMissingError extends Error {
   constructor() {
     super('Backend download disappeared before reaching a terminal state');
     this.name = 'BackendDownloadMissingError';
+  }
+}
+
+class BackendDownloadRegistrationTimeoutError extends Error {
+  constructor() {
+    super('Backend download did not appear in /api/v1/downloads');
+    this.name = 'BackendDownloadRegistrationTimeoutError';
   }
 }
 
@@ -354,8 +362,16 @@ function waitForBackendDownloadTerminal(
     let sawDownload = false;
     let unsubscribe: (() => void) | null = null;
     let unsubscribeWhenReady = false;
+    let registrationTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const clearRegistrationTimer = () => {
+      if (registrationTimer == null) return;
+      clearTimeout(registrationTimer);
+      registrationTimer = null;
+    };
 
     const cleanup = () => {
+      clearRegistrationTimer();
       signal.removeEventListener('abort', onAbort);
       if (unsubscribe) unsubscribe();
       else unsubscribeWhenReady = true;
@@ -381,6 +397,7 @@ function waitForBackendDownloadTerminal(
         }
         return;
       }
+      if (!sawDownload) clearRegistrationTimer();
       sawDownload = true;
       if (isDownloadActive(item) || item.running === true) return;
       if (item.status !== 'completed'
@@ -395,6 +412,9 @@ function waitForBackendDownloadTerminal(
       return;
     }
     signal.addEventListener('abort', onAbort, { once: true });
+    registrationTimer = setTimeout(() => {
+      finish(() => reject(new BackendDownloadRegistrationTimeoutError()));
+    }, BACKEND_DOWNLOAD_REGISTRATION_TIMEOUT_MS);
     unsubscribe = downloadStore.subscribe(inspect);
     if (unsubscribeWhenReady) unsubscribe();
   });
@@ -859,6 +879,7 @@ const BackendManager: React.FC<BackendManagerProps> = ({ isActive = true }) => {
     const downloadName = backendDownloadName(recipe, backend);
     const waitController = new AbortController();
     let actionUrl = '';
+    let installError: Error | null = null;
 
     pendingBackendActionsRef.current.set(key, {
       isUpdate,
@@ -866,7 +887,7 @@ const BackendManager: React.FC<BackendManagerProps> = ({ isActive = true }) => {
     });
     setInstalling(key);
     toast(`${actionLabel} ${engineName} · ${backend}…`);
-    downloadStore.markLocal(downloadName, 'downloading', 'backend');
+    downloadStore.wake(downloadName, 'backend');
     const terminalDownloadPromise = waitForBackendDownloadTerminal(recipe, backend, waitController.signal);
     // Observe rejection immediately; the original promise is still awaited below,
     // but this prevents an unhandled rejection if the API call itself fails first.
@@ -875,50 +896,27 @@ const BackendManager: React.FC<BackendManagerProps> = ({ isActive = true }) => {
     try {
       await api.installBackend(recipe, backend, {
         onProgress: (d) => {
-          const rawStatus = typeof d.status === 'string' ? d.status : '';
-          const normalizedStatus = rawStatus.toLowerCase();
-          const completed = d.complete === true
-            || normalizedStatus === 'completed'
-            || normalizedStatus === 'complete'
-            || normalizedStatus === 'success'
-            || normalizedStatus === 'done';
           const percent = typeof d.percent === 'number' ? d.percent : undefined;
           if (typeof d.action === 'string' && d.action.trim()) actionUrl = d.action.trim();
+          downloadStore.wake(downloadName, 'backend');
 
-          downloadStore.upsertFromPull(downloadName, {
-            ...d,
-            id: backendDownloadId(recipe, backend),
-            type: 'backend',
-            name: downloadName,
-            status: completed ? 'completed' : (rawStatus || 'downloading'),
-            complete: completed ? true : d.complete,
-            running: completed && typeof d.running !== 'boolean' ? false : d.running,
-            percent: completed ? 100 : (percent ?? d.percent),
-          }, 'backend');
-
-          if (!completed && percent != null) {
-            toast(`${actionLabel} ${engineName} · ${backend}… ${percent}%`);
+          if (percent != null) {
+            toast(`${actionLabel} ${engineName} · ${backend}... ${percent}%`);
           }
         },
         onComplete: () => {
-          void downloadStore.refresh();
+          downloadStore.wake(downloadName, 'backend');
         },
         onError: (err) => {
-          downloadStore.upsertFromPull(downloadName, {
-            id: backendDownloadId(recipe, backend),
-            type: 'backend',
-            name: downloadName,
-            status: 'error',
-            running: false,
-            error: friendlyErrorMessage(err),
-          }, 'backend');
+          installError = err;
+          downloadStore.wake(downloadName, 'backend');
         },
       });
+      if (installError) throw installError;
 
       if (actionUrl) {
         waitController.abort();
         await terminalDownloadPromise.catch(() => undefined);
-        downloadStore.remove(backendDownloadId(recipe, backend));
         window.open(actionUrl, '_blank', 'noopener,noreferrer');
         toast(`${engineName} · ${backend} requires manual setup`);
         return;
@@ -955,18 +953,7 @@ const BackendManager: React.FC<BackendManagerProps> = ({ isActive = true }) => {
       }
 
       const message = friendlyErrorMessage(err);
-      const current = downloadStore.snapshot()
-        .find(download => backendDownloadMatches(download, recipe, backend));
-      if (current?.status !== 'error' && current?.status !== 'cancelled' && current?.status !== 'paused') {
-        downloadStore.upsertFromPull(downloadName, {
-          id: backendDownloadId(recipe, backend),
-          type: 'backend',
-          name: downloadName,
-          status: 'error',
-          running: false,
-          error: message,
-        }, 'backend');
-      }
+      downloadStore.wake(downloadName, 'backend');
       toast(`${actionLabel} failed: ${message}`);
       void fetchInfo(false);
     } finally {

--- a/src/app/src/components/ChatView.tsx
+++ b/src/app/src/components/ChatView.tsx
@@ -1880,36 +1880,28 @@ const ChatView: React.FC<ChatViewProps> = ({
     if (!modelIsDownloaded(info)) {
       let pullError: Error | null = null;
       let pullCompleted = false;
-      downloadStore.markLocal(modelName, 'downloading', 'model');
+      downloadStore.wake(modelName, 'model');
       setModelPreparations(prev => ({ ...prev, [convoId]: { modelName, phase: 'downloading', percent: 0 } }));
 
       await api.pullModel(modelName, {
         onProgress: data => {
-          const item = downloadStore.upsertFromPull(modelName, data as Record<string, unknown>, 'model');
+          const item = downloadStore.wake(modelName, 'model');
           setModelPreparations(prev => ({
             ...prev,
             [convoId]: {
               modelName,
               phase: 'downloading',
-              percent: item?.percent ?? (typeof data.percent === 'number' ? data.percent : undefined),
+              percent: item?.percent ?? prev[convoId]?.percent ?? 0,
             },
           }));
         },
         onComplete: data => {
           pullCompleted = true;
-          downloadStore.upsertFromPull(modelName, {
-            ...(data as Record<string, unknown>),
-            status: 'completed',
-            complete: true,
-            percent: 100,
-          }, 'model');
+          downloadStore.wake(modelName, 'model');
         },
         onError: error => {
           pullError = error;
-          downloadStore.upsertFromPull(modelName, {
-            status: 'error',
-            error: friendlyErrorMessage(error),
-          }, 'model');
+          downloadStore.wake(modelName, 'model');
         },
       });
 

--- a/src/app/src/components/DownloadManager.tsx
+++ b/src/app/src/components/DownloadManager.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import api, { friendlyErrorMessage } from '../api';
 import { Icon } from './Icon';
-import { DownloadListItem, DownloadStatus, downloadStore, isDownloadActive } from '../features/downloadManager/downloadStore';
+import { DownloadListItem, downloadStore, isDownloadActive } from '../features/downloadManager/downloadStore';
 
 interface DownloadManagerProps {
   isVisible: boolean;
@@ -61,32 +61,19 @@ function isFinalizing(download: DownloadListItem): boolean {
     && download.bytesDownloaded >= download.bytesTotal;
 }
 
-function applyControlSnapshot(
-  download: DownloadListItem,
-  result: unknown,
-  fallbackStatus: DownloadStatus,
-): void {
-  if (!result || typeof result !== 'object' || Array.isArray(result)) return;
-  const snapshot = result as Record<string, unknown>;
-  downloadStore.upsertFromPull(download.modelName, {
-    ...snapshot,
-    status: snapshot.status || fallbackStatus,
-  }, download.downloadType);
-}
-
 async function removeDownload(download: DownloadListItem): Promise<void> {
   downloadStore.remove(download.id);
   await api.controlDownload(download.id, 'remove').catch(() => undefined);
 }
 
 const DownloadManager: React.FC<DownloadManagerProps> = ({ isVisible, onClose }) => {
-  const [downloads, setDownloads] = useState<DownloadListItem[]>(() => downloadStore.snapshot());
+  const [downloads, setDownloads] = useState<DownloadListItem[]>(() => downloadStore.visibleSnapshot());
   const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
   const [busyIds, setBusyIds] = useState<Set<string>>(() => new Set());
   const prevStatusRef = useRef<Map<string, Pick<DownloadListItem, 'status' | 'running'>> | null>(null);
   const [statusAnnouncement, setStatusAnnouncement] = useState('');
 
-  useEffect(() => downloadStore.subscribe(setDownloads), []);
+  useEffect(() => downloadStore.subscribeVisible(setDownloads), []);
 
   // Announce status transitions (start/complete/error/pause/resume) to screen readers.
   // Runs on every downloads change but only emits announcements on status transitions,
@@ -182,15 +169,13 @@ const DownloadManager: React.FC<DownloadManagerProps> = ({ isVisible, onClose })
 
   const handlePause = (download: DownloadListItem) => withBusy(download.id, async () => {
     downloadStore.markLocal(download.modelName, 'paused', download.downloadType);
-    const result = await api.controlDownload(download.id, 'pause').catch(() => undefined);
-    applyControlSnapshot(download, result, 'paused');
+    await api.controlDownload(download.id, 'pause').catch(() => undefined);
     await downloadStore.refresh();
   });
 
   const handleCancel = (download: DownloadListItem) => withBusy(download.id, async () => {
     downloadStore.markLocal(download.modelName, 'cancelled', download.downloadType);
-    const result = await api.controlDownload(download.id, 'cancel').catch(() => undefined);
-    applyControlSnapshot(download, result, 'cancelled');
+    await api.controlDownload(download.id, 'cancel').catch(() => undefined);
     await downloadStore.refresh();
   });
 

--- a/src/app/src/components/DownloadManager.tsx
+++ b/src/app/src/components/DownloadManager.tsx
@@ -62,8 +62,13 @@ function isFinalizing(download: DownloadListItem): boolean {
 }
 
 async function removeDownload(download: DownloadListItem): Promise<void> {
-  downloadStore.remove(download.id);
-  await api.controlDownload(download.id, 'remove').catch(() => undefined);
+  // Terminal history can disappear immediately, but paused/non-terminal rows
+  // stay canonical until the server confirms removal through /downloads.
+  downloadStore.dismiss(download.id);
+  await api.controlDownload(download.id, 'remove').catch(err => {
+    console.error('Remove download failed:', friendlyErrorMessage(err));
+  });
+  await downloadStore.refresh();
 }
 
 const DownloadManager: React.FC<DownloadManagerProps> = ({ isVisible, onClose }) => {
@@ -168,19 +173,16 @@ const DownloadManager: React.FC<DownloadManagerProps> = ({ isVisible, onClose })
   }, []);
 
   const handlePause = (download: DownloadListItem) => withBusy(download.id, async () => {
-    downloadStore.markLocal(download.modelName, 'paused', download.downloadType);
     await api.controlDownload(download.id, 'pause').catch(() => undefined);
     await downloadStore.refresh();
   });
 
   const handleCancel = (download: DownloadListItem) => withBusy(download.id, async () => {
-    downloadStore.markLocal(download.modelName, 'cancelled', download.downloadType);
     await api.controlDownload(download.id, 'cancel').catch(() => undefined);
     await downloadStore.refresh();
   });
 
   const handleDeletePartial = (download: DownloadListItem) => withBusy(download.id, async () => {
-    downloadStore.markLocal(download.modelName, 'deleting', download.downloadType);
     try {
       if (download.downloadType === 'model') {
         await api.deleteModel(download.modelName);
@@ -190,18 +192,24 @@ const DownloadManager: React.FC<DownloadManagerProps> = ({ isVisible, onClose })
       }
     } finally {
       await removeDownload(download);
-      await downloadStore.refresh();
     }
   });
 
   const handleResume = (download: DownloadListItem) => withBusy(download.id, async () => {
-    downloadStore.markLocal(download.modelName, 'downloading', download.downloadType);
+    downloadStore.wake(download.modelName, download.downloadType);
     if (download.downloadType === 'model') {
+      const wake = () => { downloadStore.wake(download.modelName, 'model'); };
       void api.pullModel(download.modelName, {
-        onProgress: data => downloadStore.upsertFromPull(download.modelName, data, 'model'),
-        onComplete: data => downloadStore.upsertFromPull(download.modelName, { ...data, status: 'completed', complete: true, percent: 100 }, 'model'),
-        onError: err => downloadStore.upsertFromPull(download.modelName, { status: 'error', error: friendlyErrorMessage(err) }, 'model'),
-      }).catch(err => downloadStore.upsertFromPull(download.modelName, { status: 'error', error: friendlyErrorMessage(err) }, 'model'));
+        onProgress: wake,
+        onComplete: wake,
+        onError: err => {
+          console.error('Resume download failed:', friendlyErrorMessage(err));
+          wake();
+        },
+      }).catch(err => {
+        console.error('Resume download failed:', friendlyErrorMessage(err));
+        wake();
+      });
     }
     await downloadStore.refresh();
   });
@@ -209,12 +217,19 @@ const DownloadManager: React.FC<DownloadManagerProps> = ({ isVisible, onClose })
   const handleRetry = (download: DownloadListItem) => withBusy(download.id, async () => {
     await removeDownload(download);
     if (download.downloadType === 'model') {
-      downloadStore.markLocal(download.modelName, 'downloading', 'model');
+      downloadStore.wake(download.modelName, 'model');
+      const wake = () => { downloadStore.wake(download.modelName, 'model'); };
       void api.pullModel(download.modelName, {
-        onProgress: data => downloadStore.upsertFromPull(download.modelName, data, 'model'),
-        onComplete: data => downloadStore.upsertFromPull(download.modelName, { ...data, status: 'completed', complete: true, percent: 100 }, 'model'),
-        onError: err => downloadStore.upsertFromPull(download.modelName, { status: 'error', error: friendlyErrorMessage(err) }, 'model'),
-      }).catch(err => downloadStore.upsertFromPull(download.modelName, { status: 'error', error: friendlyErrorMessage(err) }, 'model'));
+        onProgress: wake,
+        onComplete: wake,
+        onError: err => {
+          console.error('Retry download failed:', friendlyErrorMessage(err));
+          wake();
+        },
+      }).catch(err => {
+        console.error('Retry download failed:', friendlyErrorMessage(err));
+        wake();
+      });
     }
     await downloadStore.refresh();
   });
@@ -239,8 +254,9 @@ const DownloadManager: React.FC<DownloadManagerProps> = ({ isVisible, onClose })
     // server may still return the terminal row for a short window and that makes
     // the UI appear to jump into an unclear state. The dismissed ids suppress
     // stale terminal snapshots across tabs until the server forgets them.
-    downloadStore.removeMany(removable.map(download => download.id));
-    void Promise.allSettled(removable.map(download => api.controlDownload(download.id, 'remove')));
+    downloadStore.dismissMany(removable.map(download => download.id));
+    void Promise.allSettled(removable.map(download => api.controlDownload(download.id, 'remove')))
+      .then(() => downloadStore.refresh());
   };
 
   const toggleExpanded = (downloadId: string) => {

--- a/src/app/src/components/ModelManager.tsx
+++ b/src/app/src/components/ModelManager.tsx
@@ -1702,21 +1702,24 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
     const ac = new AbortController();
     pullAbortRef.current[name] = ac;
     setPulling(p => ({ ...p, [name]: 0 }));
-    downloadStore.markLocal(name, 'downloading', 'model');
+    downloadStore.wake(name, 'model');
 
     const callbacks: PullCallbacks = {
       onProgress: (data) => {
-        const item = downloadStore.upsertFromPull(name, data, 'model');
-        setPulling(p => ({ ...p, [name]: item?.percent ?? (typeof data.percent === 'number' ? data.percent : p[name] ?? 0) }));
+        const item = downloadStore.wake(name, 'model');
+        setPulling(p => ({ ...p, [name]: item?.percent ?? p[name] ?? 0 }));
       },
       onComplete: (data) => {
-        downloadStore.upsertFromPull(name, { ...data, status: 'completed', complete: true, percent: 100 }, 'model');
+        downloadStore.wake(name, 'model');
         delete pullAbortRef.current[name];
         setPulling(p => { const next = { ...p }; delete next[name]; return next; });
         refresh();
       },
       onError: (err) => {
-        downloadStore.upsertFromPull(name, { status: 'error', error: friendlyErrorMessage(err) }, 'model');
+        const message = friendlyErrorMessage(err);
+        downloadStore.wake(name, 'model');
+        setLoadError({ modelName: name, message });
+        window.setTimeout(() => setLoadError(prev => prev?.modelName === name ? null : prev), 6000);
         delete pullAbortRef.current[name];
         setPulling(p => { const next = { ...p }; delete next[name]; return next; });
       },
@@ -1740,7 +1743,7 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
     pullAbortRef.current[name]?.abort();
     await api.controlDownload(`model:${name}`, 'cancel').catch(() => undefined);
     delete pullAbortRef.current[name];
-    downloadStore.markLocal(name, 'cancelled', 'model');
+    await downloadStore.refresh();
     setPulling(p => { const next = { ...p }; delete next[name]; return next; });
   };
 
@@ -1750,15 +1753,15 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
     const ac = new AbortController();
     pullAbortRef.current[name] = ac;
     setPulling(p => ({ ...p, [name]: 0 }));
-    downloadStore.markLocal(name, 'downloading', 'model');
+    downloadStore.wake(name, 'model');
 
     const callbacks: PullCallbacks = {
       onProgress: (data) => {
-        const item = downloadStore.upsertFromPull(name, data, 'model');
-        setPulling(p => ({ ...p, [name]: item?.percent ?? (typeof data.percent === 'number' ? data.percent : p[name] ?? 0) }));
+        const item = downloadStore.wake(name, 'model');
+        setPulling(p => ({ ...p, [name]: item?.percent ?? p[name] ?? 0 }));
       },
       onComplete: async (data) => {
-        downloadStore.upsertFromPull(name, { ...data, status: 'completed', complete: true, percent: 100 }, 'model');
+        downloadStore.wake(name, 'model');
         delete pullAbortRef.current[name];
         setPulling(p => { const next = { ...p }; delete next[name]; return next; });
         await refresh();
@@ -1776,7 +1779,10 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
         setLoadingModel(null);
       },
       onError: (err) => {
-        downloadStore.upsertFromPull(name, { status: 'error', error: friendlyErrorMessage(err) }, 'model');
+        const message = friendlyErrorMessage(err);
+        downloadStore.wake(name, 'model');
+        setLoadError({ modelName: name, message });
+        window.setTimeout(() => setLoadError(prev => prev?.modelName === name ? null : prev), 6000);
         delete pullAbortRef.current[name];
         setPulling(p => { const next = { ...p }; delete next[name]; return next; });
       },
@@ -1805,28 +1811,31 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
     const ac = new AbortController();
     pullRemoteAbortRef.current[key] = ac;
     setPullingRemote(p => ({ ...p, [key]: { percent: 0, modelName: targetModelName, checkpoint } }));
-    downloadStore.markLocal(targetModelName, 'downloading', 'model');
+    downloadStore.wake(targetModelName, 'model');
 
     const callbacks: PullCallbacks = {
       onProgress: (data) => {
-        const item = downloadStore.upsertFromPull(targetModelName, data, 'model');
+        const item = downloadStore.wake(targetModelName, 'model');
         setPullingRemote(p => ({
           ...p,
           [key]: {
-            percent: item?.percent ?? (typeof data.percent === 'number' ? data.percent : p[key]?.percent ?? 0),
+            percent: item?.percent ?? p[key]?.percent ?? 0,
             modelName: targetModelName,
             checkpoint,
           },
         }));
       },
       onComplete: (data) => {
-        downloadStore.upsertFromPull(targetModelName, { ...data, status: 'completed', complete: true, percent: 100 }, 'model');
+        downloadStore.wake(targetModelName, 'model');
         delete pullRemoteAbortRef.current[key];
         setPullingRemote(p => { const next = { ...p }; delete next[key]; return next; });
         refresh();
       },
       onError: (err) => {
-        downloadStore.upsertFromPull(targetModelName, { status: 'error', error: friendlyErrorMessage(err) }, 'model');
+        const message = friendlyErrorMessage(err);
+        downloadStore.wake(targetModelName, 'model');
+        setLoadError({ modelName: targetModelName, message });
+        window.setTimeout(() => setLoadError(prev => prev?.modelName === targetModelName ? null : prev), 6000);
         console.error(`${PROVIDER_META[provider].label} pull failed:`, err);
         delete pullRemoteAbortRef.current[key];
         setPullingRemote(p => { const next = { ...p }; delete next[key]; return next; });
@@ -1865,7 +1874,7 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
     const active = activeRemotePull(provider, modelId, vdata);
     if (active) {
       await api.controlDownload(active.downloadId || `model:${active.modelName}`, 'cancel').catch(() => undefined);
-      downloadStore.markLocal(active.modelName, 'cancelled', 'model');
+      await downloadStore.refresh();
     }
     delete pullRemoteAbortRef.current[key];
     setPullingRemote(p => { const next = { ...p }; delete next[key]; return next; });

--- a/src/app/src/features/downloadManager/downloadStore.ts
+++ b/src/app/src/features/downloadManager/downloadStore.ts
@@ -37,14 +37,8 @@ export interface DownloadListItem {
 
 type Listener = (downloads: DownloadListItem[]) => void;
 
-const STORAGE_KEY = 'lemonade_download_manager_items_v1';
 const DISMISSED_STORAGE_KEY = 'lemonade_download_manager_dismissed_v1';
 const TERMINAL_TTL_MS = 60 * 60 * 1000;
-// A locally-created placeholder can briefly precede the server-owned job in
-// /downloads. Keep that row long enough for registration to appear, but do not
-// let a stale renderer/localStorage row block the model forever when the server
-// no longer knows about the job.
-const SERVER_APPEAR_GRACE_MS = 30 * 1000;
 const POLL_MS = 1000;
 const SPEED_SMOOTHING_ALPHA = 0.35;
 
@@ -127,19 +121,6 @@ function getProgressDownloadedBytes(raw: DownloadProgressEvent): number {
   const completedFilesBytes = optionalNumber((raw as any).completed_files_bytes ?? (raw as any).completedFilesBytes) ?? 0;
   const currentFileBytes = optionalNumber(raw.bytes_downloaded ?? (raw as any).bytesDownloaded) ?? 0;
   return Math.max(0, completedFilesBytes + currentFileBytes);
-}
-
-function resetActiveSpeedBaseline(download: DownloadListItem, timestamp = now()): DownloadListItem {
-  if (!isDownloadActive(download)) return download;
-  return {
-    ...download,
-    startTime: timestamp,
-    bytesResumed: Math.max(0, download.bytesDownloaded || 0),
-    speedBytesPerSecond: 0,
-    speedSampleTime: timestamp,
-    speedSampleBytes: 0,
-    updatedAt: timestamp,
-  };
 }
 
 export function isDownloadTerminal(download: Pick<DownloadListItem, 'status' | 'running'>): boolean {
@@ -452,71 +433,6 @@ function sortDownloads(downloads: DownloadListItem[]): DownloadListItem[] {
   return [...downloads].sort((a, b) => b.createdAt - a.createdAt);
 }
 
-function prune(downloads: DownloadListItem[], timestamp = now()): DownloadListItem[] {
-  return downloads.filter(download => {
-    if (!isDownloadTerminal(download)) return true;
-    const terminalAt = download.terminalAt || download.updatedAt;
-    return timestamp - terminalAt < TERMINAL_TTL_MS;
-  });
-}
-
-function coerceStoredDownload(download: DownloadListItem, timestamp = now()): DownloadListItem {
-  // Migrate rows written by older GUI3 versions. startTime was the closest
-  // available approximation before createdAt existed; once migrated, createdAt
-  // is persisted and remains independent from speed-baseline resets.
-  const createdAt = timestampNumber((download as any).createdAt)
-    ?? creationTimeFromRaw((download.raw || {}) as DownloadProgressEvent)
-    ?? timestampNumber(download.startTime)
-    ?? timestampNumber(download.updatedAt)
-    ?? timestamp;
-
-  if (isDownloadTerminal(download)) {
-    return {
-      ...download,
-      createdAt,
-      running: false,
-      speedBytesPerSecond: 0,
-      terminalAt: download.terminalAt || download.updatedAt || timestamp,
-    };
-  }
-  return {
-    ...download,
-    createdAt,
-    // A terminal-looking status with running=true is still server-owned and
-    // must survive reload as non-terminal.
-    terminalAt: undefined,
-  };
-}
-
-function readStored(resetActiveBaselines = false): DownloadListItem[] {
-  if (typeof localStorage === 'undefined') return [];
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    if (!raw) return [];
-    const parsed = JSON.parse(raw);
-    if (!Array.isArray(parsed)) return [];
-    const timestamp = now();
-    const stored = prune((parsed.filter(Boolean) as DownloadListItem[]).map(item => coerceStoredDownload(item, timestamp)), timestamp);
-    if (!resetActiveBaselines) return stored;
-    return stored.map(download => resetActiveSpeedBaseline(download, timestamp));
-  } catch {
-    return [];
-  }
-}
-
-function writeStored(downloads: DownloadListItem[]): void {
-  if (typeof localStorage === 'undefined') return;
-  try {
-    const visible = sortDownloads(prune(downloads));
-    const serialized = JSON.stringify(visible);
-    if (localStorage.getItem(STORAGE_KEY) !== serialized) {
-      localStorage.setItem(STORAGE_KEY, serialized);
-    }
-  } catch {
-    // Storage may be unavailable in privacy modes. The live in-memory store still works.
-  }
-}
-
 function readDismissed(timestamp = now()): Record<string, number> {
   if (typeof localStorage === 'undefined') return {};
   try {
@@ -548,22 +464,21 @@ function writeDismissed(dismissed: Record<string, number>): void {
 }
 
 function isDismissedTerminal(download: DownloadListItem, dismissed: Record<string, number>): boolean {
-  return Boolean(dismissed[download.id]) && !isDownloadActive(download);
+  return Boolean(dismissed[download.id]) && isDownloadTerminal(download);
 }
 
 class DownloadStore {
   private downloads: DownloadListItem[] = [];
   private listeners = new Set<Listener>();
+  private visibleListeners = new Set<Listener>();
   private pollTimer: ReturnType<typeof setTimeout> | null = null;
   private refreshInFlight: Promise<void> | null = null;
   private started = false;
 
   constructor() {
-    this.downloads = sortDownloads(readStored(false));
     if (typeof window !== 'undefined') {
       window.addEventListener('storage', (event) => {
-        if (event.key !== STORAGE_KEY && event.key !== DISMISSED_STORAGE_KEY) return;
-        this.mergeDownloads([], true);
+        if (event.key === DISMISSED_STORAGE_KEY) this.emitVisible();
       });
       window.addEventListener('focus', () => { if (this.started) void this.refresh(); });
       window.addEventListener('online', () => { if (this.started) void this.refresh(); });
@@ -574,12 +489,26 @@ class DownloadStore {
     return this.downloads;
   }
 
+  visibleSnapshot(): DownloadListItem[] {
+    const dismissed = readDismissed();
+    return this.downloads.filter(download => !isDismissedTerminal(download, dismissed));
+  }
+
   subscribe(listener: Listener): () => void {
     this.listeners.add(listener);
     listener(this.downloads);
     this.start();
     return () => {
       this.listeners.delete(listener);
+    };
+  }
+
+  subscribeVisible(listener: Listener): () => void {
+    this.visibleListeners.add(listener);
+    listener(this.visibleSnapshot());
+    this.start();
+    return () => {
+      this.visibleListeners.delete(listener);
     };
   }
 
@@ -601,11 +530,10 @@ class DownloadStore {
         const normalized = serverDownloads
           .map(raw => normalizeDownload(raw, this.findExisting(raw)))
           .filter((item): item is DownloadListItem => Boolean(item));
-        this.mergeDownloads(normalized, true, true);
+        this.replaceFromServer(normalized);
       } catch {
-        // A failed poll is not an empty authoritative snapshot. Preserve local
-        // state and retry only while an active/local-pending download exists.
-        this.mergeDownloads([], true);
+        // A failed poll is not an empty authoritative snapshot. Keep the last
+        // successful /downloads snapshot and retry only while it has active work.
       }
     })();
     try {
@@ -616,94 +544,17 @@ class DownloadStore {
     }
   }
 
-  upsertFromPull(modelName: string, data: Record<string, unknown> = {}, type: DownloadType = 'model'): DownloadListItem | null {
-    const id = String(data.id || `${type}:${modelName}`);
-    const rawStatus = data.status as DownloadProgressEvent['status'] | undefined;
-    const raw: DownloadProgressEvent = {
-      ...(data as DownloadProgressEvent),
-      id,
-      type,
-      model_name: modelName,
-      status: rawStatus || (data.complete === true ? 'completed' : 'downloading'),
-    };
-    if (payloadErrorMessage(raw)) {
-      raw.status = 'error';
-      raw.complete = false;
-    }
-    const percent = optionalNumber(data.percent);
-    if (percent != null) raw.percent = percent;
-    const previous = this.findExisting(raw);
-    const normalized = normalizeDownload(raw, previous);
-    if (normalized) this.mergeDownloads([normalized], false);
-    return normalized;
+  upsertFromPull(_modelName: string, _data: Record<string, unknown> = {}, _type: DownloadType = 'model'): DownloadListItem | null {
+    // Pull/install callbacks are only a wake-up signal. Download state itself is
+    // always replaced from GET /api/v1/downloads.
+    void this.refresh();
+    return null;
   }
 
-  markLocal(modelName: string, status: DownloadStatus, type: DownloadType = 'model'): void {
-    const id = `${type}:${modelName}`;
-    const previous = this.downloads.find(item => item.id === id || (item.modelName === modelName && item.downloadType === type));
-    const timestamp = now();
-    // Reusing the stable model:<name> id for a retry must start a genuinely new
-    // attempt. Keeping a completed row's old creation time/progress can make the
-    // authoritative empty snapshot prune the fresh placeholder during the short
-    // interval before the server registers the new job.
-    const startsNewAttempt = status === 'downloading' && (!previous || isDownloadTerminal(previous));
-    const running = status === 'downloading'
-      ? true
-      : (status === 'completed' || status === 'error')
-        ? false
-        : (status === 'paused' || status === 'cancelled' || status === 'deleting')
-          // Pause/cancel are requests. Until /downloads confirms running=false,
-          // assume the worker still owns files/locks for an active row.
-          ? (previous?.running ?? true)
-          : previous?.running;
-    const base: DownloadListItem = previous || {
-      id,
-      downloadType: type,
-      modelName,
-      fileName: '',
-      fileIndex: 1,
-      totalFiles: 1,
-      bytesDownloaded: 0,
-      bytesTotal: 0,
-      percent: 0,
-      status,
-      running,
-      createdAt: timestamp,
-      startTime: timestamp,
-      bytesResumed: 0,
-      updatedAt: timestamp,
-    };
-    const item: DownloadListItem = {
-      ...base,
-      id: previous?.id || id,
-      downloadType: type,
-      modelName,
-      status,
-      running,
-      fileName: startsNewAttempt ? '' : base.fileName,
-      fileIndex: startsNewAttempt ? 1 : base.fileIndex,
-      totalFiles: startsNewAttempt ? 1 : base.totalFiles,
-      bytesDownloaded: startsNewAttempt ? 0 : base.bytesDownloaded,
-      bytesTotal: startsNewAttempt ? (base.declaredTotalBytes || 0) : base.bytesTotal,
-      bytesTotalIsLowerBound: startsNewAttempt ? false : base.bytesTotalIsLowerBound,
-      percent: status === 'completed' ? 100 : (startsNewAttempt ? 0 : (base.percent || 0)),
-      createdAt: startsNewAttempt ? timestamp : base.createdAt,
-      startTime: startsNewAttempt ? timestamp : base.startTime,
-      bytesResumed: startsNewAttempt ? 0 : base.bytesResumed,
-      completedFilesBytes: startsNewAttempt ? 0 : base.completedFilesBytes,
-      knownFileSizes: startsNewAttempt ? {} : base.knownFileSizes,
-      preExistingBytes: startsNewAttempt ? {} : base.preExistingBytes,
-      speedBytesPerSecond: status === 'downloading'
-        ? (startsNewAttempt ? 0 : base.speedBytesPerSecond)
-        : 0,
-      speedSampleTime: startsNewAttempt ? timestamp : base.speedSampleTime,
-      speedSampleBytes: startsNewAttempt ? 0 : base.speedSampleBytes,
-      error: startsNewAttempt ? undefined : base.error,
-      updatedAt: timestamp,
-      terminalAt: isDownloadTerminal({ status, running }) ? (base.terminalAt || timestamp) : undefined,
-      raw: startsNewAttempt ? undefined : base.raw,
-    };
-    this.mergeDownloads([item], false);
+  markLocal(_modelName: string, _status: DownloadStatus, _type: DownloadType = 'model'): void {
+    // Preserve the existing call sites without creating an optimistic download
+    // row. The server registry is the only source that may change this store.
+    void this.refresh();
   }
 
   remove(downloadId: string): void {
@@ -711,17 +562,18 @@ class DownloadStore {
   }
 
   removeMany(downloadIds: string[]): void {
-    const ids = Array.from(new Set(downloadIds.filter(Boolean)));
-    if (ids.length === 0) return;
+    const ids = new Set(downloadIds.filter(Boolean));
+    if (ids.size === 0) return;
+
+    // Dismissal is presentation-only. It may hide terminal history in the
+    // Download Manager, but canonical snapshot()/subscribe() state is untouched.
     const dismissed = readDismissed();
     const timestamp = now();
-    ids.forEach(id => { dismissed[id] = timestamp; });
+    this.downloads.forEach(download => {
+      if (ids.has(download.id) && isDownloadTerminal(download)) dismissed[download.id] = timestamp;
+    });
     writeDismissed(dismissed);
-    const idSet = new Set(ids);
-    this.downloads = this.downloads.filter(download => !idSet.has(download.id));
-    writeStored(this.downloads);
-    this.emit();
-    this.syncPolling();
+    this.emitVisible();
   }
 
   private findExisting(raw: DownloadProgressEvent): DownloadListItem | undefined {
@@ -731,87 +583,35 @@ class DownloadStore {
     return this.downloads.find(item => item.id === id || (modelName && item.downloadType === type && item.modelName === modelName));
   }
 
-  private mergeDownloads(
-    incoming: DownloadListItem[],
-    includeStored: boolean,
-    reconcileServerSnapshot = false,
-  ): void {
-    const timestamp = now();
-    const stored = includeStored ? readStored() : [];
-    const dismissed = readDismissed(timestamp);
+  private replaceFromServer(incoming: DownloadListItem[]): void {
     const map = new Map<string, DownloadListItem>();
-
-    const putDownload = (rawItem: DownloadListItem) => {
-      const item = coerceStoredDownload(rawItem, timestamp);
+    incoming.forEach(item => {
       const existing = map.get(item.id);
-      if (!existing) {
-        map.set(item.id, item);
-        return;
-      }
+      if (!existing || item.updatedAt >= existing.updatedAt) map.set(item.id, item);
+    });
 
-      const itemTerminal = isDownloadTerminal(item);
-      const existingTerminal = isDownloadTerminal(existing);
-      const itemUpdated = item.updatedAt || 0;
-      const existingUpdated = existing.updatedAt || 0;
-
-      // Cross-tab error/completion snapshots are written to localStorage before
-      // the other tab receives its next server poll. Do not let an older in-memory
-      // 0 B active placeholder overwrite the newer terminal row. Conversely, a
-      // genuinely newer active server snapshot should reopen the row.
-      const createdAt = Math.min(existing.createdAt, item.createdAt);
-      if (itemTerminal !== existingTerminal) {
-        if (itemUpdated >= existingUpdated) {
-          // A terminal update belongs to the current attempt and keeps its
-          // original ordering. A newer active item reopening a terminal stable
-          // id is a fresh retry and must keep its fresh creation timestamp, or
-          // the next empty server snapshot can prune it as stale immediately.
-          map.set(item.id, { ...item, createdAt: itemTerminal ? createdAt : item.createdAt });
-        }
-        return;
-      }
-
-      if (itemUpdated >= existingUpdated) map.set(item.id, { ...item, createdAt });
-    };
-
-    for (const item of prune([...stored, ...this.downloads], timestamp)) {
-      if (!isDismissedTerminal(item, dismissed)) putDownload(item);
+    const dismissed = readDismissed();
+    for (const item of map.values()) {
+      // A retry reusing the same stable id is a new visible row. Clearing this is
+      // visual only and never changes canonical download/blocking state.
+      if (isDownloadActive(item)) delete dismissed[item.id];
     }
-    for (const rawItem of incoming) {
-      const item = coerceStoredDownload(rawItem, timestamp);
-      if (isDownloadActive(item)) {
-        delete dismissed[item.id];
-        putDownload(item);
-      } else if (!isDismissedTerminal(item, dismissed)) {
-        putDownload(item);
-      }
-    }
-
-    if (reconcileServerSnapshot) {
-      const serverIds = new Set(incoming.map(item => item.id));
-      for (const [id, item] of Array.from(map.entries())) {
-        if (!(id.startsWith('model:') || id.startsWith('backend:')) || serverIds.has(id)) continue;
-        if (isDownloadTerminal(item)) continue;
-
-        // New local rows are allowed to precede the first /downloads snapshot.
-        // Everything else is stale server-owned state and must not keep a model
-        // unavailable after another tab removed/cancelled the job or after a
-        // renderer reload recovered an obsolete localStorage row.
-        const awaitingServerRegistration = item.status === 'downloading'
-          && timestamp - item.createdAt < SERVER_APPEAR_GRACE_MS;
-        if (!awaitingServerRegistration) map.delete(id);
-      }
-    }
-
     writeDismissed(dismissed);
-    this.downloads = sortDownloads(prune(Array.from(map.values()), timestamp));
-    writeStored(this.downloads);
+
+    this.downloads = sortDownloads(Array.from(map.values()));
     this.emit();
+    this.emitVisible();
     this.syncPolling();
   }
 
   private emit(): void {
     const snapshot = this.downloads;
     this.listeners.forEach(listener => listener(snapshot));
+  }
+
+  private emitVisible(): void {
+    const snapshot = this.visibleSnapshot();
+    this.visibleListeners.forEach(listener => listener(snapshot));
   }
 
   private hasActiveDownloads(): boolean {
@@ -827,8 +627,8 @@ class DownloadStore {
   private syncPolling(): void {
     // The initial start()/explicit refresh is enough to discover server-owned
     // work. Once the authoritative snapshot is idle, do not keep hitting
-    // /downloads. Local pull events, cross-tab storage updates, focus/online,
-    // and an explicitly opened download manager can wake the store again.
+    // /downloads. Pull/install callbacks, focus/online, and an explicitly opened
+    // download manager can wake the store again.
     if (!this.started || !this.hasActiveDownloads()) {
       this.clearPollTimer();
       return;
@@ -841,7 +641,6 @@ class DownloadStore {
     }, POLL_MS);
   }
 }
-
 export const downloadStore = new DownloadStore();
 
 export function downloadsForModel(downloads: DownloadListItem[], modelName: string): DownloadListItem[] {

--- a/src/app/src/features/downloadManager/downloadStore.ts
+++ b/src/app/src/features/downloadManager/downloadStore.ts
@@ -38,8 +38,8 @@ export interface DownloadListItem {
 type Listener = (downloads: DownloadListItem[]) => void;
 
 const DISMISSED_STORAGE_KEY = 'lemonade_download_manager_dismissed_v1';
-const TERMINAL_TTL_MS = 60 * 60 * 1000;
 const POLL_MS = 1000;
+const WAKE_REFRESH_MIN_INTERVAL_MS = 500;
 const SPEED_SMOOTHING_ALPHA = 0.35;
 
 function now(): number { return Date.now(); }
@@ -433,17 +433,27 @@ function sortDownloads(downloads: DownloadListItem[]): DownloadListItem[] {
   return [...downloads].sort((a, b) => b.createdAt - a.createdAt);
 }
 
-function readDismissed(timestamp = now()): Record<string, number> {
+type DismissedDownload = {
+  createdAt: number;
+  dismissedAt: number;
+};
+
+type DismissedDownloads = Record<string, DismissedDownload>;
+
+function readDismissed(): DismissedDownloads {
   if (typeof localStorage === 'undefined') return {};
   try {
     const raw = localStorage.getItem(DISMISSED_STORAGE_KEY);
     if (!raw) return {};
     const parsed = JSON.parse(raw);
     if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
-    const kept: Record<string, number> = {};
+    const kept: DismissedDownloads = {};
     Object.entries(parsed as Record<string, unknown>).forEach(([id, value]) => {
-      const dismissedAt = finiteNumber(value, 0);
-      if (dismissedAt > 0 && timestamp - dismissedAt < TERMINAL_TTL_MS) kept[id] = dismissedAt;
+      if (!value || typeof value !== 'object' || Array.isArray(value)) return;
+      const record = value as Record<string, unknown>;
+      const createdAt = finiteNumber(record.createdAt, 0);
+      const dismissedAt = finiteNumber(record.dismissedAt, 0);
+      if (createdAt > 0 && dismissedAt > 0) kept[id] = { createdAt, dismissedAt };
     });
     return kept;
   } catch {
@@ -451,7 +461,7 @@ function readDismissed(timestamp = now()): Record<string, number> {
   }
 }
 
-function writeDismissed(dismissed: Record<string, number>): void {
+function writeDismissed(dismissed: DismissedDownloads): void {
   if (typeof localStorage === 'undefined') return;
   try {
     const serialized = JSON.stringify(dismissed);
@@ -459,12 +469,17 @@ function writeDismissed(dismissed: Record<string, number>): void {
       localStorage.setItem(DISMISSED_STORAGE_KEY, serialized);
     }
   } catch {
-    // Ignore unavailable storage; the in-memory removal still applies.
+    // Ignore unavailable storage; dismissal remains presentation-only.
   }
 }
 
-function isDismissedTerminal(download: DownloadListItem, dismissed: Record<string, number>): boolean {
-  return Boolean(dismissed[download.id]) && isDownloadTerminal(download);
+function isDismissedTerminal(download: DownloadListItem, dismissed: DismissedDownloads): boolean {
+  const record = dismissed[download.id];
+  return Boolean(
+    record
+    && Math.abs(record.createdAt - download.createdAt) < 1
+    && isDownloadTerminal(download),
+  );
 }
 
 class DownloadStore {
@@ -472,7 +487,10 @@ class DownloadStore {
   private listeners = new Set<Listener>();
   private visibleListeners = new Set<Listener>();
   private pollTimer: ReturnType<typeof setTimeout> | null = null;
+  private wakeTimer: ReturnType<typeof setTimeout> | null = null;
   private refreshInFlight: Promise<void> | null = null;
+  private wakeRefreshQueued = false;
+  private lastRefreshStartedAt = 0;
   private started = false;
 
   constructor() {
@@ -521,19 +539,31 @@ class DownloadStore {
   async refresh(): Promise<void> {
     if (this.refreshInFlight) return this.refreshInFlight;
 
-    // A manual/focus refresh supersedes a pending scheduled poll. Cancelling it
-    // here prevents the timer from firing while the same request is in flight.
+    // An explicit refresh also satisfies any queued SSE wake-up. Pull progress
+    // is deliberately coalesced so a fast SSE stream cannot turn into a burst
+    // of GET /downloads requests.
     this.clearPollTimer();
+    this.clearWakeTimer();
+    this.wakeRefreshQueued = false;
+    this.lastRefreshStartedAt = now();
     this.refreshInFlight = (async () => {
       try {
         const serverDownloads = await api.downloads();
         const normalized = serverDownloads
-          .map(raw => normalizeDownload(raw, this.findExisting(raw)))
+          .map(raw => {
+            const previous = this.findExisting(raw);
+            const serverCreatedAt = creationTimeFromRaw(raw);
+            const sameAttempt = !previous
+              || serverCreatedAt == null
+              || Math.abs(serverCreatedAt - previous.createdAt) < 1;
+            return normalizeDownload(raw, sameAttempt ? previous : undefined);
+          })
           .filter((item): item is DownloadListItem => Boolean(item));
         this.replaceFromServer(normalized);
       } catch {
         // A failed poll is not an empty authoritative snapshot. Keep the last
-        // successful /downloads snapshot and retry only while it has active work.
+        // successful /downloads snapshot and retry only when server-owned work
+        // or a coalesced wake-up asks for another refresh.
       }
     })();
     try {
@@ -541,36 +571,38 @@ class DownloadStore {
     } finally {
       this.refreshInFlight = null;
       this.syncPolling();
+      this.scheduleWakeRefresh();
     }
   }
 
-  upsertFromPull(_modelName: string, _data: Record<string, unknown> = {}, _type: DownloadType = 'model'): DownloadListItem | null {
-    // Pull/install callbacks are only a wake-up signal. Download state itself is
-    // always replaced from GET /api/v1/downloads.
-    void this.refresh();
-    return null;
+  wake(modelName?: string, type: DownloadType = 'model'): DownloadListItem | null {
+    this.start();
+    this.wakeRefreshQueued = true;
+    this.scheduleWakeRefresh();
+    if (!modelName) return null;
+    return this.downloads.find(item => (
+      item.downloadType === type
+      && (item.modelName === modelName || item.id === `${type}:${modelName}`)
+    )) || null;
   }
 
-  markLocal(_modelName: string, _status: DownloadStatus, _type: DownloadType = 'model'): void {
-    // Preserve the existing call sites without creating an optimistic download
-    // row. The server registry is the only source that may change this store.
-    void this.refresh();
+  dismiss(downloadId: string): void {
+    this.dismissMany([downloadId]);
   }
 
-  remove(downloadId: string): void {
-    this.removeMany([downloadId]);
-  }
-
-  removeMany(downloadIds: string[]): void {
+  dismissMany(downloadIds: string[]): void {
     const ids = new Set(downloadIds.filter(Boolean));
     if (ids.size === 0) return;
 
-    // Dismissal is presentation-only. It may hide terminal history in the
-    // Download Manager, but canonical snapshot()/subscribe() state is untouched.
+    // Dismissal is presentation-only and is tied to one concrete server
+    // attempt. It never expires on a wall-clock TTL: a failed server-side
+    // remove therefore cannot make old history mysteriously reappear later.
     const dismissed = readDismissed();
-    const timestamp = now();
+    const dismissedAt = now();
     this.downloads.forEach(download => {
-      if (ids.has(download.id) && isDownloadTerminal(download)) dismissed[download.id] = timestamp;
+      if (ids.has(download.id) && isDownloadTerminal(download)) {
+        dismissed[download.id] = { createdAt: download.createdAt, dismissedAt };
+      }
     });
     writeDismissed(dismissed);
     this.emitVisible();
@@ -591,11 +623,17 @@ class DownloadStore {
     });
 
     const dismissed = readDismissed();
-    for (const item of map.values()) {
-      // A retry reusing the same stable id is a new visible row. Clearing this is
-      // visual only and never changes canonical download/blocking state.
-      if (isDownloadActive(item)) delete dismissed[item.id];
-    }
+    Object.entries(dismissed).forEach(([id, record]) => {
+      const item = map.get(id);
+      // Missing rows, active rows, and a new attempt with the same stable id all
+      // invalidate an old presentation-only dismissal. This also handles a CLI
+      // retry that starts and finishes while GUI polling is idle.
+      if (!item
+        || isDownloadActive(item)
+        || Math.abs(item.createdAt - record.createdAt) >= 1) {
+        delete dismissed[id];
+      }
+    });
     writeDismissed(dismissed);
 
     this.downloads = sortDownloads(Array.from(map.values()));
@@ -618,6 +656,29 @@ class DownloadStore {
     return this.downloads.some(isDownloadActive);
   }
 
+  private clearWakeTimer(): void {
+    if (!this.wakeTimer) return;
+    clearTimeout(this.wakeTimer);
+    this.wakeTimer = null;
+  }
+
+  private scheduleWakeRefresh(): void {
+    if (!this.started || !this.wakeRefreshQueued || this.wakeTimer || this.refreshInFlight) return;
+    const elapsed = now() - this.lastRefreshStartedAt;
+    const delay = Math.max(0, WAKE_REFRESH_MIN_INTERVAL_MS - elapsed);
+    if (delay === 0) {
+      this.wakeRefreshQueued = false;
+      void this.refresh();
+      return;
+    }
+    this.wakeTimer = setTimeout(() => {
+      this.wakeTimer = null;
+      if (!this.wakeRefreshQueued) return;
+      this.wakeRefreshQueued = false;
+      void this.refresh();
+    }, delay);
+  }
+
   private clearPollTimer(): void {
     if (!this.pollTimer) return;
     clearTimeout(this.pollTimer);
@@ -627,8 +688,8 @@ class DownloadStore {
   private syncPolling(): void {
     // The initial start()/explicit refresh is enough to discover server-owned
     // work. Once the authoritative snapshot is idle, do not keep hitting
-    // /downloads. Pull/install callbacks, focus/online, and an explicitly opened
-    // download manager can wake the store again.
+    // /downloads. Coalesced pull/install wakes, focus/online, and an explicitly
+    // opened download manager can wake the store again.
     if (!this.started || !this.hasActiveDownloads()) {
       this.clearPollTimer();
       return;

--- a/src/app/tests/backend-manager-lifecycle.runtime.cjs
+++ b/src/app/tests/backend-manager-lifecycle.runtime.cjs
@@ -29,15 +29,19 @@ assert.match(
   /const terminalDownloadPromise = waitForBackendDownloadTerminal[\s\S]*?await api\.installBackend\([\s\S]*?const terminalDownload = await terminalDownloadPromise/,
 );
 assert.match(installBlock, /void terminalDownloadPromise\.catch\(\(\) => undefined\)/);
-assert.match(installBlock, /onComplete: \(\) => \{[\s\S]*?downloadStore\.refresh\(\)/);
+assert.match(installBlock, /onComplete: \(\) => \{[\s\S]*?downloadStore\.wake\(downloadName, 'backend'\)/);
 const onCompleteBlock = installBlock.match(
   /onComplete: \(\) => \{[\s\S]*?\n\s*\},\n\s*onError:/,
 )?.[0] || '';
 assert.doesNotMatch(onCompleteBlock, /status: 'completed'|still needs update/);
 
-// An API error must become a truly terminal error and can never fall through to success.
-assert.match(installBlock, /onError: \(err\) => \{[\s\S]*?status: 'error',[\s\S]*?running: false/);
+// installBackend reports errors through its callback; capture and rethrow them so
+// a failure before the server registers a backend row cannot hang the UI.
+assert.match(installBlock, /let installError: Error \| null = null/);
+assert.match(installBlock, /onError: \(err\) => \{[\s\S]*?installError = err;[\s\S]*?downloadStore\.wake/);
+assert.match(installBlock, /await api\.installBackend[\s\S]*?if \(installError\) throw installError/);
 assert.match(installBlock, /terminalDownload\.status === 'error'[\s\S]*?throw new Error/);
+assert.match(source, /BACKEND_DOWNLOAD_REGISTRATION_TIMEOUT_MS/);
 
 // Both install and update use the same post-terminal status synchronization.
 assert.match(installBlock, /const synced = await syncBackendStatus\(recipe, backend\)/);
@@ -66,7 +70,9 @@ function declarationText(name, kind) {
 
 function buildRuntimeHelpers(downloadStore) {
   const helperSource = [
+    'const BACKEND_DOWNLOAD_REGISTRATION_TIMEOUT_MS = 20;',
     declarationText('BackendDownloadMissingError', 'class'),
+    declarationText('BackendDownloadRegistrationTimeoutError', 'class'),
     declarationText('backendActionIsReflected', 'function'),
     declarationText('waitForBackendDownloadTerminal', 'function'),
     'module.exports = { backendActionIsReflected, waitForBackendDownloadTerminal };',
@@ -87,6 +93,8 @@ function buildRuntimeHelpers(downloadStore) {
     exports: module.exports,
     AbortController,
     Error,
+    setTimeout,
+    clearTimeout,
     downloadStore,
     cleanString: value => {
       const text = String(value || '').trim();
@@ -154,6 +162,16 @@ async function runBehaviorChecks() {
     const terminal = waitForBackendDownloadTerminal('llamacpp', 'cpu', controller.signal);
     store.set([]);
     await assert.rejects(terminal, error => error?.name === 'BackendDownloadMissingError');
+  }
+
+  {
+    const store = createDownloadStore([]);
+    const { waitForBackendDownloadTerminal } = buildRuntimeHelpers(store);
+    const controller = new AbortController();
+    await assert.rejects(
+      waitForBackendDownloadTerminal('llamacpp', 'cpu', controller.signal),
+      error => error?.name === 'BackendDownloadRegistrationTimeoutError',
+    );
   }
 
   {

--- a/src/app/tests/download-manager-order.spec.ts
+++ b/src/app/tests/download-manager-order.spec.ts
@@ -2,54 +2,15 @@ import { expect, test } from '@playwright/test';
 
 test('download manager keeps creation order while concurrent progress updates arrive', async ({ page }) => {
   const timestamp = Date.now();
-  const stored = [
-    {
-      id: 'model:Older-Model',
-      downloadType: 'model',
-      modelName: 'Older-Model',
-      fileName: 'older.gguf',
-      fileIndex: 1,
-      totalFiles: 1,
-      bytesDownloaded: 100,
-      bytesTotal: 1000,
-      percent: 10,
-      status: 'downloading',
-      createdAt: timestamp - 2000,
-      startTime: timestamp - 2000,
-      bytesResumed: 0,
-      running: true,
-      updatedAt: timestamp + 5000,
-    },
-    {
-      id: 'model:Newer-Model',
-      downloadType: 'model',
-      modelName: 'Newer-Model',
-      fileName: 'newer.gguf',
-      fileIndex: 1,
-      totalFiles: 1,
-      bytesDownloaded: 200,
-      bytesTotal: 1000,
-      percent: 20,
-      status: 'downloading',
-      createdAt: timestamp - 1000,
-      startTime: timestamp - 1000,
-      bytesResumed: 0,
-      running: true,
-      updatedAt: timestamp,
-    },
-  ];
-
-  await page.addInitScript((items: unknown[]) => {
-    localStorage.setItem('lemonade_download_manager_items_v1', JSON.stringify(items));
-  }, stored);
-
   let serverDownloads = [
     {
       id: 'model:Older-Model', type: 'model', model_name: 'Older-Model', status: 'downloading', running: true,
+      created_at: timestamp - 2000,
       file: 'older.gguf', file_index: 1, total_files: 1, bytes_downloaded: 150, bytes_total: 1000, percent: 15,
     },
     {
       id: 'model:Newer-Model', type: 'model', model_name: 'Newer-Model', status: 'downloading', running: true,
+      created_at: timestamp - 1000,
       file: 'newer.gguf', file_index: 1, total_files: 1, bytes_downloaded: 250, bytes_total: 1000, percent: 25,
     },
   ];
@@ -70,10 +31,12 @@ test('download manager keeps creation order while concurrent progress updates ar
   serverDownloads = [
     {
       id: 'model:Newer-Model', type: 'model', model_name: 'Newer-Model', status: 'downloading', running: true,
+      created_at: timestamp - 1000,
       file: 'newer.gguf', file_index: 1, total_files: 1, bytes_downloaded: 350, bytes_total: 1000, percent: 35,
     },
     {
       id: 'model:Older-Model', type: 'model', model_name: 'Older-Model', status: 'downloading', running: true,
+      created_at: timestamp - 2000,
       file: 'older.gguf', file_index: 1, total_files: 1, bytes_downloaded: 450, bytes_total: 1000, percent: 45,
     },
   ];
@@ -91,26 +54,6 @@ test('terminal-looking server download stays locked until the worker stops', asy
       bytes_downloaded: 1000, bytes_total: 1000, percent: 100,
     },
   ];
-
-  await page.addInitScript((item: unknown) => {
-    localStorage.setItem('lemonade_download_manager_items_v1', JSON.stringify([item]));
-  }, {
-    id: 'model:Finalizing-Model',
-    downloadType: 'model',
-    modelName: 'Finalizing-Model',
-    fileName: 'model.gguf',
-    fileIndex: 1,
-    totalFiles: 1,
-    bytesDownloaded: 1000,
-    bytesTotal: 1000,
-    percent: 100,
-    status: 'completed',
-    running: true,
-    createdAt: Date.now(),
-    startTime: Date.now(),
-    bytesResumed: 0,
-    updatedAt: Date.now(),
-  });
 
   await page.route('**/api/v1/health**', route =>
     route.fulfill({ json: { status: 'ok', all_models_loaded: [] } }),
@@ -132,7 +75,7 @@ test('terminal-looking server download stays locked until the worker stops', asy
   await expect(item.getByRole('button', { name: 'Remove from list' })).toBeEnabled();
 });
 
-test('authoritative server snapshot removes stale paused renderer state', async ({ page }) => {
+test('legacy localStorage download rows are ignored', async ({ page }) => {
   const timestamp = Date.now() - 60_000;
   await page.addInitScript((item: unknown) => {
     localStorage.setItem('lemonade_download_manager_items_v1', JSON.stringify([item]));

--- a/src/app/tests/download-manager-order.spec.ts
+++ b/src/app/tests/download-manager-order.spec.ts
@@ -107,3 +107,62 @@ test('legacy localStorage download rows are ignored', async ({ page }) => {
   await expect(page.locator('.download-item')).toHaveCount(0);
   await expect(page.locator('.download-manager__empty')).toContainText('No downloads yet');
 });
+
+test('paused remove refreshes the authoritative server snapshot', async ({ page }) => {
+  let serverDownloads = [{
+    id: 'model:Paused-Model', type: 'model', model_name: 'Paused-Model', status: 'paused', running: false,
+    created_at: Date.now() - 1000,
+    file: 'paused.gguf', file_index: 1, total_files: 1, bytes_downloaded: 100, bytes_total: 1000, percent: 10,
+  }];
+
+  await page.route('**/api/v1/health**', route =>
+    route.fulfill({ json: { status: 'ok', all_models_loaded: [] } }),
+  );
+  await page.route('**/api/v1/downloads**', route => route.fulfill({ json: { downloads: serverDownloads } }));
+  await page.route('**/api/v1/downloads/control', async route => {
+    serverDownloads = [];
+    await route.fulfill({ json: { ok: true } });
+  });
+
+  await page.goto('/');
+  await page.locator('.titlebar__download-toggle').click();
+  const item = page.locator('.download-item').filter({ hasText: 'Paused-Model' });
+  await expect(item).toHaveCount(1);
+  await item.getByRole('button', { name: 'Remove from list' }).click();
+  await expect(item).toHaveCount(0);
+});
+
+test('dismissal stays hidden on remove failure but does not hide a newer terminal attempt', async ({ page }) => {
+  const firstCreatedAt = Date.now() - 10_000;
+  let serverDownloads = [{
+    id: 'model:Retry-Model', type: 'model', model_name: 'Retry-Model', status: 'error', running: false,
+    created_at: firstCreatedAt,
+    file: 'retry.gguf', file_index: 1, total_files: 1, bytes_downloaded: 100, bytes_total: 1000, percent: 10,
+    error: 'first attempt failed',
+  }];
+
+  await page.route('**/api/v1/health**', route =>
+    route.fulfill({ json: { status: 'ok', all_models_loaded: [] } }),
+  );
+  await page.route('**/api/v1/downloads**', route => route.fulfill({ json: { downloads: serverDownloads } }));
+  await page.route('**/api/v1/downloads/control', route =>
+    route.fulfill({ status: 500, json: { error: 'remove failed' } }),
+  );
+
+  await page.goto('/');
+  await page.locator('.titlebar__download-toggle').click();
+  let item = page.locator('.download-item').filter({ hasText: 'Retry-Model' });
+  await expect(item).toHaveCount(1);
+  await item.getByRole('button', { name: 'Remove from list' }).click();
+  await expect(item).toHaveCount(0);
+
+  serverDownloads = [{
+    ...serverDownloads[0],
+    created_at: firstCreatedAt + 5000,
+    error: 'second attempt failed',
+  }];
+  await page.evaluate(() => window.dispatchEvent(new Event('focus')));
+  item = page.locator('.download-item').filter({ hasText: 'Retry-Model' });
+  await expect(item).toHaveCount(1);
+  await expect(item).toContainText('second attempt failed');
+});

--- a/src/app/tests/download-polling-lifecycle.runtime.cjs
+++ b/src/app/tests/download-polling-lifecycle.runtime.cjs
@@ -42,6 +42,8 @@ assert.doesNotMatch(
 );
 assert.match(source, /visibleSnapshot\(\): DownloadListItem\[\]/);
 assert.match(source, /isDismissedTerminal\(download, dismissed\)/);
+assert.match(source, /wake\(modelName\?: string, type: DownloadType = 'model'\)/);
+assert.doesNotMatch(source, /upsertFromPull|markLocal|TERMINAL_TTL_MS/);
 
 const originalTsLoader = require.extensions['.ts'];
 const originalApiCache = require.cache[apiPath];
@@ -142,7 +144,7 @@ async function waitFor(predicate, timeoutMs = 1500) {
       running: true,
       percent: 10,
     }];
-    downloadStore.markLocal('test-model', 'downloading', 'model');
+    downloadStore.wake('test-model', 'model');
     await waitFor(
       () => downloadRequests >= 3 && downloadStore.snapshot().some(item => item.modelName === 'test-model' && item.running === true),
       1600,
@@ -152,17 +154,12 @@ async function waitFor(predicate, timeoutMs = 1500) {
       'an active download must remain represented after polling',
     );
 
-    // Pull callbacks may wake the store, but they may not author download state.
-    // The server still says active, so a local-looking terminal callback must be ignored.
-    downloadStore.upsertFromPull('test-model', {
-      id: 'model:test-model',
-      status: 'completed',
-      complete: true,
-      running: false,
-      percent: 100,
-    }, 'model');
+    // Pull callbacks are wake-up signals only. The server still says active,
+    // so a callback may not manufacture a terminal row in canonical state.
+    const requestsBeforeCallbackWake = downloadRequests;
+    downloadStore.wake('test-model', 'model');
     await downloadStore.refresh();
-    assert.equal(downloadRequests, 4);
+    assert.equal(downloadRequests, requestsBeforeCallbackWake + 1);
     assert.ok(
       downloadStore.snapshot().some(item => item.modelName === 'test-model' && item.running === true),
       'callback data must not override the authoritative /downloads snapshot',
@@ -181,6 +178,15 @@ async function waitFor(predicate, timeoutMs = 1500) {
       'an idle authoritative snapshot must stop polling',
     );
 
+    const requestsBeforeWakeBurst = downloadRequests;
+    for (let i = 0; i < 25; i += 1) downloadStore.wake('burst-model', 'model');
+    await sleep(650);
+    assert.equal(
+      downloadRequests,
+      requestsBeforeWakeBurst + 1,
+      'many SSE-style wake signals must coalesce into one /downloads request',
+    );
+
     // Dismissed state is presentation-only: canonical state remains intact, and
     // non-terminal rows can never be hidden by a client-owned dismissed id.
     serverDownloads = [{
@@ -191,13 +197,32 @@ async function waitFor(predicate, timeoutMs = 1500) {
       complete: true,
       running: false,
       percent: 100,
+      created_at: Date.now() - 10_000,
     }];
     const requestsBeforeCompletedSnapshot = downloadRequests;
     await downloadStore.refresh();
     assert.equal(downloadRequests, requestsBeforeCompletedSnapshot + 1);
-    downloadStore.removeMany(['model:completed-model']);
+    downloadStore.dismissMany(['model:completed-model']);
     assert.equal(downloadStore.snapshot().length, 1, 'dismiss must not mutate canonical server state');
     assert.equal(downloadStore.visibleSnapshot().length, 0, 'dismiss may hide terminal history visually');
+
+    const firstAttemptCreatedAt = serverDownloads[0].created_at;
+    await downloadStore.refresh();
+    assert.equal(downloadStore.visibleSnapshot().length, 0, 'the same dismissed server attempt stays hidden');
+
+    serverDownloads = [{
+      ...serverDownloads[0],
+      status: 'error',
+      complete: false,
+      error: 'new attempt failed',
+      created_at: firstAttemptCreatedAt + 5_000,
+    }];
+    await downloadStore.refresh();
+    assert.equal(
+      downloadStore.visibleSnapshot().length,
+      1,
+      'a new terminal attempt reusing the same stable id must not inherit an old dismissal',
+    );
 
     serverDownloads = [{
       id: 'model:paused-model',
@@ -210,7 +235,7 @@ async function waitFor(predicate, timeoutMs = 1500) {
     const requestsBeforePausedSnapshot = downloadRequests;
     await downloadStore.refresh();
     assert.equal(downloadRequests, requestsBeforePausedSnapshot + 1);
-    downloadStore.removeMany(['model:paused-model']);
+    downloadStore.dismissMany(['model:paused-model']);
     assert.equal(downloadStore.snapshot().length, 1);
     assert.equal(downloadStore.visibleSnapshot().length, 1, 'paused server state must remain visible and blocking');
 

--- a/src/app/tests/download-polling-lifecycle.runtime.cjs
+++ b/src/app/tests/download-polling-lifecycle.runtime.cjs
@@ -35,6 +35,13 @@ assert.doesNotMatch(
   /if \(!api\.isConnected\)/,
   'an authoritative /downloads refresh must not depend on the global connection flag',
 );
+assert.doesNotMatch(
+  source,
+  /lemonade_download_manager_items_v1/,
+  'download rows must never be persisted client-side',
+);
+assert.match(source, /visibleSnapshot\(\): DownloadListItem\[\]/);
+assert.match(source, /isDismissedTerminal\(download, dismissed\)/);
 
 const originalTsLoader = require.extensions['.ts'];
 const originalApiCache = require.cache[apiPath];
@@ -136,12 +143,17 @@ async function waitFor(predicate, timeoutMs = 1500) {
       percent: 10,
     }];
     downloadStore.markLocal('test-model', 'downloading', 'model');
-    await waitFor(() => downloadRequests === 3, 1600);
+    await waitFor(
+      () => downloadRequests >= 3 && downloadStore.snapshot().some(item => item.modelName === 'test-model' && item.running === true),
+      1600,
+    );
     assert.ok(
       downloadStore.snapshot().some(item => item.modelName === 'test-model' && item.running === true),
       'an active download must remain represented after polling',
     );
 
+    // Pull callbacks may wake the store, but they may not author download state.
+    // The server still says active, so a local-looking terminal callback must be ignored.
     downloadStore.upsertFromPull('test-model', {
       id: 'model:test-model',
       status: 'completed',
@@ -149,23 +161,68 @@ async function waitFor(predicate, timeoutMs = 1500) {
       running: false,
       percent: 100,
     }, 'model');
+    await downloadStore.refresh();
+    assert.equal(downloadRequests, 4);
+    assert.ok(
+      downloadStore.snapshot().some(item => item.modelName === 'test-model' && item.running === true),
+      'callback data must not override the authoritative /downloads snapshot',
+    );
+
     serverDownloads = [];
+    const requestsBeforeEmptySnapshot = downloadRequests;
+    await downloadStore.refresh();
+    assert.equal(downloadRequests, requestsBeforeEmptySnapshot + 1);
+    assert.equal(downloadStore.snapshot().length, 0, 'an empty server snapshot must remove the active row immediately');
     const requestsAtCompletion = downloadRequests;
     await sleep(1200);
     assert.equal(
       downloadRequests,
       requestsAtCompletion,
-      'the last terminal download event must cancel the already-scheduled next poll',
+      'an idle authoritative snapshot must stop polling',
     );
+
+    // Dismissed state is presentation-only: canonical state remains intact, and
+    // non-terminal rows can never be hidden by a client-owned dismissed id.
+    serverDownloads = [{
+      id: 'model:completed-model',
+      type: 'model',
+      model_name: 'completed-model',
+      status: 'completed',
+      complete: true,
+      running: false,
+      percent: 100,
+    }];
+    const requestsBeforeCompletedSnapshot = downloadRequests;
+    await downloadStore.refresh();
+    assert.equal(downloadRequests, requestsBeforeCompletedSnapshot + 1);
+    downloadStore.removeMany(['model:completed-model']);
+    assert.equal(downloadStore.snapshot().length, 1, 'dismiss must not mutate canonical server state');
+    assert.equal(downloadStore.visibleSnapshot().length, 0, 'dismiss may hide terminal history visually');
+
+    serverDownloads = [{
+      id: 'model:paused-model',
+      type: 'model',
+      model_name: 'paused-model',
+      status: 'paused',
+      running: false,
+      percent: 25,
+    }];
+    const requestsBeforePausedSnapshot = downloadRequests;
+    await downloadStore.refresh();
+    assert.equal(downloadRequests, requestsBeforePausedSnapshot + 1);
+    downloadStore.removeMany(['model:paused-model']);
+    assert.equal(downloadStore.snapshot().length, 1);
+    assert.equal(downloadStore.visibleSnapshot().length, 1, 'paused server state must remain visible and blocking');
 
     const focusListeners = windowListeners.get('focus') || [];
     assert.equal(focusListeners.length, 1);
+    const requestsBeforeFocus = downloadRequests;
     focusListeners[0]();
-    await waitFor(() => downloadRequests === requestsAtCompletion + 1);
+    await waitFor(() => downloadRequests === requestsBeforeFocus + 1);
     await sleep(1150);
     assert.equal(
       downloadRequests,
-      requestsAtCompletion + 1,
+      requestsBeforeFocus + 1,
       'focus may refresh idle state once but must not restart perpetual polling',
     );
 


### PR DESCRIPTION
# PR Description

## Summary

Make `/api/v1/downloads` the sole source of truth for GUI3 download state.

* Remove persistent download items from localStorage (`lemonade_download_manager_items_v1`).
* Stop local pull callbacks and download actions from mutating canonical download state. They now only trigger a refresh from the server.
* Keep `lemonade_download_manager_dismissed_v1` client-owned for presentation only. Dismissal only hides terminal history and never changes download or blocking state.
* Update regression coverage for stale localStorage rows, authoritative empty snapshots, callback races, and dismissed non-terminal downloads.

Adresses #3161

## Scope

* [x] This PR addresses one clear issue or change.
* [x] I reviewed the full diff myself before submitting.
* [x] I removed unrelated local changes.
* [x] I kept refactoring separate unless it is required for this change.

## Testing

* [x] Code builds without errors locally.
* [x] I tested this change locally.
* [x] I described the testing performed below.

_Testing details:_

* npm test passed
* typecheck passed
* locally tested DL works correctly

## Documentation

* [x] Documentation is not affected by this change.

## Breaking Changes

* [x] This PR does not introduce breaking changes.

## AI-assisted contribution

Please select one:

* [x] I used AI tools for this PR.

If AI tools were used:

* [x] I verified that I understand the changes.
* [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.
