### PR TITLE
fix(gui): refactor memory settings to be server owned

### DIFF
--- a/src/app/src/components/ChatView.tsx
+++ b/src/app/src/components/ChatView.tsx
@@ -66,7 +66,6 @@ import {
   GLOBAL_MODEL_SETTINGS_EVENT,
   loadGlobalModelSettings,
   loadPinnedModelNames,
-  loadWithGlobalModelPolicy,
   savePinnedModelNames,
 } from '../features/modelSettings/globalModelSettings';
 
@@ -1761,21 +1760,20 @@ const ChatView: React.FC<ChatViewProps> = ({
 
   useEffect(() => () => stopAutoSpeech(), [stopAutoSpeech]);
 
-  const loadModelWithPolicy = useCallback(async (
+  const loadModelForChat = useCallback(async (
     modelName: string,
     info: ModelInfo | null,
     recipeOptions?: Record<string, unknown>,
   ) => {
     const api = await getApiClient();
-    let currentLoaded = loadedModels;
-    try {
-      currentLoaded = (await api.health()).all_models_loaded || loadedModels;
-    } catch {
-      // The render snapshot is still sufficient when a health refresh is not
-      // available (for example during a short reconnect window).
-    }
     const target = info || findModelInfoByName(knownModelInfos, modelName) || null;
     if (isRouterModelInfo(target)) {
+      let currentLoaded = loadedModels;
+      try {
+        currentLoaded = (await api.health()).all_models_loaded || loadedModels;
+      } catch {
+        // The render snapshot is sufficient if health is briefly unavailable.
+      }
       const fresh = await api.models(true).catch(() => ({ data: knownModelInfos }));
       const available = [...fresh.data, ...knownModelInfos].filter((item, index, list) => {
         const name = modelInfoName(item).toLowerCase();
@@ -1785,16 +1783,8 @@ const ChatView: React.FC<ChatViewProps> = ({
       if (!preflight.ok) throw new Error(routerPreflightError(preflight));
       return { mode: 'router', status: 'ready', virtual: true };
     }
-    return loadWithGlobalModelPolicy({
-      loadedModels: currentLoaded,
-      allModels: knownModelInfos,
-      target,
-      pinnedNames: loadPinnedModelNames(),
-      settings: globalModelSettings,
-      unload: name => api.unloadModel(name),
-      load: () => api.loadModel(modelName, recipeOptions, target),
-    });
-  }, [globalModelSettings, knownModelInfos, loadedModels]);
+    return api.loadModel(modelName, recipeOptions, target);
+  }, [knownModelInfos, loadedModels]);
 
   const waitForExistingModelDownload = useCallback(async (modelName: string, convoId: string): Promise<boolean> => {
     const [{ downloadStore }, api] = await Promise.all([getDownloadStoreModule(), getApiClient()]);
@@ -1932,7 +1922,7 @@ const ChatView: React.FC<ChatViewProps> = ({
     }
 
     setModelPreparations(prev => ({ ...prev, [convoId]: { modelName, phase: 'loading', percent: 100 } }));
-    await loadModelWithPolicy(modelName, info || initialInfo);
+    await loadModelForChat(modelName, info || initialInfo);
     await Promise.resolve(onRefresh());
     health = await api.health();
     loaded = loadedFrom(health.all_models_loaded || []);
@@ -1945,7 +1935,7 @@ const ChatView: React.FC<ChatViewProps> = ({
     return snapshotFromLoaded(loaded)
       || snapshotFromModelInfo(info || initialInfo)
       || snapshotFromName(modelName, [loaded])!;
-  }, [knownModelInfos, loadModelWithPolicy, onModelSelect, onRefresh, waitForExistingModelDownload]);
+  }, [knownModelInfos, loadModelForChat, onModelSelect, onRefresh, waitForExistingModelDownload]);
 
   const speakWithPinnedTts = useCallback(async (text: string, source: 'assistant' | 'user', force = false) => {
     const trimmed = text.trim();
@@ -1959,7 +1949,7 @@ const ChatView: React.FC<ChatViewProps> = ({
       const api = await getApiClient();
       const isLoaded = loadedModels.some(model => model.model_name.toLowerCase() === modelName.toLowerCase());
       if (!isLoaded) {
-        await loadModelWithPolicy(modelName, findModelInfoByName(knownModelInfos, modelName) || null);
+        await loadModelForChat(modelName, findModelInfoByName(knownModelInfos, modelName) || null);
       }
       const modelInfo = findModelInfoByName(knownModelInfos, modelName);
       const modelRecipe = String(
@@ -1984,7 +1974,7 @@ const ChatView: React.FC<ChatViewProps> = ({
     } catch (err) {
       console.warn(`Could not play ${source} text with TTS model:`, err);
     }
-  }, [knownModelInfos, loadModelWithPolicy, loadedModels, stopAutoSpeech, ttsPlaybackSettings.modelName, ttsPlaybackSettings.playbackMode, ttsPlaybackSettings.speakUserText]);
+  }, [knownModelInfos, loadModelForChat, loadedModels, stopAutoSpeech, ttsPlaybackSettings.modelName, ttsPlaybackSettings.playbackMode, ttsPlaybackSettings.speakUserText]);
 
   // Streaming hook — owns token buffer, flush interval, abort controllers
   const handleStreamDone = useCallback((convoId: string, stats: ChatCompletionStats, toolCalls?: ToolCallEntry[]) => {
@@ -2503,7 +2493,7 @@ ${finalText}`
           if (!model3dSettings.imageModel) throw new Error('Choose a downloaded image model for the text-to-3D reference step.');
           const imageInfo = findModelInfoByName(knownModelInfos, model3dSettings.imageModel) || null;
           if (!loadedModels.some(item => item.model_name.toLowerCase() === model3dSettings.imageModel.toLowerCase())) {
-            await loadModelWithPolicy(model3dSettings.imageModel, imageInfo);
+            await loadModelForChat(model3dSettings.imageModel, imageInfo);
           }
           const references = await api.imageGeneration(
             model3dSettings.imageModel,
@@ -2512,7 +2502,7 @@ ${finalText}`
           );
           referenceImage = references[0];
           generatedReference = [referenceImage];
-          await loadModelWithPolicy(model.name, findModelInfoByName(knownModelInfos, model.name) || null);
+          await loadModelForChat(model.name, findModelInfoByName(knownModelInfos, model.name) || null);
         } else if (!referenceImage) {
           throw new Error('Image-to-3D needs one reference image.');
         }
@@ -2548,7 +2538,7 @@ ${finalText}`
             targetModel = openMossVoiceDesignModel;
             if (openMossCloneModel) {
               if (!loadedModels.some(item => item.model_name.toLowerCase() === openMossVoiceDesignModel.toLowerCase())) {
-                await loadModelWithPolicy(
+                await loadModelForChat(
                   openMossVoiceDesignModel,
                   findModelInfoByName(knownModelInfos, openMossVoiceDesignModel) || null,
                 );
@@ -2580,7 +2570,7 @@ ${finalText}`
           }
 
           if (reloadTargetAfterVoiceDesign || !loadedModels.some(item => item.model_name.toLowerCase() === targetModel.toLowerCase())) {
-            await loadModelWithPolicy(targetModel, findModelInfoByName(knownModelInfos, targetModel) || null);
+            await loadModelForChat(targetModel, findModelInfoByName(knownModelInfos, targetModel) || null);
           }
         }
 
@@ -2625,7 +2615,7 @@ ${finalText}`
   }, [
     appendAssistantMessage, audioGenerationSettings, imageMode, imageSettings,
     isOpenMossTts, knownModelInfos, loadedModels, model3dSettings, onRefresh,
-    loadModelWithPolicy, openMossCloneModel, openMossSettings, openMossVoiceDesignModel,
+    loadModelForChat, openMossCloneModel, openMossSettings, openMossVoiceDesignModel,
     speakWithPinnedTts, trackGeneratedMediaUrl,
   ]);
 
@@ -3204,7 +3194,7 @@ ${finalText}`
     setFallbackModelOverride(option.name);
     onModelSelect(option.name);
     try {
-      await loadModelWithPolicy(option.name, option.info || null);
+      await loadModelForChat(option.name, option.info || null);
       await Promise.resolve(onRefresh());
       setFallbackModelOverride(null);
       onModelSelect(option.name);
@@ -3218,7 +3208,7 @@ ${finalText}`
     } finally {
       setModelPickerLoading(null);
     }
-  }, [connectionStatus, currentModel, loadModelWithPolicy, modelPickerLoading, onModelSelect, onRefresh]);
+  }, [connectionStatus, currentModel, loadModelForChat, modelPickerLoading, onModelSelect, onRefresh]);
 
   // ── Option select from assistant messages ───────────────────
 

--- a/src/app/src/components/ConnectView.tsx
+++ b/src/app/src/components/ConnectView.tsx
@@ -399,13 +399,13 @@ const ConnectView: React.FC<ConnectViewProps> = ({ status, isActive, activeSecti
 
         {activeSection === 'chat' && (
         <section className="connect__section global-model-settings">
-          <GlobalModelSettingsPanel section="chat" models={models} loadedModels={loadedModels} />
+          <GlobalModelSettingsPanel section="chat" models={models} loadedModels={loadedModels} connected={status === 'connected'} />
         </section>
         )}
 
         {activeSection === 'memory' && (
         <section className="connect__section global-model-settings">
-          <GlobalModelSettingsPanel section="memory" models={models} loadedModels={loadedModels} />
+          <GlobalModelSettingsPanel section="memory" models={models} loadedModels={loadedModels} connected={status === 'connected'} />
         </section>
         )}
 
@@ -444,7 +444,7 @@ const ConnectView: React.FC<ConnectViewProps> = ({ status, isActive, activeSecti
           </WorkspaceActionGroup>
           {directoryNotice && <div className="connect__notice">{directoryNotice}</div>}
           {directoryError && <div className="connect__error">{directoryError}</div>}
-          <GlobalModelSettingsPanel section="updates" models={models} loadedModels={loadedModels} />
+          <GlobalModelSettingsPanel section="updates" models={models} loadedModels={loadedModels} connected={status === 'connected'} />
         </section>
         )}
 

--- a/src/app/src/components/Dashboard.tsx
+++ b/src/app/src/components/Dashboard.tsx
@@ -1,9 +1,10 @@
-import React, { lazy, Suspense, useCallback, useMemo, useRef, useState } from 'react';
+import React, { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { api, LoadedModel } from '../api';
 import { capabilityFromLoaded } from '../modelCapabilities';
 import { backendCompactLabel } from '../modelPresentation';
 import { useDashboardData } from '../hooks/useDashboardData';
 import { dashboardMemoryTopology } from '../features/dashboard/memoryTopology';
+import { evictionRuntimeSettingsFromConfig } from '../features/modelSettings/globalModelSettings';
 import { WorkspaceActionButton, WorkspaceList, WorkspaceListRow, WorkspacePaneHeader } from './WorkspacePanels';
 
 /* ── Helpers ───────────────────────────────────────────────── */
@@ -80,7 +81,8 @@ const RingGauge = React.memo<{
   unit?: string;
   color?: string;
   subtitle?: string;
-}>(({ value, max = 100, size = 110, label, unit = '%', color, subtitle }) => {
+  thresholdPercent?: number | null;
+}>(({ value, max = 100, size = 110, label, unit = '%', color, subtitle, thresholdPercent = null }) => {
   const safeVal = value != null && value >= 0 ? value : 0;
   const pctVal = Math.min(100, (safeVal / max) * 100);
   const unavailable = value == null || value < 0;
@@ -88,6 +90,16 @@ const RingGauge = React.memo<{
   const r = 42;
   const circumference = 2 * Math.PI * r;
   const offset = circumference - (pctVal / 100) * circumference;
+  const safeThreshold = thresholdPercent != null && Number.isFinite(thresholdPercent) && thresholdPercent > 0 && thresholdPercent <= 100
+    ? thresholdPercent
+    : null;
+  const thresholdAngle = safeThreshold == null ? null : (safeThreshold / 100) * Math.PI * 2 - Math.PI / 2;
+  const thresholdMarker = thresholdAngle == null ? null : {
+    x1: 50 + Math.cos(thresholdAngle) * (r - 5),
+    y1: 50 + Math.sin(thresholdAngle) * (r - 5),
+    x2: 50 + Math.cos(thresholdAngle) * (r + 4),
+    y2: 50 + Math.sin(thresholdAngle) * (r + 4),
+  };
 
   const autoColor = pctVal < 50 ? 'var(--success)' : pctVal < 80 ? 'var(--accent)' : 'var(--danger)';
   const ringColor = color || autoColor;
@@ -119,6 +131,12 @@ const RingGauge = React.memo<{
             filter={`url(#${filterId})`}
             style={{ transition: 'stroke-dashoffset 0.8s cubic-bezier(0.4,0,0.2,1)' }}
           />
+        )}
+        {thresholdMarker && (
+          <g className="dash2-gauge__threshold" data-eviction-threshold={safeThreshold}>
+            <title>{`Eviction threshold: ${safeThreshold}%`}</title>
+            <line {...thresholdMarker} />
+          </g>
         )}
       </svg>
       <div className="dash2-gauge__center">
@@ -211,6 +229,7 @@ const Dashboard: React.FC<DashboardProps> = ({ isActive }) => {
   } = useDashboardData(isActive);
 
   const [ejecting, setEjecting] = useState<string | null>(null);
+  const [evictionThresholdPercent, setEvictionThresholdPercent] = useState<number | null>(null);
   const ejectingRef = useRef<string | null>(null);
   const handleEject = useCallback((modelName: string) => {
     if (ejectingRef.current) return;
@@ -227,12 +246,30 @@ const Dashboard: React.FC<DashboardProps> = ({ isActive }) => {
     })();
   }, [refresh]);
 
+  useEffect(() => {
+    if (!isActive) return;
+    let cancelled = false;
+    void api.getRuntimeConfig()
+      .then(config => {
+        if (cancelled) return;
+        const eviction = evictionRuntimeSettingsFromConfig(config);
+        setEvictionThresholdPercent(eviction.autoEvict ? eviction.autoEvictThresholdPercent : null);
+      })
+      .catch(() => {
+        if (!cancelled) setEvictionThresholdPercent(null);
+      });
+    return () => { cancelled = true; };
+  }, [isActive]);
+
   const memoryTopology = useMemo(() => dashboardMemoryTopology(systemInfo), [systemInfo]);
   const ramUsedGb = sysStats?.memory_gb ?? null;
   const ramGaugeMax = memoryTopology.hostTotalGb
     ?? Math.max(64, Math.ceil((ramUsedGb || 0) / 16) * 16);
   const vramGaugeMax = memoryTopology.gpuTotalGb
     ?? Math.max(32, Math.ceil(((sysStats?.vram_gb ?? 0) || 0) / 8) * 8);
+  const evictionThresholdText = evictionThresholdPercent == null
+    ? null
+    : `Eviction threshold: ${Number(evictionThresholdPercent.toFixed(2))}%`;
 
   /* ── Render ──────────────────────────────────────────────── */
 
@@ -389,7 +426,11 @@ const Dashboard: React.FC<DashboardProps> = ({ isActive }) => {
                   max={ramGaugeMax}
                   unit="GB"
                   color="var(--info)"
-                  subtitle={ramUsedGb == null ? 'Shared memory pool' : `${ramUsedGb.toFixed(1)} GB used · shared pool`}
+                  thresholdPercent={memoryTopology.hostTotalGb != null ? evictionThresholdPercent : null}
+                  subtitle={[
+                    ramUsedGb == null ? 'Shared memory pool' : `${ramUsedGb.toFixed(1)} GB used · shared pool`,
+                    memoryTopology.hostTotalGb == null ? evictionThresholdText : null,
+                  ].filter(Boolean).join(' · ')}
                 />
               ) : (
                 <RingGauge label="RAM" value={ramUsedGb} max={ramGaugeMax} unit="GB"
@@ -399,7 +440,11 @@ const Dashboard: React.FC<DashboardProps> = ({ isActive }) => {
                 color="var(--accent)" subtitle={pct(sysStats!.gpu_percent)} />}
               {!memoryTopology.unified && hasGpu && sysStats!.vram_gb != null && sysStats!.vram_gb >= 0 && (
                 <RingGauge label="VRAM" value={sysStats!.vram_gb!} max={vramGaugeMax} unit="GB"
-                  color="var(--warn)" subtitle={`${sysStats!.vram_gb!.toFixed(1)} GB`} />
+                  color="var(--warn)" thresholdPercent={memoryTopology.gpuTotalGb != null ? evictionThresholdPercent : null}
+                  subtitle={[
+                    `${sysStats!.vram_gb!.toFixed(1)} GB`,
+                    memoryTopology.gpuTotalGb == null ? evictionThresholdText : null,
+                  ].filter(Boolean).join(' · ')} />
               )}
               {hasNpu && <RingGauge label="NPU" value={sysStats!.npu_percent!}
                 color="var(--chart-series-4)" subtitle={pct(sysStats!.npu_percent)} />}

--- a/src/app/src/components/GlobalModelSettingsPanel.tsx
+++ b/src/app/src/components/GlobalModelSettingsPanel.tsx
@@ -1,16 +1,16 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import type { LoadedModel, ModelInfo } from '../api';
+import { api, friendlyErrorMessage, type LoadedModel, type ModelInfo } from '../api';
 import { capabilityFromModelInfo } from '../modelCapabilities';
 import { loadChatHistoryPreference, saveChatHistoryPreference } from '../features/chatHistory/historySettings';
 import {
   DEFAULT_GLOBAL_MODEL_SETTINGS,
-  estimatedLoadedSizeGb,
+  autoCheckModelUpdatesFromConfig,
   loadGlobalModelSettings,
+  memoryRuntimeConfigChanges,
+  memoryRuntimeSettingsFromConfig,
   saveGlobalModelSettings,
   type GlobalModelSettings,
-  type ModelEvictionPolicy,
-  type ModelLoadingPolicy,
-  type ResourceBudgetMode,
+  type MemoryRuntimeSettings,
 } from '../features/modelSettings/globalModelSettings';
 import {
   loadTtsPlaybackSettings,
@@ -28,6 +28,7 @@ interface GlobalModelSettingsPanelProps {
   section: GlobalSettingsSection;
   models: ModelInfo[];
   loadedModels: LoadedModel[];
+  connected: boolean;
 }
 
 function modelName(model: ModelInfo): string {
@@ -42,22 +43,22 @@ function modelRecipe(model: ModelInfo): string {
   return String((model as any).recipe || '').trim().toLowerCase();
 }
 
-function formatGb(value: number): string {
-  if (!Number.isFinite(value) || value <= 0) return 'Unknown';
-  return `${value.toFixed(value >= 10 ? 0 : 1)} GB`;
-}
-
 const READ_MODES: Array<{ value: TtsReadMode; title: string; description: string }> = [
   { value: 'on-demand', title: 'Agent read on demand', description: 'Play speech only when the speaker action is used.' },
   { value: 'agent', title: 'Read agent', description: 'Automatically read every assistant response.' },
   { value: 'agent-and-user', title: 'Read agent and user', description: 'Read assistant responses and submitted user text.' },
 ];
 
-const GlobalModelSettingsPanel: React.FC<GlobalModelSettingsPanelProps> = ({ section, models, loadedModels }) => {
+const GlobalModelSettingsPanel: React.FC<GlobalModelSettingsPanelProps> = ({ section, models, loadedModels, connected }) => {
   const [draft, setDraft] = useState<GlobalModelSettings>(() => loadGlobalModelSettings());
+  const [memoryDraft, setMemoryDraft] = useState<MemoryRuntimeSettings | null>(null);
+  const [autoCheckModelUpdates, setAutoCheckModelUpdates] = useState<boolean | null>(null);
   const [persistHistory, setPersistHistory] = useState(() => loadChatHistoryPreference());
   const [ttsModel, setTtsModel] = useState<string | null>(() => loadTtsPlaybackSettings().modelName);
   const [ttsReadMode, setTtsReadMode] = useState<TtsReadMode>(() => ttsReadModeFromSettings(loadTtsPlaybackSettings()));
+  const [serverLoading, setServerLoading] = useState(false);
+  const [serverSaving, setServerSaving] = useState(false);
+  const [serverError, setServerError] = useState<string | null>(null);
   const [saved, setSaved] = useState(false);
 
   useEffect(() => {
@@ -69,6 +70,38 @@ const GlobalModelSettingsPanel: React.FC<GlobalModelSettingsPanelProps> = ({ sec
     setSaved(false);
   }, [section]);
 
+  useEffect(() => {
+    if (section === 'chat') {
+      setServerError(null);
+      setServerLoading(false);
+      return;
+    }
+    if (!connected) {
+      setMemoryDraft(null);
+      setAutoCheckModelUpdates(null);
+      setServerError('Connect to a server to manage these settings.');
+      setServerLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    setServerLoading(true);
+    setServerError(null);
+    void api.getRuntimeConfig()
+      .then(config => {
+        if (cancelled) return;
+        if (section === 'memory') setMemoryDraft(memoryRuntimeSettingsFromConfig(config));
+        else setAutoCheckModelUpdates(autoCheckModelUpdatesFromConfig(config));
+      })
+      .catch(error => {
+        if (!cancelled) setServerError(`Could not load server settings: ${friendlyErrorMessage(error)}`);
+      })
+      .finally(() => {
+        if (!cancelled) setServerLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, [connected, section]);
+
   const sortedModels = useMemo(() => [...models]
     .filter(model => modelName(model))
     .sort((a, b) => modelDisplayName(a).localeCompare(modelDisplayName(b))), [models]);
@@ -76,69 +109,110 @@ const GlobalModelSettingsPanel: React.FC<GlobalModelSettingsPanelProps> = ({ sec
   const kokoroModels = ttsModels.filter(model => modelRecipe(model).includes('kokoro'));
   const openMossModels = ttsModels.filter(model => modelRecipe(model).includes('openmoss') && !/voicegen/i.test(modelName(model)));
   const otherTtsModels = ttsModels.filter(model => !kokoroModels.includes(model) && !openMossModels.includes(model));
-  const loadedEstimate = estimatedLoadedSizeGb(loadedModels, models);
 
   const patchDraft = <K extends keyof GlobalModelSettings>(key: K, value: GlobalModelSettings[K]) => {
     setDraft(current => ({ ...current, [key]: value }));
     setSaved(false);
   };
 
-  const handleSave = () => {
-    const current = loadGlobalModelSettings();
-    const next = section === 'memory'
-      ? {
-          ...current,
-          resourceBudgetMode: draft.resourceBudgetMode,
-          resourceBudgetGb: draft.resourceBudgetGb,
-          autoEvictOnPressure: draft.autoEvictOnPressure,
-          loadingPolicy: draft.loadingPolicy,
-          evictionPolicy: draft.evictionPolicy,
-          protectPinnedModels: draft.protectPinnedModels,
-        }
-      : section === 'chat'
-        ? { ...current, collapseThinkingByDefault: draft.collapseThinkingByDefault }
-        : {
-            ...current,
-            automaticModelUpdates: draft.automaticModelUpdates,
-            lastAutomaticUpdateAt: draft.lastAutomaticUpdateAt,
-          };
+  const patchMemoryDraft = <K extends keyof MemoryRuntimeSettings>(key: K, value: MemoryRuntimeSettings[K]) => {
+    setMemoryDraft(current => current ? { ...current, [key]: value } : current);
+    setSaved(false);
+  };
 
-    const savedSettings = saveGlobalModelSettings(next);
-    setDraft(savedSettings);
+  const stepEvictionThreshold = (direction: -1 | 1) => {
+    if (!memoryDraft) return;
+    const next = memoryDraft.autoEvictThresholdPercent + direction * 5;
+    if (next <= 0 || next > 100) return;
+    patchMemoryDraft('autoEvictThresholdPercent', next);
+  };
+
+  const stepMaxLoadedModels = (direction: -1 | 1) => {
+    if (!memoryDraft) return;
+    const current = memoryDraft.maxLoadedModels;
+    const next = direction > 0
+      ? (current < 1 ? 1 : current + 1)
+      : (current <= 1 ? -1 : current - 1);
+    patchMemoryDraft('maxLoadedModels', next);
+  };
+
+  const refetchServerDraft = async () => {
+    const config = await api.getRuntimeConfig();
+    if (section === 'memory') setMemoryDraft(memoryRuntimeSettingsFromConfig(config));
+    else if (section === 'updates') setAutoCheckModelUpdates(autoCheckModelUpdatesFromConfig(config));
+  };
+
+  const handleSave = async () => {
+    setSaved(false);
     if (section === 'chat') {
+      const savedSettings = saveGlobalModelSettings({ collapseThinkingByDefault: draft.collapseThinkingByDefault });
+      setDraft(savedSettings);
       saveChatHistoryPreference(persistHistory);
       saveActiveTtsModel(ttsModel);
       saveTtsReadMode(ttsReadMode);
+      setSaved(true);
+      window.setTimeout(() => setSaved(false), 1600);
+      return;
     }
-    setSaved(true);
-    window.setTimeout(() => setSaved(false), 1600);
+
+    if (!connected) {
+      setServerError('Connect to a server to manage these settings.');
+      return;
+    }
+
+    setServerSaving(true);
+    setServerError(null);
+    try {
+      if (section === 'memory') {
+        if (!memoryDraft) throw new Error('Server memory settings are not available.');
+        await api.setRuntimeConfig(memoryRuntimeConfigChanges(memoryDraft));
+      } else {
+        if (autoCheckModelUpdates === null) throw new Error('Server update settings are not available.');
+        await api.setRuntimeConfig({ auto_check_model_updates: autoCheckModelUpdates });
+      }
+      await refetchServerDraft();
+      setSaved(true);
+      window.setTimeout(() => setSaved(false), 1600);
+    } catch (error) {
+      setServerError(`Failed to save settings: ${friendlyErrorMessage(error)}`);
+      // A rejected or unconfirmed write must not leave the attempted draft
+      // looking authoritative. Refetch if possible; otherwise clear it.
+      try {
+        await refetchServerDraft();
+      } catch {
+        if (section === 'memory') setMemoryDraft(null);
+        else setAutoCheckModelUpdates(null);
+      }
+    } finally {
+      setServerSaving(false);
+    }
   };
 
-  const handleReset = () => {
-    if (section === 'memory') {
-      setDraft(current => ({
-        ...current,
-        resourceBudgetMode: DEFAULT_GLOBAL_MODEL_SETTINGS.resourceBudgetMode,
-        resourceBudgetGb: DEFAULT_GLOBAL_MODEL_SETTINGS.resourceBudgetGb,
-        autoEvictOnPressure: DEFAULT_GLOBAL_MODEL_SETTINGS.autoEvictOnPressure,
-        loadingPolicy: DEFAULT_GLOBAL_MODEL_SETTINGS.loadingPolicy,
-        evictionPolicy: DEFAULT_GLOBAL_MODEL_SETTINGS.evictionPolicy,
-        protectPinnedModels: DEFAULT_GLOBAL_MODEL_SETTINGS.protectPinnedModels,
-      }));
-    } else if (section === 'chat') {
+  const handleReset = async () => {
+    setSaved(false);
+    if (section === 'chat') {
       setDraft(current => ({ ...current, collapseThinkingByDefault: DEFAULT_GLOBAL_MODEL_SETTINGS.collapseThinkingByDefault }));
       setPersistHistory(false);
       setTtsModel(null);
       setTtsReadMode('on-demand');
-    } else {
-      setDraft(current => ({
-        ...current,
-        automaticModelUpdates: DEFAULT_GLOBAL_MODEL_SETTINGS.automaticModelUpdates,
-        lastAutomaticUpdateAt: DEFAULT_GLOBAL_MODEL_SETTINGS.lastAutomaticUpdateAt,
-      }));
+      return;
     }
-    setSaved(false);
+    if (!connected) return;
+    setServerLoading(true);
+    setServerError(null);
+    try {
+      // There is no complete authoritative reset for all lifecycle fields in the
+      // current runtime contract, so discard the draft and reload server state.
+      await refetchServerDraft();
+    } catch (error) {
+      setServerError(`Could not reload server settings: ${friendlyErrorMessage(error)}`);
+    } finally {
+      setServerLoading(false);
+    }
   };
+
+  const serverControlsDisabled = serverLoading || serverSaving || !connected;
+  const serverDraftUnavailable = section === 'memory' ? !memoryDraft : autoCheckModelUpdates === null;
 
   return (
     <div className="global-model-settings__body">
@@ -196,67 +270,98 @@ const GlobalModelSettingsPanel: React.FC<GlobalModelSettingsPanelProps> = ({ sec
         <>
           <section className="global-settings-card">
             <div className="global-settings-card__head">
-              <div><Icon name="gauge" size={18} /><h3>Memory budget</h3></div>
-              <span>{loadedModels.length} loaded · {formatGb(loadedEstimate)} estimated</span>
+              <div><Icon name="gauge" size={18} /><h3>Memory management</h3></div>
+              <span>{loadedModels.length} loaded</span>
             </div>
-            <p className="global-settings-card__description">The client uses known model sizes to pre-evict before loading. Server-managed mode leaves memory decisions entirely to Lemonade.</p>
-            <div className="global-settings-grid global-settings-grid--two">
-              <label className="global-settings-field">
-                <span>Budget source</span>
-                <select className="select" value={draft.resourceBudgetMode} onChange={event => patchDraft('resourceBudgetMode', event.target.value as ResourceBudgetMode)}>
-                  <option value="server">Automatic / server managed</option>
-                  <option value="vram">Custom VRAM budget</option>
-                  <option value="memory">Custom system memory budget</option>
-                </select>
-              </label>
-              <label className="global-settings-field">
-                <span>Budget</span>
-                <div className="global-settings-number">
-                  <input
-                    className="input"
-                    type="number"
-                    min={1}
-                    max={1024}
-                    step={0.5}
-                    disabled={draft.resourceBudgetMode === 'server'}
-                    value={draft.resourceBudgetGb}
-                    onChange={event => patchDraft('resourceBudgetGb', Number(event.target.value))}
-                  />
-                  <strong>GB</strong>
-                </div>
-              </label>
-            </div>
+            <p className="global-settings-card__description">Lemonade owns model residency and memory-pressure eviction.</p>
             <label className="global-settings-toggle">
-              <input type="checkbox" checked={draft.autoEvictOnPressure} disabled={draft.evictionPolicy === 'manual'} onChange={event => patchDraft('autoEvictOnPressure', event.target.checked)} />
-              <span><strong>Auto-evict on memory or VRAM pressure</strong><small>On an OOM-style load failure, evict eligible models and retry once.</small></span>
+              <input
+                type="checkbox"
+                checked={memoryDraft?.autoEvict ?? false}
+                disabled={serverControlsDisabled || !memoryDraft}
+                onChange={event => patchMemoryDraft('autoEvict', event.target.checked)}
+              />
+              <span><strong>Automatic eviction</strong><small>Let Lemonade manage model residency when VRAM pressure is high.</small></span>
             </label>
+            {memoryDraft?.autoEvict && (
+              <div className="global-settings-field">
+                <label htmlFor="global-auto-evict-threshold">Eviction threshold</label>
+                <div className="detail-configuration__number-control global-settings-number">
+                  <input
+                    id="global-auto-evict-threshold"
+                    className="input detail-configuration__number-input"
+                    type="number"
+                    max={100}
+                    step={5}
+                    disabled={serverControlsDisabled}
+                    value={memoryDraft.autoEvictThresholdPercent}
+                    onKeyDown={event => {
+                      if (event.key !== 'ArrowUp' && event.key !== 'ArrowDown') return;
+                      event.preventDefault();
+                      stepEvictionThreshold(event.key === 'ArrowUp' ? 1 : -1);
+                    }}
+                    onChange={event => {
+                      const next = Number(event.target.value);
+                      if (Number.isFinite(next) && next > 0 && next <= 100) {
+                        patchMemoryDraft('autoEvictThresholdPercent', next);
+                      } else {
+                        event.currentTarget.value = String(memoryDraft.autoEvictThresholdPercent);
+                      }
+                    }}
+                  />
+                  <strong>%</strong>
+                  <span className="detail-configuration__context-stepper">
+                    <button type="button" disabled={serverControlsDisabled || memoryDraft.autoEvictThresholdPercent + 5 > 100} onClick={() => stepEvictionThreshold(1)} aria-label="Increase eviction threshold">
+                      <Icon name="chevron-up" size={11} aria-hidden="true" />
+                    </button>
+                    <button type="button" disabled={serverControlsDisabled || memoryDraft.autoEvictThresholdPercent - 5 <= 0} onClick={() => stepEvictionThreshold(-1)} aria-label="Decrease eviction threshold">
+                      <Icon name="chevron-down" size={11} aria-hidden="true" />
+                    </button>
+                  </span>
+                </div>
+              </div>
+            )}
           </section>
 
           <section className="global-settings-card">
             <div className="global-settings-card__head"><div><Icon name="layers" size={18} /><h3>Loading and eviction</h3></div></div>
-            <div className="global-settings-grid global-settings-grid--two">
-              <label className="global-settings-field">
-                <span>Loading policy</span>
-                <select className="select" value={draft.loadingPolicy} onChange={event => patchDraft('loadingPolicy', event.target.value as ModelLoadingPolicy)}>
-                  <option value="keep-loaded">Keep loaded models</option>
-                  <option value="single-active">Single active model</option>
-                  <option value="budget-aware">Stay within budget</option>
-                </select>
-              </label>
-              <label className="global-settings-field">
-                <span>Eviction order</span>
-                <select className="select" value={draft.evictionPolicy} onChange={event => patchDraft('evictionPolicy', event.target.value as ModelEvictionPolicy)}>
-                  <option value="lru">Least recently used</option>
-                  <option value="largest">Largest first</option>
-                  <option value="oldest-process">Oldest process first</option>
-                  <option value="manual">Manual only</option>
-                </select>
-              </label>
+            <div className="global-settings-field">
+              <label htmlFor="global-max-loaded-models">Maximum loaded models per type</label>
+              <div className="detail-configuration__number-control">
+                <input
+                  id="global-max-loaded-models"
+                  className="input detail-configuration__number-input"
+                  type="number"
+                  min={-1}
+                  step={1}
+                  disabled={serverControlsDisabled || !memoryDraft}
+                  value={memoryDraft?.maxLoadedModels ?? ''}
+                  onKeyDown={event => {
+                    if (event.key !== 'ArrowUp' && event.key !== 'ArrowDown') return;
+                    event.preventDefault();
+                    stepMaxLoadedModels(event.key === 'ArrowUp' ? 1 : -1);
+                  }}
+                  onChange={event => {
+                    const next = Number(event.target.value);
+                    if (Number.isInteger(next) && (next === -1 || next > 0)) {
+                      patchMemoryDraft('maxLoadedModels', next);
+                    } else if (memoryDraft) {
+                      event.currentTarget.value = String(memoryDraft.maxLoadedModels);
+                    }
+                  }}
+                />
+                <span className="detail-configuration__context-stepper">
+                  <button type="button" disabled={serverControlsDisabled || !memoryDraft} onClick={() => stepMaxLoadedModels(1)} aria-label="Increase maximum loaded models per type">
+                    <Icon name="chevron-up" size={11} aria-hidden="true" />
+                  </button>
+                  <button type="button" disabled={serverControlsDisabled || !memoryDraft || memoryDraft.maxLoadedModels <= -1} onClick={() => stepMaxLoadedModels(-1)} aria-label="Decrease maximum loaded models per type">
+                    <Icon name="chevron-down" size={11} aria-hidden="true" />
+                  </button>
+                </span>
+              </div>
+              <small>Use -1 for unlimited. Lemonade applies this limit independently per model type.</small>
             </div>
-            <label className="global-settings-toggle">
-              <input type="checkbox" checked={draft.protectPinnedModels} onChange={event => patchDraft('protectPinnedModels', event.target.checked)} />
-              <span><strong>Protect pinned models from automatic eviction</strong><small>Pinned models can still be unloaded manually.</small></span>
-            </label>
+            <p className="global-settings-card__description">Eviction order is managed by Lemonade. Pinned models are protected from automatic eviction.</p>
           </section>
         </>
       )}
@@ -265,17 +370,37 @@ const GlobalModelSettingsPanel: React.FC<GlobalModelSettingsPanelProps> = ({ sec
         <section className="global-settings-card">
           <div className="global-settings-card__head"><div><Icon name="rotate-ccw" size={18} /><h3>Model updates</h3></div></div>
           <label className="global-settings-toggle">
-            <input type="checkbox" checked={draft.automaticModelUpdates} onChange={event => patchDraft('automaticModelUpdates', event.target.checked)} />
-            <span><strong>Automatic model updates</strong><small>Off by default. When enabled, GUI3 checks downloaded models at most once per day.</small></span>
+            <input
+              type="checkbox"
+              checked={autoCheckModelUpdates ?? false}
+              disabled={serverControlsDisabled || autoCheckModelUpdates === null}
+              onChange={event => { setAutoCheckModelUpdates(event.target.checked); setSaved(false); }}
+            />
+            <span><strong>Check for model updates on server startup</strong><small>Lemonade checks downloaded models for available updates when the server starts.</small></span>
           </label>
         </section>
       )}
 
+      {section !== 'chat' && serverLoading && <div className="connect__notice">Loading server settings...</div>}
+      {section !== 'chat' && serverError && <div className="connect__error" role="alert">{serverError}</div>}
+
       <WorkspaceActionGroup label={`${section} settings actions`}>
-        <WorkspaceActionButton appearance="primary" icon="check" onClick={handleSave}>
-          {saved ? 'Saved' : 'Save settings'}
+        <WorkspaceActionButton
+          appearance="primary"
+          icon="check"
+          onClick={() => { void handleSave(); }}
+          disabled={section !== 'chat' && (serverControlsDisabled || serverDraftUnavailable)}
+        >
+          {serverSaving ? 'Saving...' : saved ? 'Saved' : 'Save settings'}
         </WorkspaceActionButton>
-        <WorkspaceActionButton appearance="quiet" icon="rotate-ccw" onClick={handleReset}>Reset defaults</WorkspaceActionButton>
+        <WorkspaceActionButton
+          appearance="quiet"
+          icon="rotate-ccw"
+          onClick={() => { void handleReset(); }}
+          disabled={section !== 'chat' && (serverControlsDisabled || serverDraftUnavailable)}
+        >
+          {section === 'chat' ? 'Reset defaults' : 'Discard changes'}
+        </WorkspaceActionButton>
       </WorkspaceActionGroup>
     </div>
   );

--- a/src/app/src/components/ModelManager.tsx
+++ b/src/app/src/components/ModelManager.tsx
@@ -27,14 +27,8 @@ import Modal from './inspect/Modal';
 import { ROUTER_RECIPE, routerDisplayName, type RouterPullRequest } from '../features/router/routerTypes';
 import { isRouterModelInfo, preflightRouter, routerPreflightError } from '../features/router/routerRuntime';
 import {
-  GLOBAL_MODEL_SETTINGS_EVENT,
-  automaticUpdateIsDue,
-  loadGlobalModelSettings,
   loadPinnedModelNames,
-  loadWithGlobalModelPolicy,
-  saveGlobalModelSettings,
   savePinnedModelNames,
-  type GlobalModelSettings,
 } from '../features/modelSettings/globalModelSettings';
 import { backendLabel } from '../modelPresentation';
 import { useServerModelState } from '../features/models/modelState';
@@ -1131,8 +1125,6 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
   const [favoriteModels, setFavoriteModels] = useState<string[]>(() => loadFavoriteModels());
   // Real disk usage for the storage meter (null until/unless lemond exposes it).
   const [storageInfo, setStorageInfo] = useState<import('../api').StorageInfo | null>(null);
-  const [globalModelSettings, setGlobalModelSettings] = useState<GlobalModelSettings>(() => loadGlobalModelSettings());
-  const automaticUpdateStartedRef = useRef(false);
   const customJsonInputRef = useRef<HTMLInputElement>(null);
 
   const [serverDefaultCtxSize, setServerDefaultCtxSize] = useState<number>(DEFAULT_CONTEXT_SIZE);
@@ -1178,17 +1170,6 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
       .catch(() => { if (!cancelled) setStorageInfo(null); });
     return () => { cancelled = true; };
   }, [visibleServerModels.length]);
-
-  useEffect(() => {
-    const reloadGlobalSettings = () => {
-      setGlobalModelSettings(loadGlobalModelSettings());
-      setPinnedModels(loadPinnedModelNames());
-    };
-    automaticUpdateStartedRef.current = false;
-    reloadGlobalSettings();
-    window.addEventListener(GLOBAL_MODEL_SETTINGS_EVENT, reloadGlobalSettings);
-    return () => window.removeEventListener(GLOBAL_MODEL_SETTINGS_EVENT, reloadGlobalSettings);
-  }, []);
 
   const refreshCustomRecipeAvailability = useCallback(async () => {
     if (!api.isConnected) {
@@ -1605,18 +1586,6 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
     visited.delete(key);
   };
 
-  const loadWithGlobalPolicy = async (model: ModelInfo, overrideOptions?: Record<string, unknown>): Promise<void> => {
-    await loadWithGlobalModelPolicy({
-      loadedModels,
-      allModels,
-      target: model,
-      pinnedNames: pinnedModels,
-      settings: globalModelSettings,
-      unload: name => api.unloadModel(name),
-      load: () => loadModelRuntime(model, new Set<string>(), overrideOptions),
-    });
-  };
-
   const handleLoad = async (model: ModelInfo, overrideOptions?: Record<string, unknown>) => {
     if (loadingModel) return;
     const name = modelName(model);
@@ -1628,11 +1597,7 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
     setLoadError(null);
     setLoadingModel(name);
     try {
-      if (isRouterModelInfo(model)) {
-        await ensureServerRouterReady(name);
-      } else {
-        await loadWithGlobalPolicy(model, overrideOptions);
-      }
+      await loadModelRuntime(model, new Set<string>(), overrideOptions);
       await refresh();
       onModelSelect(name);
     } catch (err) {
@@ -2416,19 +2381,6 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
       });
     }
   }, [allModels, downloadItems, loadedNames, pulling]);
-
-  useEffect(() => {
-    if (automaticUpdateStartedRef.current || !api.isConnected || modelsLoading) return;
-    if (!automaticUpdateIsDue(globalModelSettings)) return;
-    automaticUpdateStartedRef.current = true;
-    void handleUpdateAllModels().finally(() => {
-      const next = saveGlobalModelSettings({
-        ...loadGlobalModelSettings(),
-        lastAutomaticUpdateAt: new Date().toISOString(),
-      });
-      setGlobalModelSettings(next);
-    });
-  }, [globalModelSettings, handleUpdateAllModels, modelsLoading]);
 
   const localRegistryRefs = useMemo(() => {
     const refs = new Set<string>();

--- a/src/app/src/features/modelSettings/globalModelSettings.ts
+++ b/src/app/src/features/modelSettings/globalModelSettings.ts
@@ -1,34 +1,22 @@
-import type { LoadedModel, ModelInfo } from '../../api';
 import { storageKey } from '../../storage';
 
 export const GLOBAL_MODEL_SETTINGS_EVENT = 'lemonade:global-model-settings-changed';
 
-export type ResourceBudgetMode = 'server' | 'vram' | 'memory';
-export type ModelLoadingPolicy = 'keep-loaded' | 'single-active' | 'budget-aware';
-export type ModelEvictionPolicy = 'lru' | 'largest' | 'oldest-process' | 'manual';
-
 export interface GlobalModelSettings {
-  resourceBudgetMode: ResourceBudgetMode;
-  resourceBudgetGb: number;
-  autoEvictOnPressure: boolean;
-  loadingPolicy: ModelLoadingPolicy;
-  evictionPolicy: ModelEvictionPolicy;
-  protectPinnedModels: boolean;
   collapseThinkingByDefault: boolean;
-  automaticModelUpdates: boolean;
-  lastAutomaticUpdateAt: string | null;
+}
+
+export interface EvictionRuntimeSettings {
+  autoEvict: boolean;
+  autoEvictThresholdPercent: number;
+}
+
+export interface MemoryRuntimeSettings extends EvictionRuntimeSettings {
+  maxLoadedModels: number;
 }
 
 export const DEFAULT_GLOBAL_MODEL_SETTINGS: GlobalModelSettings = {
-  resourceBudgetMode: 'server',
-  resourceBudgetGb: 16,
-  autoEvictOnPressure: false,
-  loadingPolicy: 'keep-loaded',
-  evictionPolicy: 'lru',
-  protectPinnedModels: true,
   collapseThinkingByDefault: true,
-  automaticModelUpdates: false,
-  lastAutomaticUpdateAt: null,
 };
 
 function settingsKey(): string {
@@ -39,39 +27,27 @@ function pinnedModelsKey(): string {
   return storageKey('pinned_models');
 }
 
-function finiteBudget(value: unknown): number {
-  const parsed = Number(value);
-  if (!Number.isFinite(parsed)) return DEFAULT_GLOBAL_MODEL_SETTINGS.resourceBudgetGb;
-  return Math.max(1, Math.min(1024, Math.round(parsed * 10) / 10));
-}
-
-function oneOf<T extends string>(value: unknown, values: readonly T[], fallback: T): T {
-  return values.includes(value as T) ? value as T : fallback;
-}
-
 export function sanitizeGlobalModelSettings(value: unknown): GlobalModelSettings {
   const raw = value && typeof value === 'object' && !Array.isArray(value)
     ? value as Partial<GlobalModelSettings>
     : {};
   return {
-    resourceBudgetMode: oneOf(raw.resourceBudgetMode, ['server', 'vram', 'memory'] as const, DEFAULT_GLOBAL_MODEL_SETTINGS.resourceBudgetMode),
-    resourceBudgetGb: finiteBudget(raw.resourceBudgetGb),
-    autoEvictOnPressure: raw.autoEvictOnPressure === true,
-    loadingPolicy: oneOf(raw.loadingPolicy, ['keep-loaded', 'single-active', 'budget-aware'] as const, DEFAULT_GLOBAL_MODEL_SETTINGS.loadingPolicy),
-    evictionPolicy: oneOf(raw.evictionPolicy, ['lru', 'largest', 'oldest-process', 'manual'] as const, DEFAULT_GLOBAL_MODEL_SETTINGS.evictionPolicy),
-    protectPinnedModels: raw.protectPinnedModels !== false,
     collapseThinkingByDefault: raw.collapseThinkingByDefault !== false,
-    automaticModelUpdates: raw.automaticModelUpdates === true,
-    lastAutomaticUpdateAt: typeof raw.lastAutomaticUpdateAt === 'string' && raw.lastAutomaticUpdateAt.trim()
-      ? raw.lastAutomaticUpdateAt
-      : null,
   };
 }
 
 export function loadGlobalModelSettings(): GlobalModelSettings {
   try {
     const raw = localStorage.getItem(settingsKey());
-    return raw ? sanitizeGlobalModelSettings(JSON.parse(raw)) : { ...DEFAULT_GLOBAL_MODEL_SETTINGS };
+    if (!raw) return { ...DEFAULT_GLOBAL_MODEL_SETTINGS };
+    const parsed = JSON.parse(raw);
+    const sanitized = sanitizeGlobalModelSettings(parsed);
+    // Drop lifecycle fields written by older GUI3 builds. They are server-owned
+    // and must never be restored or translated into runtime configuration.
+    if (JSON.stringify(parsed) !== JSON.stringify(sanitized)) {
+      localStorage.setItem(settingsKey(), JSON.stringify(sanitized));
+    }
+    return sanitized;
   } catch {
     return { ...DEFAULT_GLOBAL_MODEL_SETTINGS };
   }
@@ -107,184 +83,58 @@ export function savePinnedModelNames(names: Iterable<string>): string[] {
   return normalized;
 }
 
-export function automaticUpdateIsDue(settings: GlobalModelSettings, now = Date.now(), intervalMs = 24 * 60 * 60 * 1000): boolean {
-  if (!settings.automaticModelUpdates) return false;
-  if (!settings.lastAutomaticUpdateAt) return true;
-  const last = Date.parse(settings.lastAutomaticUpdateAt);
-  return !Number.isFinite(last) || now - last >= intervalMs;
-}
-
-export function isMemoryPressureError(error: unknown): boolean {
-  const text = error instanceof Error ? error.message : String(error || '');
-  return /(?:out of memory|\boom\b|vram|cuda allocation|hip allocation|memory pressure|failed to allocate|insufficient memory)/i.test(text);
-}
-
-function modelName(model: ModelInfo | null | undefined): string {
-  if (!model) return '';
-  return String((model as any).model_name || model.name || model.id || '').trim();
-}
-
-export function estimatedModelSizeGb(model: ModelInfo | null | undefined): number {
-  const size = Number((model as any)?.size);
-  return Number.isFinite(size) && size > 0 ? size : 0;
-}
-
-function modelComponentNames(model: ModelInfo | null | undefined): string[] {
-  const raw = (model as any)?.components;
-  if (Array.isArray(raw)) return raw.filter((value): value is string => typeof value === 'string' && value.trim().length > 0);
-  if (!raw || typeof raw !== 'object') return [];
-  return Object.values(raw).filter((value): value is string => typeof value === 'string' && value.trim().length > 0);
-}
-
-/** Estimate the concrete footprint of virtual collections from their components. */
-export function estimatedModelFootprintGb(
-  model: ModelInfo | null | undefined,
-  allModels: ModelInfo[],
-  seen = new Set<string>(),
-): number {
-  if (!model) return 0;
-  const name = modelName(model).toLowerCase();
-  if (name && seen.has(name)) return 0;
-  const nextSeen = new Set(seen);
-  if (name) nextSeen.add(name);
-
-  const components = modelComponentNames(model);
-  if (components.length === 0) return estimatedModelSizeGb(model);
-  const byName = new Map(allModels.map(item => [modelName(item).toLowerCase(), item] as const));
-  const componentTotal = components.reduce((sum, componentName) => {
-    const component = byName.get(componentName.toLowerCase());
-    return sum + estimatedModelFootprintGb(component, allModels, nextSeen);
-  }, 0);
-  return componentTotal > 0 ? componentTotal : estimatedModelSizeGb(model);
-}
-
-export interface EvictionCandidate {
-  name: string;
-  loaded: LoadedModel;
-  info: ModelInfo | null;
-  estimatedSizeGb: number;
-}
-
-export function evictionCandidates(
-  loadedModels: LoadedModel[],
-  allModels: ModelInfo[],
-  targetName: string,
-  pinnedNames: Iterable<string>,
-  settings: GlobalModelSettings,
-): EvictionCandidate[] {
-  const target = targetName.toLowerCase();
-  const pinned = new Set([...pinnedNames].map(name => name.toLowerCase()));
-  const infos = new Map(allModels.map(model => [modelName(model).toLowerCase(), model] as const));
-  const candidates = loadedModels
-    .filter(loaded => loaded.model_name.toLowerCase() !== target)
-    .filter(loaded => !settings.protectPinnedModels || !pinned.has(loaded.model_name.toLowerCase()))
-    .map(loaded => {
-      const info = infos.get(loaded.model_name.toLowerCase()) || null;
-      return { name: loaded.model_name, loaded, info, estimatedSizeGb: estimatedModelSizeGb(info) };
-    });
-
-  if (settings.evictionPolicy === 'largest') {
-    return candidates.sort((a, b) => b.estimatedSizeGb - a.estimatedSizeGb || a.loaded.last_use - b.loaded.last_use);
+function validMaxLoadedModels(value: unknown): number {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || (parsed < -1 || parsed === 0)) {
+    throw new Error('Maximum loaded models per type must be -1 (unlimited) or a positive integer.');
   }
-  if (settings.evictionPolicy === 'oldest-process') {
-    return candidates.sort((a, b) => a.loaded.pid - b.loaded.pid || a.loaded.last_use - b.loaded.last_use);
+  return parsed;
+}
+
+function thresholdFraction(value: unknown): number {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0 || parsed > 1) {
+    throw new Error('Eviction threshold must be greater than 0% and at most 100%.');
   }
-  return candidates.sort((a, b) => a.loaded.last_use - b.loaded.last_use || b.estimatedSizeGb - a.estimatedSizeGb);
+  return parsed;
 }
 
-export function estimatedLoadedSizeGb(loadedModels: LoadedModel[], allModels: ModelInfo[]): number {
-  const infos = new Map(allModels.map(model => [modelName(model).toLowerCase(), model] as const));
-  return loadedModels.reduce((sum, loaded) => sum + estimatedModelSizeGb(infos.get(loaded.model_name.toLowerCase())), 0);
+/** Read the effective eviction controls from the server runtime config snapshot. */
+export function evictionRuntimeSettingsFromConfig(config: Record<string, unknown>): EvictionRuntimeSettings {
+  // These fallbacks mirror RuntimeConfig's effective defaults when the optional
+  // keys have not yet been materialized in config.json.
+  const autoEvict = typeof config.auto_evict === 'boolean' ? config.auto_evict : false;
+  const fraction = config.auto_evict_threshold_pct === undefined
+    ? 0.90
+    : thresholdFraction(config.auto_evict_threshold_pct);
+  return {
+    autoEvict,
+    autoEvictThresholdPercent: fraction * 100,
+  };
 }
 
-export function evictionPlanForLoad(
-  loadedModels: LoadedModel[],
-  allModels: ModelInfo[],
-  target: ModelInfo | null,
-  pinnedNames: Iterable<string>,
-  settings: GlobalModelSettings,
-): string[] {
-  if (settings.evictionPolicy === 'manual') return [];
-  const targetName = modelName(target);
-  const candidates = evictionCandidates(loadedModels, allModels, targetName, pinnedNames, settings);
-  if (settings.loadingPolicy === 'single-active') return candidates.map(candidate => candidate.name);
-  if (settings.loadingPolicy !== 'budget-aware' || settings.resourceBudgetMode === 'server') return [];
+export function memoryRuntimeSettingsFromConfig(config: Record<string, unknown>): MemoryRuntimeSettings {
+  return {
+    maxLoadedModels: validMaxLoadedModels(config.max_loaded_models),
+    ...evictionRuntimeSettingsFromConfig(config),
+  };
+}
 
-  const budget = settings.resourceBudgetGb;
-  let projected = estimatedLoadedSizeGb(loadedModels, allModels) + estimatedModelFootprintGb(target, allModels);
-  const plan: string[] = [];
-  for (const candidate of candidates) {
-    if (projected <= budget) break;
-    plan.push(candidate.name);
-    projected -= candidate.estimatedSizeGb;
+export function memoryRuntimeConfigChanges(settings: MemoryRuntimeSettings): Record<string, unknown> {
+  const maxLoadedModels = validMaxLoadedModels(settings.maxLoadedModels);
+  const percent = Number(settings.autoEvictThresholdPercent);
+  if (!Number.isFinite(percent) || percent <= 0 || percent > 100) {
+    throw new Error('Eviction threshold must be greater than 0% and at most 100%.');
   }
-  return plan;
+  return {
+    max_loaded_models: maxLoadedModels,
+    auto_evict: settings.autoEvict,
+    auto_evict_threshold_pct: percent / 100,
+  };
 }
 
-export interface GlobalModelLoadPolicyContext<T> {
-  loadedModels: LoadedModel[];
-  allModels: ModelInfo[];
-  target: ModelInfo | null;
-  pinnedNames: Iterable<string>;
-  settings: GlobalModelSettings;
-  unload: (modelName: string) => Promise<unknown>;
-  load: () => Promise<T>;
-}
-
-/**
- * Apply the client-side model policy around one top-level load operation.
- * Internal component loads can stay inside the supplied callback, so an Omni
- * collection is treated as one unit instead of evicting its own components.
- */
-export async function loadWithGlobalModelPolicy<T>(context: GlobalModelLoadPolicyContext<T>): Promise<T> {
-  const {
-    loadedModels,
-    allModels,
-    target,
-    pinnedNames,
-    settings,
-    unload,
-    load,
-  } = context;
-
-  const plannedEvictions = evictionPlanForLoad(
-    loadedModels,
-    allModels,
-    target,
-    pinnedNames,
-    settings,
-  );
-  for (const modelNameValue of plannedEvictions) await unload(modelNameValue);
-
-  try {
-    return await load();
-  } catch (initialError) {
-    if (!settings.autoEvictOnPressure
-      || settings.evictionPolicy === 'manual'
-      || !isMemoryPressureError(initialError)) {
-      throw initialError;
-    }
-
-    const targetName = modelName(target);
-    const alreadyEvicted = new Set(plannedEvictions.map(value => value.toLowerCase()));
-    const recoveryCandidates = evictionCandidates(
-      loadedModels,
-      allModels,
-      targetName,
-      pinnedNames,
-      settings,
-    ).filter(candidate => !alreadyEvicted.has(candidate.name.toLowerCase()));
-
-    let lastError: unknown = initialError;
-    for (const candidate of recoveryCandidates) {
-      await unload(candidate.name);
-      try {
-        return await load();
-      } catch (retryError) {
-        lastError = retryError;
-        if (!isMemoryPressureError(retryError)) throw retryError;
-      }
-    }
-    throw lastError;
-  }
+export function autoCheckModelUpdatesFromConfig(config: Record<string, unknown>): boolean {
+  return typeof config.auto_check_model_updates === 'boolean'
+    ? config.auto_check_model_updates
+    : true;
 }

--- a/src/app/src/storage.ts
+++ b/src/app/src/storage.ts
@@ -11,14 +11,6 @@ const LEGACY_KEYS: Record<string, string> = {
   lemonade_custom_models: 'custom_models',
 };
 
-const OBSOLETE_LEGACY_CONFIGURATION_KEYS = [
-  'lemonade_user_presets',
-  'lemonade_applied_presets',
-  `${STORAGE_PREFIX}user_presets`,
-  `${STORAGE_PREFIX}applied_presets`,
-  `${STORAGE_PREFIX}backend_presets`,
-  `${STORAGE_PREFIX}running_presets`,
-] as const;
 
 let migrationComplete = false;
 
@@ -118,10 +110,6 @@ function copyIfMissing(store: Storage, source: string, target: string): boolean 
   }
 }
 
-function removeObsoleteLegacyConfiguration(store: Storage): void {
-  for (const key of OBSOLETE_LEGACY_CONFIGURATION_KEYS) store.removeItem(key);
-}
-
 function migrateScopedValue(
   store: Storage,
   source: string,
@@ -180,7 +168,6 @@ export function migrateClientStorage(): void {
   migrationComplete = true;
 
   try {
-    removeObsoleteLegacyConfiguration(localStorage);
     if (localStorage.getItem(MIGRATION_KEY) === 'true') return;
 
     for (const [legacyKey, key] of Object.entries(LEGACY_KEYS)) {
@@ -231,14 +218,13 @@ export function clearClientStorage(): void {
         || key === MIGRATION_KEY
         || key === PREVIOUS_MIGRATION_KEY
         || key in LEGACY_KEYS
-        || OBSOLETE_LEGACY_CONFIGURATION_KEYS.includes(key as typeof OBSOLETE_LEGACY_CONFIGURATION_KEYS[number])
         || key === 'lemonade_theme'
         || key === 'lemonade_current_view')
       .forEach(key => localStorage.removeItem(key));
     Object.keys(sessionStorage)
       .filter(key => key.startsWith(STORAGE_PREFIX)
         || key in LEGACY_KEYS
-        || OBSOLETE_LEGACY_CONFIGURATION_KEYS.includes(key as typeof OBSOLETE_LEGACY_CONFIGURATION_KEYS[number]))
+        )
       .forEach(key => sessionStorage.removeItem(key));
   } catch {
     // Ignore unavailable browser storage.

--- a/src/app/src/styles/styles.css
+++ b/src/app/src/styles/styles.css
@@ -4015,6 +4015,13 @@ optgroup {
 
 .dash2-gauge__svg { display: block; }
 
+.dash2-gauge__threshold line {
+  stroke: var(--text-primary);
+  stroke-width: 2.5;
+  stroke-linecap: round;
+  filter: drop-shadow(0 0 2px var(--surface-0));
+}
+
 .dash2-gauge__center {
   position: absolute;
   top: 0; left: 50%;
@@ -13862,7 +13869,8 @@ a.backend-card__version:focus-visible {
 .global-settings-grid { display: grid; gap: var(--space-3); }
 .global-settings-grid--two { grid-template-columns: repeat(2, minmax(0, 1fr)); }
 .global-settings-field { display: grid; gap: var(--space-2); min-width: 0; color: var(--text-secondary); font-size: var(--text-xs); }
-.global-settings-field > span { font-weight: var(--weight-semibold); }
+.global-settings-field > span,
+.global-settings-field > label { font-weight: var(--weight-semibold); }
 .global-settings-field > .select,
 .global-settings-field .input,
 .global-settings-pin-add > .select {
@@ -13870,11 +13878,11 @@ a.backend-card__version:focus-visible {
   min-width: 0;
 }
 .global-settings-number { position: relative; }
-.global-settings-number .input { padding-right: 44px; }
+.global-settings-number .input { padding-right: 72px; }
 .global-settings-number strong {
   position: absolute;
   top: 50%;
-  right: var(--space-3);
+  right: 40px;
   transform: translateY(-50%);
   color: var(--text-tertiary);
   font-size: var(--text-xs);

--- a/src/app/tests/features.spec.ts
+++ b/src/app/tests/features.spec.ts
@@ -250,6 +250,105 @@ test.describe('Lemonade UI — Feature Parity', () => {
     await expect(page.locator('.connect__notice')).toHaveCount(0);
   });
 
+  test('01b2 — lifecycle settings use authoritative runtime config', async ({ page }) => {
+    let runtimeConfig: Record<string, unknown> = {
+      models_dir: 'auto',
+      extra_models_dir: '',
+      max_loaded_models: 3,
+      auto_evict: true,
+      auto_evict_threshold_pct: 0.875,
+      auto_check_model_updates: false,
+    };
+    const configWrites: Record<string, unknown>[] = [];
+    let rejectNextWrite = false;
+
+    await page.route('**/api/v1/health**', route => route.fulfill({
+      json: {
+        status: 'ok',
+        version: 'test',
+        all_models_loaded: [
+          { model_name: 'loaded-a', model_type: 'llm' },
+          { model_name: 'loaded-b', model_type: 'embedding' },
+        ],
+      },
+    }));
+    await page.route('**/api/v1/models**', route => route.fulfill({ json: { object: 'list', data: [] } }));
+    await page.route('**/internal/config**', route => route.fulfill({ json: runtimeConfig }));
+    await page.route('**/internal/set**', async route => {
+      const body = route.request().postDataJSON() as Record<string, unknown>;
+      configWrites.push(body);
+      if (rejectNextWrite) {
+        rejectNextWrite = false;
+        await route.fulfill({
+          status: 400,
+          contentType: 'application/json',
+          body: JSON.stringify({ error: 'runtime config rejected for test' }),
+        });
+        return;
+      }
+      runtimeConfig = { ...runtimeConfig, ...body };
+      await route.fulfill({ json: { status: 'success', updated: body } });
+    });
+
+    await page.goto('/#/connect/memory');
+    await page.waitForSelector('[data-view="connect"]');
+
+    const maxLoaded = page.getByRole('spinbutton', { name: 'Maximum loaded models per type', exact: true });
+    const automaticEviction = page.getByRole('checkbox', { name: /Automatic eviction/ });
+    const evictionThreshold = page.getByRole('spinbutton', { name: 'Eviction threshold', exact: true });
+    await expect(maxLoaded).toHaveValue('3');
+    await expect(page.getByRole('button', { name: 'Increase maximum loaded models per type' })).toBeVisible();
+    await maxLoaded.fill('1');
+    await page.getByRole('button', { name: 'Decrease maximum loaded models per type' }).click();
+    await expect(maxLoaded).toHaveValue('-1');
+    await page.getByRole('button', { name: 'Increase maximum loaded models per type' }).click();
+    await expect(maxLoaded).toHaveValue('1');
+    await maxLoaded.fill('0');
+    await expect(maxLoaded).not.toHaveValue('0');
+    await expect(automaticEviction).toBeChecked();
+    await expect(evictionThreshold).toHaveValue('87.5');
+    const increaseEvictionThreshold = page.getByRole('button', { name: 'Increase eviction threshold' });
+    await expect(increaseEvictionThreshold).toBeVisible();
+    await increaseEvictionThreshold.click();
+    await expect(evictionThreshold).toHaveValue('92.5');
+    await expect(page.getByText('2 loaded', { exact: true })).toBeVisible();
+    await expect(page.getByText('Memory budget', { exact: true })).toHaveCount(0);
+    await expect(page.getByText('Loading policy', { exact: true })).toHaveCount(0);
+    await expect(page.getByText('Protect pinned models from automatic eviction', { exact: true })).toHaveCount(0);
+
+    await maxLoaded.fill('5');
+    await page.getByRole('button', { name: 'Save settings', exact: true }).click();
+    await expect.poll(() => configWrites.length).toBe(1);
+    expect(configWrites[0]).toEqual({
+      max_loaded_models: 5,
+      auto_evict: true,
+      auto_evict_threshold_pct: 0.925,
+    });
+    await expect(page.getByRole('button', { name: 'Saved', exact: true })).toBeVisible();
+
+    rejectNextWrite = true;
+    await maxLoaded.fill('7');
+    await page.getByRole('button', { name: 'Save settings', exact: true }).click();
+    await expect(page.locator('.global-model-settings__body .connect__error')).toContainText('Failed to save settings');
+    await expect(maxLoaded).toHaveValue('5');
+    await expect(page.getByRole('button', { name: 'Saved', exact: true })).toHaveCount(0);
+
+    await automaticEviction.uncheck();
+    await expect(page.getByRole('spinbutton', { name: 'Eviction threshold', exact: true })).toHaveCount(0);
+    await page.getByRole('button', { name: 'Discard changes', exact: true }).click();
+    await expect(automaticEviction).toBeChecked();
+    await expect(page.getByRole('spinbutton', { name: 'Eviction threshold', exact: true })).toHaveValue('92.5');
+
+    await page.goto('/#/connect/model-storage');
+    const startupUpdates = page.getByRole('checkbox', { name: /Check for model updates on server startup/ });
+    await expect(startupUpdates).not.toBeChecked();
+    await startupUpdates.check();
+    await page.getByRole('button', { name: 'Save settings', exact: true }).click();
+    await expect.poll(() => configWrites.length).toBe(3);
+    expect(configWrites[2]).toEqual({ auto_check_model_updates: true });
+    await expect(page.getByText('Automatic model updates', { exact: true })).toHaveCount(0);
+  });
+
   test('01c — Apps is a standalone workspace with category rail navigation', async ({ page }) => {
     await page.route('**/api/v1/health**', route => route.fulfill({
       json: { status: 'ok', version: 'test', all_models_loaded: [] },
@@ -775,39 +874,7 @@ test.describe('Lemonade UI — Feature Parity', () => {
     await page.route('**/api/v1/system-info**', route => route.fulfill({
       json: {
         recipes: {
-          llamacpp: {
-            default_backend: 'cpu',
-            selectable_backend: true,
-            uses_ctx_size: true,
-            modality: 'Text generation',
-            options: [
-              {
-                name: 'llamacpp_backend',
-                cli_flag: '--llamacpp',
-                default: '',
-                type_name: 'BACKEND',
-                help: 'LlamaCpp backend to use',
-                group: 'Llama.cpp Backend Options',
-              },
-              {
-                name: 'llamacpp_device',
-                cli_flag: '--llamacpp-device',
-                default: '',
-                type_name: 'DEVICES',
-                help: 'Comma-separated list of accelerator devices to use (e.g. Vulkan0)',
-                group: 'Llama.cpp Backend Options',
-              },
-              {
-                name: 'llamacpp_args',
-                cli_flag: '--llamacpp-args',
-                default: '',
-                type_name: 'ARGS',
-                help: 'Custom arguments to pass to llama-server',
-                group: 'Llama.cpp Backend Options',
-              },
-            ],
-            backends: { cpu: { state: 'installed', version: 'test' } },
-          },
+          llamacpp: llamacppRecipe(),
         },
       },
     }));
@@ -1652,39 +1719,7 @@ test.describe('Lemonade UI — Feature Parity', () => {
     await page.route('**/api/v1/system-info**', route => route.fulfill({
       json: {
         recipes: {
-          llamacpp: {
-            default_backend: 'cpu',
-            selectable_backend: true,
-            uses_ctx_size: true,
-            modality: 'Text generation',
-            options: [
-              {
-                name: 'llamacpp_backend',
-                cli_flag: '--llamacpp',
-                default: '',
-                type_name: 'BACKEND',
-                help: 'LlamaCpp backend to use',
-                group: 'Llama.cpp Backend Options',
-              },
-              {
-                name: 'llamacpp_device',
-                cli_flag: '--llamacpp-device',
-                default: '',
-                type_name: 'DEVICES',
-                help: 'Comma-separated list of accelerator devices to use (e.g. Vulkan0)',
-                group: 'Llama.cpp Backend Options',
-              },
-              {
-                name: 'llamacpp_args',
-                cli_flag: '--llamacpp-args',
-                default: '',
-                type_name: 'ARGS',
-                help: 'Custom arguments to pass to llama-server',
-                group: 'Llama.cpp Backend Options',
-              },
-            ],
-            backends: { cpu: { state: 'installed', version: 'test' } },
-          },
+          llamacpp: llamacppRecipe(),
         },
       },
     }));

--- a/src/app/tests/global-model-settings.runtime.cjs
+++ b/src/app/tests/global-model-settings.runtime.cjs
@@ -52,92 +52,181 @@ function loadSettingsModule() {
 const storage = installBrowserShim();
 const settings = loadSettingsModule();
 
-assert.equal(settings.DEFAULT_GLOBAL_MODEL_SETTINGS.automaticModelUpdates, false, 'automatic updates must be opt-in');
-assert.equal(settings.DEFAULT_GLOBAL_MODEL_SETTINGS.autoEvictOnPressure, false, 'pressure eviction must be opt-in');
-assert.equal(settings.DEFAULT_GLOBAL_MODEL_SETTINGS.collapseThinkingByDefault, true);
+assert.deepEqual(settings.DEFAULT_GLOBAL_MODEL_SETTINGS, { collapseThinkingByDefault: true });
+
+storage.set('lemonade:global_model_settings', JSON.stringify({
+  collapseThinkingByDefault: false,
+  resourceBudgetMode: 'vram',
+  resourceBudgetGb: 24,
+  loadingPolicy: 'single-active',
+  evictionPolicy: 'largest',
+  autoEvictOnPressure: true,
+  protectPinnedModels: false,
+  automaticModelUpdates: true,
+  lastAutomaticUpdateAt: '2026-08-01T00:00:00.000Z',
+}));
+assert.deepEqual(settings.loadGlobalModelSettings(), { collapseThinkingByDefault: false });
+assert.deepEqual(
+  JSON.parse(storage.get('lemonade:global_model_settings')),
+  { collapseThinkingByDefault: false },
+  'legacy lifecycle fields must be dropped instead of migrated into server settings',
+);
 
 const saved = settings.saveGlobalModelSettings({
-  ...settings.DEFAULT_GLOBAL_MODEL_SETTINGS,
-  resourceBudgetMode: 'vram',
-  resourceBudgetGb: 23.456,
+  collapseThinkingByDefault: true,
+  resourceBudgetGb: 99,
   loadingPolicy: 'budget-aware',
-  autoEvictOnPressure: true,
-});
-assert.equal(saved.resourceBudgetGb, 23.5);
-assert.equal(settings.loadGlobalModelSettings().loadingPolicy, 'budget-aware');
-assert.ok(storage.has('lemonade:global_model_settings'));
-const sanitized = settings.sanitizeGlobalModelSettings({
-  resourceBudgetMode: 'invalid',
-  resourceBudgetGb: -4,
-  loadingPolicy: 'invalid',
-  evictionPolicy: 'invalid',
-  protectPinnedModels: false,
-});
-assert.equal(sanitized.resourceBudgetMode, 'server');
-assert.equal(sanitized.resourceBudgetGb, 1);
-assert.equal(sanitized.loadingPolicy, 'keep-loaded');
-assert.equal(sanitized.evictionPolicy, 'lru');
-assert.equal(sanitized.protectPinnedModels, false);
-
-assert.equal(settings.isMemoryPressureError(new Error('CUDA out of memory while allocating VRAM')), true);
-assert.equal(settings.isMemoryPressureError(new Error('model file missing')), false);
-assert.equal(settings.automaticUpdateIsDue({ ...settings.DEFAULT_GLOBAL_MODEL_SETTINGS, automaticModelUpdates: true }), true);
-assert.equal(settings.automaticUpdateIsDue({
-  ...settings.DEFAULT_GLOBAL_MODEL_SETTINGS,
   automaticModelUpdates: true,
-  lastAutomaticUpdateAt: new Date().toISOString(),
-}), false);
+});
+assert.deepEqual(saved, { collapseThinkingByDefault: true });
+assert.deepEqual(JSON.parse(storage.get('lemonade:global_model_settings')), { collapseThinkingByDefault: true });
 
-const allModels = [
-  { id: 'small', size: 2 },
-  { id: 'large', size: 8 },
-  { id: 'target', size: 6 },
-];
-const loaded = [
-  { model_name: 'small', pid: 20, last_use: 200 },
-  { model_name: 'large', pid: 10, last_use: 100 },
-];
-const largestPolicy = {
-  ...settings.DEFAULT_GLOBAL_MODEL_SETTINGS,
-  resourceBudgetMode: 'vram',
-  resourceBudgetGb: 10,
-  loadingPolicy: 'budget-aware',
-  evictionPolicy: 'largest',
-};
-assert.deepEqual(settings.evictionPlanForLoad(loaded, allModels, allModels[2], [], largestPolicy), ['large']);
-assert.deepEqual(settings.evictionPlanForLoad(loaded, allModels, allModels[2], ['large'], largestPolicy), ['small'], 'pinned models must be protected');
-assert.deepEqual(settings.evictionPlanForLoad(loaded, allModels, allModels[2], [], { ...largestPolicy, evictionPolicy: 'manual' }), []);
-
-const collectionModels = [...allModels, { id: 'bundle', components: ['target', 'small'] }];
-assert.equal(settings.estimatedModelFootprintGb(collectionModels[3], collectionModels), 8, 'collection footprint must include concrete components');
+assert.deepEqual(settings.memoryRuntimeSettingsFromConfig({
+  max_loaded_models: -1,
+  auto_evict: true,
+  auto_evict_threshold_pct: 0.875,
+}), {
+  maxLoadedModels: -1,
+  autoEvict: true,
+  autoEvictThresholdPercent: 87.5,
+});
+assert.deepEqual(settings.memoryRuntimeSettingsFromConfig({ max_loaded_models: 3 }), {
+  maxLoadedModels: 3,
+  autoEvict: false,
+  autoEvictThresholdPercent: 90,
+});
+assert.deepEqual(settings.memoryRuntimeConfigChanges({
+  maxLoadedModels: 4,
+  autoEvict: true,
+  autoEvictThresholdPercent: 92.5,
+}), {
+  max_loaded_models: 4,
+  auto_evict: true,
+  auto_evict_threshold_pct: 0.925,
+});
+assert.throws(() => settings.memoryRuntimeSettingsFromConfig({ max_loaded_models: 0 }), /positive integer/);
+assert.throws(() => settings.memoryRuntimeSettingsFromConfig({ max_loaded_models: -2 }), /positive integer/);
+assert.throws(() => settings.memoryRuntimeSettingsFromConfig({ max_loaded_models: 1, auto_evict_threshold_pct: 0 }), /greater than 0%/);
+assert.throws(() => settings.memoryRuntimeConfigChanges({ maxLoadedModels: 1, autoEvict: true, autoEvictThresholdPercent: 101 }), /at most 100%/);
+assert.equal(settings.autoCheckModelUpdatesFromConfig({ auto_check_model_updates: false }), false);
+assert.equal(settings.autoCheckModelUpdatesFromConfig({ auto_check_model_updates: true }), true);
+assert.equal(settings.autoCheckModelUpdatesFromConfig({}), true);
 
 const listSource = fs.readFileSync(path.join(root, 'src/components/ModelListPanel.tsx'), 'utf8');
 const managerSource = fs.readFileSync(path.join(root, 'src/components/ModelManager.tsx'), 'utf8');
 const panelSource = fs.readFileSync(path.join(root, 'src/components/GlobalModelSettingsPanel.tsx'), 'utf8');
 const connectSource = fs.readFileSync(path.join(root, 'src/components/ConnectView.tsx'), 'utf8');
+const dashboardSource = fs.readFileSync(path.join(root, 'src/components/Dashboard.tsx'), 'utf8');
 const navigationSource = fs.readFileSync(path.join(root, 'src/features/navigation/workspaceNavigation.ts'), 'utf8');
 const stylesSource = fs.readFileSync(path.join(root, 'src/styles/styles.css'), 'utf8');
 const chatSource = fs.readFileSync(path.join(root, 'src/components/ChatView.tsx'), 'utf8');
+const settingsSource = fs.readFileSync(path.join(root, 'src/features/modelSettings/globalModelSettings.ts'), 'utf8');
 
 assert.doesNotMatch(listSource, /onOpenGlobalSettings|Open global model settings|Global model settings/);
 assert.match(listSource, /onUpdateAllModels && \([\s\S]*?icon="rotate-ccw"[\s\S]*?Update all downloaded models/);
-assert.doesNotMatch(managerSource, /showGlobalSettings|<GlobalModelSettingsPanel/);
-assert.match(managerSource, /loadWithGlobalModelPolicy/);
+assert.doesNotMatch(managerSource, /showGlobalSettings|<GlobalModelSettingsPanel|loadWithGlobalModelPolicy|automaticUpdateIsDue|lastAutomaticUpdateAt/);
+assert.match(managerSource, /await loadModelRuntime\(model\)/);
 assert.match(managerSource, /handleUpdateAllModels/);
-for (const label of ['Chat history', 'Memory budget', 'Loading and eviction', 'Collapse thinking by default', 'Default TTS model', 'Automatic model updates']) {
+
+for (const label of [
+  'Chat history',
+  'Memory management',
+  'Loading and eviction',
+  'Automatic eviction',
+  'Eviction threshold',
+  'Maximum loaded models per type',
+  'Collapse thinking by default',
+  'Default TTS model',
+  'Check for model updates on server startup',
+]) {
   assert.ok(panelSource.includes(label), `settings panel is missing ${label}`);
 }
+for (const removedLabel of [
+  'Memory budget',
+  'Budget source',
+  'Auto-evict on memory or VRAM pressure',
+  'Loading policy',
+  'Keep loaded models',
+  'Single active model',
+  'Stay within budget',
+  'Largest first',
+  'Oldest process first',
+  'Manual only',
+  'Protect pinned models from automatic eviction',
+  'Automatic model updates',
+]) {
+  assert.ok(!panelSource.includes(removedLabel), `removed setting is still present: ${removedLabel}`);
+}
+assert.match(panelSource, /api\.getRuntimeConfig\(\)/);
+assert.match(panelSource, /api\.setRuntimeConfig\(memoryRuntimeConfigChanges\(memoryDraft\)\)/);
+assert.match(panelSource, /api\.setRuntimeConfig\(\{ auto_check_model_updates: autoCheckModelUpdates \}\)/);
+assert.match(panelSource, /Failed to save settings/);
+assert.match(panelSource, /await refetchServerDraft\(\)/);
+assert.match(panelSource, /Discard changes/);
+assert.match(panelSource, /memoryDraft\?\.autoEvict && \(/);
+assert.match(panelSource, /detail-configuration__context-stepper/);
+assert.match(panelSource, /autoEvictThresholdPercent \+ direction \* 5/);
+assert.match(panelSource, /step=\{5\}/);
+assert.match(panelSource, /current < 1 \? 1 : current \+ 1/);
+assert.match(panelSource, /current <= 1 \? -1 : current - 1/);
+assert.match(panelSource, /next === -1 \|\| next > 0/);
 assert.match(panelSource, /Kokoro · English/);
 assert.match(panelSource, /OpenMOSS · Multilingual/);
 assert.match(panelSource, /section === 'chat'/);
 assert.match(panelSource, /section === 'memory'/);
 assert.match(panelSource, /section === 'updates'/);
-assert.match(connectSource, /activeSection === 'chat'[\s\S]*?<GlobalModelSettingsPanel section="chat"/);
-assert.match(connectSource, /activeSection === 'memory'[\s\S]*?<GlobalModelSettingsPanel section="memory"/);
-assert.match(connectSource, /activeSection === 'model-storage'[\s\S]*?<GlobalModelSettingsPanel section="updates"/);
+assert.match(connectSource, /<GlobalModelSettingsPanel section="chat"[\s\S]*?connected=\{status === 'connected'\}/);
+assert.match(connectSource, /<GlobalModelSettingsPanel section="memory"[\s\S]*?connected=\{status === 'connected'\}/);
+assert.match(connectSource, /<GlobalModelSettingsPanel section="updates"[\s\S]*?connected=\{status === 'connected'\}/);
 assert.match(navigationSource, /defineSection\('chat',[\s\S]*?defineSection\('memory'/);
 assert.match(stylesSource, /\.connect__section > \.global-model-settings__body\s*\{[\s\S]*?width:\s*min\(var\(--content-form-width\), 100%\);/);
 assert.match(chatSource, /defaultThinkingOpen=\{!globalModelSettings\.collapseThinkingByDefault\}/);
 assert.match(chatSource, /GLOBAL_MODEL_SETTINGS_EVENT/);
-assert.match(chatSource, /loadModelWithPolicy/);
-assert.match(chatSource, /loadWithGlobalModelPolicy/);
+assert.doesNotMatch(chatSource, /loadWithGlobalModelPolicy|isMemoryPressureError|evictionPlanForLoad/);
+assert.match(chatSource, /return api\.loadModel\(modelName, recipeOptions, target\)/);
+assert.match(dashboardSource, /evictionRuntimeSettingsFromConfig/);
+assert.match(dashboardSource, /eviction\.autoEvict \? eviction\.autoEvictThresholdPercent : null/);
+assert.match(dashboardSource, /dash2-gauge__threshold/);
+assert.match(dashboardSource, /thresholdPercent=\{memoryTopology\.hostTotalGb != null \? evictionThresholdPercent : null\}/);
+assert.match(dashboardSource, /thresholdPercent=\{memoryTopology\.gpuTotalGb != null \? evictionThresholdPercent : null\}/);
+assert.match(dashboardSource, /memoryTopology\.hostTotalGb == null \? evictionThresholdText : null/);
+assert.match(dashboardSource, /memoryTopology\.gpuTotalGb == null \? evictionThresholdText : null/);
+assert.match(dashboardSource, /label="RAM \/ VRAM"/);
+assert.match(stylesSource, /\.dash2-gauge__threshold line/);
+
+const memoryTopologyFilename = path.join(root, 'src/features/dashboard/memoryTopology.ts');
+const memoryTopologyCompiled = ts.transpileModule(fs.readFileSync(memoryTopologyFilename, 'utf8'), {
+  compilerOptions: { target: ts.ScriptTarget.ES2020, module: ts.ModuleKind.CommonJS },
+  fileName: memoryTopologyFilename,
+  reportDiagnostics: true,
+});
+assert.equal((memoryTopologyCompiled.diagnostics || []).length, 0);
+const memoryTopologyModule = { exports: {} };
+Function('exports', 'require', 'module', '__filename', '__dirname', memoryTopologyCompiled.outputText)(
+  memoryTopologyModule.exports,
+  require,
+  memoryTopologyModule,
+  memoryTopologyFilename,
+  path.dirname(memoryTopologyFilename),
+);
+assert.deepEqual(memoryTopologyModule.exports.dashboardMemoryTopology({
+  'Physical Memory': '32 GB',
+  devices: {
+    amd_igpu: { available: true, integrated: true, vram_gb: 4, virtual_mem_gb: 32 },
+  },
+}), { unified: true, hostTotalGb: 32, gpuTotalGb: null });
+
+for (const removedField of [
+  'resourceBudgetMode',
+  'resourceBudgetGb',
+  'loadingPolicy',
+  'evictionPolicy',
+  'autoEvictOnPressure',
+  'protectPinnedModels',
+  'automaticModelUpdates',
+  'lastAutomaticUpdateAt',
+]) {
+  assert.ok(!settingsSource.includes(removedField), `server-owned field remains in local settings module: ${removedField}`);
+}
+
+console.log('Global model settings use server lifecycle config and keep only client-owned local preferences.');

--- a/src/app/tests/storage.runtime.cjs
+++ b/src/app/tests/storage.runtime.cjs
@@ -59,15 +59,6 @@ values.set('lemonade:user:b:global_model_settings', JSON.stringify({ autoEvictOn
 values.set('lemonade:user:a:mcp_server_ids', JSON.stringify(['a']));
 values.set('lemonade:user:b:mcp_server_ids', JSON.stringify(['b']));
 
-[
-  'lemonade_user_presets',
-  'lemonade_applied_presets',
-  'lemonade:user_presets',
-  'lemonade:applied_presets',
-  'lemonade:backend_presets',
-  'lemonade:running_presets',
-].forEach(key => values.set(key, 'obsolete'));
-
 const storageModule = loadStorageModule();
 assert.equal(storageModule.storageKey('conversations'), 'lemonade:conversations');
 
@@ -89,32 +80,5 @@ assert.equal(localStorage.getItem('lemonade:user:a:conversations'), null);
 assert.equal(localStorage.getItem('lemonade:user:b:conversations'), null);
 assert.equal(localStorage.getItem('lemonade:lemonade_storage_migrated_v1'), null);
 assert.equal(values.get('lemonade_storage_migrated_v2'), 'true');
-[
-  'lemonade_user_presets',
-  'lemonade_applied_presets',
-  'lemonade:user_presets',
-  'lemonade:applied_presets',
-  'lemonade:backend_presets',
-  'lemonade:running_presets',
-].forEach(key => assert.equal(localStorage.getItem(key), null));
-
-[
-  'lemonade_user_presets',
-  'lemonade_applied_presets',
-  'lemonade:user_presets',
-  'lemonade:applied_presets',
-  'lemonade:backend_presets',
-  'lemonade:running_presets',
-].forEach(key => values.set(key, 'obsolete-again'));
-const rerunStorageModule = loadStorageModule();
-assert.equal(rerunStorageModule.storageKey('rerun_probe'), 'lemonade:rerun_probe');
-[
-  'lemonade_user_presets',
-  'lemonade_applied_presets',
-  'lemonade:user_presets',
-  'lemonade:applied_presets',
-  'lemonade:backend_presets',
-  'lemonade:running_presets',
-].forEach(key => assert.equal(localStorage.getItem(key), null));
 
 console.log('Client storage migration preserves scoped conversations and merges compatible settings.');


### PR DESCRIPTION
## Summary

Align GUI3's global model lifecycle settings with lemond-owned state and policy.

The Memory settings page previously maintained its own model residency and eviction behavior in the browser. This removes that second lifecycle layer and uses the existing lemond runtime configuration instead:

- `max_loaded_models`
- `auto_evict`
- `auto_evict_threshold_pct`
- `auto_check_model_updates`

Model loading now sends the intended load request without performing client-side pre-eviction or OOM-based eviction/retry decisions.

The Memory settings UI keeps the existing GUI3 layout, but only exposes lifecycle controls backed by server state. Runtime values are refetched from lemond, save failures are surfaced, and Discard restores the authoritative server values instead of maintaining another set of defaults in the client.

System Vitals also shows the configured eviction threshold when automatic eviction is enabled. A marker is used when the visualization has a reliable memory total; otherwise the threshold is shown as text rather than drawing a misleading position.

The old browser-owned automatic model-update schedule is replaced by lemond's existing startup update-check setting.

Related to #3161

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.
But opted for an additional storage reduction...

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_

- Added runtime coverage for server-backed global model settings and localStorage cleanup.
- Added Playwright coverage for reading, saving, discarding, and failed writes of lifecycle runtime config.
- Covered `max_loaded_models = -1` and the custom number controls without allowing `0`.
- Covered conversion between the displayed eviction percentage and `auto_evict_threshold_pct`.
- Covered the 5 percentage-point eviction-threshold stepper.
- Covered System Vitals threshold marker/text fallback behavior.
- Verified model load paths no longer use the removed client-side lifecycle/eviction policy.
- Verified legacy browser lifecycle values are not migrated into server configuration.

## Documentation

- [x] Documentation is not affected by this change.

## Breaking Changes

- [x] This PR does not introduce breaking changes.

## AI-assisted contribution

Please select one:

- [x] I used AI tools for this PR.
- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.