### PR TITLE
ci: temporarily disable tts-openmoss integration tests

### DIFF
--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -1071,11 +1071,11 @@ jobs:
             extra_args: "--wrapped-server trellis"
             backends: "vulkan rocm"
             runner: [Windows, rocm, vulkan, lemon-prod]
-          - name: tts-openmoss
-            script: server_tts_openmoss.py
-            extra_args: "--wrapped-server openmoss"
-            backends: "vulkan rocm"
-            runner: [Windows, rocm, vulkan, lemon-prod]
+          # - name: tts-openmoss
+          #   script: server_tts_openmoss.py
+          #   extra_args: "--wrapped-server openmoss"
+          #   backends: "vulkan rocm"
+          #   runner: [Windows, rocm, vulkan, lemon-prod]
     env:
       LEMONADE_CI_MODE: "True"
       HF_TOKEN: ${{ secrets.HUGGINGFACE_ACCESS_TOKEN }}
@@ -1324,11 +1324,11 @@ jobs:
             extra_args: "--wrapped-server trellis"
             backends: "vulkan rocm"
             runner: [Linux, vulkan, rocm, lemon-prod]
-          - name: tts-openmoss
-            script: server_tts_openmoss.py
-            extra_args: "--wrapped-server openmoss"
-            backends: "vulkan rocm"
-            runner: [Linux, vulkan, rocm, lemon-prod]
+          # - name: tts-openmoss
+          #   script: server_tts_openmoss.py
+          #   extra_args: "--wrapped-server openmoss"
+          #   backends: "vulkan rocm"
+          #   runner: [Linux, vulkan, rocm, lemon-prod]
     env:
       LEMONADE_CI_MODE: "True"
       HF_TOKEN: ${{ secrets.HUGGINGFACE_ACCESS_TOKEN }}


### PR DESCRIPTION
## Summary

**commenting out CI tests to unblock development, must fix before release!!!**

Comments out the `tts-openmoss` matrix entries (Windows and Linux) in `cpp_server_build_test_release.yml` so the packaging workflow stops running the OpenMoss TTS integration tests. The blocks are commented out rather than deleted so they can be re-enabled by uncommenting once fixed.

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_ Workflow-only change (two matrix entries commented out); verified the YAML edit is confined to those blocks via `git diff`.

## Documentation

- [x] Documentation is not affected by this change.
- [ ] Documentation is affected and has been updated.
- [ ] Documentation is affected but will be handled in a separate PR or issue.

## Breaking Changes

- [ ] This PR introduces breaking changes.
- [x] This PR does not introduce breaking changes.

## AI-assisted contribution

Please select one:

- [ ] I used AI tools for this PR.
- [x] I did not use AI tools for this PR.
