### PR TITLE
fix(server): count the iGPU firmware carveout as physical memory on Linux

### DIFF
--- a/src/cpp/include/lemon/system_info.h
+++ b/src/cpp/include/lemon/system_info.h
@@ -228,6 +228,7 @@ private:
     double get_amd_vram(const std::string& drm_render_minor);
     double get_amd_gtt(const std::string& drm_render_minor);
     bool get_amd_is_igpu(const std::string& drm_render_minor);
+    double get_igpu_carveout_gb();
 
 private:
     double parse_memory_sysfs(const std::string& drm_render_minor, const std::string& fname);

--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -3653,6 +3653,51 @@ double LinuxSystemInfo::get_amd_vram(const std::string& drm_render_minor) {
     return parse_memory_sysfs(drm_render_minor, "mem_info_vram_total");
 }
 
+double LinuxSystemInfo::get_igpu_carveout_gb() {
+    // An integrated GPU's "VRAM" is system DRAM the firmware reserved before the
+    // kernel booted, so it never appears in MemTotal. Discrete VRAM is separate
+    // silicon and must not be counted here.
+    std::string kfd_path = "/sys/class/kfd/kfd/topology/nodes";
+    if (!fs::exists(kfd_path) || !fs::is_directory(kfd_path)) {
+        return 0.0;
+    }
+
+    double carveout_gb = 0.0;
+    std::error_code ec;
+    for (const auto& node_entry : fs::directory_iterator(kfd_path, ec)) {
+        if (!node_entry.is_directory()) continue;
+
+        std::ifstream props(node_entry.path().string() + "/properties");
+        if (!props.is_open()) continue;
+
+        std::string line;
+        std::string drm_render_minor;
+        bool is_gpu = false;
+
+        while (std::getline(props, line)) {
+            if (line.find("gfx_target_version") == 0) {
+                std::string version = line.substr(line.find(" ") + 1);
+                version.erase(version.find_last_not_of(" \t\n\r") + 1);
+                try {
+                    is_gpu = !version.empty() && std::stoi(version) != 0;
+                } catch (...) {
+                    is_gpu = false;
+                }
+            } else if (line.find("drm_render_minor") == 0) {
+                drm_render_minor = line.substr(line.find(" ") + 1);
+                drm_render_minor.erase(drm_render_minor.find_last_not_of(" \t\n\r") + 1);
+            }
+        }
+
+        if (!is_gpu || drm_render_minor.empty() || drm_render_minor == "-1") continue;
+        if (!get_amd_is_igpu(drm_render_minor)) continue;
+
+        carveout_gb += get_amd_vram(drm_render_minor);
+    }
+
+    return carveout_gb;
+}
+
 json LinuxSystemInfo::get_system_info_dict() {
     json info = SystemInfo::get_system_info_dict();  // Get base fields
     info["Processor"] = get_processor_name();
@@ -3753,8 +3798,15 @@ std::string LinuxSystemInfo::get_physical_memory() {
         if(token == "MemTotal:") {
             // Get the token after "MemTotal:"
             if(double mem; file >> mem) {
+                // MemTotal excludes an integrated GPU's firmware-reserved
+                // carveout, which on a unified-memory APU is ordinary system
+                // DRAM the model can still be run out of. Report installed
+                // capacity, matching Windows, so model size filtering does not
+                // hide models that fit (a 128 GB Strix Halo with a 64 GB
+                // carveout otherwise reports ~61 GB).
+                double total_gb = mem / 1024.0 / 1024.0 + get_igpu_carveout_gb();
                 std::ostringstream oss;
-                oss << std::fixed << std::setprecision(2) << std::round(mem / 1024.0 / 1024.0 * 100.0) / 100.0 << " GB";
+                oss << std::fixed << std::setprecision(2) << std::round(total_gb * 100.0) / 100.0 << " GB";
                 return oss.str();
             }
             break;


### PR DESCRIPTION
## Summary

Split out of #3047 (ds4 backend) at reviewer request — this is a general model-size-filtering fix, not ds4-specific.

On a unified-memory APU (e.g. AMD Strix Halo), the firmware reserves a block of system DRAM as the iGPU's "VRAM" before the kernel boots, so it never appears in `MemTotal`. That DRAM is ordinary memory a model can still run out of, but reporting only `MemTotal` makes model-size filtering hide models that actually fit — a 128 GB Strix Halo with a 64 GB carveout reports ~61 GB, so anything over ~49 GB (0.8 × 61) is wrongly filtered.

This adds the detected iGPU carveout (read from the KFD topology, `/sys/class/kfd`) back into the reported physical memory, matching how Windows already reports installed capacity. Discrete GPU VRAM is separate silicon and is deliberately **not** counted.

Once this merges, #3047 will pick it up via a merge from `main` and drop these lines.

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_

- Built `lemond` on Linux and confirmed `GET /api/v1/system-info` reports `Physical Memory: 126.44 GB` on a 128 GB Strix Halo (gfx1151) whose `MemTotal` is ~62 GB (64 GB carveout added back). Previously it reported ~62 GB.
- The carveout reader is hardware/`/sys`-specific (returns 0 where no KFD iGPU topology exists, e.g. CPU-only CI), so `get_physical_memory()` degrades to `MemTotal` unchanged on non-APU hosts. Happy to extract the KFD-node parsing into a pure helper with unit coverage if the reviewer would like that.

## Documentation

- [x] Documentation is not affected by this change.

## Breaking Changes

- [x] This PR does not introduce breaking changes.

<!-- Reported physical memory increases on unified-memory APUs to include the iGPU carveout; other systems are unchanged. -->

## AI-assisted contribution

- [x] I used AI tools for this PR.

Implemented with Claude Code (Opus 4.8). Change was originally authored in #3047 and split out here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
