### PR TITLE
test(server): assert CLI parse return status and remove unused header in runtime override test

### DIFF
--- a/test/cpp/test_cli_runtime_override.cpp
+++ b/test/cpp/test_cli_runtime_override.cpp
@@ -1,6 +1,5 @@
 #include <cstdio>
 #include <filesystem>
-#include <fstream>
 #include <nlohmann/json.hpp>
 #include <lemon/cli_parser.h>
 #include <lemon/config_file.h>
@@ -55,7 +54,8 @@ int main() {
         CLIParser parser;
         const std::string temp_dir_arg = temp_dir.string();
         const char* argv[] = {"lemond", temp_dir_arg.c_str(), "--port", "8888", "--host", "127.0.0.1"};
-        parser.parse(6, const_cast<char**>(argv));
+        int res = parser.parse(6, const_cast<char**>(argv));
+        check(res == 0 && parser.should_continue(), "CLIParser parses explicit directory with overrides successfully");
         auto cli_cfg = parser.get_config();
         check(cli_cfg.cache_dir == temp_dir_arg, "CLIParser preserves explicit cache directory");
         check(cli_cfg.config_dir == temp_dir_arg, "CLIParser uses cache directory as config directory for portable installs");
@@ -102,7 +102,8 @@ int main() {
     {
         CLIParser parser;
         const char* argv[] = {"lemond"};
-        parser.parse(1, const_cast<char**>(argv));
+        int res = parser.parse(1, const_cast<char**>(argv));
+        check(res == 0 && parser.should_continue(), "CLIParser parses default lemond invocation successfully");
         auto cli_cfg = parser.get_config();
         check(cli_cfg.port == -1, "Default port is -1 when omitted");
         check(cli_cfg.host.empty(), "Default host is empty when omitted");


### PR DESCRIPTION
## Summary

Addresses pre-existing test consistency nits in `test/cpp/test_cli_runtime_override.cpp`:
* Captures and asserts `parser.parse(...) == 0 && parser.should_continue()` across all test blocks for consistency.
* Removes the unused `#include <fstream>` header.

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_

Targeted test execution:
```bash
cmake --build build --target test_cli_runtime_override
ctest --test-dir build -R '^CliRuntimeOverrideTest$' --output-on-failure
```
Result: 20/20 checks passed.

Full C++ CI test suite and boilerplate synchronization:
```bash
cmake --build build --target cpp-ci-tests lemond
python3 docs/tools/gen_backend_boilerplate.py --check --lemond ./build/lemond
ctest --test-dir build -L '^cpp-ci$' --output-on-failure
```
Result: 54/54 tests passed; zero boilerplate drift.

## Documentation

- [x] Documentation is not affected by this change.
- [ ] Documentation is affected and has been updated.
- [ ] Documentation is affected but will be handled in a separate PR or issue.

## Breaking Changes

- [ ] This PR introduces breaking changes.
- [x] This PR does not introduce breaking changes.

## AI-assisted contribution

Please select one:

- [x] I used AI tools for this PR.
- [ ] I did not use AI tools for this PR.

If AI tools were used:

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.
