### PR TITLE
docs: add MCP Gateway to the API Spec nav

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -111,6 +111,7 @@ nav:
       - OpenAI Compatible: api/openai.md
       - Ollama Compatible: api/ollama.md
       - Anthropic Compatible: api/anthropic.md
+      - MCP Gateway: api/mcp.md
       - llama.cpp Specific: api/llamacpp.md
       - Lemonade Specific: api/lemonade.md
   - Embeddable Lemonade:


### PR DESCRIPTION
## Summary

`docs/api/mcp.md` was published at https://lemonade-server.ai/docs/api/mcp/ but had no nav entry, so it was only reachable via direct link or the API Spec overview table. Adds it to the API Spec section, in the same position it occupies in `docs/api/README.md` (after Anthropic, before llama.cpp).

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_ Docs-only, one line of YAML. Parsed `mkdocs.yml` and confirmed the API Spec nav resolves in order with every target file present on disk, including the new `api/mcp.md`.

## Documentation

- [x] Documentation is affected and has been updated.

## Breaking Changes

- [x] This PR does not introduce breaking changes.

## AI-assisted contribution

- [x] I used AI tools for this PR.

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
