### PR TITLE
fix: recover repo name for extra models kept in HF-cache layout

### DIFF
--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -1171,6 +1171,37 @@ ModelInfo ModelManager::init_extra_model_info(const std::string& name) const {
     return info;
 }
 
+// A model moved (with its full hub layout) into extra_models_dir keeps its
+// "models--org--repo/snapshots/<hash>/..." shape. Walking up from a discovered
+// file to that "models--"/"modelscope--models--" ancestor recovers "org/repo"
+// so the model keeps a readable name instead of the snapshot hash that would
+// otherwise be read as the containing folder's name. Stops at `stop_at` (the
+// configured extra_models_dir root) so an unrelated ancestor name can't match.
+static std::string hf_cache_repo_name_for_path(const fs::path& path, const fs::path& stop_at) {
+    static constexpr const char kHfPrefix[] = "models--";
+    static constexpr const char kMsPrefix[] = "modelscope--models--";
+    for (fs::path cur = path; cur.has_filename() && cur != stop_at; cur = cur.parent_path()) {
+        std::string dirname = cur.filename().string();
+        std::string encoded;
+        if (dirname.rfind(kMsPrefix, 0) == 0) {
+            encoded = dirname.substr(sizeof(kMsPrefix) - 1);
+        } else if (dirname.rfind(kHfPrefix, 0) == 0) {
+            encoded = dirname.substr(sizeof(kHfPrefix) - 1);
+        } else {
+            continue;
+        }
+        // registry_repo_cache_dir_name() encodes "org/repo" as "org--repo";
+        // repo names don't contain "--", so the first occurrence is the
+        // namespace boundary.
+        size_t sep = encoded.find("--");
+        if (sep == std::string::npos || sep == 0 || sep + 2 >= encoded.size()) {
+            return encoded;
+        }
+        return encoded.substr(0, sep) + "/" + encoded.substr(sep + 2);
+    }
+    return "";
+}
+
 // Record a discovered model without ever overwriting one already found. Two
 // extra_models_dir folders can hold identically named files; qualifying the
 // newcomer with its folder keeps both and leaves the first model's id alone.
@@ -1292,6 +1323,11 @@ void ModelManager::discover_extra_models_in_directory(
     std::map<std::string, ModelInfo>& discovered) const {
 
     std::string dir_name = dir_path.filename().string();
+    std::string hf_repo_name = hf_cache_repo_name_for_path(
+        dir_path, path_from_utf8(extra_models_dir_));
+    if (!hf_repo_name.empty()) {
+        dir_name = hf_repo_name;
+    }
     fs::path main_model_path; // File the old folder-based discovery would have selected.
     std::vector<fs::path> mmproj_files;
     double total_size = 0.0;

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -1177,12 +1177,24 @@ ModelInfo ModelManager::init_extra_model_info(const std::string& name) const {
 // so the model keeps a readable name instead of the snapshot hash that would
 // otherwise be read as the containing folder's name. Stops at `stop_at` (the
 // configured extra_models_dir root) so an unrelated ancestor name can't match.
+//
+// A cache directory can hold more than one "snapshots/<hash>" revision (a
+// stale re-download, an older pinned revision, etc). Recovering "org/repo"
+// for all of them would make every snapshot race for the same model id, with
+// whichever one the directory scan happens to visit last silently winning it
+// and the "active" snapshot getting collision-qualified with its hash
+// instead. So when a snapshots/ layout is present, only the snapshot that
+// "refs/main" actually points at is trusted with the recovered name; any
+// other snapshot falls back to the pre-existing hash-named behavior, same as
+// before this recovery existed.
 static std::string hf_cache_repo_name_for_path(const fs::path& path, const fs::path& stop_at) {
     static constexpr const char kHfPrefix[] = "models--";
     static constexpr const char kMsPrefix[] = "modelscope--models--";
+
+    fs::path cache_root;
+    std::string encoded;
     for (fs::path cur = path; cur.has_filename() && cur != stop_at; cur = cur.parent_path()) {
         std::string dirname = cur.filename().string();
-        std::string encoded;
         if (dirname.rfind(kMsPrefix, 0) == 0) {
             encoded = dirname.substr(sizeof(kMsPrefix) - 1);
         } else if (dirname.rfind(kHfPrefix, 0) == 0) {
@@ -1190,16 +1202,33 @@ static std::string hf_cache_repo_name_for_path(const fs::path& path, const fs::p
         } else {
             continue;
         }
-        // registry_repo_cache_dir_name() encodes "org/repo" as "org--repo";
-        // repo names don't contain "--", so the first occurrence is the
-        // namespace boundary.
-        size_t sep = encoded.find("--");
-        if (sep == std::string::npos || sep == 0 || sep + 2 >= encoded.size()) {
-            return encoded;
-        }
-        return encoded.substr(0, sep) + "/" + encoded.substr(sep + 2);
+        cache_root = cur;
+        break;
     }
-    return "";
+    if (cache_root.empty()) {
+        return "";
+    }
+
+    // If `path` sits under cache_root/snapshots/<hash>, that hash must match
+    // refs/main before the recovered name can be trusted.
+    const fs::path snapshots_dir = cache_root / "snapshots";
+    for (fs::path cur = path; cur.has_filename() && cur != cache_root; cur = cur.parent_path()) {
+        if (cur.parent_path() != snapshots_dir) continue;
+        const std::string active_hash = read_hf_ref_main(cache_root);
+        if (active_hash.empty() || active_hash != cur.filename().string()) {
+            return "";
+        }
+        break;
+    }
+
+    // registry_repo_cache_dir_name() encodes "org/repo" as "org--repo";
+    // repo names don't contain "--", so the first occurrence is the
+    // namespace boundary.
+    size_t sep = encoded.find("--");
+    if (sep == std::string::npos || sep == 0 || sep + 2 >= encoded.size()) {
+        return encoded;
+    }
+    return encoded.substr(0, sep) + "/" + encoded.substr(sep + 2);
 }
 
 // Record a discovered model without ever overwriting one already found. Two

--- a/test/server_endpoints.py
+++ b/test/server_endpoints.py
@@ -6621,6 +6621,98 @@ class EndpointTests(ServerTestBase):
             self._set_extra_models_dir(prior_dir)
             shutil.rmtree(extra_dir, ignore_errors=True)
 
+    def test_021yb_extra_hf_cache_layout_recovers_repo_name(self):
+        """A model moved into extra_models_dir with its HF hub layout intact
+        keeps its 'org/repo' name instead of showing the snapshot hash."""
+        extra_dir = tempfile.mkdtemp(prefix="lemon_extra_hfcache_")
+        repo_dir = os.path.join(
+            extra_dir, "models--unsloth--Llama-3.2-3B-Instruct-GGUF"
+        )
+        snapshot_hash = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+        gguf_path = os.path.join(
+            repo_dir, "snapshots", snapshot_hash, "Llama-3.2-3B-Instruct-Q4_K_M.gguf"
+        )
+        self._write_stub_gguf_file(gguf_path)
+        os.makedirs(os.path.join(repo_dir, "refs"), exist_ok=True)
+        with open(os.path.join(repo_dir, "refs", "main"), "w") as f:
+            f.write(snapshot_hash)
+
+        prior_dir = self._set_extra_models_dir(extra_dir)
+        try:
+            models_response = requests.get(
+                f"{self.base_url}/models?show_all=true", timeout=TIMEOUT_DEFAULT
+            )
+            self.assertEqual(models_response.status_code, 200)
+            ids = {m["id"] for m in models_response.json()["data"]}
+
+            self.assertIn(
+                "extra.unsloth/Llama-3.2-3B-Instruct-GGUF",
+                ids,
+                f"expected recovered repo name in {ids}",
+            )
+            self.assertNotIn(
+                f"extra.{snapshot_hash}",
+                ids,
+                "should not fall back to the raw snapshot hash",
+            )
+
+            print("[OK] HF-cache-layout extra model recovers org/repo name")
+        finally:
+            self._set_extra_models_dir(prior_dir)
+            shutil.rmtree(extra_dir, ignore_errors=True)
+
+    def test_021yc_extra_hf_cache_multiple_snapshots_prefers_active_ref(self):
+        """Only the snapshot refs/main points at claims the recovered repo
+        name; a stale snapshot falls back so the two don't collide (#3297)."""
+        extra_dir = tempfile.mkdtemp(prefix="lemon_extra_hfcache_multi_")
+        repo_dir = os.path.join(extra_dir, "models--unsloth--Qwen3-4B-GGUF")
+        old_hash = "1111111111111111111111111111111111111a"
+        active_hash = "2222222222222222222222222222222222222b"
+
+        old_gguf = os.path.join(
+            repo_dir, "snapshots", old_hash, "Qwen3-4B-Q4_K_M.gguf"
+        )
+        active_gguf = os.path.join(
+            repo_dir, "snapshots", active_hash, "Qwen3-4B-Q4_K_M.gguf"
+        )
+        self._write_stub_gguf_file(old_gguf)
+        self._write_stub_gguf_file(active_gguf)
+        os.makedirs(os.path.join(repo_dir, "refs"), exist_ok=True)
+        with open(os.path.join(repo_dir, "refs", "main"), "w") as f:
+            f.write(active_hash)
+
+        prior_dir = self._set_extra_models_dir(extra_dir)
+        try:
+            models_response = requests.get(
+                f"{self.base_url}/models?show_all=true", timeout=TIMEOUT_DEFAULT
+            )
+            self.assertEqual(models_response.status_code, 200)
+            by_checkpoint = {
+                m["checkpoint"]: m["id"] for m in models_response.json()["data"]
+            }
+
+            self.assertEqual(
+                by_checkpoint.get(active_gguf),
+                "extra.unsloth/Qwen3-4B-GGUF",
+                f"active snapshot should claim the clean repo name: {by_checkpoint}",
+            )
+            self.assertIsNotNone(
+                by_checkpoint.get(old_gguf),
+                "old snapshot's model should still be discovered",
+            )
+            self.assertNotEqual(
+                by_checkpoint.get(old_gguf),
+                "extra.unsloth/Qwen3-4B-GGUF",
+                "a non-active snapshot must not also claim the active name",
+            )
+
+            print(
+                "[OK] multi-snapshot HF cache: only refs/main snapshot recovers repo name"
+            )
+        finally:
+            self._set_extra_models_dir(prior_dir)
+            shutil.rmtree(extra_dir, ignore_errors=True)
+
     def test_021r_openai_chat_extra_models_precedence(self):
         """Regression test for #2014: OpenAI API resolves aliases to local files, shadowing built-ins."""
         # Use a built-in model name to prove precedence and alias resolution simultaneously


### PR DESCRIPTION
<!--
Before submitting this PR, please read:
- docs/dev/contribute.md
- docs/dev/philosophy.md
- AGENTS.md if you used an AI coding agent or AI-assisted workflow
- docs/dev/documentation.md if this PR changes user-facing or developer-facing documentation
-->

## Summary

`discover_extra_models_in_directory` named an extra-directory model after its immediate containing folder. When a model is moved into `extra_models_dir` with its Hugging Face cache layout intact (`models--org--repo/snapshots/<hash>/...`), that folder is the snapshot hash, so the model showed up with an unreadable hash instead of its name once moved out of the default cache location.

This walks up from the discovered file to the `models--`/`modelscope--models--` ancestor (bounded by the configured `extra_models_dir` root) and decodes it back to `org/repo` when that layout is present, falling back to the previous folder-name behavior otherwise.

Fixes #3297

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [ ] Code builds without errors locally.
- [ ] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_
No C++ toolchain was available in the environment this change was authored in, so I was not able to build or run this locally — please let me know if CI surfaces anything and I'll fix it quickly. I traced the change carefully against the existing "walk up to `models--` ancestor" pattern already used elsewhere in this file (the delete-path cache lookup a few hundred lines down) to keep the decode logic consistent with it, and checked that the recovered name flows correctly through both the split-variant alias path and the non-split id path later in the function.

## Documentation

- [x] Documentation is not affected by this change.

## Breaking Changes

- [x] This PR does not introduce breaking changes.

## AI-assisted contribution

- [x] I used AI tools for this PR.

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.
