### PR TITLE
test: move llamacpp system backend policy coverage to C++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3002,6 +3002,21 @@ if(BUILD_TESTING AND EXISTS "${_GPU_ENV_TEST_SRC}")
     add_cpp_ci_test(BackendUtilsGpuEnvTest CI ON COMMAND test_backend_utils_gpu_env)
 endif()
 
+set(_LLAMACPP_SYSTEM_BACKEND_TEST_SRC
+    "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_llamacpp_system_backend.cpp"
+)
+if(BUILD_TESTING AND CMAKE_SYSTEM_NAME STREQUAL "Linux" AND EXISTS "${_LLAMACPP_SYSTEM_BACKEND_TEST_SRC}")
+    add_executable(test_llamacpp_system_backend
+        test/cpp/test_llamacpp_system_backend.cpp
+    )
+    target_include_directories(test_llamacpp_system_backend PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/server
+    )
+    target_link_libraries(test_llamacpp_system_backend PRIVATE lemonade-server-core)
+    add_dependencies(test_llamacpp_system_backend copy_resources)
+    add_cpp_ci_test(LlamaCppSystemBackendTest CI ON COMMAND test_llamacpp_system_backend)
+endif()
+
 set(_DLL_VERSION_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_backend_utils_dll_version.cpp")
 if(BUILD_TESTING AND EXISTS "${_DLL_VERSION_TEST_SRC}")
     add_executable(test_backend_utils_dll_version test/cpp/test_backend_utils_dll_version.cpp)

--- a/src/cpp/server/backends/llamacpp/llamacpp_server.cpp
+++ b/src/cpp/server/backends/llamacpp/llamacpp_server.cpp
@@ -2,6 +2,7 @@
 #include "lemon/backends/llamacpp/llamacpp.h"
 #include "lemon/backends/llamacpp/llamacpp_gguf.h"
 #include "lemon/backends/llamacpp/llamacpp_request.h"
+#include "llamacpp_system_utils.h"
 #include "lemon/backends/backend_registry.h"
 #include "lemon/backends/backend_ops.h"
 #include "lemon/backends/backend_utils.h"
@@ -737,53 +738,20 @@ bool is_ggml_hip_plugin_available() {
 #ifdef __linux__
     // Allow distros/packagers that install outside the FHS paths below
     // (e.g. NixOS, custom prefixes) to point directly at libggml-hip.so.
-    if (const char* env = std::getenv("LEMONADE_GGML_HIP_PATH"); env && *env) {
-        // Require the basename to look like the HIP plugin (libggml-hip*.so*,
-        // case-insensitive, versioned sonames allowed). This is a sanity check,
-        // not a security boundary: the path is not forwarded to ggml's loader,
-        // so we cannot verify it is actually loadable. It only guards against an
-        // accidental override pointing at an unrelated existing file.
-        std::string name = fs::path(env).filename().string();
-        std::transform(name.begin(), name.end(), name.begin(),
-                       [](unsigned char c) { return std::tolower(c); });
-        const bool name_matches = name.rfind("libggml-hip", 0) == 0 &&
-                                  name.find(".so") != std::string::npos;
-        // LEMONADE_GGML_HIP_PATH is user-controlled, so use the non-throwing
-        // filesystem overload: an odd or malformed path resolves to "not a
-        // regular file" (ec set) instead of raising a filesystem_error.
-        std::error_code hip_path_ec;
-        if (name_matches && fs::is_regular_file(env, hip_path_ec)) {
-            return true;
-        }
+    if (detail::ggml_hip_env_override_available()) {
+        return true;
     }
+
     // A self-built llama.cpp resolved from PATH ships libggml-hip.so next to
     // the binary (build tree) or in a sibling lib/ directory (installed tree).
     // find_executable_in_path() returns the bare name on POSIX, so walk PATH
     // here to recover the directory the binary actually lives in.
     if (const char* path_env = std::getenv("PATH"); path_env && *path_env) {
-        std::string path_str(path_env);
-        size_t start = 0;
-        while (start <= path_str.size()) {
-            size_t end = path_str.find(':', start);
-            std::string dir = path_str.substr(start, end == std::string::npos ? std::string::npos : end - start);
-            if (!dir.empty()) {
-                std::error_code plugin_ec;
-                fs::path bin_dir(dir);
-                fs::path llama_server = bin_dir / "llama-server";
-                if (fs::is_regular_file(llama_server, plugin_ec) &&
-                    access(llama_server.c_str(), X_OK) == 0) {
-                    plugin_ec.clear();
-                    if (fs::exists(bin_dir / "libggml-hip.so", plugin_ec) ||
-                        fs::exists(bin_dir.parent_path() / "lib" / "libggml-hip.so", plugin_ec)) {
-                        return true;
-                    }
-                    break;
-                }
-            }
-            if (end == std::string::npos) break;
-            start = end + 1;
+        if (detail::ggml_hip_plugin_near_llama_server(path_env)) {
+            return true;
         }
     }
+
     // On Linux x86_64, check common system library paths for the HIP plugin
     std::vector<std::string> possible_paths = {
         // Debian/Ubuntu multiarch path (most common)

--- a/src/cpp/server/backends/llamacpp/llamacpp_system_utils.h
+++ b/src/cpp/server/backends/llamacpp/llamacpp_system_utils.h
@@ -1,0 +1,89 @@
+#pragma once
+
+#include <algorithm>
+#include <cctype>
+#include <cstdlib>
+#include <filesystem>
+#include <string>
+#include <system_error>
+
+#ifdef __linux__
+#include <unistd.h>
+#endif
+
+namespace lemon {
+namespace backends {
+namespace llamacpp {
+namespace detail {
+
+// Private, deterministic pieces of the system llama.cpp HIP lookup. The full
+// production availability check stays in llamacpp_server.cpp so this header is
+// only a narrow test seam, not a second implementation of the policy.
+inline bool is_valid_ggml_hip_plugin_path(const std::filesystem::path& path) {
+#ifdef __linux__
+    std::string name = path.filename().string();
+    std::transform(name.begin(), name.end(), name.begin(),
+                   [](unsigned char c) { return std::tolower(c); });
+    const bool name_matches = name.rfind("libggml-hip", 0) == 0 &&
+                              name.find(".so") != std::string::npos;
+
+    std::error_code ec;
+    return name_matches && std::filesystem::is_regular_file(path, ec);
+#else
+    (void)path;
+    return false;
+#endif
+}
+
+inline bool ggml_hip_env_override_available() {
+#ifdef __linux__
+    const char* env = std::getenv("LEMONADE_GGML_HIP_PATH");
+    return env && *env && is_valid_ggml_hip_plugin_path(env);
+#else
+    return false;
+#endif
+}
+
+inline bool ggml_hip_plugin_near_llama_server(const std::string& path_str) {
+#ifdef __linux__
+    size_t start = 0;
+    while (start <= path_str.size()) {
+        size_t end = path_str.find(':', start);
+        std::string dir = path_str.substr(
+            start,
+            end == std::string::npos ? std::string::npos : end - start);
+        if (!dir.empty()) {
+            std::error_code ec;
+            std::filesystem::path bin_dir(dir);
+            std::filesystem::path llama_server = bin_dir / "llama-server";
+            if (std::filesystem::is_regular_file(llama_server, ec) &&
+                access(llama_server.c_str(), X_OK) == 0) {
+                ec.clear();
+                if (std::filesystem::exists(bin_dir / "libggml-hip.so", ec)) {
+                    return true;
+                }
+                ec.clear();
+                if (std::filesystem::exists(
+                        bin_dir.parent_path() / "lib" / "libggml-hip.so", ec)) {
+                    return true;
+                }
+                // Preserve the current resolver policy: once PATH selects an
+                // executable llama-server, do not inspect later PATH entries.
+                break;
+            }
+        }
+        if (end == std::string::npos) {
+            break;
+        }
+        start = end + 1;
+    }
+#else
+    (void)path_str;
+#endif
+    return false;
+}
+
+}  // namespace detail
+}  // namespace llamacpp
+}  // namespace backends
+}  // namespace lemon

--- a/test/cpp/test_llamacpp_system_backend.cpp
+++ b/test/cpp/test_llamacpp_system_backend.cpp
@@ -9,6 +9,7 @@
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -155,13 +156,15 @@ json test_devices() {
 json build_recipes(TestSystemInfo& system_info,
                    const fs::path& path_dir,
                    const std::string& configured_backend,
-                   bool prefer_system) {
+                   std::optional<bool> prefer_system_override) {
     // build_recipes_info() evaluates every recipe/backend row, so give
     // RuntimeConfig the same complete canonical shape used by production.
     // base_defaults() intentionally excludes host/distro overrides.
     json config_json = lemon::ConfigFile::base_defaults();
     config_json["llamacpp"]["backend"] = configured_backend;
-    config_json["llamacpp"]["prefer_system"] = prefer_system;
+    if (prefer_system_override.has_value()) {
+        config_json["llamacpp"]["prefer_system"] = *prefer_system_override;
+    }
     lemon::RuntimeConfig config(config_json);
     ScopedRuntimeConfig config_scope(&config);
     ScopedEnvVar path_scope("PATH");
@@ -267,6 +270,15 @@ int main() {
     hip_env.set(valid_hip.string());
     TestSystemInfo system_info;
 
+    // No override here: exercise the canonical prefer_system default shipped
+    // through ConfigFile::base_defaults().
+    const json default_preference = build_recipes(
+        system_info, system_bin, "auto", std::nullopt);
+    check_system_state(default_preference, "installed",
+                       "available system backend with default config");
+    check(default_preference["llamacpp"].value("default_backend", "") == "system",
+          "default config prefers an available system backend");
+
     const json not_preferred = build_recipes(
         system_info, system_bin, "auto", /*prefer_system=*/false);
     check_system_state(not_preferred, "installed",
@@ -299,6 +311,13 @@ int main() {
                       .find("llama-server not found in PATH") != std::string::npos,
               "missing system backend reports PATH discovery failure");
     }
+
+    const json unavailable_not_preferred = build_recipes(
+        system_info, empty_bin, "auto", /*prefer_system=*/false);
+    check_system_state(unavailable_not_preferred, "unsupported",
+                       "missing system backend with prefer_system=false");
+    check(unavailable_not_preferred["llamacpp"].value("default_backend", "") != "system",
+          "prefer_system=false also falls back when system llama-server is unavailable");
 
     if (failures != 0) {
         std::cerr << "Total failures: " << failures << std::endl;

--- a/test/cpp/test_llamacpp_system_backend.cpp
+++ b/test/cpp/test_llamacpp_system_backend.cpp
@@ -1,0 +1,311 @@
+// Direct coverage for the Linux llamacpp "system" backend resolver.
+//
+// These tests intentionally avoid lemond. They exercise the production PATH,
+// HIP-plugin and SystemInfo selection code with controlled filesystem/config
+// inputs, leaving subprocess/HTTP behavior to test_llamacpp_system_backend.py.
+
+#include <chrono>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <lemon/config_file.h>
+#include <lemon/runtime_config.h>
+#include <lemon/system_info.h>
+#include <lemon/utils/path_utils.h>
+
+#include "backends/llamacpp/llamacpp_system_utils.h"
+
+namespace fs = std::filesystem;
+using lemon::json;
+
+namespace {
+
+int failures = 0;
+
+void check(bool condition, const std::string& message) {
+    if (condition) {
+        std::cout << "[ok] " << message << std::endl;
+    } else {
+        std::cerr << "[FAIL] " << message << std::endl;
+        ++failures;
+    }
+}
+
+#ifdef __linux__
+
+class ScopedEnvVar {
+public:
+    explicit ScopedEnvVar(std::string name) : name_(std::move(name)) {
+        if (const char* value = std::getenv(name_.c_str())) {
+            had_value_ = true;
+            old_value_ = value;
+        }
+    }
+
+    ~ScopedEnvVar() {
+        if (had_value_) {
+            setenv(name_.c_str(), old_value_.c_str(), 1);
+        } else {
+            unsetenv(name_.c_str());
+        }
+    }
+
+    void set(const std::string& value) const {
+        setenv(name_.c_str(), value.c_str(), 1);
+    }
+
+    void clear() const {
+        unsetenv(name_.c_str());
+    }
+
+private:
+    std::string name_;
+    std::string old_value_;
+    bool had_value_ = false;
+};
+
+class ScopedRuntimeConfig {
+public:
+    explicit ScopedRuntimeConfig(lemon::RuntimeConfig* config)
+        : previous_(lemon::RuntimeConfig::global()) {
+        lemon::RuntimeConfig::set_global(config);
+    }
+
+    ~ScopedRuntimeConfig() {
+        lemon::RuntimeConfig::set_global(previous_);
+    }
+
+private:
+    lemon::RuntimeConfig* previous_;
+};
+
+class TempDir {
+public:
+    TempDir() {
+        const auto nonce = std::chrono::steady_clock::now()
+                               .time_since_epoch()
+                               .count();
+        path_ = fs::temp_directory_path() /
+                ("lemonade_llamacpp_system_" + std::to_string(nonce));
+        fs::create_directories(path_);
+    }
+
+    ~TempDir() {
+        std::error_code ec;
+        fs::remove_all(path_, ec);
+    }
+
+    const fs::path& path() const { return path_; }
+
+private:
+    fs::path path_;
+};
+
+class TestSystemInfo final : public lemon::SystemInfo {
+public:
+    lemon::CPUInfo get_cpu_device() override { return {}; }
+    lemon::GPUInfo get_amd_igpu_device() override { return {}; }
+    std::vector<lemon::GPUInfo> get_amd_dgpu_devices() override { return {}; }
+    std::vector<lemon::GPUInfo> get_nvidia_gpu_devices() override { return {}; }
+    lemon::NPUInfo get_npu_device() override { return {}; }
+};
+
+void write_file(const fs::path& path, const std::string& contents) {
+    fs::create_directories(path.parent_path());
+    std::ofstream out(path, std::ios::binary);
+    out << contents;
+    out.close();
+    check(static_cast<bool>(out), "writes test fixture " + path.string());
+}
+
+void make_executable(const fs::path& path) {
+    std::error_code ec;
+    fs::permissions(
+        path,
+        fs::perms::owner_exec | fs::perms::group_exec | fs::perms::others_exec,
+        fs::perm_options::add,
+        ec);
+    check(!ec, "marks test llama-server executable");
+}
+
+std::string test_cpu_family() {
+#if defined(__aarch64__)
+    return "arm64";
+#else
+    return "x86_64";
+#endif
+}
+
+json test_devices() {
+    return {
+        {"cpu",
+         {
+             {"name", "Test CPU"},
+             {"available", true},
+             {"family", test_cpu_family()},
+         }},
+    };
+}
+
+json build_recipes(TestSystemInfo& system_info,
+                   const fs::path& path_dir,
+                   const std::string& configured_backend,
+                   bool prefer_system) {
+    // build_recipes_info() evaluates every recipe/backend row, so give
+    // RuntimeConfig the same complete canonical shape used by production.
+    // base_defaults() intentionally excludes host/distro overrides.
+    json config_json = lemon::ConfigFile::base_defaults();
+    config_json["llamacpp"]["backend"] = configured_backend;
+    config_json["llamacpp"]["prefer_system"] = prefer_system;
+    lemon::RuntimeConfig config(config_json);
+    ScopedRuntimeConfig config_scope(&config);
+    ScopedEnvVar path_scope("PATH");
+    path_scope.set(path_dir.string());
+    return system_info.build_recipes_info(test_devices());
+}
+
+void check_system_state(const json& recipes,
+                        const std::string& expected_state,
+                        const std::string& message) {
+    check(recipes.contains("llamacpp"), message + ": llamacpp recipe exists");
+    if (!recipes.contains("llamacpp")) {
+        return;
+    }
+    const auto& backends = recipes["llamacpp"]["backends"];
+    check(backends.contains("system"), message + ": system backend exists");
+    if (backends.contains("system")) {
+        check(backends["system"].value("state", "") == expected_state,
+              message + ": system state is " + expected_state);
+    }
+}
+
+#endif  // __linux__
+
+}  // namespace
+
+int main() {
+#ifndef __linux__
+    std::cout << "llamacpp system backend resolver is Linux-only; skipped." << std::endl;
+    return 0;
+#else
+    TempDir temp;
+    const fs::path system_bin = temp.path() / "system-bin";
+    const fs::path empty_bin = temp.path() / "empty-bin";
+    const fs::path llama_server = system_bin / "llama-server";
+    fs::create_directories(system_bin);
+    fs::create_directories(empty_bin);
+    write_file(llama_server, "#!/bin/sh\nprintf 'version: 9999 (mock)\\n'\n");
+    make_executable(llama_server);
+
+    ScopedEnvVar path_env("PATH");
+    ScopedEnvVar hip_env("LEMONADE_GGML_HIP_PATH");
+
+    // PATH discovery is a direct C++ decision: no lemond is needed to prove it.
+    path_env.set(system_bin.string());
+    check(!lemon::utils::find_executable_in_path("llama-server").empty(),
+          "discovers executable llama-server from PATH");
+    path_env.set(empty_bin.string());
+    check(lemon::utils::find_executable_in_path("llama-server").empty(),
+          "reports llama-server absent when PATH has no executable");
+
+    // Validate the user-provided HIP override without requiring /sys/class/kfd
+    // or relying on whichever libraries happen to be installed on the CI host.
+    const fs::path valid_hip = temp.path() / "libggml-hip.so";
+    const fs::path wrong_name = temp.path() / "not-the-hip-plugin.so";
+    write_file(valid_hip, "stub");
+    write_file(wrong_name, "stub");
+
+    hip_env.set(valid_hip.string());
+    check(lemon::backends::llamacpp::detail::ggml_hip_env_override_available(),
+          "accepts a regular libggml-hip.so environment override");
+
+    hip_env.set((temp.path() / "missing" / "libggml-hip.so").string());
+    check(!lemon::backends::llamacpp::detail::ggml_hip_env_override_available(),
+          "rejects a nonexistent HIP environment override");
+
+    hip_env.set(temp.path().string());
+    check(!lemon::backends::llamacpp::detail::ggml_hip_env_override_available(),
+          "rejects a directory as the HIP environment override");
+
+    hip_env.set(wrong_name.string());
+    check(!lemon::backends::llamacpp::detail::ggml_hip_env_override_available(),
+          "rejects an unrelated regular file as the HIP environment override");
+
+    // The PATH layout resolver also stays deterministic: test both layouts
+    // supported by production without looking at the host's system libraries.
+    const fs::path layout_root = temp.path() / "layout";
+    const fs::path layout_bin = layout_root / "bin";
+    const fs::path layout_server = layout_bin / "llama-server";
+    const fs::path adjacent_hip = layout_bin / "libggml-hip.so";
+    const fs::path sibling_hip = layout_root / "lib" / "libggml-hip.so";
+    write_file(layout_server, "#!/bin/sh\nexit 0\n");
+    make_executable(layout_server);
+    write_file(adjacent_hip, "stub");
+    check(lemon::backends::llamacpp::detail::ggml_hip_plugin_near_llama_server(
+              layout_bin.string()),
+          "finds libggml-hip.so next to PATH llama-server");
+
+    fs::remove(adjacent_hip);
+    write_file(sibling_hip, "stub");
+    check(lemon::backends::llamacpp::detail::ggml_hip_plugin_near_llama_server(
+              layout_bin.string()),
+          "finds libggml-hip.so in sibling lib directory");
+
+    fs::remove(sibling_hip);
+    check(!lemon::backends::llamacpp::detail::ggml_hip_plugin_near_llama_server(
+              layout_bin.string()),
+          "does not invent a HIP plugin for a PATH llama-server");
+
+    // Keep the real SystemInfo resolver independent of the CI machine's AMD
+    // state. If KFD is present, this valid override satisfies the same check
+    // that production performs for the system backend.
+    hip_env.set(valid_hip.string());
+    TestSystemInfo system_info;
+
+    const json not_preferred = build_recipes(
+        system_info, system_bin, "auto", /*prefer_system=*/false);
+    check_system_state(not_preferred, "installed",
+                       "available system backend with prefer_system=false");
+    check(not_preferred["llamacpp"].value("default_backend", "") != "system",
+          "prefer_system=false keeps an available system backend out of default selection");
+
+    const json preferred = build_recipes(
+        system_info, system_bin, "auto", /*prefer_system=*/true);
+    check_system_state(preferred, "installed",
+                       "available system backend with prefer_system=true");
+    check(preferred["llamacpp"].value("default_backend", "") == "system",
+          "prefer_system=true selects the available system backend");
+
+    const json explicit_system = build_recipes(
+        system_info, system_bin, "system", /*prefer_system=*/false);
+    check(explicit_system["llamacpp"].value("default_backend", "") == "system",
+          "explicit llamacpp.backend=system overrides prefer_system=false");
+
+    const json unavailable = build_recipes(
+        system_info, empty_bin, "auto", /*prefer_system=*/true);
+    check_system_state(unavailable, "unsupported",
+                       "missing system backend with prefer_system=true");
+    check(unavailable["llamacpp"].value("default_backend", "") != "system",
+          "prefer_system=true falls back when system llama-server is unavailable");
+    if (unavailable.contains("llamacpp") &&
+        unavailable["llamacpp"]["backends"].contains("system")) {
+        check(unavailable["llamacpp"]["backends"]["system"]
+                      .value("message", "")
+                      .find("llama-server not found in PATH") != std::string::npos,
+              "missing system backend reports PATH discovery failure");
+    }
+
+    if (failures != 0) {
+        std::cerr << "Total failures: " << failures << std::endl;
+        return 1;
+    }
+
+    std::cout << "All llamacpp system backend resolver tests passed!" << std::endl;
+    return 0;
+#endif
+}

--- a/test/test_llamacpp_system_backend.py
+++ b/test/test_llamacpp_system_backend.py
@@ -1,8 +1,10 @@
 """
-Tests for the 'system' LlamaCpp backend and llamacpp.prefer_system config.
+Process/server integration tests for the external 'system' LlamaCpp backend.
 
-Each test needs a fresh server with different PATH/config, so this file
-manages its own server lifecycle independently of ServerTestBase.
+Pure PATH discovery, prefer_system selection/fallback, and HIP plugin resolution
+are covered directly in C++ by test/cpp/test_llamacpp_system_backend.cpp. This
+suite keeps the behavior that genuinely crosses the lemond/llama-server process
+boundary and shares one server lifecycle across those assertions.
 
 Usage:
     python test/test_llamacpp_system_backend.py
@@ -37,17 +39,6 @@ from utils.test_models import (
 
 args = parse_args()  # Initialize global _config
 
-# Define a dummy executable content (e.g., a simple shell script)
-# On Linux/macOS, a shell script that exits 0
-# On Windows, a batch file that exits 0
-DUMMY_LLAMA_SERVER_LINUX_MAC = """#!/bin/bash
-exit 0
-"""
-
-DUMMY_LLAMA_SERVER_WINDOWS = """@echo off
-exit 0
-"""
-
 MOCK_LLAMA_SERVER_PYTHON = """#!/usr/bin/env python3
 import json
 import os
@@ -64,8 +55,8 @@ def get_arg(flag, default):
 
 
 # lemond detects the system llama-server version by running
-# `llama-server --version` and reading one line of stdout (see
-# SystemInfo::get_system_llamacpp_version in src/cpp/server/system_info.cpp).
+# `llama-server --version` and reading one line of stdout from the llamacpp
+# backend resolver in src/cpp/server/backends/llamacpp/llamacpp_server.cpp.
 # The real binary prints a version line and exits immediately. We must mirror
 # that: otherwise the probe blocks forever on our long-lived HTTP server and
 # /internal/set hangs until the client times out.
@@ -79,8 +70,7 @@ class ReusableHTTPServer(ThreadingHTTPServer):
 
 
 capture_path = os.environ.get("MOCK_LLAMA_REQUEST_PATH", "")
-error_status = int(os.environ.get("MOCK_LLAMA_ERROR_STATUS", "0") or "0")
-error_response = os.environ.get("MOCK_LLAMA_ERROR_RESPONSE", "")
+control_path = os.environ.get("MOCK_LLAMA_CONTROL_PATH", "")
 port = int(get_arg("--port", "13305"))
 
 
@@ -110,8 +100,20 @@ class Handler(BaseHTTPRequestHandler):
             with open(capture_path, "w", encoding="utf-8") as handle:
                 handle.write(body)
 
+        control = {}
+        if control_path:
+            try:
+                with open(control_path, "r", encoding="utf-8") as handle:
+                    control = json.load(handle)
+            except (OSError, json.JSONDecodeError):
+                control = {}
+
+        error_response = control.get("error_response")
         if error_response:
-            self._send_json(json.loads(error_response), status=error_status or 400)
+            self._send_json(
+                error_response,
+                status=int(control.get("error_status", 400) or 400),
+            )
             return
 
         request_json = json.loads(body)
@@ -202,13 +204,8 @@ def _get_lemond_binary():
 def _pick_free_port():
     """Return an unused TCP port assigned by the OS on the IPv4 loopback.
 
-    Each lemond instance this test starts uses a fresh OS-assigned port. That
-    sidesteps a TCP rebind hazard: lemond (the server) initiates the close on
-    shutdown, so its accepted socket on the listen port lingers in FIN_WAIT2 /
-    TIME_WAIT. Once the process is gone that socket is orphaned and, on Linux,
-    can keep the port un-bindable for up to ~60s even with SO_REUSEADDR. Because
-    this test restarts lemond many times in quick succession, reusing one fixed
-    port makes startup flaky in CI; a fresh port is always immediately bindable.
+    This suite owns one lemond instance. An OS-assigned port avoids colliding
+    with another test/server while retaining retry-on-startup-failure behavior.
     """
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     try:
@@ -245,23 +242,11 @@ def _server_healthy(port=PORT):
 
 
 def _start_server(wrapped_server=None, backend=None, config_updates=None):
-    """Start a fresh lemond on a new OS-assigned port and wait until ready.
-
-    Each call binds a brand-new port (see _pick_free_port) and republishes it as
-    the module-level ``PORT`` so the rest of the test talks to the current
-    instance. Binding a fresh port every time means the rapid restarts this test
-    performs never contend for a port still held in a lingering TCP teardown
-    state by a previously stopped instance.
-    """
+    """Start the suite's lemond on a fresh OS-assigned port and wait until ready."""
     global PORT
 
     lemond_binary = _get_lemond_binary()
     cache_dir = LlamaCppSystemBackendTests.cache_dir
-
-    # Stop the instance we previously started, if any, so it releases its
-    # resources before we launch the next one.
-    if _is_server_running(PORT):
-        _stop_server()
 
     # Redirect output to a log file rather than a PIPE: lemond runs with
     # debug logging here, and an undrained PIPE can fill its buffer and block
@@ -317,326 +302,132 @@ def _start_server(wrapped_server=None, backend=None, config_updates=None):
         print(last_log)
         raise RuntimeError(f"lemond failed to start after {max_attempts} attempts")
 
-    runtime_config = {}
-    if wrapped_server == "llamacpp" and backend:
-        runtime_config["llamacpp"] = {"backend": backend}
-    if config_updates:
-        runtime_config.update(config_updates)
-    if runtime_config:
-        set_server_config(runtime_config, port=PORT)
+    try:
+        runtime_config = {}
+        if wrapped_server == "llamacpp" and backend:
+            runtime_config["llamacpp"] = {"backend": backend}
+        if config_updates:
+            runtime_config.update(config_updates)
+        if runtime_config:
+            set_server_config(runtime_config, port=PORT)
+    except Exception:
+        # lemond may already be healthy here; never leak it if post-start
+        # configuration fails during suite setup.
+        _stop_server()
+        raise
 
     print("Server started successfully")
 
 
 class LlamaCppSystemBackendTests(unittest.TestCase):
-    """
-    Tests for the 'system' LlamaCpp backend and the llamacpp.prefer_system config option.
-
-    Each test needs a fresh server with different PATH/config,
-    so this class manages its own server lifecycle.
-    """
-
-    _model_pulled = False
+    """Process/HTTP integration coverage for the external system llama-server."""
 
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        # Create a temporary directory for our dummy llama-server executable
-        cls.temp_bin_dir = tempfile.mkdtemp()
-        cls.dummy_llama_server_path = os.path.join(cls.temp_bin_dir, "llama-server")
-        if os.name == "nt":
-            cls.dummy_llama_server_path += ".exe"
-        cls._write_llama_server(
-            DUMMY_LLAMA_SERVER_WINDOWS
-            if os.name == "nt"
-            else DUMMY_LLAMA_SERVER_LINUX_MAC
-        )
+        cls._active = False
+        cls._linux_setup = sys.platform.startswith("linux")
+        if not cls._linux_setup:
+            return
 
-        # Dedicated cache_dir so the test doesn't disturb the user's real cache.
-        # log_level=debug surfaces backend behavior in the logs.
+        cls.temp_bin_dir = tempfile.mkdtemp(prefix="lemonade_llamacpp_mock_bin_")
         cls.cache_dir = tempfile.mkdtemp(prefix="lemonade_llamacpp_test_")
-        with open(os.path.join(cls.cache_dir, "config.json"), "w") as cf:
-            json.dump({"log_level": "debug"}, cf)
+        cls.dummy_llama_server_path = os.path.join(cls.temp_bin_dir, "llama-server")
+        cls.capture_path = os.path.join(cls.temp_bin_dir, "captured_chat_request.json")
+        cls.control_path = os.path.join(cls.temp_bin_dir, "mock_control.json")
+        cls.original_env = {
+            name: os.environ.get(name)
+            for name in ("PATH", "MOCK_LLAMA_REQUEST_PATH", "MOCK_LLAMA_CONTROL_PATH")
+        }
 
-        # Store original PATH to restore later
-        cls.original_path = os.environ.get("PATH", "")
+        try:
+            cls._write_llama_server(MOCK_LLAMA_SERVER_PYTHON)
+
+            # Keep the external-system integration deterministic on AMD hosts as
+            # well: production accepts the plugin beside a PATH llama-server.
+            with open(
+                os.path.join(cls.temp_bin_dir, "libggml-hip.so"),
+                "w",
+                encoding="utf-8",
+            ) as handle:
+                handle.write("stub")
+
+            with open(os.path.join(cls.cache_dir, "config.json"), "w") as cf:
+                json.dump({"log_level": "debug"}, cf)
+
+            original_path = cls.original_env["PATH"] or ""
+            os.environ["PATH"] = cls.temp_bin_dir + os.pathsep + original_path
+            os.environ["MOCK_LLAMA_REQUEST_PATH"] = cls.capture_path
+            os.environ["MOCK_LLAMA_CONTROL_PATH"] = cls.control_path
+            cls._write_mock_control({})
+
+            # One lemond and one spawned mock llama-server are enough for all
+            # process-boundary assertions in this file.
+            _start_server(wrapped_server="llamacpp", backend="system")
+            cls._active = True
+            pull_model_with_retry(ENDPOINT_TEST_MODEL, port=PORT)
+
+            load_response = requests.post(
+                f"http://localhost:{PORT}/api/v1/load",
+                json={"model_name": ENDPOINT_TEST_MODEL, "llamacpp_backend": "system"},
+                timeout=TIMEOUT_MODEL_OPERATION,
+            )
+            if load_response.status_code != 200:
+                raise RuntimeError(
+                    "Failed to load system llamacpp integration model: "
+                    f"{load_response.status_code} {load_response.text}"
+                )
+        except Exception:
+            if cls._active:
+                _stop_server()
+            cls._restore_environment()
+            shutil.rmtree(cls.temp_bin_dir, ignore_errors=True)
+            shutil.rmtree(cls.cache_dir, ignore_errors=True)
+            raise
 
     @classmethod
     def tearDownClass(cls):
-        # Stop any server we started
-        _stop_server()
-        # Clean up temporary directories and restore PATH
-        shutil.rmtree(cls.temp_bin_dir)
-        shutil.rmtree(cls.cache_dir, ignore_errors=True)
-        os.environ["PATH"] = cls.original_path
+        if getattr(cls, "_linux_setup", False):
+            if cls._active:
+                _stop_server()
+            shutil.rmtree(cls.temp_bin_dir, ignore_errors=True)
+            shutil.rmtree(cls.cache_dir, ignore_errors=True)
+            cls._restore_environment()
         super().tearDownClass()
+
+    @classmethod
+    def _restore_environment(cls):
+        for name, value in cls.original_env.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
 
     @classmethod
     def _write_llama_server(cls, script_contents):
         with open(cls.dummy_llama_server_path, "w", encoding="utf-8") as handle:
             handle.write(script_contents)
-        if os.name != "nt":
-            os.chmod(
-                cls.dummy_llama_server_path,
-                os.stat(cls.dummy_llama_server_path).st_mode | stat.S_IEXEC,
-            )
+        os.chmod(
+            cls.dummy_llama_server_path,
+            os.stat(cls.dummy_llama_server_path).st_mode | stat.S_IEXEC,
+        )
+
+    @classmethod
+    def _write_mock_control(cls, control):
+        with open(cls.control_path, "w", encoding="utf-8") as handle:
+            json.dump(control, handle)
 
     def setUp(self):
         print(f"\n=== Starting test: {self._testMethodName} ===")
-        _stop_server()
-        os.environ.pop("MOCK_LLAMA_REQUEST_PATH", None)
-        os.environ.pop("MOCK_LLAMA_ERROR_STATUS", None)
-        os.environ.pop("MOCK_LLAMA_ERROR_RESPONSE", None)
-        os.environ["PATH"] = self.original_path  # Ensure PATH is clean before each test
-        self._write_llama_server(
-            DUMMY_LLAMA_SERVER_WINDOWS
-            if os.name == "nt"
-            else DUMMY_LLAMA_SERVER_LINUX_MAC
-        )
-
-    def _add_dummy_llama_server_to_path(self):
-        """Adds the directory containing the dummy llama-server to PATH."""
-        os.environ["PATH"] = self.temp_bin_dir + os.pathsep + self.original_path
-
-    def _remove_dummy_llama_server_from_path(self):
-        """Removes the dummy llama-server directory from PATH."""
-        os.environ["PATH"] = self.original_path
-
-    def _get_llamacpp_backends(self):
-        """Fetches the list of supported llamacpp backends from the server."""
-        response = requests.get(f"http://localhost:{PORT}/api/v1/system-info")
-        self.assertEqual(response.status_code, 200)
-        data = response.json()
-        self.assertIn("recipes", data)
-        self.assertIn("llamacpp", data["recipes"])
-        self.assertIn("backends", data["recipes"]["llamacpp"])
-        return data["recipes"]["llamacpp"]["backends"]
-
-    @classmethod
-    def _ensure_model_pulled(cls):
-        if cls._model_pulled:
-            return
-
-        pull_model_with_retry(ENDPOINT_TEST_MODEL, port=PORT)
-        cls._model_pulled = True
-
-    @unittest.skipUnless(
-        sys.platform.startswith("linux"), "System backend only supported on Linux"
-    )
-    def test_001_system_llamacpp_not_in_path(self):
-        """
-        Verify that is_llamacpp_installed('system') is False when llama-server is not in PATH.
-        """
-        self._remove_dummy_llama_server_from_path()  # Ensure it's not in PATH
-        _start_server(config_updates={"llamacpp": {"prefer_system": False}})
-
-        backends = self._get_llamacpp_backends()
-        self.assertIn("system", backends)
-        # In the new backend manager, state is 'unsupported' if not in PATH
-        self.assertEqual(backends["system"]["state"], "unsupported")
-        self.assertIn("message", backends["system"])
-        self.assertIn("llama-server not found in PATH", backends["system"]["message"])
-
-    @unittest.skipUnless(
-        sys.platform.startswith("linux"), "System backend only supported on Linux"
-    )
-    def test_002_system_llamacpp_in_path(self):
-        """
-        Verify that is_llamacpp_installed('system') is True when llama-server is in PATH.
-        """
-        self._add_dummy_llama_server_to_path()  # Add dummy to PATH
-        _start_server(config_updates={"llamacpp": {"prefer_system": False}})
-
-        backends = self._get_llamacpp_backends()
-        self.assertIn("system", backends)
-        self.assertEqual(backends["system"]["state"], "installed")
-
-    @unittest.skipUnless(
-        sys.platform.startswith("linux"), "System backend only supported on Linux"
-    )
-    def test_003_prefer_system_llamacpp_enabled_and_available(self):
-        """
-        Verify 'system' backend is preferred when llamacpp.prefer_system=true in config
-        and llama-server is in PATH.
-        """
-        self._add_dummy_llama_server_to_path()
-        _start_server(config_updates={"llamacpp": {"prefer_system": True}})
-
-        response = requests.get(f"http://localhost:{PORT}/api/v1/system-info")
-        data = response.json()
-
-        self.assertIn("recipes", data)
-        self.assertIn("llamacpp", data["recipes"])
-        self.assertEqual(data["recipes"]["llamacpp"]["default_backend"], "system")
-
-        backends = self._get_llamacpp_backends()
-        self.assertIn("system", backends)
-        self.assertEqual(backends["system"]["state"], "installed")
-
-    @unittest.skipUnless(
-        sys.platform.startswith("linux"), "System backend only supported on Linux"
-    )
-    def test_004_prefer_system_llamacpp_enabled_but_not_available(self):
-        """
-        Verify fallback to another backend when llamacpp.prefer_system=true in config
-        but llama-server is NOT in PATH.
-        """
-        self._remove_dummy_llama_server_from_path()  # Ensure it's not in PATH
-        _start_server(config_updates={"llamacpp": {"prefer_system": True}})
-
-        response = requests.get(f"http://localhost:{PORT}/api/v1/system-info")
-        data = response.json()
-
-        self.assertIn("recipes", data)
-        self.assertIn("llamacpp", data["recipes"])
-        # Should not be system
-        self.assertNotEqual(data["recipes"]["llamacpp"]["default_backend"], "system")
-
-        backends = self._get_llamacpp_backends()
-        self.assertIn("system", backends)
-        self.assertEqual(backends["system"]["state"], "unsupported")
-        self.assertIn("llama-server not found in PATH", backends["system"]["message"])
-
-    @unittest.skipUnless(
-        sys.platform.startswith("linux"), "System backend only supported on Linux"
-    )
-    def test_005_prefer_system_llamacpp_disabled_or_unset(self):
-        """
-        Verify behavior of llamacpp.prefer_system config when llama-server is in PATH.
-        - When unset or false: system should NOT be default (explicitly disabled by default)
-        - When set to true: system backend is preferred if available
-        """
-        self._add_dummy_llama_server_to_path()
-        # Test with unset (default behavior) - system should NOT be default (it's disabled by default)
-        _start_server(config_updates={"llamacpp": {"prefer_system": False}})
-
-        response = requests.get(f"http://localhost:{PORT}/api/v1/system-info")
-        data = response.json()
-        self.assertIn("recipes", data)
-        self.assertIn("llamacpp", data["recipes"])
-        # By default, system backend is not preferred, should fall back to next backend
-        self.assertNotEqual(data["recipes"]["llamacpp"]["default_backend"], "system")
-
-        backends = self._get_llamacpp_backends()
-        self.assertIn("system", backends)
-        self.assertEqual(backends["system"]["state"], "installed")
-
-        _stop_server()
-
-        # Test with false - system backend should be explicitly skipped (same as default)
-        _start_server(config_updates={"llamacpp": {"prefer_system": False}})
-
-        response = requests.get(f"http://localhost:{PORT}/api/v1/system-info")
-        data = response.json()
-        self.assertIn("recipes", data)
-        self.assertIn("llamacpp", data["recipes"])
-        # When explicitly set to false, system should not be default (same as unset)
-        self.assertNotEqual(data["recipes"]["llamacpp"]["default_backend"], "system")
-
-        backends = self._get_llamacpp_backends()
-        self.assertIn("system", backends)
-        self.assertEqual(backends["system"]["state"], "installed")
-
-    def _require_system_backend_blocked_by_hip_plugin(self):
-        """Skip unless the running server reports the 'system' llamacpp backend
-        as blocked by a missing HIP plugin.
-
-        LEMONADE_GGML_HIP_PATH only affects is_ggml_hip_plugin_available(),
-        which system_info.cpp consults solely for the 'system' backend, only
-        when an AMD GPU is present (/sys/class/kfd) and llama-server is in PATH.
-        Its only observable effect is the system backend's "HIP plugin
-        libggml-hip.so not installed" message. Callers must add llama-server to
-        PATH and start the server before calling this.
-        """
-        system = self._get_llamacpp_backends().get("system", {})
-        if "HIP plugin" not in system.get("message", ""):
-            self.skipTest(
-                "Requires an AMD GPU without an FHS-installed HIP plugin; "
-                f"system backend reported: {system}"
-            )
-
-    @unittest.skipUnless(
-        sys.platform.startswith("linux"), "System backend only supported on Linux"
-    )
-    def test_005a_hip_path_override_satisfies_hip_plugin_check(self):
-        """A valid LEMONADE_GGML_HIP_PATH satisfies the HIP-plugin check that
-        otherwise blocks the 'system' backend on AMD GPU hosts."""
-        if not os.path.exists("/sys/class/kfd"):
-            self.skipTest("Requires an AMD GPU (/sys/class/kfd present)")
-        self._add_dummy_llama_server_to_path()
-
-        # Baseline: without the override the system backend is blocked by a
-        # missing HIP plugin, otherwise the override has nothing to satisfy.
-        _start_server()
-        self._require_system_backend_blocked_by_hip_plugin()
-        _stop_server()
-
-        valid_so = os.path.join(self.temp_bin_dir, "libggml-hip.so")
-        with open(valid_so, "w", encoding="utf-8") as handle:
-            handle.write("stub")
-
-        # _start_server() launches lemond with os.environ.copy(), so set the
-        # override in this process's environment and clean it up afterwards.
-        self.addCleanup(os.environ.pop, "LEMONADE_GGML_HIP_PATH", None)
-        os.environ["LEMONADE_GGML_HIP_PATH"] = valid_so
-        _start_server()
-        system = self._get_llamacpp_backends().get("system", {})
-        self.assertNotIn("HIP plugin", system.get("message", ""), system)
-
-    @unittest.skipUnless(
-        sys.platform.startswith("linux"), "System backend only supported on Linux"
-    )
-    def test_005b_hip_path_override_invalid_is_ignored(self):
-        """An invalid LEMONADE_GGML_HIP_PATH (nonexistent file or directory) is
-        ignored: the 'system' backend stays blocked by the missing HIP plugin."""
-        if not os.path.exists("/sys/class/kfd"):
-            self.skipTest("Requires an AMD GPU (/sys/class/kfd present)")
-        self._add_dummy_llama_server_to_path()
-
-        _start_server()
-        self._require_system_backend_blocked_by_hip_plugin()
-        _stop_server()
-
-        self.addCleanup(os.environ.pop, "LEMONADE_GGML_HIP_PATH", None)
-
-        # Nonexistent file: the override is ignored.
-        os.environ["LEMONADE_GGML_HIP_PATH"] = os.path.join(
-            self.temp_bin_dir, "missing", "libggml-hip.so"
-        )
-        _start_server()
-        system = self._get_llamacpp_backends().get("system", {})
-        self.assertIn("HIP plugin", system.get("message", ""), system)
-        _stop_server()
-
-        # A directory is not a regular file and must also be ignored.
-        os.environ["LEMONADE_GGML_HIP_PATH"] = self.temp_bin_dir
-        _start_server()
-        system = self._get_llamacpp_backends().get("system", {})
-        self.assertIn("HIP plugin", system.get("message", ""), system)
+        if os.path.exists(self.capture_path):
+            os.remove(self.capture_path)
+        self._write_mock_control({})
 
     @unittest.skipUnless(
         sys.platform.startswith("linux"), "System backend only supported on Linux"
     )
     def test_006_thinking_false_maps_to_no_think_for_chat_streams(self):
         """Verify thinking:false is mapped to /no_think prefix on the last user message."""
-        self._write_llama_server(MOCK_LLAMA_SERVER_PYTHON)
-        self._add_dummy_llama_server_to_path()
-
-        capture_path = os.path.join(self.temp_bin_dir, "captured_chat_request.json")
-        os.environ["MOCK_LLAMA_REQUEST_PATH"] = capture_path
-        self.addCleanup(os.environ.pop, "MOCK_LLAMA_REQUEST_PATH", None)
-
-        _stop_server()
-        _start_server(wrapped_server="llamacpp", backend="system")
-        self._ensure_model_pulled()
-
-        load_response = requests.post(
-            f"http://localhost:{PORT}/api/v1/load",
-            json={"model_name": ENDPOINT_TEST_MODEL, "llamacpp_backend": "system"},
-            timeout=TIMEOUT_MODEL_OPERATION,
-        )
-        self.assertEqual(load_response.status_code, 200)
-
         response = requests.post(
             f"http://localhost:{PORT}/api/v1/chat/completions",
             json={
@@ -658,7 +449,7 @@ class LlamaCppSystemBackendTests(unittest.TestCase):
         ]
         self.assertTrue(any("[DONE]" in line for line in lines))
 
-        with open(capture_path, "r", encoding="utf-8") as handle:
+        with open(self.capture_path, "r", encoding="utf-8") as handle:
             forwarded_request = json.load(handle)
 
         self.assertEqual(
@@ -673,26 +464,6 @@ class LlamaCppSystemBackendTests(unittest.TestCase):
     )
     def test_007_enable_thinking_takes_precedence_over_thinking_false(self):
         """Verify enable_thinking:true takes precedence over thinking:false."""
-        self._write_llama_server(MOCK_LLAMA_SERVER_PYTHON)
-        self._add_dummy_llama_server_to_path()
-
-        capture_path = os.path.join(
-            self.temp_bin_dir, "captured_chat_request_precedence.json"
-        )
-        os.environ["MOCK_LLAMA_REQUEST_PATH"] = capture_path
-        self.addCleanup(os.environ.pop, "MOCK_LLAMA_REQUEST_PATH", None)
-
-        _stop_server()
-        _start_server(wrapped_server="llamacpp", backend="system")
-        self._ensure_model_pulled()
-
-        load_response = requests.post(
-            f"http://localhost:{PORT}/api/v1/load",
-            json={"model_name": ENDPOINT_TEST_MODEL, "llamacpp_backend": "system"},
-            timeout=TIMEOUT_MODEL_OPERATION,
-        )
-        self.assertEqual(load_response.status_code, 200)
-
         response = requests.post(
             f"http://localhost:{PORT}/api/v1/chat/completions",
             json={
@@ -707,7 +478,7 @@ class LlamaCppSystemBackendTests(unittest.TestCase):
         )
         self.assertEqual(response.status_code, 200)
 
-        with open(capture_path, "r", encoding="utf-8") as handle:
+        with open(self.capture_path, "r", encoding="utf-8") as handle:
             forwarded_request = json.load(handle)
 
         self.assertEqual(forwarded_request["messages"][-1]["content"], "Say hello.")
@@ -719,30 +490,21 @@ class LlamaCppSystemBackendTests(unittest.TestCase):
     )
     def test_008_backend_context_error_preserves_http_status(self):
         """Verify backend context-window errors stay HTTP 400 and OpenAI-shaped."""
-        self._write_llama_server(MOCK_LLAMA_SERVER_PYTHON)
-        self._add_dummy_llama_server_to_path()
-
         error_message = (
             "request (67311 tokens) exceeds the available context size "
             "(65536 tokens), try increasing it"
         )
-        os.environ["MOCK_LLAMA_ERROR_STATUS"] = "400"
-        os.environ["MOCK_LLAMA_ERROR_RESPONSE"] = json.dumps(
-            {"error": {"message": error_message, "type": "invalid_request_error"}}
+        self._write_mock_control(
+            {
+                "error_status": 400,
+                "error_response": {
+                    "error": {
+                        "message": error_message,
+                        "type": "invalid_request_error",
+                    }
+                },
+            }
         )
-        self.addCleanup(os.environ.pop, "MOCK_LLAMA_ERROR_STATUS", None)
-        self.addCleanup(os.environ.pop, "MOCK_LLAMA_ERROR_RESPONSE", None)
-
-        _stop_server()
-        _start_server(wrapped_server="llamacpp", backend="system")
-        self._ensure_model_pulled()
-
-        load_response = requests.post(
-            f"http://localhost:{PORT}/api/v1/load",
-            json={"model_name": ENDPOINT_TEST_MODEL, "llamacpp_backend": "system"},
-            timeout=TIMEOUT_MODEL_OPERATION,
-        )
-        self.assertEqual(load_response.status_code, 200)
 
         response = requests.post(
             f"http://localhost:{PORT}/api/v1/chat/completions",


### PR DESCRIPTION
## Summary

This PR moves the pure `llamacpp` system-backend checks out of the server-heavy Python test and into direct C++ coverage.

The practical result is that `test_llamacpp_system_backend.py` goes from **14 `lemond` starts/stops to 1**.

Previously, the suite repeatedly restarted the full server just to change things like `PATH`, `prefer_system`, fallback conditions, or the HIP plugin location, then read the resulting backend state through HTTP. Those decisions are C++ backend-selection logic and do not need a running server.

The new C++ tests exercise the real production paths directly. They cover system `llama-server` discovery, installed/unsupported state, `prefer_system`, explicit system selection, fallback behavior, and HIP plugin/path validation.

This also avoids reproducing the backend-selection logic in test-side mocks. If that logic changes, the tests now exercise the changed production code directly instead of relying on a parallel mocked version that could drift from the implementation.

The Python suite keeps the cases where the process boundary actually matters: launching an external `llama-server`, request forwarding, thinking-flag translation, streaming, error forwarding, and process/environment behavior.

So this is not just a test speedup. It removes unnecessary server lifecycle complexity while moving the regression coverage closer to the code it is supposed to protect.

No backend-selection behavior is intentionally changed.

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_

```bash
cmake --build build --target test_llamacpp_system_backend
ctest --test-dir build -R '^LlamaCppSystemBackendTest$' --output-on-failure

python3 test/test_llamacpp_system_backend.py --cli-binary "$PWD/build/lemonade"

cmake --build build --target cpp-ci-tests
ctest --test-dir build -L '^cpp-ci$' --output-on-failure
```

The Python suite now uses a single lemond lifecycle for the remaining integration tests instead of restarting it for each backend-policy case.

## Documentation

- [x] Documentation is not affected by this change.

## Breaking Changes

- [x] This PR does not introduce breaking changes.

## AI-assisted contribution

Please select one:

- [x] I used AI tools for this PR.

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.