### PR TITLE
fix(gui3): scroll the Settings section list and pin the Server status footer

### DIFF
--- a/src/app/src/styles/styles.css
+++ b/src/app/src/styles/styles.css
@@ -11001,11 +11001,23 @@ optgroup {
   border-top: 1px solid var(--border-subtle);
 }
 
+/* The Settings rail's Server-status footer mirrors the Models rail's storage
+   meter, so it shares the same compact padding and stays pinned at the bottom. */
+.connect__rail .workspace-rail__footer {
+  padding: var(--space-2);
+}
+
 .workspace-nav {
   display: flex;
   flex-direction: column;
   gap: var(--space-0-5);
   padding: var(--space-3);
+  /* Scroll independently between the pinned header and pinned footer, so the
+     section list stays reachable and the Server status footer stays pinned to
+     the bottom of the rail (mirrors the Models rail layout). */
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
 }
 
 .workspace-nav button {


### PR DESCRIPTION
## Summary

Pin the Settings rail's static regions — the "Settings" header and the Server-status footer — and make only the section list (Server, Chat, Memory, Model storage, Cloud providers, MCP gateway, Help & support) scroll, mirroring the Models rail layout.

The section list (`.workspace-nav`) neither grew nor scrolled, so on short windows the sections clipped, and the Server-status footer sat directly below the list instead of pinned to the bottom of the rail. Give the nav `flex: 1 / min-height: 0 / overflow-y: auto` so the sections scroll independently between the pinned header and the pinned footer, and tighten the Settings footer's padding (`--space-3` → `--space-2`) to match the Models storage meter. The Monitor rail is unaffected — its `.monitor-nav` keeps `flex: 0 0 auto`.

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

Built the web-app from source (`cmake --build build --config Release --target web-app`) and verified in the browser that the Settings section list scrolls while the header and the Server-status footer stay pinned. Also rebuilt the Tauri desktop app and confirmed it compiles and launches.

## Documentation

- [x] Documentation is not affected by this change.

## Breaking Changes

- [x] This PR does not introduce breaking changes.

## AI-assisted contribution

- [x] I used AI tools for this PR.

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.
