### PR TITLE
Smooth Tauri titlebar centering while resizing

### DIFF
--- a/src/app/src/App.tsx
+++ b/src/app/src/App.tsx
@@ -957,7 +957,7 @@ const App: React.FC = () => {
     <>
       <a href="#main-content" className="skip-link">Skip to main content</a>
       <div className="app">
-        <header className="titlebar" data-tauri-drag-region>
+        <header className={`titlebar${isDesktop ? ' titlebar--desktop' : ''}`} data-tauri-drag-region>
         <div className="titlebar__brand" data-tauri-drag-region>
           <span className="titlebar__brand-logo" data-tauri-drag-region>
             <span className="titlebar__brand-icon" aria-hidden="true" />

--- a/src/app/src/styles/styles.css
+++ b/src/app/src/styles/styles.css
@@ -12202,6 +12202,52 @@ a.backend-card__version:focus-visible {
   }
 }
 
+@media (min-width: 769px) and (max-width: 1320px) {
+  .titlebar--desktop .titlebar__search.is-context-visible,
+  .titlebar--desktop .titlebar__search.is-context-visible:focus-within {
+    width: 32px;
+    flex-basis: 32px;
+  }
+
+  .titlebar--desktop .titlebar__search.is-context-visible .titlebar__search-leading-icon {
+    display: none;
+  }
+
+  .titlebar--desktop .titlebar__search.is-context-visible .titlebar__search-toggle {
+    display: inline-flex;
+  }
+
+  .titlebar--desktop .titlebar__search.is-context-visible .titlebar__search-popover {
+    display: none;
+  }
+
+  .titlebar--desktop .titlebar__search.is-context-visible.is-open .titlebar__search-popover {
+    width: min(320px, calc(100vw - 24px));
+    display: block;
+    position: absolute;
+    inset: auto 0 auto auto;
+    top: calc(100% + var(--space-2));
+    z-index: 80;
+    padding: var(--space-2);
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius-lg);
+    background: var(--surface-raised);
+    box-shadow: var(--shadow-lg);
+  }
+
+  .titlebar--desktop .titlebar__search.is-context-visible.is-open .titlebar__search-entry {
+    width: 100%;
+  }
+
+  .titlebar--desktop .titlebar__search.is-context-visible.is-open .titlebar__search-results {
+    position: static;
+    width: 100%;
+    max-height: min(420px, calc(100vh - var(--titlebar-height) - 80px));
+    margin-top: var(--space-1);
+    overflow-y: auto;
+  }
+}
+
 @media (max-width: 768px) {
   .titlebar__brand { display: none; }
   .titlebar__right { justify-self: end; }

--- a/src/app/src/styles/styles.css
+++ b/src/app/src/styles/styles.css
@@ -11905,6 +11905,30 @@ a.backend-card__version:focus-visible {
   .logs-workspace--embedded { grid-template-columns: 240px minmax(0, 1fr); grid-template-rows: minmax(0, 1fr); }
 }
 
+@media (max-width: 900px) {
+  .titlebar.titlebar--desktop {
+    column-gap: var(--space-1);
+    padding-inline: var(--space-2);
+  }
+
+  .titlebar--desktop .titlebar__right,
+  .titlebar--desktop .titlebar__utilities,
+  .titlebar--desktop .titlebar__utility-menu {
+    gap: var(--space-1);
+  }
+
+  .titlebar--desktop .titlebar__window-btn {
+    width: 32px;
+    height: 32px;
+  }
+}
+
+@media (max-width: 820px) {
+  .titlebar--desktop .titlebar__nav {
+    transform: translateX(clamp(-44px, calc((100vw - 820px) * 0.2), 0px));
+  }
+}
+
 @media (max-width: 768px) {
   .connect--workspace,
   .logs-workspace,
@@ -12417,6 +12441,33 @@ a.backend-card__version:focus-visible {
     height: 30px;
     gap: 0;
     padding: 0;
+  }
+
+  .titlebar.titlebar--desktop {
+    grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+    column-gap: 2px;
+    padding-inline: var(--space-1);
+  }
+
+  .titlebar--desktop .titlebar__nav {
+    gap: 0;
+    padding: 2px;
+  }
+
+  .titlebar--desktop .titlebar__nav button {
+    width: 30px;
+    min-width: 30px;
+  }
+
+  .titlebar--desktop .titlebar__right,
+  .titlebar--desktop .titlebar__utilities,
+  .titlebar--desktop .titlebar__utility-menu {
+    gap: 2px;
+  }
+
+  .titlebar--desktop .titlebar__window-btn {
+    width: 30px;
+    height: 30px;
   }
 }
 

--- a/src/app/tests/features.spec.ts
+++ b/src/app/tests/features.spec.ts
@@ -813,6 +813,71 @@ test.describe('Lemonade UI — Feature Parity', () => {
     await page.screenshot({ path: 'screenshots/12-responsive-mobile.png', fullPage: true });
   });
 
+  test('12a0 — Tauri Apps titlebar stays collision-free at narrow widths', async ({ page }) => {
+    await page.addInitScript(() => {
+      window.api = { ...window.api, isWebApp: false };
+    });
+    await page.goto('/#/apps');
+
+    const titlebar = page.locator('.titlebar');
+    const nav = page.locator('.titlebar__nav');
+    const right = page.locator('.titlebar__right');
+    const search = page.locator('.titlebar__search');
+    const windowButtons = page.locator('.titlebar__window-btn');
+
+    await expect(titlebar).toHaveClass(/titlebar--desktop/);
+    await expect(page.getByRole('button', { name: 'Apps', exact: true })).toHaveClass(/is-active/);
+    await expect(windowButtons).toHaveCount(3);
+
+    for (const width of [1321, 1280, 900, 821, 800, 769, 480, 400]) {
+      await page.setViewportSize({ width, height: 800 });
+      await page.waitForTimeout(250);
+
+      const [titlebarBox, navBox, rightBox] = await Promise.all([
+        titlebar.boundingBox(),
+        nav.boundingBox(),
+        right.boundingBox(),
+      ]);
+      expect(titlebarBox, `titlebar box at ${width}px`).not.toBeNull();
+      expect(navBox, `nav box at ${width}px`).not.toBeNull();
+      expect(rightBox, `right controls box at ${width}px`).not.toBeNull();
+
+      expect(navBox!.x + navBox!.width, `nav/right overlap at ${width}px`)
+        .toBeLessThanOrEqual(rightBox!.x);
+      expect(rightBox!.x + rightBox!.width, `right controls overflow at ${width}px`)
+        .toBeLessThanOrEqual(titlebarBox!.x + titlebarBox!.width);
+
+      const minimumWindowButtonWidth = width <= 480 ? 30 : width <= 900 ? 32 : 34;
+      const windowButtonBoxes = await windowButtons.evaluateAll(buttons => (
+        buttons.map(button => button.getBoundingClientRect().width)
+      ));
+      for (const buttonWidth of windowButtonBoxes) {
+        expect(buttonWidth, `window control shrank at ${width}px`)
+          .toBeGreaterThanOrEqual(minimumWindowButtonWidth);
+      }
+
+      if (width >= 769) {
+        const searchBox = await search.boundingBox();
+        expect(searchBox, `Apps search box at ${width}px`).not.toBeNull();
+        if (width === 1321) {
+          expect(searchBox!.width, `Apps search field collapsed at ${width}px`)
+            .toBeGreaterThanOrEqual(176);
+        } else {
+          expect(searchBox!.width, `Apps search did not compact at ${width}px`)
+            .toBeLessThanOrEqual(32);
+        }
+      }
+    }
+
+    await page.setViewportSize({ width: 900, height: 800 });
+    const searchToggle = search.getByRole('button', { name: 'Search Lemonade' });
+    await expect(searchToggle).toBeVisible();
+    await searchToggle.click();
+    await expect(search.getByRole('combobox', { name: 'Search apps' })).toBeVisible();
+    await page.keyboard.press('Escape');
+    await expect(search.getByRole('combobox', { name: 'Search apps' })).not.toBeVisible();
+  });
+
   test('12a — Every mobile workspace exposes its context panel', async ({ page }) => {
     await page.setViewportSize({ width: 390, height: 844 });
     await page.goto('/');

--- a/src/app/tests/ui-regression-contracts.runtime.cjs
+++ b/src/app/tests/ui-regression-contracts.runtime.cjs
@@ -19,6 +19,7 @@ const files = {
 const sources = Object.fromEntries(Object.entries(files).map(([key, filename]) => [key, fs.readFileSync(filename, 'utf8')]));
 const mcpClientHeader = fs.readFileSync(path.join(root, '../cpp/include/lemon/mcp_client.h'), 'utf8');
 const mcpClientSource = fs.readFileSync(path.join(root, '../cpp/server/mcp_client.cpp'), 'utf8');
+const styles = fs.readFileSync(path.join(root, 'src/styles/styles.css'), 'utf8');
 
 for (const [key, filename] of Object.entries(files)) {
   const compiled = ts.transpileModule(sources[key], {
@@ -75,6 +76,13 @@ for (const stylesheet of ['src/styles/styles.css', 'src/styles/critical.generate
 assert.match(sources.app, /<span className="titlebar__brand-name">lemonade<\/span>/);
 assert.match(sources.app, /type="search"[\s\S]*?role="combobox"[\s\S]*?aria-expanded=\{navigationSearchOpen\}/);
 assert.match(sources.app, /aria-activedescendant=/);
+assert.match(sources.app, /className=\{`titlebar\$\{isDesktop \? ' titlebar--desktop' : ''\}`\}/);
+assert.match(styles, /\.titlebar\s*\{[\s\S]*?grid-template-columns:\s*minmax\(0, 1fr\) auto minmax\(0, 1fr\)/);
+assert.match(styles, /@media \(max-width: 900px\)[\s\S]*?\.titlebar\.titlebar--desktop\s*\{[\s\S]*?column-gap:\s*var\(--space-1\)/);
+assert.match(styles, /@media \(max-width: 820px\)[\s\S]*?\.titlebar--desktop \.titlebar__nav\s*\{[\s\S]*?transform:\s*translateX\(clamp\(-44px, calc\(\(100vw - 820px\) \* 0\.2\), 0px\)\)/);
+assert.match(styles, /\.titlebar--desktop \.titlebar__right,[\s\S]*?\.titlebar--desktop \.titlebar__utility-menu\s*\{\s*gap:\s*var\(--space-1\)/);
+assert.match(styles, /@media \(max-width: 480px\)[\s\S]*?\.titlebar\.titlebar--desktop\s*\{[\s\S]*?grid-template-columns:\s*minmax\(0, 1fr\) auto minmax\(0, 1fr\)/);
+assert.match(styles, /@media \(max-width: 480px\)[\s\S]*?\.titlebar--desktop \.titlebar__nav button\s*\{[\s\S]*?min-width:\s*30px/);
 
 assert.match(sources.chat, /role="menuitem"[\s\S]*?data-mcp-entry="tools"[\s\S]*?aria-label="Tools"/);
 assert.doesNotMatch(sources.chat, /data-mcp-entry="(?:lemonade|external)"/);


### PR DESCRIPTION
## Summary

Fixes #N/A — no issue was filed for this simple UI fix.

Keep the Tauri titlebar navigation centered through 820 px, then shift it smoothly toward a capped 44 px offset as the native window narrows. Browser clients retain the existing titlebar layout. In the Tauri Apps view, use the compact search control from 769–1320 px so the navigation and native window controls stay separated at narrow widths.

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_

- `npm.cmd run typecheck`
- `npm.cmd run test:ui-regressions`
- `npm.cmd run build:renderer`
- `npm.cmd run build:renderer:prod`
- `npm.cmd run build:nobundle` for the AMD Dev and MLX Tauri variants
- `npx.cmd playwright test --project=functional --grep "Tauri Apps titlebar"` (1 passed)
- Verified Tauri Apps titlebar bounding boxes at 1321, 1280, 900, 821, 800, 769, 480, and 400 px: no nav/control overlap, no right-edge overflow, and no native window-control shrinkage
- Verified the compact Apps search opens and closes normally at 900 px
- Resized the Windows WebView2 app through 821, 760, 700, 640, and 600 px and verified continuous titlebar movement without control overlap

## Documentation

- [x] Documentation is not affected by this change.
- [ ] Documentation is affected and has been updated.
- [ ] Documentation is affected but will be handled in a separate PR or issue.

## Breaking Changes

- [ ] This PR introduces breaking changes.
- [x] This PR does not introduce breaking changes.

## AI-assisted contribution

Please select one:

- [x] I used AI tools for this PR.
- [ ] I did not use AI tools for this PR.

If AI tools were used:

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.