### PR TITLE
feat(cli): add --json output to lemonade cloud list

### DIFF
--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -724,8 +724,14 @@ lemonade cloud clear PROVIDER
 Print every installed cloud provider with its base URL, the canonical env-var name, current auth status (`env_var_set`, `runtime_key_set`), and the number of models discovered.
 
 ```bash
-lemonade cloud list
+lemonade cloud list [--json]
 ```
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--json` | Emit the provider list as a JSON array instead of human-readable text | Human-readable text |
+
+With `--json`, stdout is a JSON array of provider objects (the same `cloud.providers` payload from `/v1/system-info`). An empty installation emits `[]`. Fields include `name`, `base_url`, `allow_insecure_http`, `env_var`, `env_var_set`, `runtime_key_set`, and `models_discovered`. API keys are never included.
 
 ## Options for scan
 

--- a/src/cpp/cli/lemonade_client.cpp
+++ b/src/cpp/cli/lemonade_client.cpp
@@ -1262,15 +1262,19 @@ int LemonadeClient::cloud_auth_clear(const std::string& provider) {
     }
 }
 
-int LemonadeClient::cloud_list() const {
+int LemonadeClient::cloud_list(bool json_output) const {
     try {
         std::string response = make_request("/api/v1/system-info", "GET");
         auto info = json::parse(response);
-        if (!info.contains("cloud") || !info["cloud"].contains("providers")) {
-            std::cout << "No cloud providers installed." << std::endl;
+        json providers = json::array();
+        if (info.contains("cloud") && info["cloud"].contains("providers") &&
+            info["cloud"]["providers"].is_array()) {
+            providers = info["cloud"]["providers"];
+        }
+        if (json_output) {
+            std::cout << providers.dump() << std::endl;
             return 0;
         }
-        const auto& providers = info["cloud"]["providers"];
         if (providers.empty()) {
             std::cout << "No cloud providers installed." << std::endl;
             return 0;

--- a/src/cpp/cli/main.cpp
+++ b/src/cpp/cli/main.cpp
@@ -1328,6 +1328,7 @@ int main(int argc, char* argv[]) {
     cloud_clear_cmd->add_option("provider", config.cloud_provider, "Provider name")->required()->type_name("PROVIDER");
 
     CLI::App* cloud_list_cmd = cloud_cmd->add_subcommand("list", "List installed cloud providers")->group("Subcommands");
+    cloud_list_cmd->add_flag("--json", config.json_output, "Output providers as JSON");
 
     // Pull options
     pull_cmd->add_option("model", config.model,
@@ -1641,7 +1642,7 @@ int main(int argc, char* argv[]) {
             return client.cloud_auth_clear(config.cloud_provider);
         }
         if (cloud_list_cmd->count() > 0) {
-            return client.cloud_list();
+            return client.cloud_list(config.json_output);
         }
         // No subcommand specified: print help.
         std::cout << cloud_cmd->help() << std::endl;

--- a/src/cpp/include/lemon_cli/lemonade_client.h
+++ b/src/cpp/include/lemon_cli/lemonade_client.h
@@ -120,7 +120,7 @@ public:
                    const std::string& api_key,
                    bool allow_insecure_http = false);
     int cloud_auth_clear(const std::string& provider);
-    int cloud_list() const;
+    int cloud_list(bool json_output = false) const;
 
     // Cache management
     int cleanup_cache(bool dry_run) const;

--- a/test/server_cli2.py
+++ b/test/server_cli2.py
@@ -6,6 +6,7 @@ Tests the lemonade CLI client commands (HTTP client for Lemonade Server):
 - list
 - export
 - backends
+- cloud
 - import (from JSON file)
 - pull with labels and checkpoints
 - load
@@ -576,6 +577,51 @@ sys.exit(0)
         """Test backends uninstall."""
         result = self.assertCommandSucceeds(["backends", "uninstall", "llamacpp:cpu"])
         print(f"Backends uninstall exit code: {result.returncode}")
+
+    # =============================================================================
+    # Cloud Tests
+    # =============================================================================
+
+    def test_046_cloud_list_json(self):
+        """Test `cloud list --json` emits the provider array from system-info."""
+        result = self.assertCommandSucceeds(["cloud", "list", "--json"])
+        providers = json.loads(result.stdout)
+        self.assertIsInstance(providers, list)
+
+        provider = "clijsonprobe"
+        base_url = "https://example.invalid/v1"
+        try:
+            self.assertCommandSucceeds(
+                ["cloud", "install", provider, "--base-url", base_url]
+            )
+            result = self.assertCommandSucceeds(["cloud", "list", "--json"])
+            providers = json.loads(result.stdout)
+            self.assertIsInstance(providers, list)
+            entry = next((p for p in providers if p.get("name") == provider), None)
+            self.assertIsNotNone(entry, f"{provider} missing from {providers}")
+            for key in (
+                "name",
+                "base_url",
+                "env_var",
+                "env_var_set",
+                "runtime_key_set",
+                "models_discovered",
+                "allow_insecure_http",
+            ):
+                self.assertIn(key, entry)
+            self.assertEqual(entry["base_url"], base_url)
+            self.assertEqual(entry["env_var"], "LEMONADE_CLIJSONPROBE_API_KEY")
+            self.assertFalse(entry["env_var_set"])
+            self.assertFalse(entry["runtime_key_set"])
+            self.assertEqual(entry["models_discovered"], 0)
+            self.assertFalse(entry["allow_insecure_http"])
+
+            human = self.assertCommandSucceeds(["cloud", "list"])
+            with self.assertRaises(json.JSONDecodeError):
+                json.loads(human.stdout)
+            self.assertIn(provider, human.stdout)
+        finally:
+            run_cli_command(["cloud", "uninstall", provider])
 
     # =============================================================================
     # Runtime Config Tests


### PR DESCRIPTION
Lemonade cloud list can show the info in json format.

This PR Fixes #3239  it allows getting cloud models info on a json format.

## Summary
It adds a flag (--json) that formats the output of  lemonade cloud list  

If there are no cloud models, it returns [].
If models are found, it will print the same information as the CLI version to maintain consistency ( that is,  the  data received in info["cloud"]["providers"] from /api/v1/system-info endpoint).

<img width="985" height="705" alt="image" src="https://github.com/user-attachments/assets/8484d7cb-1a86-4211-8734-419c1f47ed73" />

The main changes are : 

- Added the flag at cli/main.cpp
- Updated the LemonadeClient::cloud_list function, now it has a bool arg to decide whether  print models as json or as usual.  
That function, made a GET request to endpoint:  /api/v1/system-info  and then it  proccessed the response. Now, it also checks that providers json tag is an array before getting models.
- Updated lemonade_client.h , it added the previous bool arg to the header definition of the function.
- Added a new test on server_cli2.py that adds an unreal cloud model and then call to the new cli function.
- Updated documentation cli.md . It was added info about the new option


Fixes #3239 

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [ ] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_

1.  Test with no cloud models
<img width="719" height="104" alt="image" src="https://github.com/user-attachments/assets/c819968c-3739-4ea7-add3-439910eb0b7b" />

2. Test with a unreal model added
Preparing the environment.
<img width="1147" height="123" alt="image" src="https://github.com/user-attachments/assets/9916a92b-e167-47ff-9660-582b0126e6be" />
Making the call to lemonade
<img width="1658" height="274" alt="image" src="https://github.com/user-attachments/assets/b5f0cffd-3864-49ab-b593-3811853c4723" />

I also tested with server_cli2.py  => def test_046_cloud_list_json(self):


## Documentation
- [ ] Documentation is not affected by this change.
- [x] Documentation is affected and has been updated.
- [ ] Documentation is affected but will be handled in a separate PR or issue.



## Breaking Changes
- [ ] This PR introduces breaking changes.
- [x] This PR does not introduce breaking changes.


## AI-assisted contribution

Please select one:

- [x] I used AI tools for this PR.
- [ ] I did not use AI tools for this PR.
- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.

I used AI to do some invetigation, generate a proposal,  the testing and the doc. I reviewed the proposed changes manually ( it is a little PR ) and i think they are correct.