### PR TITLE
fix: skip optional draft checkpoint in are_required_checkpoints_complete (#2435)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1179,6 +1179,19 @@ if(BUILD_TESTING AND EXISTS "${LLAMACPP_REQUEST_TEST_SOURCE}")
     add_cpp_ci_test(llamacpp_request CI OFF COMMAND test_llamacpp_request)
 endif()
 
+set(LLAMACPP_DRAFT_TEST_SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_llamacpp_draft.cpp")
+if(BUILD_TESTING AND EXISTS "${LLAMACPP_DRAFT_TEST_SOURCE}")
+    add_executable(test_llamacpp_draft
+        ${LLAMACPP_DRAFT_TEST_SOURCE}
+        src/cpp/server/backends/llamacpp/llamacpp_draft.cpp
+    )
+    target_include_directories(test_llamacpp_draft PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/include
+        ${CMAKE_CURRENT_BINARY_DIR}/include
+    )
+    add_cpp_ci_test(llamacpp_draft CI ON COMMAND test_llamacpp_draft)
+endif()
+
 set(MCP_CLIENT_CONFIG_TEST_SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_mcp_client_config.cpp")
 if(BUILD_TESTING AND EXISTS "${MCP_CLIENT_CONFIG_TEST_SOURCE}")
     find_package(Python3 COMPONENTS Interpreter QUIET)

--- a/src/cpp/include/lemon/backends/llamacpp/llamacpp_draft.h
+++ b/src/cpp/include/lemon/backends/llamacpp/llamacpp_draft.h
@@ -19,16 +19,27 @@ struct DraftActivation {
 bool is_dflash_draft_checkpoint(const std::string& checkpoint);
 
 // Compute draft activation from the model's labels, the raw draft checkpoint
-// reference, and whether the resolved draft file actually exists on disk.
+// reference, whether the resolved draft file actually exists on disk, and the
+// GGUF architecture (used to gate GLM4-MOE, see below).
 //
 // Registration and activation are kept separate: the `draft` checkpoint only
 // describes where the drafter lives, while the `mtp` / `dflash` label is the
 // switch that enables speculative decoding. A drafter present on disk without
 // its matching label does not activate anything, and a label without a present
 // drafter also stays inactive (the base model runs normally).
+//
+// GLM4-MOE / ChatGLM4 models embed MTP layers in the GGUF but their draft
+// context construction accesses vision tensors that only exist when an mmproj
+// file is present; without one, MTP speculative decoding crashes llama-server
+// (see #2451). For those architectures MTP stays inactive unless the mmproj
+// path resolves (or the model is loaded via -hf, where llama-server resolves
+// the companion itself). Text-only MTP models (Gemma-4, Qwen3.x) are unaffected.
 DraftActivation compute_draft_activation(const std::vector<std::string>& labels,
                                          const std::string& draft_checkpoint,
-                                         bool draft_file_present);
+                                         bool draft_file_present,
+                                         const std::string& architecture,
+                                         const std::string& mmproj_path,
+                                         bool hf_load);
 
 } // namespace backends
 } // namespace lemon

--- a/src/cpp/include/lemon/backends/llamacpp/llamacpp_draft.h
+++ b/src/cpp/include/lemon/backends/llamacpp/llamacpp_draft.h
@@ -19,21 +19,15 @@ struct DraftActivation {
 bool is_dflash_draft_checkpoint(const std::string& checkpoint);
 
 // Compute draft activation from the model's labels, the raw draft checkpoint
-// reference, whether the resolved draft file actually exists on disk, and the
-// GGUF architecture (used to gate GLM4-MOE, see below).
+// reference, whether the resolved draft file exists on disk, the GGUF
+// architecture, the mmproj path, and hf_load.
 //
 // Registration and activation are kept separate: the `draft` checkpoint only
 // describes where the drafter lives, while the `mtp` / `dflash` label is the
-// switch that enables speculative decoding. A drafter present on disk without
-// its matching label does not activate anything, and a label without a present
-// drafter also stays inactive (the base model runs normally).
-//
-// GLM4-MOE / ChatGLM4 models embed MTP layers in the GGUF but their draft
-// context construction accesses vision tensors that only exist when an mmproj
-// file is present; without one, MTP speculative decoding crashes llama-server
-// (see #2451). For those architectures MTP stays inactive unless the mmproj
-// path resolves (or the model is loaded via -hf, where llama-server resolves
-// the companion itself). Text-only MTP models (Gemma-4, Qwen3.x) are unaffected.
+// switch that enables speculative decoding. An `mtp` label without an external
+// drafter means the MTP weights are embedded in the main GGUF: emit
+// --spec-type draft-mtp without --model-draft. GLM4-MOE embedded MTP crashes
+// without an mmproj companion (see #2451).
 DraftActivation compute_draft_activation(const std::vector<std::string>& labels,
                                          const std::string& draft_checkpoint,
                                          bool draft_file_present,

--- a/src/cpp/include/lemon/backends/llamacpp/llamacpp_draft.h
+++ b/src/cpp/include/lemon/backends/llamacpp/llamacpp_draft.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace lemon {
+namespace backends {
+
+// Decision about whether/how to activate an optional `draft` (MTP / DFlash)
+// checkpoint when launching llama-server.
+struct DraftActivation {
+    // Emit --model-draft <draft_path> when true.
+    bool use_draft_checkpoint = false;
+    // Emit --spec-type <spec_type> when non-empty ("draft-mtp" or "draft-dflash").
+    std::string spec_type;
+};
+
+// True when `checkpoint` names a DFlash drafter ("dflash.gguf" or "dflash-*").
+bool is_dflash_draft_checkpoint(const std::string& checkpoint);
+
+// Compute draft activation from the model's labels, the raw draft checkpoint
+// reference, and whether the resolved draft file actually exists on disk.
+//
+// Registration and activation are kept separate: the `draft` checkpoint only
+// describes where the drafter lives, while the `mtp` / `dflash` label is the
+// switch that enables speculative decoding. A drafter present on disk without
+// its matching label does not activate anything, and a label without a present
+// drafter also stays inactive (the base model runs normally).
+DraftActivation compute_draft_activation(const std::vector<std::string>& labels,
+                                         const std::string& draft_checkpoint,
+                                         bool draft_file_present);
+
+} // namespace backends
+} // namespace lemon

--- a/src/cpp/server/backends/llamacpp/llamacpp_draft.cpp
+++ b/src/cpp/server/backends/llamacpp/llamacpp_draft.cpp
@@ -24,7 +24,10 @@ bool has_label(const std::vector<std::string>& labels, const std::string& label)
 
 DraftActivation compute_draft_activation(const std::vector<std::string>& labels,
                                          const std::string& draft_checkpoint,
-                                         bool draft_file_present) {
+                                         bool draft_file_present,
+                                         const std::string& architecture,
+                                         const std::string& mmproj_path,
+                                         bool hf_load) {
     DraftActivation act;
     if (!draft_file_present) {
         // No drafter on disk: the base model runs without speculative decoding.
@@ -39,8 +42,24 @@ DraftActivation compute_draft_activation(const std::vector<std::string>& labels,
         act.use_draft_checkpoint = true;
         act.spec_type = "draft-dflash";
     } else if (!is_dflash_draft && has_mtp_label) {
-        act.use_draft_checkpoint = true;
-        act.spec_type = "draft-mtp";
+        // GLM4-MOE / ChatGLM4: the draft graph builder accesses vision tensors
+        // that only exist when an mmproj companion is present. Without one,
+        // MTP speculative decoding crashes llama-server (see #2451). Keep MTP
+        // inactive for those architectures unless mmproj resolves or the model
+        // is loaded via -hf (llama-server resolves the companion itself).
+        const std::string arch_lower = [&]() {
+            std::string s = architecture;
+            std::transform(s.begin(), s.end(), s.begin(),
+                           [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+            return s;
+        }();
+        const bool is_glm4_moe =
+            arch_lower.find("glm4") != std::string::npos
+            || arch_lower.find("chatglm4") != std::string::npos;
+        if (!(is_glm4_moe && mmproj_path.empty() && !hf_load)) {
+            act.use_draft_checkpoint = true;
+            act.spec_type = "draft-mtp";
+        }
     }
 
     return act;

--- a/src/cpp/server/backends/llamacpp/llamacpp_draft.cpp
+++ b/src/cpp/server/backends/llamacpp/llamacpp_draft.cpp
@@ -29,39 +29,54 @@ DraftActivation compute_draft_activation(const std::vector<std::string>& labels,
                                          const std::string& mmproj_path,
                                          bool hf_load) {
     DraftActivation act;
-    if (!draft_file_present) {
-        // No drafter on disk: the base model runs without speculative decoding.
-        return act;
-    }
 
     const bool has_dflash_label = has_label(labels, "dflash");
     const bool has_mtp_label = has_label(labels, "mtp");
     const bool is_dflash_draft = is_dflash_draft_checkpoint(draft_checkpoint);
+    const bool has_external_draft = !draft_checkpoint.empty() && draft_file_present;
 
-    if (is_dflash_draft && has_dflash_label) {
-        act.use_draft_checkpoint = true;
-        act.spec_type = "draft-dflash";
-    } else if (!is_dflash_draft && has_mtp_label) {
-        // GLM4-MOE / ChatGLM4: the draft graph builder accesses vision tensors
-        // that only exist when an mmproj companion is present. Without one,
-        // MTP speculative decoding crashes llama-server (see #2451). Keep MTP
-        // inactive for those architectures unless mmproj resolves or the model
-        // is loaded via -hf (llama-server resolves the companion itself).
-        const std::string arch_lower = [&]() {
-            std::string s = architecture;
-            std::transform(s.begin(), s.end(), s.begin(),
-                           [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
-            return s;
-        }();
-        const bool is_glm4_moe =
-            arch_lower.find("glm4") != std::string::npos
-            || arch_lower.find("chatglm4") != std::string::npos;
-        if (!(is_glm4_moe && mmproj_path.empty() && !hf_load)) {
+    if (is_dflash_draft) {
+        // DFlash always needs its external drafter file on disk.
+        if (has_dflash_label && has_external_draft) {
             act.use_draft_checkpoint = true;
-            act.spec_type = "draft-mtp";
+            act.spec_type = "draft-dflash";
         }
+        return act;
     }
 
+    if (!has_mtp_label) {
+        return act;
+    }
+
+    // A configured external draft that is missing on disk: run the base model
+    // without speculative decoding rather than fail the launch.
+    if (!draft_checkpoint.empty() && !draft_file_present) {
+        return act;
+    }
+
+    // GLM4-MOE / ChatGLM4: the draft graph builder accesses vision tensors that
+    // only exist when an mmproj companion is present. Without one, MTP
+    // speculative decoding crashes llama-server (see #2451) — embedded MTP
+    // included. Keep MTP inactive unless mmproj resolves or the model loads via
+    // -hf (llama-server resolves the companion itself).
+    const std::string arch_lower = [&]() {
+        std::string s = architecture;
+        std::transform(s.begin(), s.end(), s.begin(),
+                       [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+        return s;
+    }();
+    const bool is_glm4_moe =
+        arch_lower.find("glm4") != std::string::npos
+        || arch_lower.find("chatglm4") != std::string::npos;
+    if (is_glm4_moe && mmproj_path.empty() && !hf_load) {
+        return act;
+    }
+
+    // MTP activates. With an external drafter on disk emit --model-draft as
+    // well; an `mtp` label without one means the MTP weights are embedded in
+    // the main GGUF, so --spec-type draft-mtp alone is enough.
+    act.use_draft_checkpoint = has_external_draft;
+    act.spec_type = "draft-mtp";
     return act;
 }
 

--- a/src/cpp/server/backends/llamacpp/llamacpp_draft.cpp
+++ b/src/cpp/server/backends/llamacpp/llamacpp_draft.cpp
@@ -1,0 +1,50 @@
+#include "lemon/backends/llamacpp/llamacpp_draft.h"
+
+#include <algorithm>
+#include <cctype>
+
+namespace lemon {
+namespace backends {
+
+bool is_dflash_draft_checkpoint(const std::string& checkpoint) {
+    std::string lowered = checkpoint;
+    std::transform(lowered.begin(), lowered.end(), lowered.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+    const size_t separator = lowered.find_last_of("/:\\");
+    const std::string filename =
+        separator == std::string::npos ? lowered : lowered.substr(separator + 1);
+    return filename.rfind("dflash-", 0) == 0 || filename == "dflash.gguf";
+}
+
+namespace {
+bool has_label(const std::vector<std::string>& labels, const std::string& label) {
+    return std::find(labels.begin(), labels.end(), label) != labels.end();
+}
+} // namespace
+
+DraftActivation compute_draft_activation(const std::vector<std::string>& labels,
+                                         const std::string& draft_checkpoint,
+                                         bool draft_file_present) {
+    DraftActivation act;
+    if (!draft_file_present) {
+        // No drafter on disk: the base model runs without speculative decoding.
+        return act;
+    }
+
+    const bool has_dflash_label = has_label(labels, "dflash");
+    const bool has_mtp_label = has_label(labels, "mtp");
+    const bool is_dflash_draft = is_dflash_draft_checkpoint(draft_checkpoint);
+
+    if (is_dflash_draft && has_dflash_label) {
+        act.use_draft_checkpoint = true;
+        act.spec_type = "draft-dflash";
+    } else if (!is_dflash_draft && has_mtp_label) {
+        act.use_draft_checkpoint = true;
+        act.spec_type = "draft-mtp";
+    }
+
+    return act;
+}
+
+} // namespace backends
+} // namespace lemon

--- a/src/cpp/server/backends/llamacpp/llamacpp_server.cpp
+++ b/src/cpp/server/backends/llamacpp/llamacpp_server.cpp
@@ -117,7 +117,10 @@ static std::string resolve_llamacpp_runtime_args(const ModelInfo& model_info,
     const DraftActivation draft_activation = compute_draft_activation(
         model_info.labels,
         model_info.checkpoint("draft"),
-        draft_file_present);
+        draft_file_present,
+        model_info.gguf.architecture,
+        model_info.resolved_path("mmproj"),
+        model_info.extra<bool>("hf_load", false));
 
     if (draft_activation.spec_type == "draft-dflash") {
         defaults.push_back({"--spec-type draft-dflash", "--spec-type"});
@@ -362,7 +365,10 @@ void LlamaCppServer::load(const std::string& model_name,
         model_info.labels,
         model_info.checkpoint("draft"),
         !draft_path.empty() &&
-            lemon::backends::hf_cache::exists(path_from_utf8(draft_path)));
+            lemon::backends::hf_cache::exists(path_from_utf8(draft_path)),
+        model_info.gguf.architecture,
+        model_info.resolved_path("mmproj"),
+        model_info.extra<bool>("hf_load", false));
 
     if (draft_activation.use_draft_checkpoint) {
         push_arg(args, reserved_flags, "--model-draft", draft_path);

--- a/src/cpp/server/backends/llamacpp/llamacpp_server.cpp
+++ b/src/cpp/server/backends/llamacpp/llamacpp_server.cpp
@@ -358,9 +358,9 @@ void LlamaCppServer::load(const std::string& model_name,
 
     // A `draft` checkpoint is optional acceleration. Registration (the `draft`
     // checkpoint) and activation (the `mtp` / `dflash` label) are separate
-    // concerns: the label is the switch that enables speculative decoding, and
-    // a drafter is only wired into the llama-server invocation when it is both
-    // present on disk and enabled by its matching label (see #2435).
+    // concerns: --model-draft is only emitted when the drafter file is present
+    // on disk and enabled by its matching label. Embedded MTP (mtp label,
+    // no external drafter) emits --spec-type draft-mtp only (see #2435).
     const DraftActivation draft_activation = compute_draft_activation(
         model_info.labels,
         model_info.checkpoint("draft"),

--- a/src/cpp/server/backends/llamacpp/llamacpp_server.cpp
+++ b/src/cpp/server/backends/llamacpp/llamacpp_server.cpp
@@ -1,8 +1,10 @@
 #include "lemon/backends/llamacpp/llamacpp_server.h"
 #include "lemon/backends/llamacpp/llamacpp.h"
 #include "lemon/backends/llamacpp/llamacpp_gguf.h"
+#include "lemon/backends/llamacpp/llamacpp_draft.h"
 #include "lemon/backends/llamacpp/llamacpp_request.h"
 #include "llamacpp_system_utils.h"
+#include "lemon/backends/hf_cache_util.h"
 #include "lemon/backends/backend_registry.h"
 #include "lemon/backends/backend_ops.h"
 #include "lemon/backends/backend_utils.h"
@@ -101,16 +103,6 @@ static bool is_llamacpp_cuda_backend(const std::string& backend) {
     return backend == "cuda";
 }
 
-static bool is_dflash_draft_checkpoint(std::string checkpoint) {
-    std::transform(checkpoint.begin(), checkpoint.end(), checkpoint.begin(),
-                   [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
-    size_t separator = checkpoint.find_last_of("/:\\");
-    std::string filename = separator == std::string::npos
-                               ? checkpoint
-                               : checkpoint.substr(separator + 1);
-    return filename.rfind("dflash-", 0) == 0 || filename == "dflash.gguf";
-}
-
 static std::string resolve_llamacpp_runtime_args(const ModelInfo& model_info,
                                                  const std::string& custom_args,
                                                  bool merge_args) {
@@ -118,19 +110,18 @@ static std::string resolve_llamacpp_runtime_args(const ModelInfo& model_info,
 
     std::vector<RuntimeArgDefault> defaults;
 
-    const std::string draft_checkpoint = model_info.checkpoint("draft");
-    const bool has_dflash_label =
-        std::find(model_info.labels.begin(), model_info.labels.end(), "dflash") !=
-        model_info.labels.end();
-    const bool is_dflash_draft =
-        !draft_checkpoint.empty() && is_dflash_draft_checkpoint(draft_checkpoint);
-    const bool uses_mtp =
-        std::find(model_info.labels.begin(), model_info.labels.end(), "mtp") !=
-        model_info.labels.end();
+    const std::string draft_path = model_info.resolved_path("draft");
+    const bool draft_file_present =
+        !draft_path.empty() &&
+        hf_cache::exists(path_from_utf8(draft_path));
+    const DraftActivation draft_activation = compute_draft_activation(
+        model_info.labels,
+        model_info.checkpoint("draft"),
+        draft_file_present);
 
-    if (is_dflash_draft && has_dflash_label) {
+    if (draft_activation.spec_type == "draft-dflash") {
         defaults.push_back({"--spec-type draft-dflash", "--spec-type"});
-    } else if (uses_mtp) {
+    } else if (draft_activation.spec_type == "draft-mtp") {
         defaults.push_back({"--spec-type draft-mtp", "--spec-type"});
     }
 
@@ -362,14 +353,18 @@ void LlamaCppServer::load(const std::string& model_name,
     }
     push_reserved(reserved_flags, "--mmproj", std::vector<std::string>{"-mm", "-mmu", "--mmproj-url", "--no-mmproj", "--mmproj-auto", "--no-mmproj-auto"});
 
-    const bool has_dflash_label =
-        std::find(model_info.labels.begin(), model_info.labels.end(), "dflash") != model_info.labels.end();
-    const bool is_dflash_draft =
-        !draft_path.empty() && is_dflash_draft_checkpoint(model_info.checkpoint("draft"));
-    const bool use_draft_checkpoint =
-        !draft_path.empty() && (!is_dflash_draft || has_dflash_label);
+    // A `draft` checkpoint is optional acceleration. Registration (the `draft`
+    // checkpoint) and activation (the `mtp` / `dflash` label) are separate
+    // concerns: the label is the switch that enables speculative decoding, and
+    // a drafter is only wired into the llama-server invocation when it is both
+    // present on disk and enabled by its matching label (see #2435).
+    const DraftActivation draft_activation = compute_draft_activation(
+        model_info.labels,
+        model_info.checkpoint("draft"),
+        !draft_path.empty() &&
+            lemon::backends::hf_cache::exists(path_from_utf8(draft_path)));
 
-    if (use_draft_checkpoint) {
+    if (draft_activation.use_draft_checkpoint) {
         push_arg(args, reserved_flags, "--model-draft", draft_path);
     }
     push_reserved(reserved_flags, "--model-draft", std::vector<std::string>{"-md", "--spec-draft-model"});

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -2745,12 +2745,13 @@ static bool is_checkpoint_path_complete(const std::string& path_str) {
 /**
  * Returns true if all files required by the model recipe are present and complete.
  * Note: npu_cache is skipped as it is managed lazily by the flm-npu backend.
+ * Note: draft is skipped as it is an optional MTP checkpoint.
  */
 static bool are_required_checkpoints_complete(const ModelInfo& info) {
     for (const auto& [type, checkpoint] : info.checkpoints) {
         (void)checkpoint;
 
-        if (type == "npu_cache") continue;
+        if (type == "npu_cache" || type == "draft") continue;
 
         const std::string resolved_path = info.resolved_path(type);
         if (!is_checkpoint_path_complete(resolved_path)) {

--- a/test/cpp/test_llamacpp_draft.cpp
+++ b/test/cpp/test_llamacpp_draft.cpp
@@ -1,0 +1,105 @@
+// Test for lemon::backends::compute_draft_activation() — the pure decision
+// behind --model-draft / --spec-type emission in llama-server launches.
+// Build with: cmake --build --preset default --target test_llamacpp_draft
+// Run with: ctest --test-dir build -R llamacpp_draft --output-on-failure
+
+#include "lemon/backends/llamacpp/llamacpp_draft.h"
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using lemon::backends::DraftActivation;
+using lemon::backends::compute_draft_activation;
+using lemon::backends::is_dflash_draft_checkpoint;
+
+static bool expect_activation(const char* name,
+                              const DraftActivation& actual,
+                              bool want_use_draft,
+                              const std::string& want_spec_type) {
+    bool ok = actual.use_draft_checkpoint == want_use_draft &&
+              actual.spec_type == want_spec_type;
+    std::printf("[%s] %s\n  got:  use_draft=%s spec_type=\"%s\"\n"
+                "  want: use_draft=%s spec_type=\"%s\"\n",
+                ok ? "PASS" : "FAIL",
+                name,
+                actual.use_draft_checkpoint ? "true" : "false",
+                actual.spec_type.c_str(),
+                want_use_draft ? "true" : "false",
+                want_spec_type.c_str());
+    return ok;
+}
+
+static bool expect_dflash_checkpoint(const char* name,
+                                     const std::string& checkpoint,
+                                     bool want) {
+    bool ok = is_dflash_draft_checkpoint(checkpoint) == want;
+    std::printf("[%s] %s\n  got:  is_dflash(%s)=%s\n  want: %s\n",
+                ok ? "PASS" : "FAIL",
+                name,
+                checkpoint.c_str(),
+                is_dflash_draft_checkpoint(checkpoint) ? "true" : "false",
+                want ? "true" : "false");
+    return ok;
+}
+
+int main() {
+    int failures = 0;
+
+    // The three activation cases called out in review of PR #3253.
+    failures += !expect_activation(
+        "draft present + no mtp label -> inactive",
+        compute_draft_activation({}, "mtp-drafter.gguf", /*draft_file_present=*/true),
+        false, "");
+
+    failures += !expect_activation(
+        "draft missing + mtp label -> inactive",
+        compute_draft_activation({"mtp"}, "mtp-drafter.gguf", /*draft_file_present=*/false),
+        false, "");
+
+    failures += !expect_activation(
+        "draft present + mtp label -> --model-draft + --spec-type draft-mtp",
+        compute_draft_activation({"mtp"}, "mtp-drafter.gguf", /*draft_file_present=*/true),
+        true, "draft-mtp");
+
+    // DFlash stays gated on its own label.
+    failures += !expect_activation(
+        "dflash draft present + dflash label -> draft-dflash",
+        compute_draft_activation({"dflash"}, "dflash-v2.gguf", /*draft_file_present=*/true),
+        true, "draft-dflash");
+
+    failures += !expect_activation(
+        "dflash draft present + mtp label only -> inactive",
+        compute_draft_activation({"mtp"}, "dflash.gguf", /*draft_file_present=*/true),
+        false, "");
+
+    failures += !expect_activation(
+        "dflash draft present + no label -> inactive",
+        compute_draft_activation({}, "dflash.gguf", /*draft_file_present=*/true),
+        false, "");
+
+    // A plain (non-dflash) drafter with a dflash label but no mtp label must
+    // not activate MTP either: the label has to match the drafter kind.
+    failures += !expect_activation(
+        "mtp draft present + dflash label only -> inactive",
+        compute_draft_activation({"dflash"}, "mtp-drafter.gguf", /*draft_file_present=*/true),
+        false, "");
+
+    // Unrelated labels must not trigger activation.
+    failures += !expect_activation(
+        "draft present + unrelated labels -> inactive",
+        compute_draft_activation({"chat", "vision"}, "mtp-drafter.gguf", /*draft_file_present=*/true),
+        false, "");
+
+    // DFlash checkpoint-name detection (filename only, path separators ignored).
+    failures += !expect_dflash_checkpoint("dflash.gguf", "dflash.gguf", true);
+    failures += !expect_dflash_checkpoint("dflash-v2.gguf", "dflash-v2.gguf", true);
+    failures += !expect_dflash_checkpoint("mtp.gguf", "mtp.gguf", false);
+    failures += !expect_dflash_checkpoint("path/to/dflash.gguf", "path/to/dflash.gguf", true);
+    failures += !expect_dflash_checkpoint("backslash dflash-v2", "dir\\dflash-v2.gguf", true);
+    failures += !expect_dflash_checkpoint("case-insensitive", "Dflash-V2.gguf", true);
+    failures += !expect_dflash_checkpoint("prefix but not match", "mydflash.gguf", false);
+
+    std::printf("\n%d failures\n", failures);
+    return failures == 0 ? 0 : 1;
+}

--- a/test/cpp/test_llamacpp_draft.cpp
+++ b/test/cpp/test_llamacpp_draft.cpp
@@ -58,14 +58,14 @@ static bool expect_dflash_checkpoint(const char* name,
 int main() {
     int failures = 0;
 
-    // The three activation cases called out in review of PR #3253.
+    // The four activation cases called out in review of PR #3253.
     failures += !expect_activation(
         "draft present + no mtp label -> inactive",
         act({}, "mtp-drafter.gguf", /*draft_file_present=*/true),
         false, "");
 
     failures += !expect_activation(
-        "draft missing + mtp label -> inactive",
+        "configured draft missing + mtp label -> inactive",
         act({"mtp"}, "mtp-drafter.gguf", /*draft_file_present=*/false),
         false, "");
 
@@ -73,6 +73,19 @@ int main() {
         "draft present + mtp label -> --model-draft + --spec-type draft-mtp",
         act({"mtp"}, "mtp-drafter.gguf", /*draft_file_present=*/true),
         true, "draft-mtp");
+
+    // Embedded MTP: an mtp label without any external draft checkpoint means
+    // the MTP weights live in the main GGUF (Qwen3.5/3.6-*-MTP-GGUF, ...).
+    // Emit --spec-type draft-mtp only, no --model-draft.
+    failures += !expect_activation(
+        "mtp label + no external draft -> embedded MTP (spec-type only)",
+        act({"mtp"}, "", /*draft_file_present=*/false),
+        false, "draft-mtp");
+
+    failures += !expect_activation(
+        "mtp label + no external draft + draft present on disk -> still embedded (no --model-draft)",
+        act({"mtp"}, "", /*draft_file_present=*/true),
+        false, "draft-mtp");
 
     // DFlash stays gated on its own label.
     failures += !expect_activation(
@@ -115,6 +128,26 @@ int main() {
         act({"mtp"}, "mtp-drafter.gguf", /*draft_file_present=*/true,
             /*arch=*/"chatglm4"),
         false, "");
+
+    // GLM4-MOE embedded MTP (no external draft) without mmproj must stay
+    // MTP-inactive (crash guard, #2451).
+    failures += !expect_activation(
+        "glm4-moe embedded mtp + no mmproj -> inactive (crash guard)",
+        act({"mtp"}, "", /*draft_file_present=*/false,
+            /*arch=*/"glm4-moe"),
+        false, "");
+
+    failures += !expect_activation(
+        "glm4-moe embedded mtp + mmproj present -> draft-mtp (spec-type only)",
+        act({"mtp"}, "", /*draft_file_present=*/false,
+            /*arch=*/"glm4-moe", /*mmproj_path=*/"/models/mmproj-f16.gguf"),
+        false, "draft-mtp");
+
+    failures += !expect_activation(
+        "glm4-moe embedded mtp + hf_load -> draft-mtp (spec-type only)",
+        act({"mtp"}, "", /*draft_file_present=*/false,
+            /*arch=*/"glm4-moe", /*mmproj_path=*/"", /*hf_load=*/true),
+        false, "draft-mtp");
 
     // GLM4-MOE with an mmproj present is fine: MTP activates.
     failures += !expect_activation(

--- a/test/cpp/test_llamacpp_draft.cpp
+++ b/test/cpp/test_llamacpp_draft.cpp
@@ -13,6 +13,18 @@ using lemon::backends::DraftActivation;
 using lemon::backends::compute_draft_activation;
 using lemon::backends::is_dflash_draft_checkpoint;
 
+// Defaults that keep the GLM4-MOE mmproj guard out of the way for the
+// non-GLM4 cases below.
+static DraftActivation act(const std::vector<std::string>& labels,
+                           const std::string& checkpoint,
+                           bool draft_present,
+                           const std::string& arch = "qwen3",
+                           const std::string& mmproj_path = "",
+                           bool hf_load = false) {
+    return compute_draft_activation(labels, checkpoint, draft_present,
+                                    arch, mmproj_path, hf_load);
+}
+
 static bool expect_activation(const char* name,
                               const DraftActivation& actual,
                               bool want_use_draft,
@@ -49,47 +61,88 @@ int main() {
     // The three activation cases called out in review of PR #3253.
     failures += !expect_activation(
         "draft present + no mtp label -> inactive",
-        compute_draft_activation({}, "mtp-drafter.gguf", /*draft_file_present=*/true),
+        act({}, "mtp-drafter.gguf", /*draft_file_present=*/true),
         false, "");
 
     failures += !expect_activation(
         "draft missing + mtp label -> inactive",
-        compute_draft_activation({"mtp"}, "mtp-drafter.gguf", /*draft_file_present=*/false),
+        act({"mtp"}, "mtp-drafter.gguf", /*draft_file_present=*/false),
         false, "");
 
     failures += !expect_activation(
         "draft present + mtp label -> --model-draft + --spec-type draft-mtp",
-        compute_draft_activation({"mtp"}, "mtp-drafter.gguf", /*draft_file_present=*/true),
+        act({"mtp"}, "mtp-drafter.gguf", /*draft_file_present=*/true),
         true, "draft-mtp");
 
     // DFlash stays gated on its own label.
     failures += !expect_activation(
         "dflash draft present + dflash label -> draft-dflash",
-        compute_draft_activation({"dflash"}, "dflash-v2.gguf", /*draft_file_present=*/true),
+        act({"dflash"}, "dflash-v2.gguf", /*draft_file_present=*/true),
         true, "draft-dflash");
 
     failures += !expect_activation(
         "dflash draft present + mtp label only -> inactive",
-        compute_draft_activation({"mtp"}, "dflash.gguf", /*draft_file_present=*/true),
+        act({"mtp"}, "dflash.gguf", /*draft_file_present=*/true),
         false, "");
 
     failures += !expect_activation(
         "dflash draft present + no label -> inactive",
-        compute_draft_activation({}, "dflash.gguf", /*draft_file_present=*/true),
+        act({}, "dflash.gguf", /*draft_file_present=*/true),
         false, "");
 
     // A plain (non-dflash) drafter with a dflash label but no mtp label must
     // not activate MTP either: the label has to match the drafter kind.
     failures += !expect_activation(
         "mtp draft present + dflash label only -> inactive",
-        compute_draft_activation({"dflash"}, "mtp-drafter.gguf", /*draft_file_present=*/true),
+        act({"dflash"}, "mtp-drafter.gguf", /*draft_file_present=*/true),
         false, "");
 
     // Unrelated labels must not trigger activation.
     failures += !expect_activation(
         "draft present + unrelated labels -> inactive",
-        compute_draft_activation({"chat", "vision"}, "mtp-drafter.gguf", /*draft_file_present=*/true),
+        act({"chat", "vision"}, "mtp-drafter.gguf", /*draft_file_present=*/true),
         false, "");
+
+    // GLM4-MOE without mmproj must stay MTP-inactive (crash guard, #2451).
+    failures += !expect_activation(
+        "glm4-moe + mtp label + no mmproj -> inactive (crash guard)",
+        act({"mtp"}, "mtp-drafter.gguf", /*draft_file_present=*/true,
+            /*arch=*/"glm4-moe"),
+        false, "");
+
+    failures += !expect_activation(
+        "chatglm4 + mtp label + no mmproj -> inactive (crash guard)",
+        act({"mtp"}, "mtp-drafter.gguf", /*draft_file_present=*/true,
+            /*arch=*/"chatglm4"),
+        false, "");
+
+    // GLM4-MOE with an mmproj present is fine: MTP activates.
+    failures += !expect_activation(
+        "glm4-moe + mtp label + mmproj present -> draft-mtp",
+        act({"mtp"}, "mtp-drafter.gguf", /*draft_file_present=*/true,
+            /*arch=*/"glm4-moe", /*mmproj_path=*/"/models/mmproj-f16.gguf"),
+        true, "draft-mtp");
+
+    // GLM4-MOE loaded via -hf: llama-server resolves mmproj itself -> MTP ok.
+    failures += !expect_activation(
+        "glm4-moe + mtp label + hf_load -> draft-mtp",
+        act({"mtp"}, "mtp-drafter.gguf", /*draft_file_present=*/true,
+            /*arch=*/"glm4-moe", /*mmproj_path=*/"", /*hf_load=*/true),
+        true, "draft-mtp");
+
+    // Case-insensitive architecture matching (GLM4 vs glm4).
+    failures += !expect_activation(
+        "GLM4 (uppercase) + mtp label + no mmproj -> inactive",
+        act({"mtp"}, "mtp-drafter.gguf", /*draft_file_present=*/true,
+            /*arch=*/"GLM4"),
+        false, "");
+
+    // Non-GLM4 architectures are unaffected by the crash guard.
+    failures += !expect_activation(
+        "gemma-4 + mtp label + no mmproj -> draft-mtp (text-only ok)",
+        act({"mtp"}, "mtp-drafter.gguf", /*draft_file_present=*/true,
+            /*arch=*/"gemma4"),
+        true, "draft-mtp");
 
     // DFlash checkpoint-name detection (filename only, path separators ignored).
     failures += !expect_dflash_checkpoint("dflash.gguf", "dflash.gguf", true);

--- a/test/cpp/test_model_download_state.cpp
+++ b/test/cpp/test_model_download_state.cpp
@@ -213,6 +213,36 @@ static void test_collection_component_download_state(
           !manager.get_model_info("user.coll-test").downloaded);
 }
 
+static void test_optional_draft_checkpoint_not_required(
+    ModelManager& manager, const fs::path& root) {
+    // A `draft` checkpoint is optional acceleration (#2435): a model whose
+    // `main` checkpoint is present must still be reported as downloaded when
+    // its `draft` checkpoint is missing, so auto-load does not treat an absent
+    // drafter as a missing required file.
+    fs::path main_path = root / "optional-draft" / "main.gguf";
+    fs::path draft_path = root / "optional-draft" / "draft.gguf";
+
+    ModelInfo info;
+    info.recipe = "llamacpp";
+    info.checkpoints = {{"main", "main"}, {"draft", "draft"}};
+    info.resolved_paths = {
+        {"main", path_to_utf8(main_path)},
+        {"draft", path_to_utf8(draft_path)},
+    };
+
+    write_file(main_path, "GGUF");
+    check("optional draft: main present + draft missing is downloaded",
+          manager.checkpoints_complete(info));
+
+    write_file(draft_path, "GGUF");
+    check("optional draft: main + draft present is downloaded",
+          manager.checkpoints_complete(info));
+
+    fs::remove(main_path);
+    check("optional draft: main missing + draft present is incomplete",
+          !manager.checkpoints_complete(info));
+}
+
 int main() {
     fs::path temp = make_temp_dir();
     fs::path hf_root = temp / "hf";
@@ -231,6 +261,7 @@ int main() {
         test_hf_manifest_marks_variant_incomplete(manager, fixtures);
         test_variantless_snapshot_commit_state(manager, fixtures);
         test_collection_component_download_state(manager, fixtures);
+        test_optional_draft_checkpoint_not_required(manager, temp);
     }
 
     fs::remove_all(temp);


### PR DESCRIPTION
Re-opened cleanly from the closed stacked PR #2465 (that branch was stacked on #2452's base; this is just the draft-checkpoint commit on current main).

Follow-up to #2435.

`are_required_checkpoints_complete()` iterated all checkpoint types including the optional `draft` MTP checkpoint, so a missing/stale draft model made the whole model appear not-downloaded (invisible in UI, unusable). Now skips `draft` checkpoints the same way `npu_cache` is skipped.

To keep the runtime consistent with that optional-draft semantics, `llamacpp_server.cpp` now only passes `--model-draft` / `--spec-type draft-mtp` (and the dflash equivalent) when the draft file actually resolves on disk — a missing drafter now loads and runs normally instead of failing llama-server startup.

Added regression coverage in `test_multi_checkpoint_completeness.py` asserting a main-only model is reported downloaded while main remains required.

---

**Update: merged the GLM4-MOE crash guard from #3255 into this PR** (both touched the same draft-activation path).

`compute_draft_activation()` now also gates MTP on mmproj presence (see #2451): GLM4-MOE / ChatGLM4 embed MTP layers in the GGUF but their draft graph builder accesses vision tensors that only exist when an mmproj companion is present — without one, MTP speculative decoding crashes llama-server. For those architectures MTP stays inactive unless mmproj resolves or the model is loaded via `-hf`. Text-only MTP models (Gemma-4, Qwen3.x) are unaffected. Case-insensitive architecture match; covered by new unit cases in `test_llamacpp_draft.cpp`.