### PR TITLE
fix(gui3): pin model-source tabs above the models rail scroll area

### DIFF
--- a/src/app/src/components/ModelNavRail.tsx
+++ b/src/app/src/components/ModelNavRail.tsx
@@ -314,8 +314,9 @@ export const ModelNavRail: React.FC<ModelNavRailProps> = ({
         onToggle={onToggleCollapsed}
         onMobileClose={mobileOpen ? onMobileClose : undefined}
       />
-      <div className="model-nav-rail__scroll">
-      {/* 1. Primary nav */}
+      {/* 1. Primary nav — pinned above the scroll area so the model-source
+          tabs (All Models / Downloaded / Favorites) stay visible;
+          only the collapsible filter sections below scroll. */}
       <ul className="model-nav-rail__primary workspace-filter-list" role="list">
         {PRIMARY_ITEMS.map(item => {
           const active = primaryFilter === item.key;
@@ -338,7 +339,7 @@ export const ModelNavRail: React.FC<ModelNavRailProps> = ({
 
       </ul>
 
-
+      <div className="model-nav-rail__scroll">
       <section className="model-nav-rail__section model-nav-rail__section--tasks">
         <h2 className="model-nav-rail__section-head">
           <button

--- a/src/app/src/styles/styles.css
+++ b/src/app/src/styles/styles.css
@@ -6710,7 +6710,7 @@ optgroup {
   padding: 0 var(--space-2) var(--space-2);
 }
 
-/* 2. Primary nav */
+/* 2. Primary nav — pinned above the scroll area (direct child of the rail) */
 .model-nav-rail__primary {
   list-style: none;
   margin: 0;
@@ -6718,11 +6718,11 @@ optgroup {
   display: flex;
   flex-direction: column;
   gap: var(--space-0-5);
+  flex-shrink: 0;
 }
 
 .model-nav-rail__primary.workspace-filter-list {
-  margin-inline: calc(-1 * var(--space-2));
-  padding-bottom: 0;
+  padding-bottom: var(--space-3);
 }
 
 .model-nav-rail__nav-item {


### PR DESCRIPTION
## Summary

Pin the model-source tabs (All Models / Downloaded / Favorites) in the Models rail so they stay visible above the scroll area, leaving only the collapsible filter sections (Task, Backends, Online Catalogs, Tags) scrollable.

The tab list was rendered inside `.model-nav-rail__scroll`, so it scrolled out of view along with the filters. This moves it out of the scroll container into a fixed section directly below the rail header. The tabs keep their full-bleed item styling — the old negative-margin workaround is removed since the list is now a direct child of the rail — and they stay hidden when the rail is collapsed (the existing `.workspace-rail.is-collapsed` rule covers all non-header children).

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

Built the web-app from source (`cmake --build build --config Release --target web-app`) and verified in the browser that the tabs stay pinned while the filter sections scroll independently. Also rebuilt the Tauri desktop app and confirmed it compiles and launches.

## Documentation

- [x] Documentation is not affected by this change.

## Breaking Changes

- [x] This PR does not introduce breaking changes.

## AI-assisted contribution

- [x] I used AI tools for this PR.

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.
