### PR TITLE
fix: strip mtp label for GLM-4 architecture to prevent MTP crash (#2451)

### DIFF
--- a/src/cpp/server/backends/llamacpp/llamacpp_server.cpp
+++ b/src/cpp/server/backends/llamacpp/llamacpp_server.cpp
@@ -868,6 +868,20 @@ public:
         // reclassify the model away from its endpoint type.
         if (info.type == ModelType::LLM) {
             apply_gguf_capability_labels(info.labels, info.gguf.caps);
+            // GLM-4 MoE models crash with MTP speculative decoding because
+            // the GGUF conversion doesn't include multimodal metadata the graph
+            // builder expects when constructing the draft context. Strip the
+            // mtp label until upstream llama.cpp fixes glm4-moe.cpp draft
+            // context construction. See #2451, #2621.
+            std::string arch_lower = info.gguf.architecture;
+            std::transform(arch_lower.begin(), arch_lower.end(),
+                           arch_lower.begin(), ::tolower);
+            if (arch_lower.find("glm4") == 0) {
+                auto it = std::remove(info.labels.begin(), info.labels.end(), "mtp");
+                if (it != info.labels.end()) {
+                    info.labels.erase(it, info.labels.end());
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Re-opened cleanly from the closed stacked PR #2621 (that branch carried the unmerged mlx-engine backend; this is just the GLM-4 MTP-strip commit on current main).

Fixes #2451.

GLM-4 MoE models (e.g. GLM-4.5-Air) embed MTP layers in the GGUF, which triggers `draft-mtp` speculative decoding — but the GLM-4 MoE graph builder in llama.cpp asserts on missing multimodal metadata when constructing the MTP draft context, crashing on first prompt. After `apply_gguf_capability_labels()`, strip the `mtp` label for GGUF architectures starting with `glm4` (case-insensitive) until upstream fixes glm4-moe.cpp.