### PR TITLE
feat(tray): add --spawn-server to natively supervise a local lemond

### DIFF
--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -1977,6 +1977,9 @@ jobs:
           echo "Running WebSocket auth tests..."
           .venv/bin/python test/server_websocket_auth.py
           echo "WebSocket auth tests PASSED!"
+          echo "Running tray supervisor watchdog test..."
+          .venv/bin/python test/test_tray_supervisor_watchdog.py
+          echo "Tray supervisor watchdog test PASSED!"
 
       - name: Test log rotation
         if: ${{ !cancelled() && steps.setup.outcome == 'success' }}
@@ -2410,6 +2413,7 @@ jobs:
           $VENV_PYTHON test/test_websocket_idle.py
           $VENV_PYTHON test/server_websocket_auth.py
           $VENV_PYTHON test/test_tray_https.py
+          LEMONADE_LEMOND_BINARY="$LEMOND_BINARY" $VENV_PYTHON test/test_tray_supervisor_watchdog.py
           $VENV_PYTHON test/server_jobs.py --lemond-binary "$LEMOND_BINARY"
 
       - name: Test router

--- a/docs/dev/getting-started.md
+++ b/docs/dev/getting-started.md
@@ -586,6 +586,12 @@ A GUI application for desktop users that exposes the server via a system tray ic
 - Used by application launchers, desktop shortcuts, and autostart entries
 - Provides seamless GUI experience for non-technical users
 
+**`lemonade-tray` options (Linux/macOS):**
+- `--port, -p <port>` / `--host <host>` - server to connect to (defaults read from the server's `config.json`).
+- `--spawn-server` - if no server is reachable, spawn a local `lemond` and supervise it. The tray opens a watchdog pipe and passes `--watchdog-fd <FD>` to the child; when the tray exits for any reason (including SIGKILL), the OS closes the pipe and `lemond` shuts itself down, so no orphaned server is left behind. This flag is intended for standalone environments where `lemond` is not already managed by a service manager (`systemd` on Linux or `LaunchDaemon` on macOS); when running alongside a managed daemon, the existing server is detected and no child is spawned.
+- `--launch-app, --open` - open the desktop app once the server is ready.
+- `--silent` - suppress the startup notification.
+
 ### Client-Server Communication
 
 The `lemonade` client communicates with `lemond` server via HTTP:

--- a/src/cpp/include/lemon/cli_parser.h
+++ b/src/cpp/include/lemon/cli_parser.h
@@ -15,6 +15,7 @@ struct ServerConfig {
     std::string log_file;                 // Empty = not specified on CLI, use config.json value
     int log_max_file_size_mb = -1;        // -1 = not specified on CLI, use config.json value
     int log_max_files = -1;               // -1 = not specified on CLI, use config.json value
+    int watchdog_fd = -1;                 // -1 = not specified on CLI, supervisor pipe descriptor (POSIX only)
 };
 
 class CLIParser {

--- a/src/cpp/include/lemon_tray/tray_ui.h
+++ b/src/cpp/include/lemon_tray/tray_ui.h
@@ -5,6 +5,7 @@
 #include <httplib.h>
 #include <nlohmann/json.hpp>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 #include <set>
@@ -65,7 +66,7 @@ private:
     httplib::Client make_client() const;
 
     // Data fetchers
-    std::pair<bool, std::vector<LoadedModelInfo>> fetch_server_state();
+    std::optional<std::vector<LoadedModelInfo>> fetch_server_state();
     std::vector<LoadedModelInfo> get_all_loaded_models();
     std::vector<ModelInfo> get_downloaded_models();
     void fetch_runtime_config();

--- a/src/cpp/include/lemon_tray/tray_ui.h
+++ b/src/cpp/include/lemon_tray/tray_ui.h
@@ -4,6 +4,7 @@
 #include "lemon_tray/platform/tray_interface.h"
 #include <httplib.h>
 #include <nlohmann/json.hpp>
+#include <csignal>
 #include <memory>
 #include <optional>
 #include <string>
@@ -47,6 +48,8 @@ struct TrayUIOptions {
     std::string host = "127.0.0.1";
     bool is_ssl = false;
     bool silent = false;
+    bool launch_app = false;
+    bool server_initially_connected = false;
 };
 
 class TrayUI {
@@ -57,6 +60,11 @@ public:
     bool initialize();
     void run();   // Blocking event loop (main thread)
     void stop();  // Thread-safe, posts quit to event loop
+
+    // Set by the POSIX SIGINT/SIGTERM handler; polled by the refresh thread so
+    // the tray quits cleanly through the event loop instead of std::exit() from
+    // a signal handler (which is not async-signal-safe).
+    static volatile std::sig_atomic_t g_quit_requested;
 
 private:
     // HTTP helpers (inline, using httplib::Client)
@@ -110,6 +118,9 @@ private:
     bool is_ssl_ = false;
     int max_loaded_models_ = 1;  // Mirrors server config; default 1 per configuration.md
     bool silent_;  // Suppress startup notification
+    bool launch_app_;
+    bool server_initially_connected_;
+    std::atomic<bool> stop_refresh_{false};
     std::unique_ptr<TrayInterface> tray_;
 
     // Model loading state
@@ -126,13 +137,7 @@ private:
     // Recipe options (for context size tracking)
     nlohmann::json recipe_options_;
 
-    // Signal handling (non-Windows)
-#ifndef _WIN32
-    std::thread signal_monitor_thread_;
-    std::atomic<bool> stop_signal_monitor_{false};
-public:
-    static int signal_pipe_[2];
-#endif
+
 };
 
 } // namespace lemon_tray

--- a/src/cpp/server/cli_parser.cpp
+++ b/src/cpp/server/cli_parser.cpp
@@ -42,6 +42,10 @@ CLIParser::CLIParser()
     app_.add_option("--log-max-files", config_.log_max_files, "Max number of rotated log backup files to retain (0..100, overrides config.json)")
         ->type_name("N")
         ->check(CLI::Range(0, 100));
+
+    app_.add_option("--watchdog-fd", config_.watchdog_fd, "Internal supervisor watchdog pipe descriptor")
+        ->type_name("FD")
+        ->group("");
 }
 
 int CLIParser::parse(int argc, char** argv) {

--- a/src/cpp/server/main.cpp
+++ b/src/cpp/server/main.cpp
@@ -25,6 +25,27 @@
 
 #ifndef _WIN32
 #include <unistd.h>
+void start_parent_watchdog(int fd = -1) {
+    if (fd < 0) {
+        const char* fd_str = std::getenv("LEMONADE_WATCHDOG_FD");
+        if (fd_str && fd_str[0] != '\0') {
+            try {
+                fd = std::stoi(fd_str);
+            } catch (...) {}
+        }
+    }
+    if (fd >= 0) {
+        // Blocks until the parent dies and the OS closes the pipe write end.
+        std::thread([fd]() {
+            char buf;
+            ssize_t res = read(fd, &buf, 1);
+            if (res <= 0) {
+                std::cerr << "[Watchdog] Parent process died or closed pipe. Shutting down." << std::endl;
+                std::raise(SIGTERM);
+            }
+        }).detach();
+    }
+}
 #endif
 
 using namespace lemon;
@@ -140,6 +161,10 @@ int main(int argc, char** argv) {
         }
 
         auto cli_config = parser.get_config();
+
+#ifndef _WIN32
+        start_parent_watchdog(cli_config.watchdog_fd);
+#endif
 
         // Initialize logging early with INFO so config loading messages are captured
         {

--- a/src/cpp/tray/main.cpp
+++ b/src/cpp/tray/main.cpp
@@ -68,7 +68,12 @@ static void create_child_process_job() {
 // Helpers
 // ---------------------------------------------------------------------------
 
-static bool wait_for_server(const std::string& clean_host, int clean_port, bool is_ssl, int timeout_seconds) {
+enum class ServerProbeMode {
+    ready_only,     // 200, 401, 403 (503 retries until ready or timeout)
+    allow_starting  // 200, 401, 403, 503 (returns true immediately if starting or ready)
+};
+
+static bool wait_for_server(const std::string& clean_host, int clean_port, bool is_ssl, int timeout_seconds, ServerProbeMode mode = ServerProbeMode::ready_only) {
     std::string connect_host;
     if (is_ssl) {
         connect_host = (clean_host.empty() || clean_host == "0.0.0.0")
@@ -86,7 +91,8 @@ static bool wait_for_server(const std::string& clean_host, int clean_port, bool 
         headers.emplace("Authorization", std::string("Bearer ") + api_key);
     }
 
-    for (int i = 0; i < timeout_seconds * 2; ++i) {
+    int max_attempts = std::max(1, timeout_seconds * 2);
+    for (int i = 0; i < max_attempts; ++i) {
         try {
 #ifndef LEMONADE_HTTPLIB_HAS_TLS
             if (is_ssl) {
@@ -109,11 +115,23 @@ static bool wait_for_server(const std::string& clean_host, int clean_port, bool 
             // Use /api/v1/health instead of /live — /live responds before the model
             // cache is built, which causes 500s on /models if clients connect too early.
             auto res = cli.Get("/api/v1/health", headers);
-            if (res && res->status == 200) {
-                return true;
+            if (res) {
+                if (res->status == 200 || res->status == 401 || res->status == 403) {
+                    return true;
+                }
+                if (res->status == 503 && mode == ServerProbeMode::allow_starting) {
+                    return true;
+                }
             }
-        } catch (...) {}
-        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+        } catch (const std::exception&) {
+            // Socket or network errors while probing an offline or starting server are expected;
+            // continue polling until max_attempts expires.
+        } catch (...) {
+            // Non-std exception during probe setup; continue polling.
+        }
+        if (i + 1 < max_attempts) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(500));
+        }
     }
     return false;
 }
@@ -244,6 +262,7 @@ int WINAPI wWinMain(HINSTANCE, HINSTANCE, LPWSTR, int) {
         options.host = runtime_config->host();
         options.is_ssl = false;
         options.silent = silent;
+        options.server_initially_connected = true;  // Embedded server is always up
         lemon_tray::TrayUI tray(options);
         if (tray.initialize()) {
             tray.run();  // Blocks until quit
@@ -293,29 +312,108 @@ int WINAPI wWinMain(HINSTANCE, HINSTANCE, LPWSTR, int) {
 
 #else
 
-// Signal handler writes to self-pipe for clean shutdown
+#include <CLI/CLI.hpp>
+#include <lemon/utils/url_utils.h>
+#include <lemon/utils/path_utils.h>
+#include <lemon/single_instance.h>
+#include <filesystem>
+#include <spawn.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <vector>
+#include <fstream>
+#include <nlohmann/json.hpp>
+
+// std::exit() is not async-signal-safe; set a flag the refresh thread polls.
 static void tray_signal_handler(int sig) {
     if (sig == SIGINT || sig == SIGTERM) {
-        char c = (char)sig;
-        ssize_t written = write(lemon_tray::TrayUI::signal_pipe_[1], &c, 1);
-        (void)written;
+        lemon_tray::TrayUI::g_quit_requested = 1;
     }
 }
 
+static std::string find_lemond_binary(const char* argv0 = nullptr) {
+    const std::string bin_name = "lemond";
+    std::error_code ec;
+
+    if (argv0 && argv0[0]) {
+        const std::filesystem::path p(argv0);
+        if (p.has_parent_path()) {
+            const auto candidate = p.parent_path() / bin_name;
+            if (std::filesystem::is_regular_file(candidate, ec)) {
+                return candidate.string();
+            }
+        }
+    }
+
+    try {
+        const std::string exe_dir = lemon::utils::get_executable_dir();
+        if (!exe_dir.empty()) {
+            const auto candidate = std::filesystem::path(exe_dir) / bin_name;
+            if (std::filesystem::is_regular_file(candidate, ec)) {
+                return candidate.string();
+            }
+        }
+    } catch (const std::runtime_error&) {
+        // get_executable_dir() throws on Linux/macOS if /proc/self/exe resolution fails;
+        // catch to allow falling through to PATH discovery.
+    }
+
+    return lemon::utils::find_executable_in_path(bin_name);
+}
+
+static void read_fallback_config(int& port, std::string& host) {
+    std::error_code ec;
+    const std::filesystem::path config_dir = lemon::utils::get_config_dir();
+    if (config_dir.empty()) {
+        return;
+    }
+    const auto config_path = config_dir / "config.json";
+    if (!std::filesystem::is_regular_file(config_path, ec)) {
+        return;
+    }
+    std::ifstream f(config_path);
+    if (!f.is_open()) {
+        return;
+    }
+    const auto j = nlohmann::json::parse(f, nullptr, false);
+    if (!j.is_discarded() && j.is_object()) {
+        if (auto it = j.find("port"); it != j.end() && it->is_number_integer()) {
+            auto p = it->get<int64_t>();
+            if (p > 0 && p <= 65535) {
+                port = static_cast<int>(p);
+            }
+        }
+        if (auto it = j.find("host"); it != j.end() && it->is_string()) {
+            host = it->get<std::string>();
+        }
+    }
+}
+
+extern char **environ;
+
 int main(int argc, char* argv[]) {
-    // Single instance check
     if (lemon::SingleInstance::IsAnotherInstanceRunning("Tray")) {
         std::cerr << "lemonade-tray is already running." << std::endl;
         return 0;
     }
 
-    // Parse args
     CLI::App app{"Lemonade Tray - system tray interface for Lemonade Server"};
+
+    // config.json supplies the defaults that --port/--host override
     int port = 13305;
     std::string host = "localhost";
+    read_fallback_config(port, host);
 
     app.add_option("--port,-p", port, "Server port to connect to");
     app.add_option("--host", host, "Server host to connect to");
+
+    bool silent = false;
+    bool spawn_server = false;
+    bool launch_app = false;
+    app.add_flag("--silent", silent, "Suppress startup notification");
+    app.add_flag("--spawn-server", spawn_server, "Spawn a local lemond instance if none is running");
+    app.add_flag("--launch-app,--open", launch_app, "Launch desktop app once server is ready");
 
     try {
         app.parse(argc, argv);
@@ -332,23 +430,103 @@ int main(int argc, char* argv[]) {
     // Install signal handlers
     signal(SIGINT, tray_signal_handler);
     signal(SIGTERM, tray_signal_handler);
+    signal(SIGPIPE, SIG_IGN);
 
-    // Wait for router to be reachable (retry with backoff up to 30s)
-    std::cout << "Connecting to lemond at " << clean_host << ":" << clean_port << (is_ssl ? " (SSL)" : "") << "..." << std::endl;
-    if (!wait_for_server(clean_host, clean_port, is_ssl, 30)) {
-        std::cerr << "Error: Could not connect to lemond at " << clean_host << ":" << clean_port << std::endl;
-        std::cerr << "Make sure lemond is running." << std::endl;
-        return 1;
+    bool server_present = wait_for_server(clean_host, clean_port, is_ssl, 1, ServerProbeMode::allow_starting);
+    bool server_initially_connected = false;
+
+    if (!server_present && spawn_server) {
+        std::string lemond_bin = find_lemond_binary(argv[0]);
+        if (lemond_bin.empty()) {
+            std::cerr << "Error: Could not find lemond binary." << std::endl;
+            return 1;
+        }
+
+        int watchdog_pipe[2];
+        if (pipe(watchdog_pipe) == -1) {
+            std::cerr << "Error: Could not create watchdog pipe." << std::endl;
+            return 1;
+        }
+
+        // On POSIX: pipes do not have FD_CLOEXEC set by default. Explicitly set
+        // FD_CLOEXEC on the parent's write end so child processes launched by
+        // the tray (e.g. desktop app or browser via xdg-open) do not inherit it
+        // and keep the pipe open if the tray dies. Clear FD_CLOEXEC on the read
+        // end so it survives posix_spawn in the child.
+        fcntl(watchdog_pipe[1], F_SETFD, FD_CLOEXEC);
+        fcntl(watchdog_pipe[0], F_SETFD, 0);
+
+        std::string watchdog_fd_arg = "--watchdog-fd=" + std::to_string(watchdog_pipe[0]);
+
+        std::vector<const char*> c_args;
+        c_args.push_back(lemond_bin.c_str());
+        c_args.push_back(watchdog_fd_arg.c_str());
+        // Forward the tray's args to lemond, dropping the tray-only flags (also
+        // in --flag=value form, which CLI11 accepts for booleans).
+        auto is_tray_only_arg = [](const std::string& arg) {
+            static const char* tray_flags[] = {"--spawn-server", "--silent", "--launch-app", "--open"};
+            for (const char* flag : tray_flags) {
+                std::string flag_s = flag;
+                if (arg == flag_s || (arg.rfind(flag_s, 0) == 0 && arg[flag_s.size()] == '=')) {
+                    return true;
+                }
+            }
+            return false;
+        };
+        for (int i = 1; i < argc; ++i) {
+            if (is_tray_only_arg(argv[i])) {
+                continue;
+            }
+            c_args.push_back(argv[i]);
+        }
+        c_args.push_back(nullptr);
+
+        pid_t pid;
+        posix_spawn_file_actions_t actions;
+        posix_spawn_file_actions_init(&actions);
+
+        // The child must not inherit the write end of the watchdog pipe. If it
+        // does, the child's blocking read() in start_parent_watchdog() never sees
+        // EOF (a live writer always exists) and an orphaned server survives the
+        // tray exiting, even via SIGKILL. Closing it in the child also prevents
+        // lemond from passing it down to its backend subprocesses.
+        if (posix_spawn_file_actions_addclose(&actions, watchdog_pipe[1]) != 0) {
+            std::cerr << "Error: Could not configure watchdog pipe." << std::endl;
+            return 1;
+        }
+
+        if (posix_spawnp(&pid, lemond_bin.c_str(), &actions, nullptr, const_cast<char* const*>(c_args.data()), environ) != 0) {
+            std::cerr << "Error: Could not spawn lemond." << std::endl;
+            return 1;
+        }
+        posix_spawn_file_actions_destroy(&actions);
+
+        close(watchdog_pipe[0]);
+
+        std::cout << "Starting local lemond instance..." << std::endl;
+        if (!wait_for_server(clean_host, clean_port, is_ssl, 15, ServerProbeMode::ready_only)) {
+            std::cerr << "Error: Spawned lemond failed to start within 15 seconds." << std::endl;
+            return 1;
+        }
+        server_initially_connected = true;
+    } else if (server_present) {
+        server_initially_connected = wait_for_server(clean_host, clean_port, is_ssl, 0, ServerProbeMode::ready_only);
     }
 
-    std::cout << "Connected to lemond v" << LEMON_VERSION_STRING << std::endl;
+    if (!server_present && !spawn_server) {
+        std::cout << "Lemonade Server is offline. Starting tray in disconnected mode..." << std::endl;
+    } else if (server_present && !server_initially_connected) {
+        std::cout << "Lemonade Server is starting. Starting tray in waiting mode..." << std::endl;
+    }
 
-    // Create and run tray UI
     lemon_tray::TrayUIOptions options;
     options.port = clean_port;
     options.host = clean_host;
     options.is_ssl = is_ssl;
-    options.silent = false;
+    options.silent = silent;
+    options.launch_app = launch_app;
+    options.server_initially_connected = server_initially_connected;
+
     lemon_tray::TrayUI tray(options);
     if (!tray.initialize()) {
         return 1;
@@ -356,7 +534,6 @@ int main(int argc, char* argv[]) {
 
     tray.run();  // Blocks until quit
 
-    // On macOS/Linux, just exit — the router keeps running
     return 0;
 }
 

--- a/src/cpp/tray/tray_ui.cpp
+++ b/src/cpp/tray/tray_ui.cpp
@@ -247,13 +247,13 @@ std::string TrayUI::http_post(const std::string& endpoint, const std::string& bo
 // Data fetchers
 // ---------------------------------------------------------------------------
 
-std::pair<bool, std::vector<LoadedModelInfo>> TrayUI::fetch_server_state() {
-    std::vector<LoadedModelInfo> loaded_models;
+std::optional<std::vector<LoadedModelInfo>> TrayUI::fetch_server_state() {
     try {
         std::string body = http_get("/api/v1/health");
-        if (body.empty()) return {false, loaded_models};
+        if (body.empty()) return std::nullopt;
 
         auto health = nlohmann::json::parse(body);
+        std::vector<LoadedModelInfo> loaded_models;
         if (health.contains("all_models_loaded") && health["all_models_loaded"].is_array()) {
             for (const auto& model : health["all_models_loaded"]) {
                 LoadedModelInfo info;
@@ -268,14 +268,14 @@ std::pair<bool, std::vector<LoadedModelInfo>> TrayUI::fetch_server_state() {
                 }
             }
         }
-        return {true, loaded_models};
+        return loaded_models;
     } catch (...) {
-        return {false, loaded_models};
+        return std::nullopt;
     }
 }
 
 std::vector<LoadedModelInfo> TrayUI::get_all_loaded_models() {
-    return fetch_server_state().second;
+    return fetch_server_state().value_or(std::vector<LoadedModelInfo>{});
 }
 
 void TrayUI::fetch_runtime_config() {
@@ -327,7 +327,9 @@ void TrayUI::build_menu() {
     if (!tray_) return;
 
     // Fetch once, use for both the menu and the cache
-    auto [reachable, loaded_models] = fetch_server_state();
+    auto server_state = fetch_server_state();
+    bool reachable = server_state.has_value();
+    auto loaded_models = server_state.value_or(std::vector<LoadedModelInfo>{});
     auto available_models = get_downloaded_models();
     if (reachable) fetch_runtime_config();
 
@@ -349,7 +351,9 @@ void TrayUI::refresh_menu() {
 
 bool TrayUI::menu_needs_refresh() {
     // Fetch outside the lock to avoid blocking other threads during HTTP calls
-    auto [reachable, loaded] = fetch_server_state();
+    auto server_state = fetch_server_state();
+    bool reachable = server_state.has_value();
+    auto loaded = server_state.value_or(std::vector<LoadedModelInfo>{});
     auto current_available = get_downloaded_models();
 
     std::lock_guard<std::mutex> lock(state_mutex_);

--- a/src/cpp/tray/tray_ui.cpp
+++ b/src/cpp/tray/tray_ui.cpp
@@ -28,9 +28,7 @@ namespace fs = std::filesystem;
 
 namespace lemon_tray {
 
-#ifndef _WIN32
-int TrayUI::signal_pipe_[2] = {-1, -1};
-#endif
+volatile std::sig_atomic_t TrayUI::g_quit_requested = 0;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -58,6 +56,8 @@ TrayUI::TrayUI(const TrayUIOptions& options)
     , host_(options.host)
     , is_ssl_(options.is_ssl)
     , silent_(options.silent)
+    , launch_app_(options.launch_app)
+    , server_initially_connected_(options.server_initially_connected)
     , recipe_options_(nlohmann::json::object())
 {
     std::string clean_host;
@@ -68,32 +68,10 @@ TrayUI::TrayUI(const TrayUIOptions& options)
     port_ = clean_port;
     is_ssl_ = clean_is_ssl;
 
-#ifndef _WIN32
-    if (pipe(signal_pipe_) == -1) {
-        std::cerr << "Failed to create signal pipe" << std::endl;
-    } else {
-        // Set write end to non-blocking
-        int flags = fcntl(signal_pipe_[1], F_GETFL);
-        if (flags != -1) {
-            fcntl(signal_pipe_[1], F_SETFL, flags | O_NONBLOCK);
-        }
-    }
-#endif
+
 }
 
 TrayUI::~TrayUI() {
-#ifndef _WIN32
-    if (signal_monitor_thread_.joinable()) {
-        stop_signal_monitor_ = true;
-        signal_monitor_thread_.join();
-    }
-    if (signal_pipe_[0] != -1) {
-        close(signal_pipe_[0]);
-        close(signal_pipe_[1]);
-        signal_pipe_[0] = signal_pipe_[1] = -1;
-    }
-#endif
-
 }
 
 // ---------------------------------------------------------------------------
@@ -108,8 +86,15 @@ bool TrayUI::initialize() {
     }
 
     tray_->set_ready_callback([this]() {
-        if (!silent_) {
-            show_notification("Woohoo!", "Lemonade Server is running! Right-click the tray icon to access options.");
+        // Only announce the server if it was reachable at startup; when the tray
+        // starts in disconnected mode the periodic refresher notifies on reconnect.
+        if (server_initially_connected_) {
+            if (!silent_) {
+                show_notification("Woohoo!", "Lemonade Server is running! Right-click the tray icon to access options.");
+            }
+            if (launch_app_) {
+                open_desktop_app();
+            }
         }
     });
 
@@ -133,37 +118,52 @@ bool TrayUI::initialize() {
 }
 
 void TrayUI::run() {
+    if (!tray_) return;
+
+    // On POSIX, a background thread refreshes the menu so the tray reflects
+    // server state and recovers if it goes offline and later comes back
+    // (disconnected mode), and polls g_quit_requested to quit cleanly on
+    // SIGINT/SIGTERM. This thread is non-Windows only: Windows already refreshes
+    // on its UI thread via set_menu_update_callback, and WindowsTray::set_menu
+    // mutates Win32 menu handles without synchronization, so it must only be
+    // called from the UI thread. On Linux/macOS set_menu marshals to the UI
+    // thread (g_idle_add / dispatch_async), so cross-thread calls are safe.
 #ifndef _WIN32
-    // Background thread to monitor signals and periodically refresh the menu
-    signal_monitor_thread_ = std::thread([this]() {
+    std::thread refresher([this]() {
         auto last_tick = std::chrono::steady_clock::now();
-        while (!stop_signal_monitor_) {
-            fd_set readfds;
-            FD_ZERO(&readfds);
-            FD_SET(signal_pipe_[0], &readfds);
-
-            struct timeval tv = {0, 100000};  // 100ms
-            int result = select(signal_pipe_[0] + 1, &readfds, nullptr, nullptr, &tv);
-
+        bool notified_reconnect = server_initially_connected_;
+        while (!stop_refresh_) {
+            if (g_quit_requested) {
+                stop();
+                break;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
             auto now = std::chrono::steady_clock::now();
             if (std::chrono::duration_cast<std::chrono::seconds>(now - last_tick).count() >= 5) {
                 refresh_menu();
+                if (!notified_reconnect) {
+                    if (fetch_server_state().has_value()) {
+                        notified_reconnect = true;
+                        if (!silent_) {
+                            show_notification("Lemonade Server", "Lemonade Server is now available.");
+                        }
+                        if (launch_app_) {
+                            open_desktop_app();
+                        }
+                    }
+                }
                 last_tick = now;
-            }
-
-            if (result > 0 && FD_ISSET(signal_pipe_[0], &readfds)) {
-                char sig;
-                ssize_t bytes_read = read(signal_pipe_[0], &sig, 1);
-                (void)bytes_read;
-                std::cout << "\nReceived interrupt signal, shutting down..." << std::endl;
-                stop();
-                break;
             }
         }
     });
 #endif
 
     tray_->run();  // Blocks in platform event loop
+
+#ifndef _WIN32
+    stop_refresh_ = true;
+    if (refresher.joinable()) refresher.join();
+#endif
 }
 
 void TrayUI::stop() {

--- a/test/cpp/test_cli_runtime_override.cpp
+++ b/test/cpp/test_cli_runtime_override.cpp
@@ -40,6 +40,16 @@ int main() {
         auto cli_cfg = parser.get_config();
         check(cli_cfg.port == 9000, "CLIParser captured port 9000");
         check(cli_cfg.host == "0.0.0.0", "CLIParser captured host 0.0.0.0");
+        check(cli_cfg.watchdog_fd == -1, "CLIParser defaults watchdog_fd to -1");
+    }
+
+    {
+        CLIParser parser;
+        const char* argv[] = {"lemond", "--watchdog-fd", "42"};
+        int res = parser.parse(3, const_cast<char**>(argv));
+        check(res == 0 && parser.should_continue(), "CLIParser parses --watchdog-fd successfully");
+        auto cli_cfg = parser.get_config();
+        check(cli_cfg.watchdog_fd == 42, "CLIParser captured watchdog_fd 42");
     }
 
     {

--- a/test/test_tray_supervisor_watchdog.py
+++ b/test/test_tray_supervisor_watchdog.py
@@ -1,0 +1,254 @@
+"""
+Regression test for the tray's OS-native server supervisor watchdog.
+
+The tray spawns `lemond` with LEMONADE_WATCHDOG_FD pointing at the read end of
+a pipe, keeping the write end open only in the tray process. When the tray
+exits for any reason (even SIGKILL) the OS closes the write end, so lemond's
+blocking read() returns EOF and it shuts itself down. This simulates that
+contract directly: spawn lemond with only the read end inherited, then close
+the write end (as the OS would on parent death) and assert lemond exits.
+
+Runs standalone (no inference backend needed). POSIX-only.
+"""
+
+import os
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+
+from utils.test_models import get_default_lemond_binary
+
+
+def _free_port():
+    with socket.socket() as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]
+
+
+def _wait_reachable(port, proc, timeout=30):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if proc.poll() is not None:
+            return False
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=1):
+                return True
+        except OSError:
+            time.sleep(0.2)
+    return False
+
+
+def test_watchdog_shutdown():
+    lemond = _resolve_lemond()
+    port = _free_port()
+    read_fd, write_fd = os.pipe()
+    proc = None
+    try:
+        with tempfile.TemporaryDirectory() as cache:
+            proc = subprocess.Popen(
+                [
+                    lemond,
+                    cache,
+                    "--port",
+                    str(port),
+                    "--host",
+                    "127.0.0.1",
+                    "--no-broadcast",
+                    f"--watchdog-fd={read_fd}",
+                ],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                pass_fds=(read_fd,),
+            )
+
+            # Parent no longer needs its own read-end copy.
+            os.close(read_fd)
+            read_fd = -1
+
+            if not _wait_reachable(port, proc):
+                sys.exit(f"[FAIL] Spawned lemond did not become reachable on {port}")
+
+            if proc.poll() is not None:
+                sys.exit("[FAIL] lemond exited while the watchdog pipe was still open")
+
+            # Simulate the tray dying: the OS closes the write end of the pipe.
+            os.close(write_fd)
+            write_fd = -1
+
+            deadline = time.time() + 15
+            while time.time() < deadline and proc.poll() is None:
+                time.sleep(0.2)
+
+            if proc.poll() is None:
+                proc.kill()
+                sys.exit(
+                    "[FAIL] lemond did not shut down after the watchdog write end closed"
+                )
+
+            print("[PASS] Tray supervisor watchdog terminated lemond on parent death.")
+    finally:
+        if read_fd >= 0:
+            os.close(read_fd)
+        if write_fd >= 0:
+            os.close(write_fd)
+        if proc is not None and proc.poll() is None:
+            proc.kill()
+            proc.wait()
+
+
+def test_watchdog_cloexec_prevents_writer_leak():
+    """Verify that child processes spawned by the parent (e.g. desktop app / browser)
+    do not keep the watchdog write-end alive if close-on-exec (FD_CLOEXEC) is set."""
+    lemond = _resolve_lemond()
+    port = _free_port()
+    read_fd, write_fd = os.pipe()
+    proc = None
+    child_proc = None
+    try:
+        with tempfile.TemporaryDirectory() as cache:
+            proc = subprocess.Popen(
+                [
+                    lemond,
+                    cache,
+                    "--port",
+                    str(port),
+                    "--host",
+                    "127.0.0.1",
+                    "--no-broadcast",
+                    f"--watchdog-fd={read_fd}",
+                ],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                pass_fds=(read_fd,),
+            )
+            os.close(read_fd)
+            read_fd = -1
+
+            if not _wait_reachable(port, proc):
+                sys.exit(f"[FAIL] Spawned lemond did not become reachable on {port}")
+
+            # Spawn a simulated external helper (e.g. sleep / browser) with close_fds=True (CLOEXEC behavior)
+            child_proc = subprocess.Popen(
+                ["sleep", "30"],
+                close_fds=True,
+            )
+
+            # Parent closes write_fd (simulating tray exit while external helper is still running)
+            os.close(write_fd)
+            write_fd = -1
+
+            # lemond MUST exit because child_proc did not inherit write_fd
+            deadline = time.time() + 15
+            while time.time() < deadline and proc.poll() is None:
+                time.sleep(0.2)
+
+            if proc.poll() is None:
+                proc.kill()
+                sys.exit(
+                    "[FAIL] lemond stayed alive because a spawned process inherited the watchdog writer"
+                )
+
+            print("[PASS] Watchdog writer is not leaked to spawned helper processes.")
+    finally:
+        if read_fd >= 0:
+            os.close(read_fd)
+        if write_fd >= 0:
+            os.close(write_fd)
+        if proc is not None and proc.poll() is None:
+            proc.kill()
+            proc.wait()
+        if child_proc is not None and child_proc.poll() is None:
+            child_proc.kill()
+            child_proc.wait()
+
+
+def _resolve_lemond():
+    default_build = get_default_lemond_binary()
+    lemond = (
+        os.environ.get("LEMONADE_LEMOND_BINARY")
+        or (default_build if os.path.exists(default_build) else None)
+        or shutil.which("lemond")
+    )
+    if not lemond or not os.path.exists(lemond):
+        print(
+            f"lemond binary not found at {lemond or default_build}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    return lemond
+
+
+def test_path_based_lemond_spawn():
+    """Verify that lemond can be found and executed when resolved purely via PATH."""
+    lemond = _resolve_lemond()
+    port = _free_port()
+    read_fd, write_fd = os.pipe()
+    proc = None
+    try:
+        with tempfile.TemporaryDirectory() as cache:
+            lemond_dir = os.path.dirname(os.path.abspath(lemond))
+            env = os.environ.copy()
+            env["PATH"] = f"{lemond_dir}:{env.get('PATH', '')}"
+            env["LEMONADE_WATCHDOG_FD"] = str(read_fd)
+
+            # Invoke with bare "lemond" on PATH (testing posix_spawnp behavior)
+            proc = subprocess.Popen(
+                [
+                    "lemond",
+                    cache,
+                    "--port",
+                    str(port),
+                    "--host",
+                    "127.0.0.1",
+                    "--no-broadcast",
+                ],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                env=env,
+                pass_fds=(read_fd,),
+            )
+            os.close(read_fd)
+            read_fd = -1
+
+            if not _wait_reachable(port, proc):
+                sys.exit(
+                    f"[FAIL] PATH-spawned lemond did not become reachable on {port}"
+                )
+
+            os.close(write_fd)
+            write_fd = -1
+
+            deadline = time.time() + 15
+            while time.time() < deadline and proc.poll() is None:
+                time.sleep(0.2)
+
+            if proc.poll() is None:
+                proc.kill()
+                sys.exit("[FAIL] PATH-spawned lemond did not exit on watchdog EOF")
+
+            print("[PASS] PATH-based lemond discovery and execution succeeded.")
+    finally:
+        if read_fd >= 0:
+            os.close(read_fd)
+        if write_fd >= 0:
+            os.close(write_fd)
+        if proc is not None and proc.poll() is None:
+            proc.kill()
+            proc.wait()
+
+
+def run_test():
+    if os.name == "nt":
+        print("[SKIP] POSIX pipe watchdog not applicable on Windows", file=sys.stderr)
+        sys.exit(0)
+
+    test_watchdog_shutdown()
+    test_watchdog_cloexec_prevents_writer_leak()
+    test_path_based_lemond_spawn()
+
+
+if __name__ == "__main__":
+    run_test()


### PR DESCRIPTION
## Summary

- Adds `--spawn-server` to `lemonade-tray` for natively spawning and supervising a local `lemond` instance. On POSIX it uses `posix_spawn` with a pipe-EOF watchdog so no orphaned `lemond` is left behind when the tray exits, even via `SIGKILL`.
- Refactors `TrayUI::fetch_server_state()` to return `std::optional<std::vector<LoadedModelInfo>>`.

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

*Testing details:*
- Built `lemonade-tray` and `lemond` (compile-clean).
- Ran `test/test_tray_supervisor_watchdog.py` locally; verifies:
  1. `lemond` terminates immediately when the watchdog pipe write end is closed.
  2. Helper processes spawned with `FD_CLOEXEC` do not leak the writer or keep `lemond` alive on tray exit.
  3. `lemond` resolved purely via `$PATH` launches correctly via `posix_spawnp` and terminates on watchdog EOF.
- Ran all C++ unit tests locally via `ctest -L "^cpp-ci$"`; 66/66 tests pass.
- The watchdog test is wired into CI (`test/test_tray_supervisor_watchdog.py` on the Ubuntu and macOS jobs).

## Documentation

- [ ] Documentation is not affected by this change.
- [x] Documentation is affected and has been updated.
- [ ] Documentation is affected but will be handled in a separate PR or issue.

## Breaking Changes

- [ ] This PR introduces breaking changes.
- [x] This PR does not introduce breaking changes.

## AI-assisted contribution

Please select one:

- [x] I used AI tools for this PR.
- [ ] I did not use AI tools for this PR.

If AI tools were used:

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.
