### PR TITLE
test(telemetry): prevent dangling RuntimeConfig pointer and worker race in telemetry helpers test

### DIFF
--- a/test/cpp/test_telemetry_helpers.cpp
+++ b/test/cpp/test_telemetry_helpers.cpp
@@ -492,7 +492,7 @@ int main() {
             {"port", 13305},
             {"host", "localhost"},
             {"telemetry", {
-                {"enabled", true},
+                {"enabled", false},
                 {"max_attribute_length", 20},
                 {"otlp", {
                     {"semantics", {"openinference", "otel_genai"}}
@@ -579,7 +579,7 @@ int main() {
             {"port", 13305},
             {"host", "localhost"},
             {"telemetry", {
-                {"enabled", true},
+                {"enabled", false},
                 {"hide_outputs", false},
                 {"hide_thinking", true},
                 {"otlp", {
@@ -601,7 +601,7 @@ int main() {
             {"port", 13305},
             {"host", "localhost"},
             {"telemetry", {
-                {"enabled", true},
+                {"enabled", false},
                 {"hide_outputs", true},
                 {"otlp", {
                     {"semantics", {"openinference", "otel_genai"}}
@@ -627,7 +627,7 @@ int main() {
                 {"port", 13305},
                 {"host", "localhost"},
                 {"telemetry", {
-                    {"enabled", true},
+                    {"enabled", false},
                     {"max_attribute_length", bound},
                     {"otlp", {
                         {"semantics", {"openinference"}}
@@ -645,11 +645,14 @@ int main() {
                 nlohmann::json p = nlohmann::json::parse(bound_args, nullptr, false);
                 check_bool("InferenceSpan unicode args valid JSON", p.is_discarded(), false);
             }
+            lemon::RuntimeConfig::set_global(nullptr);
         }
 
         // Clean up
         lemon::telemetry::unregister_span_listener();
         lemon::RuntimeConfig::set_global(nullptr);
+        lemon::telemetry::flush();
+        lemon::telemetry::shutdown();
     }
 
     std::printf("===========================================\n");


### PR DESCRIPTION
## Summary

Fixes intermittent segmentation fault in `TelemetryHelpersTest` caused by a race condition with stack-allocated `RuntimeConfig` pointers and asynchronous background workers:

- Reset the global `RuntimeConfig` pointer on each iteration of the Unicode bound truncation test loop before stack-allocated config objects go out of scope.
- Set `telemetry.enabled: false` in test configs so unit test spans are handled synchronously via span listeners without enqueueing live network exports to the background worker thread.
- Explicitly flush and shut down telemetry workers (`lemon::telemetry::flush()` and `lemon::telemetry::shutdown()`) at test completion to ensure clean background thread teardown.

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_
- Executed 20-iteration stress run of `test_telemetry_helpers`: 20/20 runs passed with zero segfaults.
- Ran `ctest -L cpp-ci`: all C++ unit tests passed.
- Verified backend boilerplate sync via `python3 docs/tools/gen_backend_boilerplate.py --check`: 0 drift.

## Documentation

- [x] Documentation is not affected by this change.
- [ ] Documentation is affected and has been updated.
- [ ] Documentation is affected but will be handled in a separate PR or issue.

## Breaking Changes

- [ ] This PR introduces breaking changes.
- [x] This PR does not introduce breaking changes.

## AI-assisted contribution

- [x] I used AI tools for this PR.
- [ ] I did not use AI tools for this PR.

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.