### PR TITLE
fix: respect GitHub API rate-limit headers in fetch_latest_github_tag (#2441)

### DIFF
--- a/src/cpp/server/backend_manager.cpp
+++ b/src/cpp/server/backend_manager.cpp
@@ -14,6 +14,7 @@
 #include <fstream>
 #include <functional>
 #include <iostream>
+#include <ctime>
 #include <map>
 #include <optional>
 #include <thread>
@@ -390,6 +391,26 @@ std::string BackendManager::get_version_from_config(const std::string& recipe, c
 
 std::string BackendManager::fetch_latest_github_tag(const std::string& repo,
                                                      bool throw_on_failure) {
+    // Rate-limit guard: GitHub returns 429/403 when unauthenticated requests
+    // exceed 60 req/hr per IP. Once hit, back off until Retry-After expires
+    // instead of spamming the API (which resets the clock on each 429).
+    static std::chrono::steady_clock::time_point s_rate_limit_until;
+    {
+        auto now = std::chrono::steady_clock::now();
+        if (now < s_rate_limit_until) {
+            auto remaining = std::chrono::duration_cast<std::chrono::seconds>(
+                s_rate_limit_until - now).count();
+            LOG(WARNING, "BackendManager") << "GitHub API rate limited for " << repo
+                                           << ", skipping (" << remaining << "s remaining)" << std::endl;
+            if (throw_on_failure) {
+                throw std::runtime_error(
+                    "GitHub API rate limited for " + repo
+                    + " (" + std::to_string(remaining) + "s remaining)");
+            }
+            return "";
+        }
+    }
+
     {
         std::lock_guard<std::mutex> lock(latest_version_cache_mutex_);
         auto it = latest_version_cache_.find(repo);
@@ -430,13 +451,40 @@ std::string BackendManager::fetch_latest_github_tag(const std::string& repo,
         return "";
     }
     if (resp.status_code < 200 || resp.status_code >= 300) {
+        // On rate-limit responses (429 or 403), parse Retry-After and set a
+        // backoff clock so we don't spam the API until the window expires.
+        if (resp.status_code == 429 || resp.status_code == 403) {
+            int retry_seconds = 60;
+            auto retry_it = resp.headers.find("Retry-After");
+            if (retry_it != resp.headers.end()) {
+                try { retry_seconds = std::stoi(retry_it->second); } catch (...) {}
+            }
+            // Fallback: x-ratelimit-reset (Unix timestamp) if no Retry-After
+            if (retry_it == resp.headers.end()) {
+                auto reset_it = resp.headers.find("x-ratelimit-reset");
+                if (reset_it != resp.headers.end()) {
+                    try {
+                        auto reset_t = static_cast<std::time_t>(std::stoll(reset_it->second));
+                        auto now_t = std::chrono::system_clock::to_time_t(
+                            std::chrono::system_clock::now());
+                        if (reset_t > now_t) retry_seconds = static_cast<int>(reset_t - now_t);
+                    } catch (...) {}
+                }
+            }
+            s_rate_limit_until = std::chrono::steady_clock::now()
+                + std::chrono::seconds(retry_seconds);
+            LOG(WARNING, "BackendManager") << "GitHub returned HTTP " << resp.status_code
+                                           << " for " << repo << ", backing off "
+                                           << retry_seconds << "s" << std::endl;
+        } else {
+            LOG(WARNING, "BackendManager") << "GitHub returned HTTP " << resp.status_code
+                                           << " for " << repo << std::endl;
+        }
         if (throw_on_failure) {
             throw std::runtime_error(
                 "GitHub returned HTTP " + std::to_string(resp.status_code)
                 + " when querying latest release of " + repo);
         }
-        LOG(WARNING, "BackendManager") << "GitHub returned HTTP " << resp.status_code
-                                       << " for " << repo << std::endl;
         return "";
     }
 

--- a/src/cpp/server/backend_manager.cpp
+++ b/src/cpp/server/backend_manager.cpp
@@ -394,8 +394,12 @@ std::string BackendManager::fetch_latest_github_tag(const std::string& repo,
     // Rate-limit guard: GitHub returns 429/403 when unauthenticated requests
     // exceed 60 req/hr per IP. Once hit, back off until Retry-After expires
     // instead of spamming the API (which resets the clock on each 429).
+    // s_rate_limit_until is shared across concurrent calls, so guard it with a
+    // mutex to avoid a data race.
+    static std::mutex rate_limit_mutex;
     static std::chrono::steady_clock::time_point s_rate_limit_until;
     {
+        std::lock_guard<std::mutex> lock(rate_limit_mutex);
         auto now = std::chrono::steady_clock::now();
         if (now < s_rate_limit_until) {
             auto remaining = std::chrono::duration_cast<std::chrono::seconds>(
@@ -455,7 +459,8 @@ std::string BackendManager::fetch_latest_github_tag(const std::string& repo,
         // backoff clock so we don't spam the API until the window expires.
         if (resp.status_code == 429 || resp.status_code == 403) {
             int retry_seconds = 60;
-            auto retry_it = resp.headers.find("Retry-After");
+            // HttpClient normalizes response header keys to lowercase.
+            auto retry_it = resp.headers.find("retry-after");
             if (retry_it != resp.headers.end()) {
                 try { retry_seconds = std::stoi(retry_it->second); } catch (...) {}
             }
@@ -471,8 +476,11 @@ std::string BackendManager::fetch_latest_github_tag(const std::string& repo,
                     } catch (...) {}
                 }
             }
-            s_rate_limit_until = std::chrono::steady_clock::now()
-                + std::chrono::seconds(retry_seconds);
+            {
+                std::lock_guard<std::mutex> lock(rate_limit_mutex);
+                s_rate_limit_until = std::chrono::steady_clock::now()
+                    + std::chrono::seconds(retry_seconds);
+            }
             LOG(WARNING, "BackendManager") << "GitHub returned HTTP " << resp.status_code
                                            << " for " << repo << ", backing off "
                                            << retry_seconds << "s" << std::endl;

--- a/src/cpp/server/utils/http_client.cpp
+++ b/src/cpp/server/utils/http_client.cpp
@@ -42,6 +42,35 @@ static std::string lower_copy(std::string value) {
     return value;
 }
 
+struct ResponseHeaderCollector {
+    std::map<std::string, std::string>* headers;
+};
+
+// Collects response headers into a caller-provided map. Keys are lower-cased
+// for case-insensitive lookup (HTTP header names are case-insensitive).
+static size_t collect_response_header_callback(char* buffer, size_t size, size_t nitems,
+                                               void* userdata) {
+    const size_t total = size * nitems;
+    auto* collector = static_cast<ResponseHeaderCollector*>(userdata);
+    if (!collector || !collector->headers || total == 0) {
+        return total;
+    }
+
+    std::string line(buffer, total);
+
+    // Skip the status line and blank separator lines.
+    if (line.rfind("HTTP/", 0) == 0) return total;
+    if (line == "\r\n" || line == "\n") return total;
+
+    const auto colon = line.find(':');
+    if (colon == std::string::npos) return total;
+
+    const std::string key = lower_copy(trim_copy(line.substr(0, colon)));
+    const std::string value = trim_copy(line.substr(colon + 1));
+    (*collector->headers)[key] = value;
+    return total;
+}
+
 static size_t curl_off_to_size(curl_off_t value) {
     return value > 0 ? static_cast<size_t>(value) : 0;
 }
@@ -454,10 +483,13 @@ HttpResponse HttpClient::get(const std::string& url,
 
     HttpResponse response;
     std::string response_body;
+    ResponseHeaderCollector header_collector{&response.headers};
 
     curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_callback);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response_body);
+    curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, collect_response_header_callback);
+    curl_easy_setopt(curl, CURLOPT_HEADERDATA, &header_collector);
     if (!apply_http_security_policy(curl, policy, true)) {
         curl_easy_cleanup(curl);
         throw std::runtime_error("Failed to apply HTTP security policy");


### PR DESCRIPTION
Re-opened cleanly from the closed stacked PR #2456 (that branch carried the unmerged mlx-engine backend; this is just the rate-limit commit on current main).

Fixes #2441.

Adds a static backoff clock checked before every GitHub API call in `fetch_latest_github_tag`: on 429/403 it parses `Retry-After`, falls back to `x-ratelimit-reset`, and defaults to 60s — logging a warning with remaining seconds during the backoff window.