### PR TITLE
docs: document draft checkpoint key and add MTP model example (#2435)

### DIFF
--- a/docs/guide/configuration/custom-models.md
+++ b/docs/guide/configuration/custom-models.md
@@ -101,7 +101,7 @@ Supported registration flags:
 | Flag | Description |
 |------|-------------|
 | `--source SOURCE` | Remote registry for every checkpoint in this model: `huggingface` or `modelscope`. When omitted, the server's configured `default_model_source` applies. |
-| `--checkpoint TYPE CHECKPOINT` | Add a checkpoint entry. Repeat for multi-file models such as `main` + `mmproj`, `main` + `vae`, or `main` + `draft`. Known types: `main`, `mmproj`, `vae`, `draft`, `text_encoder`, `npu_cache`. |
+| `--checkpoint TYPE CHECKPOINT` | Add a checkpoint entry. Repeat for multi-file models. Known types: `main`, `mmproj`, `vae`, `draft`, `text_encoder`, `npu_cache`. |
 | `--recipe RECIPE` | Recipe to associate with the new `user.*` model. Common values: <!-- BEGIN GENERATED: recipe-values -->`llamacpp`, `whispercpp`, `moonshine`, `kokoro`, `sd-cpp`, `flm`, `ryzenai-llm`, `vllm`, `thenoise`, `thinksound`, `acestep`, `onnxruntime`, `trellis`, `openmoss`, `collection.omni`<!-- END GENERATED: recipe-values -->. |
 | `--label LABEL` | Add a label to the new model. Repeatable. Valid labels include `chat`, `coding`, `dflash`, `embeddings`, `hot`, `mtp`, `reasoning`, `reranking`, `tool-calling`, `vision`. When no [deployment label](../../api/openai.md#model-labels) is given, the recipe's default is added — `chat` for `llamacpp`, `flm`, `ryzenai-llm` and `vllm`; `transcription` for `whispercpp`; `image` for `sd-cpp`; and so on. |
 | `--components MODEL [MODEL ...]` | Components for an omni collection (see below). Use with `--recipe collection.omni`. |

--- a/docs/guide/configuration/custom-models.md
+++ b/docs/guide/configuration/custom-models.md
@@ -81,12 +81,27 @@ lemonade pull user.MyCodingModel \
     --label tool-calling
 ```
 
+### Multi-Token Prediction (MTP) models
+
+Models with a separate MTP head / draft checkpoint file (e.g. Gemma 4) can be registered with an optional `draft` checkpoint. The `mtp` label enables `--spec-type draft-mtp` for speculative decoding acceleration. The `draft` checkpoint is optional — without it, the model loads and runs normally but without MTP acceleration.
+
+```bash
+lemonade pull user.My-Gemma-4-MTP \
+    --checkpoint main unsloth/Gemma-4-27B-IT-GGUF:Q4_K_M \
+    --checkpoint draft unsloth/Gemma-4-27B-IT-MTP-GGUF:gemma-4-27b-mtp-q4_k_m.gguf \
+    --checkpoint mmproj unsloth/Gemma-4-27B-IT-GGUF:mmproj-model-f16.gguf \
+    --recipe llamacpp \
+    --label mtp \
+    --label vision \
+    --label tool-calling
+```
+
 Supported registration flags:
 
 | Flag | Description |
 |------|-------------|
 | `--source SOURCE` | Remote registry for every checkpoint in this model: `huggingface` or `modelscope`. When omitted, the server's configured `default_model_source` applies. |
-| `--checkpoint TYPE CHECKPOINT` | Add a checkpoint entry. Repeat for multi-file models such as `main` + `mmproj` or `main` + `vae`. |
+| `--checkpoint TYPE CHECKPOINT` | Add a checkpoint entry. Repeat for multi-file models such as `main` + `mmproj`, `main` + `vae`, or `main` + `draft`. Known types: `main`, `mmproj`, `vae`, `draft`, `npu_cache`. |
 | `--recipe RECIPE` | Recipe to associate with the new `user.*` model. Common values: <!-- BEGIN GENERATED: recipe-values -->`llamacpp`, `whispercpp`, `moonshine`, `kokoro`, `sd-cpp`, `flm`, `ryzenai-llm`, `vllm`, `thenoise`, `thinksound`, `acestep`, `onnxruntime`, `trellis`, `openmoss`, `collection.omni`<!-- END GENERATED: recipe-values -->. |
 | `--label LABEL` | Add a label to the new model. Repeatable. Valid labels include `chat`, `coding`, `dflash`, `embeddings`, `hot`, `mtp`, `reasoning`, `reranking`, `tool-calling`, `vision`. When no [deployment label](../../api/openai.md#model-labels) is given, the recipe's default is added — `chat` for `llamacpp`, `flm`, `ryzenai-llm` and `vllm`; `transcription` for `whispercpp`; `image` for `sd-cpp`; and so on. |
 | `--components MODEL [MODEL ...]` | Components for an omni collection (see below). Use with `--recipe collection.omni`. |
@@ -421,6 +436,7 @@ Supported checkpoint keys:
 | Key | Used by | Description |
 |-----|---------|-------------|
 | `main` | All | Primary model file |
+| `draft` | llamacpp | Optional MTP head / draft checkpoint for speculative decoding |
 | `npu_cache` | whispercpp | NPU-accelerated encoder cache |
 | `text_encoder` | sd-cpp | Text encoder for image generation models |
 | `vae` | sd-cpp | VAE for image generation models |

--- a/docs/guide/configuration/custom-models.md
+++ b/docs/guide/configuration/custom-models.md
@@ -83,13 +83,13 @@ lemonade pull user.MyCodingModel \
 
 ### Multi-Token Prediction (MTP) models
 
-Models with a separate MTP head / draft checkpoint file (e.g. Gemma 4) can be registered with an optional `draft` checkpoint. The `mtp` label enables `--spec-type draft-mtp` for speculative decoding acceleration. The `draft` checkpoint is optional — without it, the model loads and runs normally but without MTP acceleration.
+Models with a separate MTP head / draft checkpoint file (e.g. Gemma 4) can be registered with an optional `draft` checkpoint. When the `draft` checkpoint is present, the `mtp` label enables `--spec-type draft-mtp` for speculative decoding acceleration. The `draft` checkpoint is optional — without it, the model loads and runs normally, just without MTP acceleration.
 
 ```bash
 lemonade pull user.My-Gemma-4-MTP \
-    --checkpoint main unsloth/Gemma-4-27B-IT-GGUF:Q4_K_M \
-    --checkpoint draft unsloth/Gemma-4-27B-IT-MTP-GGUF:gemma-4-27b-mtp-q4_k_m.gguf \
-    --checkpoint mmproj unsloth/Gemma-4-27B-IT-GGUF:mmproj-model-f16.gguf \
+    --checkpoint main unsloth/gemma-4-26B-A4B-it-GGUF:UD-Q4_K_M \
+    --checkpoint draft unsloth/gemma-4-26B-A4B-it-GGUF:mtp-gemma-4-26B-A4B-it.gguf \
+    --checkpoint mmproj unsloth/gemma-4-26B-A4B-it-GGUF:mmproj-F16.gguf \
     --recipe llamacpp \
     --label mtp \
     --label vision \
@@ -101,7 +101,7 @@ Supported registration flags:
 | Flag | Description |
 |------|-------------|
 | `--source SOURCE` | Remote registry for every checkpoint in this model: `huggingface` or `modelscope`. When omitted, the server's configured `default_model_source` applies. |
-| `--checkpoint TYPE CHECKPOINT` | Add a checkpoint entry. Repeat for multi-file models such as `main` + `mmproj`, `main` + `vae`, or `main` + `draft`. Known types: `main`, `mmproj`, `vae`, `draft`, `npu_cache`. |
+| `--checkpoint TYPE CHECKPOINT` | Add a checkpoint entry. Repeat for multi-file models such as `main` + `mmproj`, `main` + `vae`, or `main` + `draft`. Known types: `main`, `mmproj`, `vae`, `draft`, `text_encoder`, `npu_cache`. |
 | `--recipe RECIPE` | Recipe to associate with the new `user.*` model. Common values: <!-- BEGIN GENERATED: recipe-values -->`llamacpp`, `whispercpp`, `moonshine`, `kokoro`, `sd-cpp`, `flm`, `ryzenai-llm`, `vllm`, `thenoise`, `thinksound`, `acestep`, `onnxruntime`, `trellis`, `openmoss`, `collection.omni`<!-- END GENERATED: recipe-values -->. |
 | `--label LABEL` | Add a label to the new model. Repeatable. Valid labels include `chat`, `coding`, `dflash`, `embeddings`, `hot`, `mtp`, `reasoning`, `reranking`, `tool-calling`, `vision`. When no [deployment label](../../api/openai.md#model-labels) is given, the recipe's default is added — `chat` for `llamacpp`, `flm`, `ryzenai-llm` and `vllm`; `transcription` for `whispercpp`; `image` for `sd-cpp`; and so on. |
 | `--components MODEL [MODEL ...]` | Components for an omni collection (see below). Use with `--recipe collection.omni`. |


### PR DESCRIPTION
Re-opened as the clean docs-only PR @fl0rianr requested on #2469 (that branch carried the unmerged mlx-engine backend; the code half — skipping the optional `draft` checkpoint — is now its own PR #3253).

Follow-up to #2435.

- Checkpoint keys table: adds `draft` as a known type alongside `main`, `npu_cache`, etc.
- New "Multi-Token Prediction (MTP) models" section: `user.Gemma-4-MTP` registration example with `draft` checkpoint, `mtp` label, and `mmproj` — using the verified `unsloth/gemma-4-26B-A4B-it-GGUF` repo.
- `--checkpoint` flag help: documents `draft` and lists known types (including `text_encoder`).