### PR TITLE
feat(server): add context_length to the models endpoints

### DIFF
--- a/docs/api/openai.md
+++ b/docs/api/openai.md
@@ -1045,7 +1045,7 @@ curl http://localhost:13305/v1/models?show_all=true
   - `recipe` - Backend/device recipe used to load the model (e.g., `"ryzenai-llm"`, `"llamacpp"`, `"flm"`)
   - `size` - Model size in GB (omitted for models without size information)
   - `max_context_window` - Optional integer indicating the maximum model-supported text context discovered from local static metadata. Currently populated for downloaded GGUF/llama.cpp models and installed FLM text-context models.
-  - `context_length` - Integer indicating the effective context window the model is served with, rather than the native maximum in `max_context_window`. Populated from the loaded context when the model is running and the configured `ctx_size` otherwise (omitted when neither is known).
+  - `context_length` - Number of tokens the model can handle in one request. Uses the loaded value when the model is running and the configured `ctx_size` otherwise (omitted when neither is known).
   - `downloaded` - Boolean indicating if the model is downloaded and available locally
   - `update_available` - Boolean indicating a newer commit exists on HuggingFace for this model. Only set for downloaded HF-backed models. `false` otherwise.
   - `suggested` - Boolean indicating if the model is recommended for general use

--- a/docs/api/openai.md
+++ b/docs/api/openai.md
@@ -956,7 +956,7 @@ The generated audio file is returned as-is.
 ## `GET /v1/models`
 <sub>![Status](https://img.shields.io/badge/status-fully_available-green)</sub>
 
-Returns a list of models available on the server in an OpenAI-compatible format. Each model object includes extended fields like `checkpoint`, `recipe`, `size`, `downloaded`, `labels`, and, when known, `max_context_window`.
+Returns a list of models available on the server in an OpenAI-compatible format. Each model object includes extended fields like `checkpoint`, `recipe`, `size`, `downloaded`, `labels`, `context_length`, and, when known, `max_context_window`.
 
 By default, only models available locally (downloaded) are shown, matching OpenAI API behavior.
 
@@ -993,6 +993,7 @@ curl http://localhost:13305/v1/models?show_all=true
       "recipe": "llamacpp",
       "size": 0.38,
       "max_context_window": 40960,
+      "context_length": 8192,
       "downloaded": true,
       "suggested": true,
       "update_available": false,
@@ -1044,6 +1045,7 @@ curl http://localhost:13305/v1/models?show_all=true
   - `recipe` - Backend/device recipe used to load the model (e.g., `"ryzenai-llm"`, `"llamacpp"`, `"flm"`)
   - `size` - Model size in GB (omitted for models without size information)
   - `max_context_window` - Optional integer indicating the maximum model-supported text context discovered from local static metadata. Currently populated for downloaded GGUF/llama.cpp models and installed FLM text-context models.
+  - `context_length` - Integer indicating the effective context window the model is served with, rather than the native maximum in `max_context_window`. Populated from the loaded context when the model is running and the configured `ctx_size` otherwise (omitted when neither is known).
   - `downloaded` - Boolean indicating if the model is downloaded and available locally
   - `update_available` - Boolean indicating a newer commit exists on HuggingFace for this model. Only set for downloaded HF-backed models. `false` otherwise.
   - `suggested` - Boolean indicating if the model is recommended for general use
@@ -1167,6 +1169,7 @@ Returns a single model object with the same fields as described in the [models l
   "recipe": "llamacpp",
   "size": 0.38,
   "max_context_window": 40960,
+  "context_length": 8192,
   "downloaded": true,
   "suggested": true,
   "labels": ["reasoning"],

--- a/src/cpp/include/lemon/server.h
+++ b/src/cpp/include/lemon/server.h
@@ -338,6 +338,12 @@ private:
     nlohmann::json model_info_to_json(const std::string& model_id, const ModelInfo& info,
                                       int depth = 0);
 
+    // Effective context window, or 0 when nothing knows it: a loaded backend's
+    // own ctx_size, else the resolved options, else max_context_window.
+    // Deliberately skips the VRAM auto-tuner, which probes the system on every
+    // call and would do so once per model across a full listing.
+    int64_t resolve_context_length(const std::string& model_id, const ModelInfo& info) const;
+
     // Warm model list cache in the background after startup dependencies are initialized
     void start_model_cache_warmup();
 

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -2840,6 +2840,34 @@ void Server::handle_model_register(const httplib::Request& req, httplib::Respons
     }
 }
 
+int64_t Server::resolve_context_length(const std::string& model_id, const ModelInfo& info) const {
+    // ctx_size stores -1 for "size this automatically", so only a positive
+    // value answers; anything else falls through to the next source.
+    auto ctx_size_of = [](const RecipeOptions& options) -> int64_t {
+        const nlohmann::json ctx_json = options.get_option("ctx_size");
+        return ctx_json.is_number() ? ctx_json.get<int64_t>() : 0;
+    };
+
+    if (router_) {
+        // A live backend was started with a resolved ctx_size, so it answers
+        // exactly. An unloaded model yields empty options here, which resolve
+        // to the -1 default and fall through to the configured value below.
+        const int64_t loaded_ctx = ctx_size_of(router_->get_model_recipe_options(model_id));
+        if (loaded_ctx > 0) {
+            return loaded_ctx;
+        }
+
+        const RecipeOptions no_request_options(info.recipe, nlohmann::json::object());
+        const int64_t configured_ctx =
+            ctx_size_of(router_->resolve_effective_options(info, no_request_options));
+        if (configured_ctx > 0) {
+            return configured_ctx;
+        }
+    }
+
+    return info.max_context_window > 0 ? info.max_context_window : 0;
+}
+
 // Maximum collection-component nesting depth embedded in "models" arrays.
 // Collection components are normally leaf models, but nothing prevents
 // registering a collection as a component of another collection — including
@@ -2887,6 +2915,14 @@ nlohmann::json Server::model_info_to_json(const std::string& model_id, const Mod
 
     if (info.max_context_window > 0) {
         model_json["max_context_window"] = info.max_context_window;
+    }
+
+    // OpenAI-compatible clients read context_length to budget a session.
+    // max_context_window is the GGUF training ceiling, not what the model runs
+    // with, so clients that fall back to it overflow mid-session.
+    const int64_t context_length = resolve_context_length(model_id, info);
+    if (context_length > 0) {
+        model_json["context_length"] = context_length;
     }
 
     // Per-million-token pricing in USD, when the provider reported it (cloud

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -2849,10 +2849,8 @@ int64_t Server::resolve_context_length(const std::string& model_id, const ModelI
     };
 
     if (router_) {
-        // A live backend was started with a resolved ctx_size, so it answers
-        // exactly. An unloaded model yields empty options here, which resolve
-        // to the -1 default and fall through to the configured value below.
-        const int64_t loaded_ctx = ctx_size_of(router_->get_model_recipe_options(model_id));
+        const int64_t loaded_ctx =
+            ctx_size_of(router_->get_model_recipe_options(resolve_alias_target(model_id)));
         if (loaded_ctx > 0) {
             return loaded_ctx;
         }
@@ -2917,9 +2915,7 @@ nlohmann::json Server::model_info_to_json(const std::string& model_id, const Mod
         model_json["max_context_window"] = info.max_context_window;
     }
 
-    // OpenAI-compatible clients read context_length to budget a session.
-    // max_context_window is the GGUF training ceiling, not what the model runs
-    // with, so clients that fall back to it overflow mid-session.
+    // OpenAI-compatible clients use context_length to set token limits.
     const int64_t context_length = resolve_context_length(model_id, info);
     if (context_length > 0) {
         model_json["context_length"] = context_length;

--- a/test/server_endpoints.py
+++ b/test/server_endpoints.py
@@ -715,6 +715,110 @@ class EndpointTests(ServerTestBase):
 
         print("[OK] NotFoundError raised for non-existent model")
 
+    def _retrieve_model_json(self, model=ENDPOINT_TEST_MODEL):
+        """Fetch one model entry. The OpenAI SDK object does not expose
+        context_length, so read the raw JSON."""
+        response = requests.get(
+            f"{self.base_url}/models/{model}", timeout=TIMEOUT_DEFAULT
+        )
+        self.assertEqual(response.status_code, 200, response.text)
+        return response.json()
+
+    def _unload_for_configured_context(self):
+        """Unload first: a loaded model reports its own size, which outranks
+        the configured value these tests check."""
+        requests.post(f"{self.base_url}/unload", json={}, timeout=TIMEOUT_DEFAULT)
+
+    def test_006a_context_length_uses_explicit_ctx_size(self):
+        """An explicit per-model ctx_size is what context_length reports."""
+        self._snapshot_options()
+        self._unload_for_configured_context()
+        self._reset_options()
+
+        requests.post(
+            self._options_url(), json={"ctx_size": 8192}, timeout=TIMEOUT_DEFAULT
+        )
+
+        model = self._retrieve_model_json()
+        self.assertEqual(
+            model.get("context_length"),
+            8192,
+            "context_length should match the explicitly saved ctx_size",
+        )
+
+        print("[OK] context_length reflects an explicit ctx_size")
+
+    def test_006b_context_length_inherits_global_ctx_size(self):
+        """With nothing saved on the model, context_length follows the global."""
+        original_ctx_size = requests.get(
+            f"{self.internal_url}/config", timeout=TIMEOUT_DEFAULT
+        ).json()["ctx_size"]
+        self._snapshot_options()
+        self.addCleanup(self._set_global_ctx_size, original_ctx_size)
+
+        self._unload_for_configured_context()
+        self._reset_options()
+        self._set_global_ctx_size(4096)
+
+        model = self._retrieve_model_json()
+        self.assertEqual(
+            model.get("context_length"),
+            4096,
+            "context_length should inherit the server-wide ctx_size",
+        )
+
+        print("[OK] context_length inherits the global ctx_size")
+
+    def test_006c_context_length_never_reports_a_sentinel(self):
+        """ctx_size=-1 means "size automatically" and must never be returned."""
+        self._snapshot_options()
+        self._unload_for_configured_context()
+        self._reset_options()
+
+        requests.post(
+            self._options_url(), json={"ctx_size": -1}, timeout=TIMEOUT_DEFAULT
+        )
+
+        model = self._retrieve_model_json()
+        context_length = model.get("context_length")
+        self.assertIsNotNone(
+            context_length,
+            "context_length should still be present when ctx_size is automatic",
+        )
+        self.assertGreater(
+            context_length,
+            0,
+            "context_length must never surface the -1 auto sentinel",
+        )
+
+        print(
+            f"[OK] context_length with automatic ctx_size resolved to {context_length}"
+        )
+
+    def test_006d_context_length_agrees_between_list_and_retrieve(self):
+        """The list and retrieve endpoints must report the same value."""
+        response = requests.get(f"{self.base_url}/models", timeout=TIMEOUT_DEFAULT)
+        self.assertEqual(response.status_code, 200)
+
+        listed = {m["id"]: m for m in response.json()["data"]}
+        self.assertIn(ENDPOINT_TEST_MODEL, listed)
+
+        for model_id, entry in listed.items():
+            if "context_length" in entry:
+                self.assertGreater(
+                    entry["context_length"],
+                    0,
+                    f"{model_id} reported a non-positive context_length",
+                )
+
+        self.assertEqual(
+            listed[ENDPOINT_TEST_MODEL].get("context_length"),
+            self._retrieve_model_json().get("context_length"),
+            "list and retrieve should report the same context_length",
+        )
+
+        print("[OK] context_length agrees across /models and /models/{id}")
+
     def test_007_pull_model_non_streaming(self):
         """Test pulling/downloading a model (non-streaming mode)."""
         # First delete model if it exists to ensure we're actually testing pull

--- a/test/server_endpoints.py
+++ b/test/server_endpoints.py
@@ -819,6 +819,64 @@ class EndpointTests(ServerTestBase):
 
         print("[OK] context_length agrees across /models and /models/{id}")
 
+    def test_006e_context_length_resolves_user_alias(self):
+        """An alias and its loaded target must report the same context length."""
+        alias_name = "test-context-length-alias"
+        loaded_ctx_size = 3072
+
+        self.addCleanup(
+            requests.post,
+            f"{self.base_url}/unload",
+            json={"model_name": ENDPOINT_TEST_MODEL},
+            timeout=TIMEOUT_DEFAULT,
+        )
+
+        try:
+            add_res = requests.post(
+                f"{self.internal_url}/aliases",
+                json={"alias": alias_name, "target": ENDPOINT_TEST_MODEL},
+                headers=_auth_headers(),
+                timeout=TIMEOUT_DEFAULT,
+            )
+            self.assertEqual(add_res.status_code, 200, add_res.text)
+
+            load_res = requests.post(
+                f"{self.base_url}/load",
+                json={
+                    "model_name": ENDPOINT_TEST_MODEL,
+                    "ctx_size": loaded_ctx_size,
+                },
+                timeout=TIMEOUT_MODEL_OPERATION,
+            )
+            self.assertEqual(load_res.status_code, 200, load_res.text)
+
+            list_res = requests.get(f"{self.base_url}/models", timeout=TIMEOUT_DEFAULT)
+            self.assertEqual(list_res.status_code, 200, list_res.text)
+            listed = {model["id"]: model for model in list_res.json()["data"]}
+
+            self.assertIn(ENDPOINT_TEST_MODEL, listed)
+            self.assertIn(alias_name, listed)
+            self.assertEqual(
+                listed[ENDPOINT_TEST_MODEL].get("context_length"), loaded_ctx_size
+            )
+            self.assertEqual(
+                listed[alias_name].get("context_length"),
+                listed[ENDPOINT_TEST_MODEL].get("context_length"),
+            )
+            self.assertEqual(
+                self._retrieve_model_json(alias_name).get("context_length"),
+                listed[ENDPOINT_TEST_MODEL].get("context_length"),
+            )
+        finally:
+            delete_res = requests.delete(
+                f"{self.internal_url}/aliases/{requests.utils.quote(alias_name)}",
+                headers=_auth_headers(),
+                timeout=TIMEOUT_DEFAULT,
+            )
+            self.assertIn(delete_res.status_code, (200, 404), delete_res.text)
+
+        print("[OK] context_length resolves user aliases")
+
     def test_007_pull_model_non_streaming(self):
         """Test pulling/downloading a model (non-streaming mode)."""
         # First delete model if it exists to ensure we're actually testing pull


### PR DESCRIPTION
## Summary

Fixes #3046.

`/v1/models` only returned `max_context_window`, which is the model's
built-in maximum rather than the size it is actually served with.
Clients that size a session from `context_length` had nothing to read,
so they guessed and ran out of room mid-session.

`context_length` now resolves in order:

1. the running backend's `ctx_size`, when the model is loaded
2. the configured `ctx_size`, per model then server-wide
3. `max_context_window` as a floor

I did not implement the VRAM auto-sizing step listed in the issue. It
may be a little out of scope here and probably belongs in its own
issue. Would you prefer it in this PR, or tracked separately?

Models with no context window, such as Whisper and Kokoro, currently
omit the field.

## Testing

Builds clean. Four new cases in `test/server_endpoints.py` cover an
explicit `ctx_size`, an inherited global, the `-1` automatic sentinel,
and list/retrieve agreement, and all pass.

## Documentation

Documentation is affected and has been updated: `docs/api/openai.md`.

## AI-assisted contribution

Used AI tools for research and implementation guidance. Reviewed to
make sure only the changes needed were made.
