### PR TITLE
test: move multi-checkpoint download-state coverage to C++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2805,6 +2805,21 @@ if(BUILD_TESTING AND EXISTS "${_MODEL_MANAGER_COLLECTION_VALIDATION_TEST_SRC}")
     add_cpp_ci_test(ModelManagerCollectionValidationTest CI ON COMMAND test_model_manager_collection_validation)
 endif()
 
+set(_MODEL_DOWNLOAD_STATE_TEST_SRC
+    "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_model_download_state.cpp"
+)
+if(BUILD_TESTING AND EXISTS "${_MODEL_DOWNLOAD_STATE_TEST_SRC}")
+    add_executable(test_model_download_state
+        test/cpp/test_model_download_state.cpp
+    )
+    target_link_libraries(test_model_download_state PRIVATE lemonade-server-core)
+    add_dependencies(test_model_download_state copy_resources)
+
+    include(CTest)
+    add_cpp_ci_test(ModelDownloadStateTest CI ON COMMAND test_model_download_state)
+endif()
+
+
 # Recipe hiding: a backend with every built-in model dropped by the system-memory
 # heuristic (and no user model left) is hidden from the recipe/backends listing.
 set(_RECIPE_HIDING_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_recipe_hiding.cpp")

--- a/test/cpp/test_model_download_state.cpp
+++ b/test/cpp/test_model_download_state.cpp
@@ -1,0 +1,244 @@
+#include "lemon/model_manager.h"
+#include "lemon/utils/path_utils.h"
+
+#include <chrono>
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+namespace fs = std::filesystem;
+using lemon::ModelInfo;
+using lemon::ModelManager;
+using lemon::json;
+using lemon::utils::path_from_utf8;
+using lemon::utils::path_to_utf8;
+
+static int g_failures = 0;
+
+static void check(const char* name, bool ok) {
+    std::printf("[%s] %s\n", ok ? "PASS" : "FAIL", name);
+    if (!ok) ++g_failures;
+}
+
+static fs::path make_temp_dir() {
+    fs::path dir = fs::temp_directory_path();
+    dir /= "model_download_state_" +
+           std::to_string(std::chrono::steady_clock::now().time_since_epoch().count());
+    fs::create_directories(dir);
+    return dir;
+}
+
+static void write_file(const fs::path& path, const std::string& contents = "data") {
+    fs::create_directories(path.parent_path());
+    std::ofstream out(path, std::ios::binary);
+    out.write(contents.data(), static_cast<std::streamsize>(contents.size()));
+}
+
+struct RegistryFixtures {
+    fs::path hf_variant_snapshot;
+    fs::path hf_uncommitted_repo;
+    fs::path hf_uncommitted_snapshot;
+    fs::path collection_main;
+    fs::path collection_vae;
+};
+
+static RegistryFixtures create_registry_fixtures(const fs::path& root,
+                                                  const fs::path& hf_root) {
+    RegistryFixtures fixtures;
+
+    fs::path hf_variant_repo = hf_root / "models--org--variant";
+    fixtures.hf_variant_snapshot = hf_variant_repo / "snapshots" / "snapshot-one";
+    write_file(fixtures.hf_variant_snapshot / "model.gguf", "GGUF");
+    write_file(hf_variant_repo / "refs" / "main", "snapshot-one");
+
+    fixtures.hf_uncommitted_repo = hf_root / "models--org--uncommitted";
+    fixtures.hf_uncommitted_snapshot =
+        fixtures.hf_uncommitted_repo / "snapshots" / "incomplete-snapshot";
+    write_file(fixtures.hf_uncommitted_snapshot / ".download_manifest.json", "{}");
+    write_file(
+        fixtures.hf_uncommitted_snapshot / "model-00002-of-00004.safetensors.partial",
+        "partial");
+
+    fs::path collection_dir = root / "collection";
+    fixtures.collection_main = collection_dir / "main.bin";
+    fixtures.collection_vae = collection_dir / "vae.bin";
+    write_file(fixtures.collection_main);
+
+    json user_models = {
+        {"hf-variant",
+         json{{"checkpoint", "org/variant:model.gguf"}, {"recipe", "llamacpp"}}},
+        {"hf-uncommitted",
+         json{{"checkpoint", "org/uncommitted"}, {"recipe", "sd-cpp"}}},
+        {"comp-multi",
+         json{{"checkpoints",
+               json{{"main", path_to_utf8(fixtures.collection_main)},
+                    {"vae", path_to_utf8(fixtures.collection_vae)}}},
+              {"recipe", "llamacpp"},
+              {"source", "local_path"}}},
+        {"coll-test",
+         json{{"components", json::array({"user.comp-multi"})},
+              {"recipe", "collection.omni"}}},
+    };
+    write_file(root / "user_models.json", user_models.dump(2));
+    return fixtures;
+}
+
+static void test_required_checkpoint_completeness(ModelManager& manager,
+                                                  const fs::path& root) {
+    fs::path dir = root / "required-checkpoints";
+    fs::path main_path = dir / "main.bin";
+    fs::path vae_path = dir / "vae.bin";
+
+    ModelInfo info;
+    info.recipe = "llamacpp";
+    info.checkpoints = {{"main", "main"}, {"vae", "vae"}};
+    info.resolved_paths = {
+        {"main", path_to_utf8(main_path)},
+        {"vae", path_to_utf8(vae_path)},
+    };
+
+    check("multi-checkpoint: no files is incomplete",
+          !manager.checkpoints_complete(info));
+
+    write_file(main_path);
+    check("multi-checkpoint: missing auxiliary file is incomplete",
+          !manager.checkpoints_complete(info));
+
+    write_file(vae_path);
+    check("multi-checkpoint: all required files is complete",
+          manager.checkpoints_complete(info));
+
+    fs::path partial_path = main_path;
+    partial_path += ".partial";
+    write_file(partial_path, "partial");
+    check("multi-checkpoint: .partial makes checkpoint incomplete",
+          !manager.checkpoints_complete(info));
+
+    fs::remove(partial_path);
+    check("multi-checkpoint: removing .partial restores completeness",
+          manager.checkpoints_complete(info));
+
+    fs::path manifest = dir / ".download_manifest.json";
+    write_file(manifest, "{}");
+    check("multi-checkpoint: download manifest marks interrupted download",
+          !manager.checkpoints_complete(info));
+
+    fs::remove(manifest);
+    check("multi-checkpoint: removing manifest restores completeness",
+          manager.checkpoints_complete(info));
+}
+
+static void test_single_checkpoint_partial_guard(ModelManager& manager,
+                                                 const fs::path& root) {
+    fs::path model_path = root / "single-checkpoint" / "model.bin";
+    write_file(model_path);
+
+    ModelInfo info;
+    info.recipe = "llamacpp";
+    info.checkpoints = {{"main", "main"}};
+    info.resolved_paths = {{"main", path_to_utf8(model_path)}};
+
+    check("single checkpoint remains complete without marker",
+          manager.checkpoints_complete(info));
+
+    fs::path partial_path = model_path;
+    partial_path += ".partial";
+    write_file(partial_path, "partial");
+    check("single checkpoint .partial guard remains active",
+          !manager.checkpoints_complete(info));
+}
+
+static void test_hf_manifest_marks_variant_incomplete(
+    ModelManager& manager, const RegistryFixtures& fixtures) {
+    check("HF variant: committed file is downloaded",
+          manager.get_model_info("user.hf-variant").downloaded);
+
+    write_file(fixtures.hf_variant_snapshot / ".download_manifest.json", "{}");
+    manager.invalidate_models_cache();
+    check("HF variant: manifest marks interrupted snapshot incomplete",
+          !manager.get_model_info("user.hf-variant").downloaded);
+}
+
+static void test_variantless_snapshot_commit_state(
+    ModelManager& manager, const RegistryFixtures& fixtures) {
+    check("variantless HF: uncommitted snapshot is incomplete",
+          !manager.get_model_info("user.hf-uncommitted").downloaded);
+
+    fs::remove(fixtures.hf_uncommitted_snapshot / ".download_manifest.json");
+    fs::remove(
+        fixtures.hf_uncommitted_snapshot / "model-00002-of-00004.safetensors.partial");
+    write_file(fixtures.hf_uncommitted_snapshot / "config.json", "{}");
+    write_file(fixtures.hf_uncommitted_repo / "refs" / "main", "incomplete-snapshot");
+    manager.invalidate_models_cache();
+
+    ModelInfo committed = manager.get_model_info("user.hf-uncommitted");
+    check("variantless HF: committed snapshot is downloaded",
+          committed.downloaded &&
+          path_from_utf8(committed.resolved_path()) == fixtures.hf_uncommitted_snapshot);
+
+    fs::path interrupted_update =
+        fixtures.hf_uncommitted_repo / "snapshots" / "new-incomplete-snapshot";
+    write_file(interrupted_update / ".download_manifest.json", "{}");
+    write_file(interrupted_update / "model.safetensors.partial", "partial");
+    manager.invalidate_models_cache();
+
+    ModelInfo updating = manager.get_model_info("user.hf-uncommitted");
+    check("variantless HF: interrupted update keeps committed snapshot usable",
+          updating.downloaded &&
+          path_from_utf8(updating.resolved_path()) == fixtures.hf_uncommitted_snapshot);
+}
+
+static void test_collection_component_download_state(
+    ModelManager& manager, const RegistryFixtures& fixtures) {
+    check("collection: incomplete component is not downloaded",
+          !manager.get_model_info("user.comp-multi").downloaded);
+    check("collection: incomplete component keeps collection incomplete",
+          !manager.get_model_info("user.coll-test").downloaded);
+
+    write_file(fixtures.collection_vae);
+    manager.invalidate_models_cache();
+    check("collection: complete component is downloaded",
+          manager.get_model_info("user.comp-multi").downloaded);
+    check("collection: all complete components make collection downloaded",
+          manager.get_model_info("user.coll-test").downloaded);
+
+    fs::path partial_path = fixtures.collection_main;
+    partial_path += ".partial";
+    write_file(partial_path, "partial");
+    manager.invalidate_models_cache();
+    check("collection: component .partial makes component incomplete again",
+          !manager.get_model_info("user.comp-multi").downloaded);
+    check("collection: component .partial propagates to collection status",
+          !manager.get_model_info("user.coll-test").downloaded);
+}
+
+int main() {
+    fs::path temp = make_temp_dir();
+    fs::path hf_root = temp / "hf";
+    fs::create_directories(hf_root);
+
+    lemon::utils::set_cache_dir(path_to_utf8(temp));
+    lemon::utils::set_config_dir(path_to_utf8(temp));
+    lemon::utils::set_models_dir(path_to_utf8(hf_root));
+
+    RegistryFixtures fixtures = create_registry_fixtures(temp, hf_root);
+
+    {
+        ModelManager manager;
+        test_required_checkpoint_completeness(manager, temp);
+        test_single_checkpoint_partial_guard(manager, temp);
+        test_hf_manifest_marks_variant_incomplete(manager, fixtures);
+        test_variantless_snapshot_commit_state(manager, fixtures);
+        test_collection_component_download_state(manager, fixtures);
+    }
+
+    fs::remove_all(temp);
+
+    if (g_failures == 0) {
+        std::printf("All model download-state tests passed.\n");
+    } else {
+        std::printf("%d model download-state test(s) failed.\n", g_failures);
+    }
+    return g_failures == 0 ? 0 : 1;
+}

--- a/test/test_multi_checkpoint_completeness.py
+++ b/test/test_multi_checkpoint_completeness.py
@@ -12,17 +12,11 @@ from utils.test_models import get_default_lemond_binary, get_default_cli_binary
 
 class TestMultiCheckpointCompleteness(unittest.TestCase):
     """
-    Integration tests for multi-checkpoint download integrity.
+    Thin server/CLI integration coverage for multi-checkpoint completeness.
 
-    These tests verify that models requiring multiple files (e.g., Image Gen with VAEs)
-    are only marked as 'Downloaded' when all required components are 100% present.
-
-    Operation:
-    - Creates a temporary workspace for each test case.
-    - Simulates 'broken' or 'partial' downloads by creating fake files and marker files
-      (.partial, .download_manifest.json) on disk.
-    - Launches the 'lemond' server and uses the 'lemonade' CLI to verify the
-      reported download status matches expectations.
+    Filesystem-state transitions are covered directly by C++ unit tests. This
+    suite only verifies that an incomplete component reaches the CLI and that
+    collection pull fan-out does not skip it.
     """
 
     def setUp(self):
@@ -78,187 +72,7 @@ class TestMultiCheckpointCompleteness(unittest.TestCase):
                 self.server_stderr = stderr if stderr else ""
             self.server_proc = None
 
-    def test_multi_checkpoint_completeness(self):
-        model_id = "multi-test"
-        path1 = os.path.join(self.tmp_dir, "model1.gguf")
-        path2 = os.path.join(self.tmp_dir, "model2.gguf")
-
-        user_models = {
-            model_id: {
-                "checkpoints": {"main": path1, "vae": path2},
-                "recipe": "llamacpp",
-                "source": "local_path",
-            }
-        }
-
-        with open(os.path.join(self.tmp_dir, "user_models.json"), "w") as f:
-            json.dump(user_models, f)
-
-        # 1. No files
-        self.start_server()
-        res = subprocess.run(
-            [self.cli_bin, "--port", str(self.port), "list"],
-            capture_output=True,
-            text=True,
-        )
-        self.assertIn("No", [l for l in res.stdout.splitlines() if model_id in l][0])
-
-        # 2. One file
-        with open(path1, "w") as f:
-            f.write("fake")
-        self.start_server()
-        res = subprocess.run(
-            [self.cli_bin, "--port", str(self.port), "list"],
-            capture_output=True,
-            text=True,
-        )
-        self.assertIn("No", [l for l in res.stdout.splitlines() if model_id in l][0])
-
-        # 3. Two files
-        with open(path2, "w") as f:
-            f.write("fake")
-        self.start_server()
-        res = subprocess.run(
-            [self.cli_bin, "--port", str(self.port), "list"],
-            capture_output=True,
-            text=True,
-        )
-        self.assertIn("Yes", [l for l in res.stdout.splitlines() if model_id in l][0])
-
-        # 4. Partial file
-        partial = path1 + ".partial"
-        with open(partial, "w") as f:
-            f.write("partial")
-        self.start_server()
-        res = subprocess.run(
-            [self.cli_bin, "--port", str(self.port), "list"],
-            capture_output=True,
-            text=True,
-        )
-        self.assertIn("No", [l for l in res.stdout.splitlines() if model_id in l][0])
-        os.remove(partial)
-
-        # 5. HF Marker logic
-        # We'll use a fake HF repo structure
-        hf_model_id = "hf-test"
-        repo = "org/repo"
-        # models--org--repo/snapshots/main/model.gguf
-        repo_dir = os.path.join(self.tmp_dir, "hf", "models--org--repo")
-        snapshot_dir = os.path.join(repo_dir, "snapshots", "main")
-        os.makedirs(snapshot_dir, exist_ok=True)
-        gguf_path = os.path.join(snapshot_dir, "model.gguf")
-        with open(gguf_path, "w") as f:
-            f.write("fake")
-
-        # Register it
-        with open(os.path.join(self.tmp_dir, "user_models.json"), "r") as f:
-            user_models = json.load(f)
-        user_models[hf_model_id] = {
-            "checkpoint": f"{repo}:model.gguf",
-            "recipe": "llamacpp",
-        }
-        with open(os.path.join(self.tmp_dir, "user_models.json"), "w") as f:
-            json.dump(user_models, f)
-
-        # Should be Yes initially
-        self.start_server()
-        res = subprocess.run(
-            [self.cli_bin, "--port", str(self.port), "list"],
-            capture_output=True,
-            text=True,
-        )
-        self.assertIn(
-            "Yes", [l for l in res.stdout.splitlines() if hf_model_id in l][0]
-        )
-
-        # Add manifest at snapshot root
-        manifest = os.path.join(snapshot_dir, ".download_manifest.json")
-        with open(manifest, "w") as f:
-            f.write("{}")
-        self.start_server()
-        res = subprocess.run(
-            [self.cli_bin, "--port", str(self.port), "list"],
-            capture_output=True,
-            text=True,
-        )
-        self.assertIn("No", [l for l in res.stdout.splitlines() if hf_model_id in l][0])
-
-    def test_uncommitted_variantless_snapshot_is_not_downloaded(self):
-        model_id = "hf-uncommitted"
-        repo = "org/uncommitted"
-        snapshot_id = "incomplete-snapshot"
-        repo_dir = os.path.join(self.tmp_dir, "hf", "models--org--uncommitted")
-        snapshot_dir = os.path.join(repo_dir, "snapshots", snapshot_id)
-        os.makedirs(snapshot_dir, exist_ok=True)
-
-        # Simulate Lemonade exiting during a large variantless repository pull.
-        # The modern cache tree exists, but refs/main was never committed.
-        manifest = os.path.join(snapshot_dir, ".download_manifest.json")
-        partial = os.path.join(snapshot_dir, "model-00002-of-00004.safetensors.partial")
-        with open(manifest, "w") as f:
-            f.write("{}")
-        with open(partial, "wb") as f:
-            f.write(b"partial")
-
-        user_models = {
-            model_id: {
-                "checkpoint": repo,
-                "recipe": "sd-cpp",
-            }
-        }
-        with open(os.path.join(self.tmp_dir, "user_models.json"), "w") as f:
-            json.dump(user_models, f)
-
-        # The old resolver returned the repository cache directory here and the
-        # server reported Downloaded. It must remain resumable/not downloaded.
-        self.start_server()
-        res = subprocess.run(
-            [self.cli_bin, "--port", str(self.port), "list"],
-            capture_output=True,
-            text=True,
-        )
-        self.assertIn("No", [l for l in res.stdout.splitlines() if model_id in l][0])
-
-        # Finish and commit the snapshot. The same directory checkpoint is now
-        # valid.
-        os.remove(manifest)
-        os.remove(partial)
-        with open(os.path.join(snapshot_dir, "config.json"), "w") as f:
-            f.write("{}")
-        refs_dir = os.path.join(repo_dir, "refs")
-        os.makedirs(refs_dir, exist_ok=True)
-        with open(os.path.join(refs_dir, "main"), "w") as f:
-            f.write(snapshot_id)
-
-        self.start_server()
-        res = subprocess.run(
-            [self.cli_bin, "--port", str(self.port), "list"],
-            capture_output=True,
-            text=True,
-        )
-        self.assertIn("Yes", [l for l in res.stdout.splitlines() if model_id in l][0])
-
-        # A later interrupted update must not hide the still-committed old snapshot.
-        update_dir = os.path.join(repo_dir, "snapshots", "new-incomplete-snapshot")
-        os.makedirs(update_dir, exist_ok=True)
-        with open(os.path.join(update_dir, ".download_manifest.json"), "w") as f:
-            f.write("{}")
-        with open(os.path.join(update_dir, "model.safetensors.partial"), "wb") as f:
-            f.write(b"partial")
-
-        self.start_server()
-        res = subprocess.run(
-            [self.cli_bin, "--port", str(self.port), "list"],
-            capture_output=True,
-            text=True,
-        )
-        self.assertIn("Yes", [l for l in res.stdout.splitlines() if model_id in l][0])
-
-    def test_collection_status_with_incomplete_component(self):
-        # Status-regression coverage for the collection fan-out skip predicate.
-        # If a component is missing an auxiliary checkpoint, it must not be
-        # reported as downloaded; collection pull uses that downloaded status
-        # to decide whether a component can be skipped.
+    def test_incomplete_component_reaches_cli_and_collection_pull(self):
         comp_id = "comp-multi"
         coll_id = "coll-test"
         path1 = os.path.join(self.tmp_dir, "model1.gguf")
@@ -276,68 +90,33 @@ class TestMultiCheckpointCompleteness(unittest.TestCase):
         with open(os.path.join(self.tmp_dir, "user_models.json"), "w") as f:
             json.dump(user_models, f)
 
-        # 1. Component incomplete (only 1 file)
-        with open(path1, "w") as f:
-            f.write("fake")
+        with open(path1, "wb") as f:
+            f.write(b"GGUF")
 
-        # Start server and capture output to verify fan-out logs
         self.start_server(capture_output=True)
 
-        # 2. Run 'pull' on the collection.
-        # The pull subprocess return code is intentionally not asserted here
-        # because the fake local-path component may fail later. This test
-        # only asserts that collection fan-out reaches the incomplete component,
-        # not that the full pull succeeds.
+        list_result = subprocess.run(
+            [self.cli_bin, "--port", str(self.port), "list"],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(list_result.returncode, 0, list_result.stderr)
+        component_rows = [
+            line for line in list_result.stdout.splitlines() if comp_id in line
+        ]
+        self.assertTrue(component_rows, list_result.stdout)
+        self.assertIn("No", component_rows[0])
+
         subprocess.run(
             [self.cli_bin, "--port", str(self.port), "pull", coll_id],
             capture_output=True,
             text=True,
         )
 
-        # Stop server to flush logs
         self.stop_server()
 
-        # Check server logs for the fan-out decision
         log_output = self.server_stdout + self.server_stderr
         self.assertIn(f"Downloading component: {comp_id}", log_output)
-
-    def test_single_checkpoint_guard(self):
-        # Ensure standard models still work normally
-        model_id = "single-test"
-        path = os.path.join(self.tmp_dir, "single.gguf")
-
-        user_models = {
-            model_id: {
-                "checkpoint": path,
-                "recipe": "llamacpp",
-                "source": "local_path",
-            }
-        }
-
-        with open(os.path.join(self.tmp_dir, "user_models.json"), "w") as f:
-            json.dump(user_models, f)
-
-        # Downloaded
-        with open(path, "w") as f:
-            f.write("fake")
-        self.start_server()
-        res = subprocess.run(
-            [self.cli_bin, "--port", str(self.port), "list"],
-            capture_output=True,
-            text=True,
-        )
-        self.assertIn("Yes", [l for l in res.stdout.splitlines() if model_id in l][0])
-
-        # Partial
-        with open(path + ".partial", "w") as f:
-            f.write("fake")
-        self.start_server()
-        res = subprocess.run(
-            [self.cli_bin, "--port", str(self.port), "list"],
-            capture_output=True,
-            text=True,
-        )
-        self.assertIn("No", [l for l in res.stdout.splitlines() if model_id in l][0])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Move multi-checkpoint download-state coverage from server-heavy Python integration tests to direct C++ unit tests.

The filesystem and checkpoint completeness cases now exercise the real `ModelManager` logic directly, while Python keeps only a thin server/CLI smoke test to verify the state reaches the public interface.


## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_

- Added `cpp-ci` coverage for multi-checkpoint completeness, `.partial` files, download manifests, uncommitted HF snapshots, interrupted updates with a previous committed snapshot, and collection component state.
- Reduced the Python suite to a single server/CLI integration smoke test.
- No production download behavior was changed.

## Documentation

- [x] Documentation is not affected by this change.

## Breaking Changes

- [x] This PR does not introduce breaking changes.

## AI-assisted contribution

- [x] I used AI tools for this PR.

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.