### PR TITLE
feat(config): add configurable download rate limit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -979,6 +979,7 @@ set(SOURCES_CORE
     src/cpp/server/utils/json_utils.cpp
     src/cpp/server/utils/process_manager.cpp
     src/cpp/server/utils/path_utils.cpp
+    src/cpp/server/utils/rate_limit_utils.cpp
     src/cpp/server/utils/url_utils.cpp
     src/cpp/server/utils/version_utils.cpp
     src/cpp/server/utils/wmi_helper.cpp
@@ -2974,6 +2975,19 @@ if(BUILD_TESTING AND EXISTS "${_CONFIG_TELEMETRY_TEST_SRC}")
     add_executable(test_config_telemetry test/cpp/test_config_telemetry.cpp)
     target_link_libraries(test_config_telemetry PRIVATE lemonade-server-core)
     add_cpp_ci_test(ConfigTelemetryTest CI ON COMMAND test_config_telemetry)
+endif()
+
+set(_CONFIG_DOWNLOAD_RATE_LIMIT_TEST_SRC
+    "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_config_download_rate_limit.cpp"
+)
+if(BUILD_TESTING AND EXISTS "${_CONFIG_DOWNLOAD_RATE_LIMIT_TEST_SRC}")
+    add_executable(test_config_download_rate_limit
+        test/cpp/test_config_download_rate_limit.cpp
+    )
+    target_link_libraries(test_config_download_rate_limit PRIVATE lemonade-server-core)
+    add_cpp_ci_test(ConfigDownloadRateLimitTest CI ON
+        COMMAND test_config_download_rate_limit
+    )
 endif()
 
 set(_RUNTIME_CONFIG_BACKEND_VALIDATION_TEST_SRC

--- a/docs/dev/getting-started.md
+++ b/docs/dev/getting-started.md
@@ -644,6 +644,7 @@ Accepts a JSON object with one or more keys to update atomically. Returns `{"sta
 | `host` | string | HTTP rebind |
 | `log_level` | string (`trace`, `debug`, `info`, `warning`, `error`, `fatal`, `none`) | Reconfigures log filter |
 | `global_timeout` | int (positive) | Updates default HTTP client timeout |
+| `download_rate_limit` | string (`0`/`""` = unlimited) | Sets the active download-rate cap (curl-style byte rate) |
 | `broadcast` | bool | Starts or stops UDP beacon |
 | `extra_models_dir` | string | Updates model manager search path |
 

--- a/docs/embeddable/runtime.md
+++ b/docs/embeddable/runtime.md
@@ -167,6 +167,7 @@ Accepts a JSON object with one or more keys to update atomically. Returns `{"sta
 | `host` | string | HTTP rebind |
 | `log_level` | string (`trace`, `debug`, `info`, `warning`, `error`, `fatal`, `none`) | Reconfigures log filter |
 | `global_timeout` | int (positive) | Updates default HTTP client timeout |
+| `download_rate_limit` | string (`0`/`""` = unlimited) | Sets the active download-rate cap (curl-style byte rate) |
 | `broadcast` | bool | Starts or stops UDP beacon |
 | `models_dir` | string (`"auto"` or path) | Updates the primary model cache location |
 | `extra_models_dir` | string | Validates access and updates the external GGUF search path |

--- a/docs/guide/configuration/README.md
+++ b/docs/guide/configuration/README.md
@@ -52,6 +52,7 @@ When `lemond` starts, effective configuration is resolved by deep-merging settin
   "ctx_size": -1,
   "default_model_source": "huggingface",
   "disable_model_filtering": false,
+  "download_rate_limit": "",
   "enable_dgpu_gtt": false,
   "extra_models_dir": "",
   "flm": {
@@ -196,6 +197,7 @@ When `lemond` starts, effective configuration is resolved by deep-merging settin
 | `models_dir` | string | "auto" | Directory for cached model files. `"auto"` follows `HF_HUB_CACHE` / `HF_HOME` / platform default |
 | `ctx_size` | int | -1 | Default context size for LLM models. Use `-1` for auto-resolution: the server computes the largest context that fits in available device memory using GGUF architecture metadata. Use a positive integer to set an explicit size. |
 | `default_model_source` | string | "huggingface" | Remote registry used to pull checkpoints when a request does not name one (`huggingface` or `modelscope`). Explicit `--source`, a `source`/`registry_source` field, or a provider URL always overrides it. |
+| `download_rate_limit` | string | "" | Caps model/backend download speed. Byte rate with curl-style suffixes: `512`, `100K`, `10M`, etc. Use `""` for unlimited download speed. A non-empty value also serializes concurrent transfers. |
 | `offline` | bool | false | Skip model downloads |
 | `auto_check_model_updates` | bool | true | Check downloaded Hugging Face-backed models for updates during server startup. Set to `false` to check only with `lemonade check-updates` or `POST /v1/models/check-updates`. Manual downloads and updates remain enabled. |
 | `auto_update_models` | bool | false | Automatically download model updates when available. Can be overridden per model via `auto_update` in model options. |

--- a/src/cpp/include/lemon/runtime_config.h
+++ b/src/cpp/include/lemon/runtime_config.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <functional>
 #include <map>
 #include <optional>
@@ -36,6 +37,8 @@ public:
     void set_broadcast_override(std::optional<bool> override_val);
     long global_timeout() const;
     int max_loaded_models() const;
+    int64_t download_rate_limit_bytes_per_second() const;
+
     std::string models_dir() const;
     int ctx_size() const;
     bool auto_evict() const;

--- a/src/cpp/include/lemon/utils/http_client.h
+++ b/src/cpp/include/lemon/utils/http_client.h
@@ -1,14 +1,15 @@
 #pragma once
 
-#include <string>
-#include <map>
-#include <vector>
-#include <functional>
-#include <chrono>
-#include <memory>
-#include <iostream>
-#include <iomanip>
 #include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <functional>
+#include <iomanip>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
 
 namespace lemon {
 namespace utils {
@@ -102,6 +103,16 @@ public:
         return default_timeout_seconds_;
     }
 
+    // Global cap; when set, downloads are also serialized so concurrent
+    // transfers cannot exceed it in aggregate.
+    static void set_download_rate_limit(int64_t bytes_per_second) {
+        download_rate_limit_bytes_per_second_ = bytes_per_second;
+    }
+
+    static int64_t get_download_rate_limit() {
+        return download_rate_limit_bytes_per_second_.load();
+    }
+
     // Simple GET request. timeout_seconds=0 (default) uses default_timeout_seconds_.
     static HttpResponse get(const std::string& url,
                            const std::map<std::string, std::string>& headers = {},
@@ -154,6 +165,7 @@ public:
 
 private:
     static std::atomic<long> default_timeout_seconds_;
+    static std::atomic<int64_t> download_rate_limit_bytes_per_second_;
 
     // Single download attempt, may resume from offset
     static DownloadResult download_attempt(const std::string& url,

--- a/src/cpp/include/lemon/utils/rate_limit_utils.h
+++ b/src/cpp/include/lemon/utils/rate_limit_utils.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace lemon::utils {
+
+// curl --limit-rate style byte rate ("512", "1.5M", "10G"); ""/"0" = 0, invalid = -1.
+// Integer-only (mirrors curl GetSizeParameter): value*mul + frac adjust, suffixes K/M/G/T/P.
+int64_t parse_rate_limit_to_bytes(const std::string& raw);
+
+} // namespace lemon::utils

--- a/src/cpp/resources/defaults.json
+++ b/src/cpp/resources/defaults.json
@@ -14,6 +14,7 @@
   "ctx_size": -1,
   "default_model_source": "huggingface",
   "disable_model_filtering": false,
+  "download_rate_limit": "",
   "enable_dgpu_gtt": false,
   "extra_models_dir": "",
   "flm": {

--- a/src/cpp/server/runtime_config.cpp
+++ b/src/cpp/server/runtime_config.cpp
@@ -3,6 +3,7 @@
 #include "lemon/system_info.h"
 #include "lemon/utils/aixlog.hpp"
 #include "lemon/utils/path_utils.h"
+#include "lemon/utils/rate_limit_utils.h"
 #include <algorithm>
 #include <atomic>
 #include <cstdlib>
@@ -353,6 +354,19 @@ long RuntimeConfig::global_timeout() const {
 int RuntimeConfig::max_loaded_models() const {
     std::shared_lock lock(mutex_);
     return config_["max_loaded_models"].get<int>();
+}
+
+int64_t RuntimeConfig::download_rate_limit_bytes_per_second() const {
+    std::shared_lock lock(mutex_);
+    if (!config_.contains("download_rate_limit") || !config_["download_rate_limit"].is_string()) {
+        return 0;
+    }
+    const int64_t parsed = utils::parse_rate_limit_to_bytes(config_["download_rate_limit"].get<std::string>());
+    if (parsed < 0) {
+        LOG(WARNING, "RuntimeConfig") << "Invalid download_rate_limit value in config, treating as unlimited" << std::endl;
+        return 0;
+    }
+    return parsed;
 }
 
 std::string RuntimeConfig::models_dir() const {
@@ -732,6 +746,15 @@ void RuntimeConfig::validate(const std::string& key, const json& value) const {
         if (source != "huggingface" && source != "modelscope") {
             throw std::invalid_argument(
                 "'default_model_source' must be either 'huggingface', or 'modelscope'");
+        }
+    } else if (key == "download_rate_limit") {
+        if (!value.is_string()) {
+            throw std::invalid_argument("'download_rate_limit' must be a byte rate string");
+        }
+        if (utils::parse_rate_limit_to_bytes(value.get<std::string>()) < 0) {
+            throw std::invalid_argument(
+                "'download_rate_limit' must be a byte rate like \"512\", \"100K\", \"10M\", etc. "
+                "Use \"\" for unlimited download speed");
         }
     } else if (key == "broadcast" || key == "no_broadcast" || key == "offline" ||
                key == "auto_check_model_updates" ||

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -375,6 +375,9 @@ Server::Server(std::shared_ptr<RuntimeConfig> config,
     // Set global HttpClient timeout
     utils::HttpClient::set_default_timeout(config->global_timeout());
 
+    // Global download rate limit
+    utils::HttpClient::set_download_rate_limit(config->download_rate_limit_bytes_per_second());
+
     cloud_registry_ = std::make_unique<CloudProviderRegistry>();
     // Seed installed providers from config.json. Runtime keys stay empty
     // until either an env var resolves them per-request or a client POSTs
@@ -7259,6 +7262,14 @@ void Server::apply_config_side_effects(const json& applied_changes) {
             long timeout = config_->global_timeout();
             LOG(INFO, "Server") << "Global timeout changed to: " << timeout << "s" << std::endl;
             utils::HttpClient::set_default_timeout(timeout);
+        } else if (key == "download_rate_limit") {
+            const int64_t bps = config_->download_rate_limit_bytes_per_second();
+            if (bps > 0) {
+                LOG(INFO, "Server") << "Download rate limit enabled at " << bps << " B/s" << std::endl;
+            } else {
+                LOG(INFO, "Server") << "Download rate limit disabled" << std::endl;
+            }
+            utils::HttpClient::set_download_rate_limit(bps);
         } else if (key == "broadcast" || key == "no_broadcast") {
             bool bcast = config_->broadcast();
             LOG(INFO, "Server") << "Broadcast " << (bcast ? "enabled" : "disabled") << std::endl;

--- a/src/cpp/server/utils/http_client.cpp
+++ b/src/cpp/server/utils/http_client.cpp
@@ -13,6 +13,8 @@
 #include <cctype>
 #include <fstream>
 #include <memory>
+#include <mutex>
+#include <optional>
 #include <string_view>
 #include <vector>
 #include <mbedtls/md.h>
@@ -25,6 +27,11 @@ namespace utils {
 std::atomic<bool> g_download_cancelled{false};
 
 std::atomic<long> HttpClient::default_timeout_seconds_{300};
+
+std::atomic<int64_t> HttpClient::download_rate_limit_bytes_per_second_{0};
+
+// Serializes transfers so concurrent downloads cannot exceed the cap in aggregate.
+static std::mutex g_download_gate;
 
 namespace {
 
@@ -817,6 +824,11 @@ DownloadResult HttpClient::download_attempt(const std::string& url,
     curl_easy_setopt(curl, CURLOPT_LOW_SPEED_LIMIT, static_cast<long>(options.low_speed_limit));
     curl_easy_setopt(curl, CURLOPT_LOW_SPEED_TIME, static_cast<long>(options.low_speed_time));
 
+    const int64_t rate_limit = download_rate_limit_bytes_per_second_.load();
+    if (rate_limit > 0) {
+        curl_easy_setopt(curl, CURLOPT_MAX_RECV_SPEED_LARGE, static_cast<curl_off_t>(rate_limit));
+    }
+
     if (resume_from > 0) {
         curl_easy_setopt(curl, CURLOPT_RESUME_FROM_LARGE, static_cast<curl_off_t>(resume_from));
     } else if (initial_range_request) {
@@ -1168,9 +1180,17 @@ DownloadResult HttpClient::download_file(const std::string& url,
             options.force_initial_range_request ||
             (retrying_without_partial && options.range_retry_on_zero_byte_retry);
 
-        final_result = download_attempt(url, partial_path, resume_offset,
-                                        adjusted_callback, headers, options,
-                                        initial_range_request, policy);
+        {
+            // Released between attempts so retry backoff does not stall other downloads.
+            const int64_t rate_limit = download_rate_limit_bytes_per_second_.load();
+            std::optional<std::lock_guard<std::mutex>> gate;
+            if (rate_limit > 0) {
+                gate.emplace(g_download_gate);
+            }
+            final_result = download_attempt(url, partial_path, resume_offset,
+                                            adjusted_callback, headers, options,
+                                            initial_range_request, policy);
+        }
 
         // If cancelled by user, return immediately without retrying
         if (final_result.cancelled) {

--- a/src/cpp/server/utils/rate_limit_utils.cpp
+++ b/src/cpp/server/utils/rate_limit_utils.cpp
@@ -1,0 +1,82 @@
+#include <lemon/utils/rate_limit_utils.h>
+
+#include <cctype>
+#include <cstdint>
+#include <string>
+
+namespace lemon::utils {
+
+int64_t parse_rate_limit_to_bytes(const std::string& raw) {
+    size_t start = raw.find_first_not_of(" \t\r\n");
+    if (start == std::string::npos) return 0;
+    size_t end = raw.find_last_not_of(" \t\r\n");
+    const std::string s = raw.substr(start, end - start + 1);
+    if (s.empty()) return 0;
+
+    size_t i = 0;
+    uint64_t value = 0;
+    for (; i < s.size() && s[i] >= '0' && s[i] <= '9'; ++i) {
+        if (value > (INT64_MAX - (uint64_t)(s[i] - '0')) / 10) return -1;
+        value = value * 10 + (uint64_t)(s[i] - '0');
+    }
+    if (i == 0) return -1;  // Must start with a digit (no sign or exponent).
+
+    uint64_t prec = 0;
+    size_t plen = 0;
+    if (i < s.size() && s[i] == '.') {
+        ++i;
+        const size_t dstart = i;
+        for (; i < s.size() && s[i] >= '0' && s[i] <= '9'; ++i) {
+            prec = prec * 10 + (uint64_t)(s[i] - '0');
+            ++plen;
+            if (prec > INT64_MAX) return -1;
+        }
+        if (i == dstart) return -1;  // "." with no following digits.
+    }
+
+    std::string suffix = s.substr(i);
+    if (!suffix.empty() && (suffix.back() == 'b' || suffix.back() == 'B')) {
+        suffix.pop_back();
+    }
+    if (!suffix.empty() && suffix.size() != 1) return -1;  // Single unit character only.
+
+    uint64_t mul = 1;
+    size_t mlen = 0;  // Decimal digits in mul (for fractional precision trimming).
+    if (!suffix.empty()) {
+        switch (static_cast<char>(std::toupper(static_cast<unsigned char>(suffix[0])))) {
+        case 'K': mul = 1024ULL; mlen = 4; break;
+        case 'M': mul = 1024ULL * 1024ULL; mlen = 7; break;
+        case 'G': mul = 1024ULL * 1024ULL * 1024ULL; mlen = 10; break;
+        case 'T': mul = 1024ULL * 1024ULL * 1024ULL * 1024ULL; mlen = 13; break;
+        case 'P': mul = 1024ULL * 1024ULL * 1024ULL * 1024ULL * 1024ULL; mlen = 16; break;
+        default: return -1;
+        }
+    }
+
+    // A fractional part without a unit is ambiguous; reject it like curl.
+    if (plen > 0 && mul == 1) return -1;
+
+    uint64_t add = 0;
+    if (prec) {
+        while (plen > mlen) {  // Trim precision digits beyond the unit's resolution.
+            prec /= 10;
+            --plen;
+        }
+        uint64_t frac = 1;
+        for (size_t k = 0; k < plen; ++k) frac *= 10;
+        if (prec != 0) {
+            if (INT64_MAX / mul >= prec) {
+                add = mul * prec / frac;
+            } else {
+                add = (mul / frac) * prec;
+            }
+        }
+    }
+
+    if (value > (static_cast<uint64_t>(INT64_MAX) - add) / mul) return -1;
+    const uint64_t bytes = value * mul + add;
+    if (bytes > static_cast<uint64_t>(INT64_MAX)) return -1;
+    return static_cast<int64_t>(bytes);
+}
+
+} // namespace lemon::utils

--- a/test/cpp/test_config_download_rate_limit.cpp
+++ b/test/cpp/test_config_download_rate_limit.cpp
@@ -1,0 +1,87 @@
+#include <cstdio>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+
+#include <nlohmann/json.hpp>
+#include <lemon/runtime_config.h>
+
+#include "test_config_helpers.h"
+
+using json = nlohmann::json;
+using lemon::RuntimeConfig;
+using test_helpers::check;
+using test_helpers::report_results;
+
+static int64_t getter_for(const json& cfg) {
+    return RuntimeConfig(cfg).download_rate_limit_bytes_per_second();
+}
+
+static bool set_throws(const json& cfg, const json& changes) {
+    try {
+        RuntimeConfig(cfg).set(changes);
+        return false;
+    } catch (const std::invalid_argument&) {
+        return true;
+    }
+}
+
+int main() {
+    std::puts("=== RUNNING DOWNLOAD RATE LIMIT CONFIG TESTS ===");
+
+    const int64_t KIB = 1024LL;
+    const int64_t MIB = 1024LL * 1024LL;
+    const int64_t GIB = 1024LL * 1024LL * 1024LL;
+
+    auto cfg_with = [](const std::string& limit) {
+        return json::object({{"download_rate_limit", limit}});
+    };
+
+    // --- Getter reads download_rate_limit string ---
+    check(getter_for(cfg_with("512")) == 512, "'512' -> 512 B/s");
+    check(getter_for(cfg_with("100K")) == 100 * KIB, "'100K' -> 102400 B/s");
+    check(getter_for(cfg_with("100k")) == 100 * KIB, "'100k' -> 102400 B/s");
+    check(getter_for(cfg_with("100KB")) == 100 * KIB, "'100KB' -> 102400 B/s");
+    check(getter_for(cfg_with("10M")) == 10 * MIB, "'10M' -> 10 MiB/s");
+    check(getter_for(cfg_with("10MB")) == 10 * MIB, "'10MB' -> 10 MiB/s");
+    check(getter_for(cfg_with("2g")) == 2 * GIB, "'2g' -> 2 GiB/s");
+    check(getter_for(cfg_with("1.5G")) == GIB + GIB / 2, "'1.5G' -> 1.5 GiB/s");
+    check(getter_for(cfg_with("0.12345K")) == 126, "fractional precision kept within unit resolution");
+    check(getter_for(cfg_with("  10M  ")) == 10 * MIB, "trims surrounding whitespace");
+    check(getter_for(cfg_with("0")) == 0, "'0' -> unlimited");
+    check(getter_for(cfg_with("")) == 0, "empty string -> unlimited");
+    check(getter_for(cfg_with("-5")) == 0, "invalid '-5' -> unlimited");
+    check(getter_for(cfg_with("10M5")) == 0, "invalid '10M5' -> unlimited");
+    check(getter_for(cfg_with("1e3")) == 0, "invalid scientific -> unlimited");
+    check(getter_for(cfg_with("1.5")) == 0, "fraction without unit -> invalid (unlimited)");
+
+    // Missing key / not a string -> unlimited.
+    check(getter_for(json::object({{"download_rate_limit", 123}})) == 0, "non-string value -> 0");
+    check(getter_for(json::object({})) == 0, "missing key -> 0");
+
+    // --- validate()/set() accepts valid values ---
+    check(!set_throws(cfg_with("10M"), json::object({{"download_rate_limit", "20M"}})), "set accepts change");
+    check(!set_throws(cfg_with("10M"), json::object({{"download_rate_limit", ""}})), "set accepts clearing");
+    check(!set_throws(cfg_with(""), json::object({{"download_rate_limit", "10M"}})), "set accepts setting from empty");
+    check(!set_throws(cfg_with("10M"), json::object({{"download_rate_limit", "0"}})), "set accepts explicit '0'");
+
+    // --- validate()/set() rejects invalid values ---
+    check(set_throws(cfg_with("10M"), json::object({{"download_rate_limit", 123}})), "rejects non-string value");
+    check(set_throws(cfg_with("10M"), json::object({{"download_rate_limit", "10M5"}})), "rejects malformed value");
+    check(set_throws(cfg_with("10M"), json::object({{"download_rate_limit", "-5"}})), "rejects negative value");
+
+    // --- apply_changes updates the cap ---
+    {
+        RuntimeConfig rc(cfg_with("10M"));
+        rc.set(json::object({{"download_rate_limit", "50M"}}));
+        check(getter_for(rc.snapshot()) == 50 * MIB, "cap update applied");
+
+        rc.set(json::object({{"download_rate_limit", "50M"}}));
+        check(getter_for(rc.snapshot()) == 50 * MIB, "idempotent re-apply");
+
+        rc.set(json::object({{"download_rate_limit", ""}}));
+        check(getter_for(rc.snapshot()) == 0, "clearing applied");
+    }
+
+    return report_results("download rate limit");
+}

--- a/test/server_endpoints.py
+++ b/test/server_endpoints.py
@@ -20,6 +20,7 @@ Usage:
     python server_endpoints.py
 """
 
+import contextlib
 import json
 import os
 import platform
@@ -101,6 +102,62 @@ def _lemond_health_ok(port, headers):
         return response.status_code == 200
     except requests.RequestException:
         return False
+
+
+@contextlib.contextmanager
+def _running_lemond(config=None, cache_prefix="lemond_test_"):
+    """Spawn lemond on a free port with the given config.json body.
+
+    Skips the calling test when no daemon binary is available. Yields
+    (proc, port, headers, log_path) and terminates the daemon plus removes
+    its cache directory on exit.
+    """
+    lemond_binary = _resolve_lemond_binary()
+    if not lemond_binary:
+        raise unittest.SkipTest("lemond binary not found (build it or add it to PATH)")
+
+    headers = {}
+    api_key = os.environ.get("LEMONADE_API_KEY")
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+
+    port = _pick_free_port()
+    cache_dir = tempfile.mkdtemp(prefix=cache_prefix)
+    log_path = os.path.join(cache_dir, "lemond.log")
+    with open(os.path.join(cache_dir, "config.json"), "w", encoding="utf-8") as f:
+        json.dump({"config_version": 2, **(config or {})}, f)
+
+    proc = None
+    try:
+        with open(log_path, "w", encoding="utf-8") as log:
+            proc = subprocess.Popen(
+                [lemond_binary, cache_dir, "--port", str(port)],
+                stdout=log,
+                stderr=subprocess.STDOUT,
+                env=os.environ.copy(),
+            )
+        yield proc, port, headers, log_path
+    finally:
+        if proc is not None and proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait(timeout=10)
+        shutil.rmtree(cache_dir, ignore_errors=True)
+
+
+def _wait_until_healthy(proc, port, headers, timeout_s=60):
+    """Poll /api/v1/health until lemond answers or the deadline expires."""
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        if proc.poll() is not None:
+            return False
+        if _lemond_health_ok(port, headers):
+            return True
+        time.sleep(1)
+    return False
 
 
 class EndpointTests(ServerTestBase):
@@ -8148,6 +8205,195 @@ class EndpointTests(ServerTestBase):
         )
 
         print("[OK] /internal/models/sync security boundary is secure")
+
+    def test_057_download_rate_limit_config(self):
+        """download_rate_limit is a string cap that validates and round-trips
+        via /internal/set. Spawns its own lemond so it does not depend on an
+        externally-managed server (unlike the shared-server assumption of
+        ServerTestBase)."""
+        with _running_lemond(cache_prefix="lemond_ratecfg_") as (
+            proc,
+            port,
+            headers,
+            log_path,
+        ):
+            self.assertTrue(
+                _wait_until_healthy(proc, port, headers),
+                f"lemond never became healthy on port {port} (see {log_path})",
+            )
+
+            config_url = f"http://localhost:{port}/internal/config"
+            set_url = f"http://localhost:{port}/internal/set"
+
+            # Invalid values are rejected by config validation.
+            bad_changes = [
+                {"download_rate_limit": "10M5"},  # malformed rate string
+                {"download_rate_limit": -5},  # non-string / negative
+                {"download_rate_limit": "abc"},  # invalid rate string
+            ]
+            for body in bad_changes:
+                resp = requests.post(
+                    set_url,
+                    headers=headers,
+                    json=body,
+                    timeout=TIMEOUT_DEFAULT,
+                )
+                self.assertEqual(
+                    resp.status_code,
+                    400,
+                    f"expected 400 for {body!r}, got {resp.status_code}: {resp.text}",
+                )
+
+            # A full round-trip persists in the config snapshot.
+            resp = requests.post(
+                set_url,
+                headers=headers,
+                json={"download_rate_limit": "10M"},
+                timeout=TIMEOUT_DEFAULT,
+            )
+            self.assertEqual(
+                resp.status_code, 200, f"/internal/set failed: {resp.text}"
+            )
+            cfg = requests.get(
+                config_url, headers=headers, timeout=TIMEOUT_DEFAULT
+            ).json()
+            self.assertEqual(cfg["download_rate_limit"], "10M")
+
+            # A partial update preserves unrelated keys.
+            resp = requests.post(
+                set_url,
+                headers=headers,
+                json={"download_rate_limit": "20M"},
+                timeout=TIMEOUT_DEFAULT,
+            )
+            self.assertEqual(
+                resp.status_code, 200, f"/internal/set failed: {resp.text}"
+            )
+            cfg = requests.get(
+                config_url, headers=headers, timeout=TIMEOUT_DEFAULT
+            ).json()
+            self.assertEqual(cfg["download_rate_limit"], "20M")
+
+            # Clearing the cap means runtime unlimited.
+            resp = requests.post(
+                set_url,
+                headers=headers,
+                json={"download_rate_limit": ""},
+                timeout=TIMEOUT_DEFAULT,
+            )
+            self.assertEqual(
+                resp.status_code, 200, f"/internal/set failed: {resp.text}"
+            )
+            cfg = requests.get(
+                config_url, headers=headers, timeout=TIMEOUT_DEFAULT
+            ).json()
+            self.assertEqual(cfg["download_rate_limit"], "")
+
+            print(
+                "[OK] download_rate_limit validates and round-trips via /internal/set"
+            )
+
+    def test_058_download_rate_limit_invalid_config_startup(self):
+        """An invalid download_rate_limit in config.json must not crash
+        lemond: the raw value is preserved in the snapshot and the server stays
+        healthy (invalid caps are treated as unlimited)."""
+        with _running_lemond(
+            config={"download_rate_limit": "-1"},
+            cache_prefix="lemond_badcfg_",
+        ) as (proc, port, headers, log_path):
+            if not _wait_until_healthy(proc, port, headers):
+                with open(log_path, "r", encoding="utf-8", errors="replace") as f:
+                    log = f.read()
+                self.fail(
+                    f"lemond with invalid download_rate_limit crashed or never "
+                    f"became healthy on port {port}.\n=== lemond log ===\n{log}"
+                )
+
+            cfg = requests.get(
+                f"http://localhost:{port}/internal/config",
+                headers=headers,
+                timeout=TIMEOUT_DEFAULT,
+            ).json()
+            # The raw value is preserved verbatim in the config snapshot.
+            self.assertEqual(cfg.get("download_rate_limit"), "-1")
+
+            print(
+                "[OK] lemond stays healthy with an invalid download_rate_limit "
+                "in config.json"
+            )
+
+    def test_059_download_rate_limit_runtime_effect(self):
+        """Changing download_rate_limit via /internal/set must actually apply
+        the cap to HttpClient at runtime: the side-effect log line records the
+        newly active byte rate, clearing it disables capping, and the last
+        value is persisted to config.json."""
+        with _running_lemond(
+            config={"download_rate_limit": "10M"},
+            cache_prefix="lemond_ratecfg_",
+        ) as (proc, port, headers, log_path):
+            config_path = os.path.join(os.path.dirname(log_path), "config.json")
+            self.assertTrue(
+                _wait_until_healthy(proc, port, headers),
+                f"lemond never became healthy on port {port} (see {log_path})",
+            )
+
+            config_url = f"http://localhost:{port}/internal/config"
+            set_url = f"http://localhost:{port}/internal/set"
+
+            def _wait_for_log(needle, timeout_s=10.0):
+                deadline = time.time() + timeout_s
+                while time.time() < deadline:
+                    with open(log_path, "r", encoding="utf-8", errors="replace") as f:
+                        if needle in f.read():
+                            return True
+                    time.sleep(0.2)
+                return False
+
+            cfg = requests.get(
+                config_url, headers=headers, timeout=TIMEOUT_DEFAULT
+            ).json()
+            self.assertEqual(cfg.get("download_rate_limit"), "10M")
+
+            # Raising the cap takes effect immediately and is logged.
+            resp = requests.post(
+                set_url,
+                headers=headers,
+                json={"download_rate_limit": "50M"},
+                timeout=TIMEOUT_DEFAULT,
+            )
+            self.assertEqual(resp.status_code, 200, resp.text)
+            self.assertTrue(
+                _wait_for_log("Download rate limit enabled at 52428800 B/s"),
+                "runtime cap change was not applied to HttpClient",
+            )
+
+            # Clearing the cap disables limiting at runtime too.
+            resp = requests.post(
+                set_url,
+                headers=headers,
+                json={"download_rate_limit": ""},
+                timeout=TIMEOUT_DEFAULT,
+            )
+            self.assertEqual(resp.status_code, 200, resp.text)
+            self.assertTrue(
+                _wait_for_log("Download rate limit disabled"),
+                "clearing the cap did not disable runtime limiting",
+            )
+
+            # The persistent channel wrote the final value; "" equals the
+            # default, so the key may be pruned from disk.
+            with open(config_path, "r", encoding="utf-8") as f:
+                self.assertEqual(json.load(f).get("download_rate_limit", ""), "")
+
+            cfg = requests.get(
+                config_url, headers=headers, timeout=TIMEOUT_DEFAULT
+            ).json()
+            self.assertEqual(cfg.get("download_rate_limit"), "")
+
+            print(
+                "[OK] /internal/set applies download_rate_limit at runtime "
+                "and persists it"
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
Before submitting this PR, please read:
- docs/dev/contribute.md
- docs/dev/philosophy.md
- AGENTS.md if you used an AI coding agent or AI-assisted workflow
- docs/dev/documentation.md if this PR changes user-facing or developer-facing documentation
-->

## Summary

Adds a configurable download rate limit for backend/model downloads. The limit is configured in `config.json`:

- `download_rate_limit` — active limit as a string (e.g. `"10M"`, `""` or `"0"` = unlimited).

Fixes #1585

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_
- C++ unit test `test/cpp/test_config_download_rate_limit.cpp`
- Python integration tests
  `test_056` (validate + round-trip via `/internal/set`),
  `test_057` (invalid config value does not crash server startup),
  `test_058` (runtime vs persisted semantics).
- `python docs/tools/gen_backend_boilerplate.py --check`: all generated files up to date.

## Documentation

- [x] Documentation is affected and has been updated.
  (configuration/README.md config-example + table, runtime.md, getting-started.md)

## Breaking Changes

- [x] This PR does not introduce breaking changes.

## AI-assisted contribution

- [x] I used AI tools for this PR.

If AI tools were used:

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.