### PR TITLE
fix(server): treat --port and --host CLI flags as ephemeral overrides

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2940,6 +2940,13 @@ if(BUILD_TESTING AND EXISTS "${_CONFIG_DEFAULT_SOURCE_TEST_SRC}")
     add_cpp_ci_test(ConfigDefaultSourceTest CI ON COMMAND test_config_default_source)
 endif()
 
+set(_CLI_RUNTIME_OVERRIDE_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_cli_runtime_override.cpp")
+if(BUILD_TESTING AND EXISTS "${_CLI_RUNTIME_OVERRIDE_TEST_SRC}")
+    add_executable(test_cli_runtime_override test/cpp/test_cli_runtime_override.cpp)
+    target_link_libraries(test_cli_runtime_override PRIVATE lemonade-server-core)
+    add_cpp_ci_test(CliRuntimeOverrideTest CI ON COMMAND test_cli_runtime_override)
+endif()
+
 # ROCm root resolution (ROCM_PATH / rocm-sdk / /opt/rocm priority): covers the
 # external-ROCm detection that lets Lemonade skip the bundled TheRock download.
 set(_ROCM_ROOT_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_rocm_root_resolution.cpp")

--- a/docs/guide/configuration/README.md
+++ b/docs/guide/configuration/README.md
@@ -391,17 +391,22 @@ lemonade config set telemetry.otlp.semantics='["openinference"]'
 lemonade config set telemetry.otlp.headers='{"Authorization":"Bearer key"}'
 ```
 
-### lemond CLI arguments (fallback)
+### lemond CLI arguments (runtime overrides)
 
-If the server cannot start (e.g., invalid port in config.json), `lemond` accepts `--port` and `--host` as CLI arguments to override config.json. These overrides are persisted so the server can start normally next time:
+`lemond` accepts `--port` and `--host` as CLI arguments to provide ephemeral runtime overrides for that specific server process without modifying `config.json`:
 
 ```bash
 lemond --port 9000 --host 0.0.0.0
 ```
 
+Because CLI overrides are ephemeral and do not mutate `config.json` on disk, if the server cannot start due to an invalid port or host setting in `config.json`:
+1. Start `lemond` using the CLI override: `lemond --port 9000`
+2. Run `lemonade config set port=9000` against the running server to persist the fix for subsequent restarts.
+3. Alternatively, edit `config.json` directly as shown below.
+
 ### Edit config.json manually (last resort)
 
-If the server won't start and CLI arguments aren't sufficient, you can edit config.json directly. Restart the server after making changes:
+If the server won't start and CLI tools aren't sufficient, you can edit config.json directly. Restart the server after making changes:
 
 ```bash
 # Linux (Debian/Ubuntu)
@@ -423,9 +428,8 @@ sudo systemctl restart lemond
 lemond [cache_dir] [--port PORT] [--host HOST] [--broadcast] [--no-broadcast]
 ```
 
-- **cache_dir** — Path to the lemonade cache directory containing config.json and model data. Optional; defaults to platform-specific location.
-- **--port** — Port to serve on (overrides config.json, persisted). Use as a fallback if the server cannot start.
-- **--host** — Address to bind (overrides config.json, persisted). Use as a fallback if the server cannot start.
+- **--port** — Port to serve on (runtime override, does not mutate config.json).
+- **--host** — Address to bind (runtime override, does not mutate config.json).
 - **--broadcast** / **--no-broadcast** — Enable or disable UDP broadcasting for server discovery (non-persistent override).
 
 ## API Key and Security

--- a/src/cpp/include/lemon/runtime_config.h
+++ b/src/cpp/include/lemon/runtime_config.h
@@ -26,7 +26,9 @@ public:
     // --- Thread-safe typed getters (shared lock) ---
     // Top-level server settings
     int port() const;
+    void set_port_override(std::optional<int> override_val);
     std::string host() const;
+    void set_host_override(std::optional<std::string> override_val);
     int websocket_port() const;
     std::string log_level() const;
     std::string extra_models_dir() const;
@@ -152,6 +154,8 @@ private:
     json config_;
 
     // Transient CLI overrides (not persisted to disk)
+    std::optional<int> port_override_;
+    std::optional<std::string> host_override_;
     std::optional<bool> broadcast_override_;
 
     // Valid log levels

--- a/src/cpp/server/cli_parser.cpp
+++ b/src/cpp/server/cli_parser.cpp
@@ -19,10 +19,10 @@ CLIParser::CLIParser()
         ->type_name("DIR")
         ->default_val(utils::get_cache_dir());
 
-    app_.add_option("--port", config_.port, "Port number to serve on (overrides config.json)")
+    app_.add_option("--port", config_.port, "Port number to serve on (runtime override)")
         ->type_name("PORT");
 
-    app_.add_option("--host", config_.host, "Address to bind for connections (overrides config.json)")
+    app_.add_option("--host", config_.host, "Address to bind for connections (runtime override)")
         ->type_name("HOST");
 
     app_.add_flag("--broadcast,!--no-broadcast", config_.broadcast, "Enable or disable UDP broadcasting for server discovery");

--- a/src/cpp/server/main.cpp
+++ b/src/cpp/server/main.cpp
@@ -83,22 +83,13 @@ int main(int argc, char** argv) {
         utils::set_cache_dir(cli_config.cache_dir);
         json config_json = ConfigFile::load(cli_config.cache_dir);
 
-        // CLI --port/--host override config.json and persist
-        bool cli_overrides = false;
+        auto config = std::make_shared<RuntimeConfig>(config_json);
         if (cli_config.port != -1) {
-            config_json["port"] = cli_config.port;
-            cli_overrides = true;
+            config->set_port_override(cli_config.port);
         }
         if (!cli_config.host.empty()) {
-            config_json["host"] = cli_config.host;
-            cli_overrides = true;
+            config->set_host_override(cli_config.host);
         }
-
-        if (cli_overrides) {
-            ConfigFile::save(cli_config.cache_dir, config_json);
-        }
-
-        auto config = std::make_shared<RuntimeConfig>(config_json);
         if (cli_config.broadcast.has_value()) {
             config->set_broadcast_override(cli_config.broadcast);
         }
@@ -106,15 +97,6 @@ int main(int argc, char** argv) {
 
         // Initialize logging with the configured level — console + file + log hub
         configure_application_logging(config->log_level(), LoggingMode::direct_server);
-
-        if (cli_overrides) {
-            if (cli_config.port != -1) {
-                LOG(INFO) << "Persisted port=" << cli_config.port << " to config.json" << std::endl;
-            }
-            if (!cli_config.host.empty()) {
-                LOG(INFO) << "Persisted host=" << cli_config.host << " to config.json" << std::endl;
-            }
-        }
 
         utils::set_models_dir(config->models_dir());
 

--- a/src/cpp/server/runtime_config.cpp
+++ b/src/cpp/server/runtime_config.cpp
@@ -283,12 +283,28 @@ RuntimeConfig::RuntimeConfig(const json& config)
 
 int RuntimeConfig::port() const {
     std::shared_lock lock(mutex_);
+    if (port_override_.has_value()) {
+        return *port_override_;
+    }
     return config_["port"].get<int>();
+}
+
+void RuntimeConfig::set_port_override(std::optional<int> override_val) {
+    std::unique_lock lock(mutex_);
+    port_override_ = override_val;
 }
 
 std::string RuntimeConfig::host() const {
     std::shared_lock lock(mutex_);
+    if (host_override_.has_value()) {
+        return *host_override_;
+    }
     return config_["host"].get<std::string>();
+}
+
+void RuntimeConfig::set_host_override(std::optional<std::string> override_val) {
+    std::unique_lock lock(mutex_);
+    host_override_ = override_val;
 }
 
 int RuntimeConfig::websocket_port() const {

--- a/src/cpp/tray/main.cpp
+++ b/src/cpp/tray/main.cpp
@@ -172,22 +172,13 @@ int WINAPI wWinMain(HINSTANCE, HINSTANCE, LPWSTR, int) {
     lemon::utils::set_cache_dir(cli_config.cache_dir);
 
     auto config_json = lemon::ConfigFile::load(cli_config.cache_dir);
-
-    // CLI overrides (persist to config.json)
-    bool cli_overrides = false;
+    auto runtime_config = std::make_shared<lemon::RuntimeConfig>(config_json);
     if (cli_config.port != -1) {
-        config_json["port"] = cli_config.port;
-        cli_overrides = true;
+        runtime_config->set_port_override(cli_config.port);
     }
     if (!cli_config.host.empty()) {
-        config_json["host"] = cli_config.host;
-        cli_overrides = true;
+        runtime_config->set_host_override(cli_config.host);
     }
-    if (cli_overrides) {
-        lemon::ConfigFile::save(cli_config.cache_dir, config_json);
-    }
-
-    auto runtime_config = std::make_shared<lemon::RuntimeConfig>(config_json);
     lemon::RuntimeConfig::set_global(runtime_config.get());
 
     lemon::utils::set_models_dir(runtime_config->models_dir());

--- a/test/cpp/test_cli_runtime_override.cpp
+++ b/test/cpp/test_cli_runtime_override.cpp
@@ -1,0 +1,110 @@
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <nlohmann/json.hpp>
+#include <lemon/cli_parser.h>
+#include <lemon/config_file.h>
+#include <lemon/runtime_config.h>
+
+namespace fs = std::filesystem;
+using json = nlohmann::json;
+using lemon::CLIParser;
+using lemon::ConfigFile;
+using lemon::RuntimeConfig;
+
+static int passed = 0;
+static int failures = 0;
+
+static void check(bool cond, const char* desc) {
+    if (cond) {
+        std::printf("[PASS] %s\n", desc);
+        ++passed;
+    } else {
+        std::printf("[FAIL] %s\n", desc);
+        ++failures;
+    }
+}
+
+static fs::path make_temp_cache_dir(const std::string& tag) {
+    static int counter = 0;
+    fs::path root = fs::temp_directory_path() / ("lemonade_cli_override_test_" + tag + "_" + std::to_string(counter++));
+    fs::create_directories(root);
+    return root;
+}
+
+int main() {
+    {
+        CLIParser parser;
+        const char* argv[] = {"lemond", "--port", "9000", "--host", "0.0.0.0"};
+        int res = parser.parse(5, const_cast<char**>(argv));
+        check(res == 0 && parser.should_continue(), "CLIParser parses --port and --host successfully");
+        auto cli_cfg = parser.get_config();
+        check(cli_cfg.port == 9000, "CLIParser captured port 9000");
+        check(cli_cfg.host == "0.0.0.0", "CLIParser captured host 0.0.0.0");
+    }
+
+    {
+        fs::path temp_dir = make_temp_cache_dir("ephemeral");
+        json initial_cfg = {
+            {"port", 13305},
+            {"host", "localhost"},
+            {"log_level", "info"}
+        };
+        ConfigFile::save(temp_dir.string(), initial_cfg);
+
+        CLIParser parser;
+        const char* argv[] = {"lemond", temp_dir.string().c_str(), "--port", "8888", "--host", "127.0.0.1"};
+        parser.parse(6, const_cast<char**>(argv));
+        auto cli_cfg = parser.get_config();
+
+        json loaded = ConfigFile::load(cli_cfg.cache_dir);
+        check(loaded["port"] == 13305, "Loaded config before override has original port");
+        check(loaded["host"] == "localhost", "Loaded config before override has original host");
+
+        RuntimeConfig runtime_cfg(loaded);
+        if (cli_cfg.port != -1) {
+            runtime_cfg.set_port_override(cli_cfg.port);
+        }
+        if (!cli_cfg.host.empty()) {
+            runtime_cfg.set_host_override(cli_cfg.host);
+        }
+
+        check(runtime_cfg.port() == 8888, "RuntimeConfig::port() returns overridden port 8888");
+        check(runtime_cfg.host() == "127.0.0.1", "RuntimeConfig::host() returns overridden host 127.0.0.1");
+
+        // Verify snapshot() does NOT leak the CLI overrides into the persistent representation
+        json snap = runtime_cfg.snapshot();
+        check(snap["port"] == 13305, "snapshot() contains persistent port 13305, not override");
+        check(snap["host"] == "localhost", "snapshot() contains persistent host localhost, not override");
+
+        // Simulate `lemonade config set log_level=debug` which calls ConfigFile::save(cache_dir, snapshot())
+        runtime_cfg.set(json{{"log_level", "debug"}});
+        ConfigFile::save(cli_cfg.cache_dir, runtime_cfg.snapshot());
+
+        // Re-read from disk to ensure config.json was updated with log_level but did NOT leak port/host overrides
+        json disk_cfg = ConfigFile::load(cli_cfg.cache_dir);
+        check(disk_cfg["log_level"] == "debug", "config.json on disk updated log_level to debug");
+        check(disk_cfg["port"] == 13305, "config.json on disk preserved original port 13305 after config set");
+        check(disk_cfg["host"] == "localhost", "config.json on disk preserved original host localhost after config set");
+
+        // Verify removing overrides reverts to underlying config values
+        runtime_cfg.set_port_override(std::nullopt);
+        runtime_cfg.set_host_override(std::nullopt);
+        check(runtime_cfg.port() == 13305, "RuntimeConfig::port() reverts to persistent port after clearing override");
+        check(runtime_cfg.host() == "localhost", "RuntimeConfig::host() reverts to persistent host after clearing override");
+
+        fs::remove_all(temp_dir);
+    }
+
+    {
+        CLIParser parser;
+        const char* argv[] = {"lemond"};
+        parser.parse(1, const_cast<char**>(argv));
+        auto cli_cfg = parser.get_config();
+        check(cli_cfg.port == -1, "Default port is -1 when omitted");
+        check(cli_cfg.host.empty(), "Default host is empty when omitted");
+    }
+
+    std::printf("\nSummary: %d passed, %d failed\n", passed, failures);
+    return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Treats `lemond` and `LemonadeServer.exe` CLI `--port` and `--host` flags as ephemeral in-memory runtime overrides in `RuntimeConfig` rather than modifying `config_` or persisting them to `<cache_dir>/config.json`.

### Rationale and Motivation
- **Principle of Least Surprise (POLA):** Standard CLI conventions expect invocation flags to apply only to the running process without unintended persistent side-effects on disk.
- **Developer Experience & Multi-Instance Workflows:** Running ad-hoc or test instances on alternative ports (e.g. `lemond --port 9000`) no longer clobbers `config.json`, preventing regressions for background services.
- **Consistent Architectural Pattern:** Adopts the same `broadcast_override_` pattern in `RuntimeConfig` (`port_override_` / `host_override_`), ensuring CLI overrides never enter `config_` and cannot leak to disk when `RuntimeConfig::snapshot()` is saved during `lemonade config set ...`.
- **Clear Separation of Concerns:** Persistent configuration remains cleanly handled by dedicated configuration tools (`lemonade config set`, `POST /internal/set`, or manual `config.json` edits) and environment variables (`LEMONADE_PORT`, `LEMONADE_HOST`).

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_
- Added unit test `test/cpp/test_cli_runtime_override.cpp` verifying CLI flag parsing, in-memory `RuntimeConfig` overrides, exclusion of overrides from `snapshot()`, non-leakage to disk after `config set` operations, and revert behavior upon clearing overrides.
- Built and ran all 44 C++ CI tests (`ctest -L cpp-ci`) with 100% pass rate.
- Performed end-to-end launch of `lemond <temp_dir> --port 13309` and confirmed `config.json` retains canonical defaults without writing the CLI port to disk.

## Documentation

- [ ] Documentation is not affected by this change.
- [x] Documentation is affected and has been updated.
- [ ] Documentation is affected but will be handled in a separate PR or issue.

## Breaking Changes

- [x] This PR introduces breaking changes.
- [ ] This PR does not introduce breaking changes.

_Breaking change details & migration path:_
`lemond` and `LemonadeServer.exe` CLI flags `--port` and `--host` no longer persist to `config.json`. Workflows or scripts that previously called `lemond --port <P>` once to permanently reconfigure the daemon must now use `lemonade config set port=<P>` against the running server (or edit `config.json`) for persistence.

## AI-assisted contribution

Please select one:

- [x] I used AI tools for this PR.
- [ ] I did not use AI tools for this PR.

If AI tools were used:

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.
