### PR TITLE
test: fix dangling CLI temp path in runtime override test

### DIFF
--- a/test/cpp/test_cli_runtime_override.cpp
+++ b/test/cpp/test_cli_runtime_override.cpp
@@ -53,9 +53,12 @@ int main() {
         ConfigFile::save(temp_dir.string(), initial_cfg);
 
         CLIParser parser;
-        const char* argv[] = {"lemond", temp_dir.string().c_str(), "--port", "8888", "--host", "127.0.0.1"};
+        const std::string temp_dir_arg = temp_dir.string();
+        const char* argv[] = {"lemond", temp_dir_arg.c_str(), "--port", "8888", "--host", "127.0.0.1"};
         parser.parse(6, const_cast<char**>(argv));
         auto cli_cfg = parser.get_config();
+        check(cli_cfg.cache_dir == temp_dir_arg, "CLIParser preserves explicit cache directory");
+        check(cli_cfg.config_dir == temp_dir_arg, "CLIParser uses cache directory as config directory for portable installs");
 
         json loaded = ConfigFile::load(cli_cfg.cache_dir, cli_cfg.config_dir);
         check(loaded["port"] == 13305, "Loaded config before override has original port");
@@ -77,9 +80,9 @@ int main() {
         check(snap["port"] == 13305, "snapshot() contains persistent port 13305, not override");
         check(snap["host"] == "localhost", "snapshot() contains persistent host localhost, not override");
 
-        // Simulate `lemonade config set log_level=debug` which calls ConfigFile::save(cache_dir, snapshot())
+        // Simulate persisting a config update without leaking runtime overrides
         runtime_cfg.set(json{{"log_level", "debug"}});
-        ConfigFile::save(cli_cfg.cache_dir, runtime_cfg.snapshot());
+        ConfigFile::save(cli_cfg.config_dir, runtime_cfg.snapshot());
 
         // Re-read from disk to ensure config.json was updated with log_level but did NOT leak port/host overrides
         json disk_cfg = ConfigFile::load(cli_cfg.cache_dir, cli_cfg.config_dir);


### PR DESCRIPTION
## Summary

Fixes the macOS failure in `CliRuntimeOverrideTest`.

The test passed `temp_dir.string().c_str()` as a CLI argument, leaving a dangling pointer after the temporary string was destroyed. On macOS/libc++ this could result in an empty path and eventually fail in `std::filesystem::create_directories("")`.

Keep the path string alive through CLI parsing, add assertions for the parsed cache/config directories, and use `config_dir` for persistence to match the current config layout.

No production code is changed.

## Scope

* [x] This PR addresses one clear issue or change.
* [x] I reviewed the full diff myself before submitting.
* [x] I removed unrelated local changes.
* [x] I kept refactoring separate unless it is required for this change.

## Testing

* [x] Code builds without errors locally.
* [x] I tested this change locally.
* [x] I described the testing performed below.

_Testing details:_

Targeted validation:

```bash
cmake --build --preset default --target test_cli_runtime_override
ctest --test-dir build -R '^CliRuntimeOverrideTest$' --output-on-failure
```

Full C++ CI suite:

```bash
cmake --build --preset default --target cpp-ci-tests
ctest --test-dir build -L '^cpp-ci$' --output-on-failure
```

## Documentation

* [x] Documentation is not affected by this change.

## Breaking Changes

* [ ] This PR introduces breaking changes.
* [x] This PR does not introduce breaking changes.

## AI-assisted contribution

* [x] I used AI tools for this PR.

* [x] I verified that I understand the changes.
* [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.
