### PR TITLE
fix(server): resolve custom args by scope

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2293,6 +2293,18 @@ if(BUILD_TESTING AND EXISTS "${_CUSTOM_ARGS_TEST_SRC}")
     add_cpp_ci_test(CustomArgsTest CI ON COMMAND test_custom_args)
 endif()
 
+# Recipe custom-argument scope resolution.
+set(_RECIPE_ARG_RESOLVER_TEST_SRC
+    "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_recipe_arg_resolution.cpp"
+)
+if(BUILD_TESTING AND EXISTS "${_RECIPE_ARG_RESOLVER_TEST_SRC}")
+    add_executable(test_recipe_arg_resolution ${_RECIPE_ARG_RESOLVER_TEST_SRC})
+    target_include_directories(test_recipe_arg_resolution PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/include
+    )
+    add_cpp_ci_test(RecipeArgResolutionTest CI ON COMMAND test_recipe_arg_resolution)
+endif()
+
 set(_DIR_WATCHER_TEST_SRC
     "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_directory_watcher.cpp"
 )

--- a/docs/api/lemonade.md
+++ b/docs/api/lemonade.md
@@ -953,7 +953,7 @@ Explicitly load a registered model into memory. This is useful to ensure that th
 
 > Note: loading a collection (`recipe: "collection.omni"`) loads each of its components in turn. Per-model options like `ctx_size` or `llamacpp_backend` are not forwarded to components — set them on each component's own `recipe_options.json` entry instead.
 
-Recipe option fields on `/v1/load` have three-state semantics. Omitting a field keeps using its saved per-model value. Passing explicit `null` ignores only that saved key for this load and falls through to the lower default layers without changing `recipe_options.json`. Passing a concrete value overrides the saved value. `ctx_size: -1` is a concrete value meaning automatic context sizing, not a tombstone. With `save_options: true`, concrete values are persisted as usual while a `null` tombstone preserves the existing saved value for that key.
+Recipe option fields on `/v1/load` have three-state semantics. Omitting a field keeps using its saved per-model value. Passing explicit `null` ignores only that saved key for this load and falls through to the lower default layers without changing `recipe_options.json`. Passing a concrete value overrides the saved value. For `*_args`, a concrete value replaces the model/architecture args scope for that load; backend/machine args remain only when `merge_args` is true. `ctx_size: -1` is a concrete value meaning automatic context sizing, not a tombstone. With `save_options: true`, concrete values are persisted as usual while a `null` tombstone preserves the existing saved value for that key.
 
 ### Parameters
 
@@ -971,7 +971,7 @@ Recipe option fields on `/v1/load` have three-state semantics. Omitting a field 
 | `cfg_scale` | No | sd-cpp | Classifier-free guidance scale for image generation. Default: 7.0. |
 | `width` | No | sd-cpp | Image width in pixels. Default: 512. |
 | `height` | No | sd-cpp | Image height in pixels. Default: 512. |
-| `merge_args` | No | All | Boolean. If true (default), `*_args` values from global config and per-model config are merged (per-model takes priority). If false, per-model `*_args` replace global `*_args` entirely. |
+| `merge_args` | No | All | Boolean. If true (default), backend/machine `*_args` are inherited; concrete request `*_args` replace model/architecture args while keeping backend args. If false, no inherited custom args or overridable runtime defaults are applied. |
 
 **Setting Priority:**
 

--- a/src/cpp/include/lemon/backends/backend_ops.h
+++ b/src/cpp/include/lemon/backends/backend_ops.h
@@ -49,6 +49,13 @@ public:
         (void)ctx;
     }
 
+    // Add automatic overridable options before exposing/passing to a backend.
+    // Managed arguments (model paths/ports) do not belong here. Default: none.
+    virtual void resolve_runtime_options(const ModelInfo& info, RecipeOptions& options) const {
+        (void)info;
+        (void)options;
+    }
+
     // Resolve a checkpoint to its absolute on-disk path (file or directory).
     // Default: the shared registry-cache behavior — locate the variant/aux file in the active
     // snapshot, else fall back to the model cache directory.

--- a/src/cpp/include/lemon/recipe_options.h
+++ b/src/cpp/include/lemon/recipe_options.h
@@ -19,8 +19,8 @@ public:
     json get_option(const std::string& opt) const;
     void set_option(const std::string& opt, const json& value);
     void remove_option(const std::string& opt);
-    // True when constructor input named this option, even if its sentinel value
-    // was dropped from options_.
+    // True when this layer explicitly named or set this option, even if its
+    // sentinel value was dropped from options_. inherit() preserves this provenance.
     bool has_explicit_option(const std::string& opt) const;
     json get_explicit_option(const std::string& opt) const;
     std::string get_recipe() const { return recipe_; };

--- a/src/cpp/include/lemon/recipe_options.h
+++ b/src/cpp/include/lemon/recipe_options.h
@@ -19,6 +19,10 @@ public:
     json get_option(const std::string& opt) const;
     void set_option(const std::string& opt, const json& value);
     void remove_option(const std::string& opt);
+    // True when constructor input named this option, even if its sentinel value
+    // was dropped from options_.
+    bool has_explicit_option(const std::string& opt) const;
+    json get_explicit_option(const std::string& opt) const;
     std::string get_recipe() const { return recipe_; };
 
 #ifdef LEMONADE_CLI
@@ -42,6 +46,7 @@ public:
     static bool is_default_sentinel(const std::string& key, const json& value);
 private:
     json options_ = json::object();
+    json explicit_options_ = json::object();
     std::string recipe_ = "";
 };
 }

--- a/src/cpp/include/lemon/router.h
+++ b/src/cpp/include/lemon/router.h
@@ -153,8 +153,10 @@ public:
         LoadPurpose load_purpose = LoadPurpose::UserInference,
         std::atomic<bool>* cancel_flag = nullptr);
 
-    // Collapse the option precedence chain — request > model > per-architecture
-    // > global config > built-in defaults — into the set a load would use.
+    // Collapse the option precedence chain into the set a load would use.
+    // *_args are resolved by scope: a concrete request replaces model/architecture
+    // args, backend/machine args are inherited only while merge_args is enabled,
+    // and overridable runtime defaults are materialized before this returns.
     // ctx_size may still be the -1 auto sentinel; the concrete value is only
     // resolved inside load_model, once eviction has freed memory.
     RecipeOptions resolve_effective_options(const ModelInfo& model_info,

--- a/src/cpp/include/lemon/utils/custom_args.h
+++ b/src/cpp/include/lemon/utils/custom_args.h
@@ -92,9 +92,16 @@ inline CustomArgsMap build_custom_args_map(const std::vector<std::string>& token
 
     for (const auto& token : tokens) {
         if (!token.empty() && token[0] == '-' && !is_negative_number(token)) {
-            // This is a flag; start a new entry
-            result[token].push_back({});
-            last_flag = token;
+            // This is a flag; start a new entry. Normalize --flag=value so it
+            // has the same precedence key as --flag value.
+            size_t eq_pos = token.find('=');
+            if (eq_pos != std::string::npos) {
+                last_flag = token.substr(0, eq_pos);
+                result[last_flag].push_back({token.substr(eq_pos + 1)});
+            } else {
+                result[token].push_back({});
+                last_flag = token;
+            }
         } else if (!last_flag.empty()) {
             // Append to the most recently seen flag
             result[last_flag].back().push_back(token);

--- a/src/cpp/include/lemon/utils/recipe_arg_resolver.h
+++ b/src/cpp/include/lemon/utils/recipe_arg_resolver.h
@@ -1,0 +1,104 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "lemon/utils/custom_args.h"
+
+namespace lemon {
+namespace utils {
+
+enum class CustomArgsRequestState {
+    Omitted,
+    Tombstone,
+    Value,
+};
+
+struct ScopedCustomArgs {
+    std::string backend;
+    std::string architecture;
+    std::string model_defaults;
+    std::string model;
+    CustomArgsRequestState request_state = CustomArgsRequestState::Omitted;
+    std::string request;
+    bool merge_args = true;
+};
+
+struct RuntimeArgDefault {
+    std::string args;
+    std::string flag;
+    std::vector<std::string> aliases;
+    bool negatable = false;
+};
+
+inline bool is_custom_args_option(const std::string& key) {
+    return key.size() >= 5 && key.compare(key.size() - 5, 5, "_args") == 0;
+}
+
+inline std::string merge_custom_args(const std::string& high,
+                                     const std::string& low) {
+    if (high.empty()) return low;
+    if (low.empty()) return high;
+
+    const auto high_map = build_custom_args_map(parse_custom_args(high, true));
+    const auto low_map = build_custom_args_map(parse_custom_args(low, true));
+    return map_to_args_string(merge_args_maps(high_map, low_map));
+}
+
+inline std::string resolve_scoped_custom_args(const ScopedCustomArgs& args) {
+    if (!args.merge_args) {
+        return args.request_state == CustomArgsRequestState::Value ? args.request : "";
+    }
+
+    if (args.request_state == CustomArgsRequestState::Value) {
+        return merge_custom_args(args.request, args.backend);
+    }
+
+    const std::string& model_args =
+        args.request_state == CustomArgsRequestState::Tombstone
+            ? args.model_defaults
+            : args.model;
+    const std::string model_scope = merge_custom_args(model_args, args.architecture);
+    return merge_custom_args(model_scope, args.backend);
+}
+
+inline std::string append_runtime_arg_defaults(
+    const std::string& custom_args,
+    const std::vector<RuntimeArgDefault>& defaults,
+    bool enabled = true) {
+    if (!enabled) return custom_args;
+
+    std::string result = custom_args;
+    std::vector<std::string> resolved_tokens = parse_custom_args(custom_args);
+
+    for (const auto& runtime_default : defaults) {
+        bool overridden = custom_args_has_flag(resolved_tokens, runtime_default.flag);
+
+        if (!overridden && runtime_default.negatable) {
+            const std::string negated = negate_flag(runtime_default.flag);
+            overridden = !negated.empty() && custom_args_has_flag(resolved_tokens, negated);
+        }
+
+        if (!overridden) {
+            for (const auto& alias : runtime_default.aliases) {
+                if (custom_args_has_flag(resolved_tokens, alias)) {
+                    overridden = true;
+                    break;
+                }
+            }
+        }
+
+        if (overridden || runtime_default.args.empty()) continue;
+
+        if (!result.empty()) result += " ";
+        result += runtime_default.args;
+
+        const auto added_tokens = parse_custom_args(runtime_default.args);
+        resolved_tokens.insert(resolved_tokens.end(), added_tokens.begin(), added_tokens.end());
+    }
+
+    return result;
+}
+
+} // namespace utils
+} // namespace lemon

--- a/src/cpp/include/lemon/utils/recipe_arg_resolver.h
+++ b/src/cpp/include/lemon/utils/recipe_arg_resolver.h
@@ -27,8 +27,6 @@ struct ScopedCustomArgs {
 struct RuntimeArgDefault {
     std::string args;
     std::string flag;
-    std::vector<std::string> aliases;
-    bool negatable = false;
 };
 
 inline bool is_custom_args_option(const std::string& key) {
@@ -74,22 +72,8 @@ inline std::string append_runtime_arg_defaults(
     std::vector<std::string> resolved_tokens = parse_custom_args(custom_args);
 
     for (const auto& runtime_default : defaults) {
-        bool overridden = custom_args_has_flag(resolved_tokens, runtime_default.flag);
-
-        if (!overridden && runtime_default.negatable) {
-            const std::string negated = negate_flag(runtime_default.flag);
-            overridden = !negated.empty() && custom_args_has_flag(resolved_tokens, negated);
-        }
-
-        if (!overridden) {
-            for (const auto& alias : runtime_default.aliases) {
-                if (custom_args_has_flag(resolved_tokens, alias)) {
-                    overridden = true;
-                    break;
-                }
-            }
-        }
-
+        const bool overridden =
+            custom_args_has_flag(resolved_tokens, runtime_default.flag);
         if (overridden || runtime_default.args.empty()) continue;
 
         if (!result.empty()) result += " ";

--- a/src/cpp/include/lemon/utils/recipe_arg_resolver.h
+++ b/src/cpp/include/lemon/utils/recipe_arg_resolver.h
@@ -32,7 +32,9 @@ struct RuntimeArgDefault {
 };
 
 inline bool is_custom_args_option(const std::string& key) {
-    return key.size() >= 5 && key.compare(key.size() - 5, 5, "_args") == 0;
+    return key != "merge_args" &&
+           key.size() > 5 &&
+           key.compare(key.size() - 5, 5, "_args") == 0;
 }
 
 inline std::string merge_custom_args(const std::string& high,

--- a/src/cpp/server/backends/llamacpp/llamacpp_server.cpp
+++ b/src/cpp/server/backends/llamacpp/llamacpp_server.cpp
@@ -119,12 +119,12 @@ static std::string resolve_llamacpp_runtime_args(const ModelInfo& model_info,
         {"--reasoning-format auto", "--reasoning-format", {}, false},
     };
 
-    const std::string draft_path = model_info.resolved_path("draft");
+    const std::string draft_checkpoint = model_info.checkpoint("draft");
     const bool has_dflash_label =
         std::find(model_info.labels.begin(), model_info.labels.end(), "dflash") !=
         model_info.labels.end();
     const bool is_dflash_draft =
-        !draft_path.empty() && is_dflash_draft_checkpoint(model_info.checkpoint("draft"));
+        !draft_checkpoint.empty() && is_dflash_draft_checkpoint(draft_checkpoint);
     const bool uses_mtp =
         std::find(model_info.labels.begin(), model_info.labels.end(), "mtp") !=
         model_info.labels.end();

--- a/src/cpp/server/backends/llamacpp/llamacpp_server.cpp
+++ b/src/cpp/server/backends/llamacpp/llamacpp_server.cpp
@@ -115,9 +115,7 @@ static std::string resolve_llamacpp_runtime_args(const ModelInfo& model_info,
                                                  bool merge_args) {
     if (!merge_args) return custom_args;
 
-    std::vector<RuntimeArgDefault> defaults = {
-        {"--reasoning-format auto", "--reasoning-format", {}, false},
-    };
+    std::vector<RuntimeArgDefault> defaults;
 
     const std::string draft_checkpoint = model_info.checkpoint("draft");
     const bool has_dflash_label =
@@ -130,21 +128,9 @@ static std::string resolve_llamacpp_runtime_args(const ModelInfo& model_info,
         model_info.labels.end();
 
     if (is_dflash_draft && has_dflash_label) {
-        defaults.push_back({"--spec-type draft-dflash", "--spec-type", {}, false});
+        defaults.push_back({"--spec-type draft-dflash", "--spec-type"});
     } else if (uses_mtp) {
-        defaults.push_back({"--spec-type draft-mtp", "--spec-type", {}, false});
-    }
-
-    defaults.push_back({"--no-ui", "--no-ui", {}, true});
-
-    if (SystemInfo::get_has_igpu()) {
-        defaults.push_back({
-            "--load-mode none",
-            "--load-mode",
-            {"--direct-io", "--no-direct-io", "-dio", "-ndio", "--mmap",
-             "--no-mmap", "--mlock", "-lm"},
-            false,
-        });
+        defaults.push_back({"--spec-type draft-mtp", "--spec-type"});
     }
 
     return append_runtime_arg_defaults(custom_args, defaults);
@@ -293,10 +279,6 @@ void LlamaCppServer::load(const std::string& model_name,
     std::string llamacpp_backend_option = options.get_option("llamacpp_backend");
     std::string llamacpp_backend = resolve_llamacpp_backend(llamacpp_backend_option);
     std::string llamacpp_args = options.get_option("llamacpp_args");
-    const json merge_args_value = options.get_option("merge_args");
-    const bool merge_args =
-        merge_args_value.is_boolean() ? merge_args_value.get<bool>() : true;
-    llamacpp_args = resolve_llamacpp_runtime_args(model_info, llamacpp_args, merge_args);
 
     RuntimeConfig::validate_backend_choice("llamacpp", llamacpp_backend_option);
 

--- a/src/cpp/server/backends/llamacpp/llamacpp_server.cpp
+++ b/src/cpp/server/backends/llamacpp/llamacpp_server.cpp
@@ -18,6 +18,7 @@
 #include "lemon/backend_manager.h"
 #include "lemon/runtime_config.h"
 #include "lemon/utils/custom_args.h"
+#include "lemon/utils/recipe_arg_resolver.h"
 #include "lemon/utils/process_manager.h"
 #include "lemon/utils/json_utils.h"
 #include "lemon/utils/path_utils.h"
@@ -79,44 +80,6 @@ static void push_arg(std::vector<std::string>& args,
     push_reserved(reserved, key, aliases);
 }
 
-// Helper to add a flag-only overridable argument (e.g., --context-shift)
-static void push_overridable_arg(std::vector<std::string>& args,
-                    const std::string& custom_args,
-                    const std::string& key) {
-    // boolean flags in llama-server can be turned off adding the --no- prefix to their name
-    std::string anti_key;
-    if (key.rfind("--no-", 0) == 0) {
-        anti_key = "--" + key.substr(5); // remove --no- prefix
-    } else {
-        anti_key = "--no-" + key.substr(2); //remove -- prefix
-    }
-
-    const std::vector<std::string> tokens = parse_custom_args(custom_args);
-    if (!custom_args_has_flag(tokens, key) && !custom_args_has_flag(tokens, anti_key)) {
-        args.push_back(key);
-    }
-}
-
-// Helper to add a flag-value overridable pair (e.g., --keep 16)
-static void push_overridable_arg(std::vector<std::string>& args,
-                    const std::string& custom_args,
-                    const std::string& key,
-                    const std::string& value,
-                    const std::vector<std::string>& aliases = {}) {
-    const std::vector<std::string> tokens = parse_custom_args(custom_args);
-
-    for (const auto& alias : aliases) {
-        if (custom_args_has_flag(tokens, alias)) {
-            return;
-        }
-    }
-
-    if (!custom_args_has_flag(tokens, key)) {
-        args.push_back(key);
-        args.push_back(value);
-    }
-}
-
 static std::string resolve_llamacpp_backend(const std::string& backend) {
     if (backend == "rocm") {
         // Map "rocm" to the appropriate channel based on config
@@ -145,6 +108,46 @@ static bool is_dflash_draft_checkpoint(std::string checkpoint) {
                                ? checkpoint
                                : checkpoint.substr(separator + 1);
     return filename.rfind("dflash-", 0) == 0 || filename == "dflash.gguf";
+}
+
+static std::string resolve_llamacpp_runtime_args(const ModelInfo& model_info,
+                                                 const std::string& custom_args,
+                                                 bool merge_args) {
+    if (!merge_args) return custom_args;
+
+    std::vector<RuntimeArgDefault> defaults = {
+        {"--reasoning-format auto", "--reasoning-format", {}, false},
+    };
+
+    const std::string draft_path = model_info.resolved_path("draft");
+    const bool has_dflash_label =
+        std::find(model_info.labels.begin(), model_info.labels.end(), "dflash") !=
+        model_info.labels.end();
+    const bool is_dflash_draft =
+        !draft_path.empty() && is_dflash_draft_checkpoint(model_info.checkpoint("draft"));
+    const bool uses_mtp =
+        std::find(model_info.labels.begin(), model_info.labels.end(), "mtp") !=
+        model_info.labels.end();
+
+    if (is_dflash_draft && has_dflash_label) {
+        defaults.push_back({"--spec-type draft-dflash", "--spec-type", {}, false});
+    } else if (uses_mtp) {
+        defaults.push_back({"--spec-type draft-mtp", "--spec-type", {}, false});
+    }
+
+    defaults.push_back({"--no-ui", "--no-ui", {}, true});
+
+    if (SystemInfo::get_has_igpu()) {
+        defaults.push_back({
+            "--load-mode none",
+            "--load-mode",
+            {"--direct-io", "--no-direct-io", "-dio", "-ndio", "--mmap",
+             "--no-mmap", "--mlock", "-lm"},
+            false,
+        });
+    }
+
+    return append_runtime_arg_defaults(custom_args, defaults);
 }
 
 static std::string trim_version_prefix(const std::string& version) {
@@ -290,6 +293,10 @@ void LlamaCppServer::load(const std::string& model_name,
     std::string llamacpp_backend_option = options.get_option("llamacpp_backend");
     std::string llamacpp_backend = resolve_llamacpp_backend(llamacpp_backend_option);
     std::string llamacpp_args = options.get_option("llamacpp_args");
+    const json merge_args_value = options.get_option("merge_args");
+    const bool merge_args =
+        merge_args_value.is_boolean() ? merge_args_value.get<bool>() : true;
+    llamacpp_args = resolve_llamacpp_runtime_args(model_info, llamacpp_args, merge_args);
 
     RuntimeConfig::validate_backend_choice("llamacpp", llamacpp_backend_option);
 
@@ -383,28 +390,6 @@ void LlamaCppServer::load(const std::string& model_name,
         push_arg(args, reserved_flags, "--model-draft", draft_path);
     }
     push_reserved(reserved_flags, "--model-draft", std::vector<std::string>{"-md", "--spec-draft-model"});
-
-    // Use legacy reasoning formatting
-    push_overridable_arg(args, llamacpp_args, "--reasoning-format", "auto");
-
-    const bool uses_mtp =
-        std::find(model_info.labels.begin(), model_info.labels.end(), "mtp") != model_info.labels.end();
-
-    if (is_dflash_draft && has_dflash_label) {
-        LOG(INFO, "LlamaCpp") << "Model uses DFlash, adding draft decoding defaults" << std::endl;
-        push_overridable_arg(args, llamacpp_args, "--spec-type", "draft-dflash");
-    } else if (uses_mtp) {
-        LOG(INFO, "LlamaCpp") << "Model uses MTP, adding draft decoding defaults" << std::endl;
-        push_overridable_arg(args, llamacpp_args, "--spec-type", "draft-mtp");
-    }
-
-    // Disable llamacpp webui by default
-    push_overridable_arg(args, llamacpp_args, "--no-ui");
-
-    // Disable mmap on iGPU
-    if (SystemInfo::get_has_igpu()) {
-        push_overridable_arg(args, llamacpp_args, "--load-mode", "none", {"--direct-io", "--no-direct-io", "-dio", "-ndio", "--mmap", "--no-mmap", "--mlock", "-lm"});
-    }
 
     // Add embeddings support if the model supports it
     if (supports_embeddings) {
@@ -844,6 +829,18 @@ bool is_ggml_hip_plugin_available() {
 // llamacpp model-management behavior: GGUF metadata + capability labels.
 class LlamaCppOps : public BackendOps {
 public:
+    void resolve_runtime_options(const ModelInfo& info, RecipeOptions& options) const override {
+        const json merge_args_value = options.get_option("merge_args");
+        const bool merge_args =
+            merge_args_value.is_boolean() ? merge_args_value.get<bool>() : true;
+        const json custom_args_value = options.get_option("llamacpp_args");
+        const std::string custom_args =
+            custom_args_value.is_string() ? custom_args_value.get<std::string>() : "";
+        options.set_option(
+            "llamacpp_args",
+            resolve_llamacpp_runtime_args(info, custom_args, merge_args));
+    }
+
     void populate_metadata(ModelInfo& info, const BackendOpsContext&) const override {
         const std::string gguf_path = info.resolved_path();
         if (gguf_path.size() < 5) {

--- a/src/cpp/server/recipe_options.cpp
+++ b/src/cpp/server/recipe_options.cpp
@@ -175,7 +175,11 @@ RecipeOptions::RecipeOptions(const std::string& recipe, const json& options) {
     std::vector<std::string> to_copy = get_keys_for_recipe(recipe_);
 
     for (auto key : to_copy) {
-        if (options.contains(key) && !is_empty_option(key, options[key])) {
+        if (!options.contains(key)) {
+            continue;
+        }
+        explicit_options_[key] = options[key];
+        if (!is_empty_option(key, options[key])) {
             options_[key] = options[key];
         }
     }
@@ -210,41 +214,11 @@ std::string RecipeOptions::to_log_string(bool resolve_defaults) const {
 
 RecipeOptions RecipeOptions::inherit(const RecipeOptions& options) const {
     json merged = options_;
-    // Read defensively: a hand-edited recipe_options.json can hold any type
-    // here, and throwing would take down every read of the model.
-    const json own_merge_args = options_.contains("merge_args") ? options_["merge_args"]
-                                                                : options.get_option("merge_args");
-    bool merge_args = own_merge_args.is_boolean() ? own_merge_args.get<bool>() : true;
-
     for (auto it = options.options_.begin(); it != options.options_.end(); ++it) {
-        if (merge_args && it.key().size() >= 5 && it.key().substr(it.key().size() - 5) == "_args") {
-            // Special handling for _args options: parse, merge maps, re-stringify
-            std::string target_str = "";
-            if (merged.contains(it.key()) && merged[it.key()].is_string()) {
-                target_str = merged[it.key()];
-            }
-
-            std::string incoming_str = it.value().is_string() ? it.value() : "";
-
-            if (target_str.empty()) {
-                merged[it.key()] = incoming_str;
-            } else if (incoming_str.empty()) {
-                merged[it.key()] = target_str;
-            } else {
-                auto target_tokens = lemon::utils::parse_custom_args(target_str, true);
-                auto incoming_tokens = lemon::utils::parse_custom_args(incoming_str, true);
-
-                auto target_map = lemon::utils::build_custom_args_map(target_tokens);
-                auto incoming_map = lemon::utils::build_custom_args_map(incoming_tokens);
-
-                auto merged_map = lemon::utils::merge_args_maps(target_map, incoming_map);
-                merged[it.key()] = lemon::utils::map_to_args_string(merged_map);
-            }
-        } else if (!merged.contains(it.key()) && !is_empty_option(it.key(), it.value())) {
+        if (!merged.contains(it.key()) && !is_empty_option(it.key(), it.value())) {
             merged[it.key()] = it.value();
         }
     }
-
     return RecipeOptions(recipe_, merged);
 }
 
@@ -266,10 +240,21 @@ json RecipeOptions::get_option(const std::string& opt) const {
 
 void RecipeOptions::set_option(const std::string& opt, const json& value) {
     options_[opt] = value;
+    explicit_options_[opt] = value;
 }
 
 void RecipeOptions::remove_option(const std::string& opt) {
     options_.erase(opt);
+    explicit_options_.erase(opt);
+}
+
+bool RecipeOptions::has_explicit_option(const std::string& opt) const {
+    return explicit_options_.contains(opt);
+}
+
+json RecipeOptions::get_explicit_option(const std::string& opt) const {
+    auto it = explicit_options_.find(opt);
+    return it != explicit_options_.end() ? *it : json();
 }
 
 #ifdef LEMONADE_CLI

--- a/src/cpp/server/recipe_options.cpp
+++ b/src/cpp/server/recipe_options.cpp
@@ -219,7 +219,9 @@ RecipeOptions RecipeOptions::inherit(const RecipeOptions& options) const {
             merged[it.key()] = it.value();
         }
     }
-    return RecipeOptions(recipe_, merged);
+    RecipeOptions inherited(recipe_, merged);
+    inherited.explicit_options_ = explicit_options_;
+    return inherited;
 }
 
 json RecipeOptions::get_option(const std::string& opt) const {

--- a/src/cpp/server/router.cpp
+++ b/src/cpp/server/router.cpp
@@ -1433,8 +1433,7 @@ RecipeOptions Router::resolve_effective_options(const ModelInfo& model_info,
             }
         }
 
-        effective.set_option(
-            key,
+        const std::string resolved_args =
             utils::resolve_scoped_custom_args({
                 args_value(backend_defaults_json, key),
                 args_value(arch_json, key),
@@ -1443,7 +1442,10 @@ RecipeOptions Router::resolve_effective_options(const ModelInfo& model_info,
                 request_state,
                 request_args,
                 merge_args,
-            }));
+            });
+        // Keep empty results: explicit "" is a meaningful clear value and the
+        // effective layer is also used as replayable load input.
+        effective.set_option(key, resolved_args);
     }
 
     if (const auto* ops = backends::ops_for(model_info.recipe)) {

--- a/src/cpp/server/router.cpp
+++ b/src/cpp/server/router.cpp
@@ -1,5 +1,6 @@
 #include "lemon/router.h"
 #include "lemon/cloud_provider_registry.h"
+#include "lemon/backends/backend_ops.h"
 #include "lemon/backends/backend_registry.h"
 #include "lemon/backends/cloud/cloud_server.h"
 #include "lemon/backends/llamacpp/llamacpp_server.h"
@@ -27,6 +28,7 @@
 #include "lemon/eviction_engine.h"
 #include "lemon/suspend_inhibitor.h"
 #include "lemon/utils/http_client.h"
+#include "lemon/utils/recipe_arg_resolver.h"
 
 namespace lemon {
 
@@ -1394,12 +1396,60 @@ RecipeOptions Router::resolve_effective_options(const ModelInfo& model_info,
     json backend_json = tentative.get_option(backend_option);
     const std::string backend = backend_json.is_string() ? backend_json.get<std::string>() : "";
 
-    // Second pass: rebuild defaults using the resolved backend.
-    // Per-architecture defaults sit between global config and model-level recipe_options.
-    RecipeOptions default_opt = RecipeOptions(model_info.recipe, config_->recipe_options(backend));
+    RecipeOptions default_opt(model_info.recipe, config_->recipe_options(backend));
     RecipeOptions arch_opts(model_info.recipe,
                             model_manager_->get_architecture_defaults(model_info.gguf.architecture));
-    return request_options.inherit(model_info.recipe_options.inherit(arch_opts.inherit(default_opt)));
+    RecipeOptions effective =
+        request_options.inherit(model_info.recipe_options.inherit(arch_opts.inherit(default_opt)));
+
+    const json model_json = model_info.recipe_options.to_json();
+    const json model_defaults_json =
+        model_manager_->get_model_default_options(model_info).to_json();
+    const json arch_json = arch_opts.to_json();
+    const json backend_defaults_json = default_opt.to_json();
+    const json merge_value = effective.get_option("merge_args");
+    const bool merge_args = merge_value.is_boolean() ? merge_value.get<bool>() : true;
+
+    auto args_value = [](const json& layer, const std::string& key) {
+        auto it = layer.find(key);
+        return it != layer.end() && it->is_string() ? it->get<std::string>() : "";
+    };
+
+    for (const auto& key : RecipeOptions::keys_for_recipe(model_info.recipe)) {
+        if (!utils::is_custom_args_option(key)) continue;
+
+        utils::CustomArgsRequestState request_state =
+            utils::CustomArgsRequestState::Omitted;
+        std::string request_args;
+        if (request_options.has_explicit_option(key)) {
+            const json raw_request = request_options.get_explicit_option(key);
+            if (raw_request.is_null()) {
+                request_state = utils::CustomArgsRequestState::Tombstone;
+            } else if (raw_request.is_string()) {
+                request_state = utils::CustomArgsRequestState::Value;
+                request_args = raw_request.get<std::string>();
+            } else {
+                throw std::invalid_argument("'" + key + "' must be a string or null");
+            }
+        }
+
+        effective.set_option(
+            key,
+            utils::resolve_scoped_custom_args({
+                args_value(backend_defaults_json, key),
+                args_value(arch_json, key),
+                args_value(model_defaults_json, key),
+                args_value(model_json, key),
+                request_state,
+                request_args,
+                merge_args,
+            }));
+    }
+
+    if (const auto* ops = backends::ops_for(model_info.recipe)) {
+        ops->resolve_runtime_options(model_info, effective);
+    }
+    return effective;
 }
 
 RecipeOptions Router::get_model_recipe_options(const std::string& model_name) const {

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -5850,7 +5850,6 @@ void Server::handle_load(const httplib::Request& req, httplib::Response& res) {
             info = model_manager_->get_model_info(model_name);
         }
 
-        // ModelInfo::recipe_options contains the model-level defaults plus the
         // Null tombstones are load-local: remove only those saved keys from the
         // local model layer without changing recipe_options.json.
         if (!transient_saved_option_tombstones.empty()) {

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -5807,26 +5807,13 @@ void Server::handle_load(const httplib::Request& req, httplib::Response& res) {
         auto info = model_manager_->get_model_info(model_name);
 
         // Extract optional per-model settings. Omitted options keep saved values;
-        // explicit *_args keys mask them for this load, and null acts as a tombstone.
-        // ctx_size=-1 explicitly requests automatic sizing.
-        // ctx_size=-1 remains an explicit request for automatic sizing.
+        // null masks only its saved key for this load. Concrete *_args scope is
+        // resolved later by Router. ctx_size=-1 remains an explicit auto value.
         RecipeOptions options = RecipeOptions(info.recipe, request_json);
         std::set<std::string> transient_saved_option_tombstones;
-        std::set<std::string> transient_saved_option_masks;
         for (const auto& key : RecipeOptions::keys_for_recipe(info.recipe)) {
-            if (!request_json.contains(key)) {
-                continue;
-            }
-
-            if (request_json[key].is_null()) {
+            if (request_json.contains(key) && request_json[key].is_null()) {
                 transient_saved_option_tombstones.insert(key);
-                transient_saved_option_masks.insert(key);
-                continue;
-            }
-
-            if (key.size() >= 5 &&
-                key.compare(key.size() - 5, 5, "_args") == 0) {
-                transient_saved_option_masks.insert(key);
             }
         }
 
@@ -5864,17 +5851,14 @@ void Server::handle_load(const httplib::Request& req, httplib::Response& res) {
         }
 
         // ModelInfo::recipe_options contains the model-level defaults plus the
-        // recipe_options.json overlay. Rebuild that local copy with request-masked
-        // saved keys removed. Concrete *_args then override the saved same-key
-        // layer while merge_args can still combine model defaults and the lower
-        // architecture/backend/global layers. This load does not alter the
-        // persistent recipe_options.json entry.
-        if (!transient_saved_option_masks.empty()) {
+        // Null tombstones are load-local: remove only those saved keys from the
+        // local model layer without changing recipe_options.json.
+        if (!transient_saved_option_tombstones.empty()) {
             json per_model_options = model_manager_->get_model_default_options(info).to_json();
             const json saved = model_manager_->get_saved_model_options(model_name);
             if (saved.is_object()) {
                 for (const auto& [key, value] : saved.items()) {
-                    if (transient_saved_option_masks.count(key) == 0) {
+                    if (transient_saved_option_tombstones.count(key) == 0) {
                         per_model_options[key] = value;
                     }
                 }

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -2446,12 +2446,13 @@ void Server::ensure_collection_loaded(const ModelInfo& info) {
             comp_info = model_manager_->get_model_info(component);
         }
         LOG(INFO, "Server") << "Loading component: " << component << std::endl;
-        // Per the documented contract, per-model options like ctx_size or
-        // llamacpp_backend are NOT forwarded from the collection's load request
-        // to its components. Each component uses its own saved recipe_options.json
-        // entry.
-        router_->load_model(component, comp_info, comp_info.recipe_options, true,
-                            /*allow_reload_on_option_change=*/true);
+        // The collection load request does not become the component request
+        // layer. Router already reads the component's saved options from comp_info,
+        // so an empty request preserves normal model/architecture/backend scope
+        // semantics.
+        router_->load_model(
+            component, comp_info, RecipeOptions(comp_info.recipe, json::object()), true,
+            /*allow_reload_on_option_change=*/true);
     }
 }
 

--- a/test/cpp/test_recipe_arg_resolution.cpp
+++ b/test/cpp/test_recipe_arg_resolution.cpp
@@ -1,0 +1,147 @@
+#include "lemon/utils/recipe_arg_resolver.h"
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using lemon::utils::CustomArgsRequestState;
+using lemon::utils::RuntimeArgDefault;
+using lemon::utils::ScopedCustomArgs;
+using lemon::utils::append_runtime_arg_defaults;
+using lemon::utils::build_custom_args_map;
+using lemon::utils::parse_custom_args;
+using lemon::utils::resolve_scoped_custom_args;
+
+static bool expect_args(const char* name, const std::string& actual,
+                        const std::string& expected) {
+    const auto actual_map = build_custom_args_map(parse_custom_args(actual));
+    const auto expected_map = build_custom_args_map(parse_custom_args(expected));
+    const bool ok = actual_map == expected_map;
+    std::printf("[%s] %s\n", ok ? "PASS" : "FAIL", name);
+    if (!ok) {
+        std::printf("  got:  %s\n  want: %s\n", actual.c_str(), expected.c_str());
+    }
+    return ok;
+}
+
+int main() {
+    int failures = 0;
+
+    const std::string backend = "-b 2048 -ub 1024 -np 1";
+    const std::string architecture = "--temp 0.8 --top-k 40";
+    const std::string model_defaults = "--flash-attn on";
+    const std::string model = "--no-mmap --threads 8";
+
+    failures += !expect_args(
+        "no request inherits backend and model scope",
+        resolve_scoped_custom_args(
+            {backend, architecture, model_defaults, model,
+             CustomArgsRequestState::Omitted, "", true}),
+        "-b 2048 -ub 1024 -np 1 --temp 0.8 --top-k 40 --no-mmap --threads 8");
+
+    failures += !expect_args(
+        "request replaces model scope and keeps backend",
+        resolve_scoped_custom_args(
+            {backend, architecture, model_defaults, model,
+             CustomArgsRequestState::Value, "--threads 4", true}),
+        "-b 2048 -ub 1024 -np 1 --threads 4");
+
+    failures += !expect_args(
+        "empty request clears model scope and keeps backend",
+        resolve_scoped_custom_args(
+            {backend, architecture, model_defaults, model,
+             CustomArgsRequestState::Value, "", true}),
+        backend);
+
+    failures += !expect_args(
+        "null tombstone skips saved args and falls through to defaults",
+        resolve_scoped_custom_args(
+            {backend, architecture, model_defaults, model,
+             CustomArgsRequestState::Tombstone, "", true}),
+        "-b 2048 -ub 1024 -np 1 --temp 0.8 --top-k 40 --flash-attn on");
+
+    failures += !expect_args(
+        "merge false without request inherits no custom args",
+        resolve_scoped_custom_args(
+            {backend, architecture, model_defaults, model,
+             CustomArgsRequestState::Omitted, "", false}),
+        "");
+
+    failures += !expect_args(
+        "merge false with request uses request only",
+        resolve_scoped_custom_args(
+            {backend, architecture, model_defaults, model,
+             CustomArgsRequestState::Value, "--threads 4", false}),
+        "--threads 4");
+
+    failures += !expect_args(
+        "merge false with null tombstone inherits no custom args",
+        resolve_scoped_custom_args(
+            {backend, architecture, model_defaults, model,
+             CustomArgsRequestState::Tombstone, "", false}),
+        "");
+
+    failures += !expect_args(
+        "request overrides same backend flag with equals syntax",
+        resolve_scoped_custom_args(
+            {"--threads 12 -b 2048", "", "", "",
+             CustomArgsRequestState::Value, "--threads=4", true}),
+        "-b 2048 --threads 4");
+
+    failures += !expect_args(
+        "request negation overrides backend opposite",
+        resolve_scoped_custom_args(
+            {"--mmap -b 2048", "", "", "",
+             CustomArgsRequestState::Value, "--no-mmap", true}),
+        "-b 2048 --no-mmap");
+
+    failures += !expect_args(
+        "repeatable request flags survive wholesale model replacement",
+        resolve_scoped_custom_args(
+            {"-b 2048", "--threads 8", "", "--threads 6",
+             CustomArgsRequestState::Value,
+             "--override-kv a=bool:false --override-kv b=bool:false", true}),
+        "-b 2048 --override-kv a=bool:false --override-kv b=bool:false");
+
+    const std::vector<RuntimeArgDefault> runtime_defaults = {
+        {"--reasoning-format auto", "--reasoning-format", {}, false},
+        {"--no-ui", "--no-ui", {}, true},
+        {"--load-mode none", "--load-mode",
+         {"--direct-io", "--no-direct-io", "-dio", "-ndio", "--mmap",
+          "--no-mmap", "--mlock", "-lm"},
+         false},
+    };
+
+    failures += !expect_args(
+        "runtime defaults become part of effective args",
+        append_runtime_arg_defaults("--threads 4", runtime_defaults),
+        "--threads 4 --reasoning-format auto --no-ui --load-mode none");
+
+    failures += !expect_args(
+        "runtime exact option overrides default",
+        append_runtime_arg_defaults("--reasoning-format=deepseek", runtime_defaults),
+        "--reasoning-format deepseek --no-ui --load-mode none");
+
+    failures += !expect_args(
+        "runtime binary negation overrides default",
+        append_runtime_arg_defaults("--ui", runtime_defaults),
+        "--ui --reasoning-format auto --load-mode none");
+
+    failures += !expect_args(
+        "runtime alias overrides load-mode default",
+        append_runtime_arg_defaults("--no-mmap", runtime_defaults),
+        "--no-mmap --reasoning-format auto --no-ui");
+
+    failures += !expect_args(
+        "runtime equals-form alias overrides load-mode default",
+        append_runtime_arg_defaults("--mmap=auto", runtime_defaults),
+        "--mmap auto --reasoning-format auto --no-ui");
+
+    failures += !expect_args(
+        "merge false suppresses overridable runtime defaults",
+        append_runtime_arg_defaults("--threads 4", runtime_defaults, false),
+        "--threads 4");
+
+    std::printf("\n%d failures\n", failures);
+    return failures == 0 ? 0 : 1;
+}

--- a/test/cpp/test_recipe_arg_resolution.cpp
+++ b/test/cpp/test_recipe_arg_resolution.cpp
@@ -9,6 +9,7 @@ using lemon::utils::RuntimeArgDefault;
 using lemon::utils::ScopedCustomArgs;
 using lemon::utils::append_runtime_arg_defaults;
 using lemon::utils::build_custom_args_map;
+using lemon::utils::is_custom_args_option;
 using lemon::utils::parse_custom_args;
 using lemon::utils::resolve_scoped_custom_args;
 
@@ -24,8 +25,29 @@ static bool expect_args(const char* name, const std::string& actual,
     return ok;
 }
 
+static bool expect_bool(const char* name, bool actual, bool expected) {
+    const bool ok = actual == expected;
+    std::printf("[%s] %s\n", ok ? "PASS" : "FAIL", name);
+    if (!ok) {
+        std::printf("  got:  %s\n  want: %s\n",
+                    actual ? "true" : "false",
+                    expected ? "true" : "false");
+    }
+    return ok;
+}
+
 int main() {
     int failures = 0;
+
+    failures += !expect_bool(
+        "llamacpp_args is a custom args option",
+        is_custom_args_option("llamacpp_args"), true);
+    failures += !expect_bool(
+        "sdcpp_args is a custom args option",
+        is_custom_args_option("sdcpp_args"), true);
+    failures += !expect_bool(
+        "merge_args is not a custom args option",
+        is_custom_args_option("merge_args"), false);
 
     const std::string backend = "-b 2048 -ub 1024 -np 1";
     const std::string architecture = "--temp 0.8 --top-k 40";

--- a/test/cpp/test_recipe_arg_resolution.cpp
+++ b/test/cpp/test_recipe_arg_resolution.cpp
@@ -126,38 +126,18 @@ int main() {
         "-b 2048 --override-kv a=bool:false --override-kv b=bool:false");
 
     const std::vector<RuntimeArgDefault> runtime_defaults = {
-        {"--reasoning-format auto", "--reasoning-format", {}, false},
-        {"--no-ui", "--no-ui", {}, true},
-        {"--load-mode none", "--load-mode",
-         {"--direct-io", "--no-direct-io", "-dio", "-ndio", "--mmap",
-          "--no-mmap", "--mlock", "-lm"},
-         false},
+        {"--spec-type draft-mtp", "--spec-type"},
     };
 
     failures += !expect_args(
-        "runtime defaults become part of effective args",
+        "runtime default becomes part of effective args",
         append_runtime_arg_defaults("--threads 4", runtime_defaults),
-        "--threads 4 --reasoning-format auto --no-ui --load-mode none");
+        "--threads 4 --spec-type draft-mtp");
 
     failures += !expect_args(
-        "runtime exact option overrides default",
-        append_runtime_arg_defaults("--reasoning-format=deepseek", runtime_defaults),
-        "--reasoning-format deepseek --no-ui --load-mode none");
-
-    failures += !expect_args(
-        "runtime binary negation overrides default",
-        append_runtime_arg_defaults("--ui", runtime_defaults),
-        "--ui --reasoning-format auto --load-mode none");
-
-    failures += !expect_args(
-        "runtime alias overrides load-mode default",
-        append_runtime_arg_defaults("--no-mmap", runtime_defaults),
-        "--no-mmap --reasoning-format auto --no-ui");
-
-    failures += !expect_args(
-        "runtime equals-form alias overrides load-mode default",
-        append_runtime_arg_defaults("--mmap=auto", runtime_defaults),
-        "--mmap auto --reasoning-format auto --no-ui");
+        "explicit runtime option overrides default",
+        append_runtime_arg_defaults("--spec-type=draft-dflash", runtime_defaults),
+        "--spec-type draft-dflash");
 
     failures += !expect_args(
         "merge false suppresses overridable runtime defaults",

--- a/test/server_endpoints.py
+++ b/test/server_endpoints.py
@@ -1764,7 +1764,6 @@ class EndpointTests(ServerTestBase):
                 "max_completion_tokens",
                 "model",
                 "pinned",
-                "llamacpp_args",
                 "auto_evict",
                 "evict_idle_timeout",
             ]
@@ -1775,6 +1774,15 @@ class EndpointTests(ServerTestBase):
                     f"Request-scoped field '{field}' must NOT leak into recipe_options "
                     f"on auto-load (found: {recipe_options.get(field)})",
                 )
+
+            # Runtime defaults may populate llamacpp_args; the inference request must not.
+            effective_llamacpp_args = recipe_options.get("llamacpp_args", "")
+            self.assertIsInstance(effective_llamacpp_args, str)
+            self.assertNotIn(
+                "--foo-bar",
+                effective_llamacpp_args,
+                "Request llamacpp_args must not leak into recipe_options on auto-load",
+            )
 
             print(
                 f"[OK] Auto-load forwarded only ctx_size={custom_ctx_size}; "

--- a/test/test_ollama.py
+++ b/test/test_ollama.py
@@ -597,7 +597,6 @@ class OllamaTests(ServerTestBase):
                 "top_p",
                 "num_predict",
                 "pinned",
-                "llamacpp_args",
                 "auto_evict",
                 "evict_idle_timeout",
             ):
@@ -606,6 +605,14 @@ class OllamaTests(ServerTestBase):
                     recipe_options,
                     f"Request-scoped field '{field}' must not leak into recipe_options",
                 )
+
+            effective_llamacpp_args = recipe_options.get("llamacpp_args", "")
+            self.assertIsInstance(effective_llamacpp_args, str)
+            self.assertNotIn(
+                "--foo-bar",
+                effective_llamacpp_args,
+                "Ollama request llamacpp_args must not leak into recipe_options",
+            )
         finally:
             unload_all_models()
 


### PR DESCRIPTION
## Summary

Fix the `*_args` resolution semantics by separating backend/machine arguments from model-scoped and request-scoped arguments.

The effective custom-argument order is now:

`backend/machine -> model defaults -> explicit request -> runtime defaults`

The important behavior changes are:

- without request `*_args`, model and architecture args are inherited normally
- explicit request `*_args` replace the model/architecture `*_args` layer while preserving backend/machine args
- `merge_args=false` disables inherited custom args completely
- explicit empty `*_args` clears the model-scoped args for that load
- existing transient `null` semantics are preserved
- overridable llama.cpp runtime defaults are resolved into the effective options before backend startup instead of being added later as hidden arguments

This also makes the effective options a better representation of the backend configuration that will actually be launched.

The existing per-model save behavior remains key-based: supplying a new `*_args` value replaces the stored value rather than merging the argument strings.

Adds focused C++ regression coverage for the argument precedence and override rules.

Fixes #3226

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_

```bash
cmake --build --preset default --target test_recipe_arg_resolution
ctest --test-dir build -R '^RecipeArgResolutionTest$' --output-on-failure
git diff --check
```

Regression coverage includes:

- backend + model args when no request `*_args` are supplied
- backend + request args when request `*_args` are supplied
- explicit empty request args
- transient `null` request behavior
- `merge_args=false` with and without request args
- conflicting flags such as `--threads`
- boolean negation pairs such as `--mmap` / `--no-mmap`
- `--flag=value` syntax
- repeatable arguments
- llama.cpp runtime-default overrides and aliases
- runtime defaults appearing in the resolved effective args

## Documentation

- [ ] Documentation is not affected by this change.
- [x] Documentation is affected and has been updated.
- [ ] Documentation is affected but will be handled in a separate PR or issue.

## Breaking Changes

- [x] This PR introduces breaking changes.
- [ ] This PR does not introduce breaking changes.

The precedence of custom `*_args` is intentionally changed.

Clients that explicitly provide request `*_args` will no longer also receive model or architecture `*_args`. Backend/machine arguments are still inherited when `merge_args=true`.

Setting `merge_args=false` now means no lower-level custom arguments are inherited.

These changes are the intended semantics discussed in #3226.

## AI-assisted contribution

- [x] I used AI tools for this PR.
- [ ] I did not use AI tools for this PR.

If AI tools were used:

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.