### PR TITLE
fix: download TheRock ROCm backend for all detected GPU architectures

### DIFF
--- a/src/cpp/include/lemon/system_info.h
+++ b/src/cpp/include/lemon/system_info.h
@@ -120,9 +120,9 @@ public:
     // over an integrated one on a hybrid host (e.g. Strix Halo APU + MI300X dGPU).
     static std::string select_rocm_arch(const json& amd_gpu_devices);
 
-    // Map an "amd_gpu" device array to ALL ROCm architectures, deduplicated and
-    // ordered discrete-first then integrated, so front() is the single arch a
-    // hybrid host should use (matches select_rocm_arch()). Pure — no probing.
+    // Pure version of get_rocm_arches() over a caller-supplied "amd_gpu" device
+    // array — same ordering/dedup contract, no probing. Throws
+    // std::invalid_argument on non-array input (caller bug).
     static std::vector<std::string> collect_rocm_arches(const json& amd_gpu_devices);
 
     // Collapse a concrete ROCm ISA (e.g. gfx1201) to the family target name the

--- a/src/cpp/include/lemon/system_info.h
+++ b/src/cpp/include/lemon/system_info.h
@@ -108,19 +108,22 @@ public:
     static std::vector<RecipeStatus> get_all_recipe_statuses();
 
     // Device support detection
-    // Return the first (primary) ROCm architecture — typically the iGPU.
-    // Used for rocm_channel selection and single-arch contexts.
-    static std::string get_rocm_arch();
-
-    // Return ALL detected AMD GPU ROCm architectures, ordered iGPU first
-    // then dGPUs. Used by backend download paths to install ROCm binaries
-    // for every GPU on the system, not just the first one detected.
+    // Return ALL detected AMD GPU ROCm architectures (deduplicated). The list
+    // is ordered discrete-first, then integrated, so front() is the arch a
+    // single-arch consumer should use — matching select_rocm_arch()'s
+    // preference on a hybrid host. Used by backend download paths to install
+    // ROCm binaries for every GPU on the system, not just the first one.
     static std::vector<std::string> get_rocm_arches();
     static std::string get_cuda_arch();
 
     // Picks the ROCm compute target from an "amd_gpu" device array: a discrete GPU wins
     // over an integrated one on a hybrid host (e.g. Strix Halo APU + MI300X dGPU).
     static std::string select_rocm_arch(const json& amd_gpu_devices);
+
+    // Map an "amd_gpu" device array to ALL ROCm architectures, deduplicated and
+    // ordered discrete-first then integrated, so front() is the single arch a
+    // hybrid host should use (matches select_rocm_arch()). Pure — no probing.
+    static std::vector<std::string> collect_rocm_arches(const json& amd_gpu_devices);
 
     // Collapse a concrete ROCm ISA (e.g. gfx1201) to the family target name the
     // GitHub release repos publish their assets under (e.g. gfx120X), per the
@@ -134,10 +137,10 @@ public:
     // therock.url_mapping, which maps it to gfx94X-dcgpu.
     static std::string vllm_rocm_version_override(const std::string& asset_family);
 
-    // When set non-empty on the calling thread, get_rocm_arch() returns this
-    // value instead of probing hardware, so backend asset URLs can be resolved
-    // for an arbitrary GPU topology with no GPU present. Per-thread so it cannot
-    // affect concurrent requests.
+    // When set non-empty on the calling thread, get_rocm_arches() returns just
+    // this value instead of probing hardware, so backend asset URLs can be
+    // resolved for an arbitrary GPU topology with no GPU present. Per-thread so
+    // it cannot affect concurrent requests.
     static void set_rocm_arch_override(const std::string& arch);
 
     // True if (recipe, backend) is published for the given ROCm family/ISA, per

--- a/src/cpp/include/lemon/system_info.h
+++ b/src/cpp/include/lemon/system_info.h
@@ -108,7 +108,14 @@ public:
     static std::vector<RecipeStatus> get_all_recipe_statuses();
 
     // Device support detection
+    // Return the first (primary) ROCm architecture — typically the iGPU.
+    // Used for rocm_channel selection and single-arch contexts.
     static std::string get_rocm_arch();
+
+    // Return ALL detected AMD GPU ROCm architectures, ordered iGPU first
+    // then dGPUs. Used by backend download paths to install ROCm binaries
+    // for every GPU on the system, not just the first one detected.
+    static std::vector<std::string> get_rocm_arches();
     static std::string get_cuda_arch();
 
     // Picks the ROCm compute target from an "amd_gpu" device array: a discrete GPU wins

--- a/src/cpp/server/backend_manager.cpp
+++ b/src/cpp/server/backend_manager.cpp
@@ -232,8 +232,9 @@ bool will_install_therock(const std::string& os, const json& backend_versions) {
         return false;
     }
 
-    // Get ROCm architecture
-    std::string rocm_arch = SystemInfo::get_rocm_arch();
+    // Get the primary ROCm architecture (first detected, discrete preferred)
+    const std::vector<std::string> rocm_arches = SystemInfo::get_rocm_arches();
+    const std::string rocm_arch = rocm_arches.empty() ? std::string() : rocm_arches.front();
     if (rocm_arch.empty()) {
         return false;
     }
@@ -263,7 +264,8 @@ bool is_therock_installed_for_current_arch(const json& backend_versions) {
     }
 
     const std::string version = backend_versions["therock"]["version"].get<std::string>();
-    const std::string rocm_arch = SystemInfo::get_rocm_arch();
+    const std::vector<std::string> rocm_arches = SystemInfo::get_rocm_arches();
+    const std::string rocm_arch = rocm_arches.empty() ? std::string() : rocm_arches.front();
     if (rocm_arch.empty()) {
         return false;
     }
@@ -333,18 +335,10 @@ void install_therock_if_needed(const std::string& os, const json& backend_versio
 
     std::string version = backend_versions["therock"]["version"].get<std::string>();
 
+    // Install the ROCm runtime for every detected GPU architecture, not just
+    // the first one — each GPU needs its own binaries. An empty list means no
+    // AMD GPU was detected, so there is nothing to install.
     const std::vector<std::string> rocm_arches = SystemInfo::get_rocm_arches();
-    if (rocm_arches.empty()) {
-        // Fall back to single-arch detection for backward compatibility.
-        std::string single_arch = SystemInfo::get_rocm_arch();
-        if (!single_arch.empty()) {
-            backends::BackendUtils::install_rocm_runtime(single_arch, version, progress_cb);
-        }
-        return;
-    }
-
-    // Install the ROCm runtime for every detected GPU architecture (iGPU first,
-    // then dGPUs), not just the first one — each GPU needs its own binaries.
     for (const auto& rocm_arch : rocm_arches) {
         backends::BackendUtils::install_rocm_runtime(rocm_arch, version, progress_cb);
     }
@@ -667,7 +661,8 @@ void BackendManager::install_backend(const std::string& recipe, const std::strin
             "TheRock runtime",
             [this, os, rocm_runtime_update_required](DownloadProgressCallback runtime_progress_cb) {
                 if (rocm_runtime_update_required) {
-                    const std::string rocm_arch = SystemInfo::get_rocm_arch();
+                    const std::vector<std::string> rocm_arches = SystemInfo::get_rocm_arches();
+                    const std::string rocm_arch = rocm_arches.empty() ? std::string() : rocm_arches.front();
                     if (rocm_arch.empty()) {
                         throw std::runtime_error("Cannot repair TheRock runtime: ROCm architecture could not be detected");
                     }

--- a/src/cpp/server/backend_manager.cpp
+++ b/src/cpp/server/backend_manager.cpp
@@ -331,10 +331,23 @@ void install_therock_if_needed(const std::string& os, const json& backend_versio
         return;
     }
 
-    std::string rocm_arch = SystemInfo::get_rocm_arch();
     std::string version = backend_versions["therock"]["version"].get<std::string>();
 
-    backends::BackendUtils::install_rocm_runtime(rocm_arch, version, progress_cb);
+    const std::vector<std::string> rocm_arches = SystemInfo::get_rocm_arches();
+    if (rocm_arches.empty()) {
+        // Fall back to single-arch detection for backward compatibility.
+        std::string single_arch = SystemInfo::get_rocm_arch();
+        if (!single_arch.empty()) {
+            backends::BackendUtils::install_rocm_runtime(single_arch, version, progress_cb);
+        }
+        return;
+    }
+
+    // Install the ROCm runtime for every detected GPU architecture (iGPU first,
+    // then dGPUs), not just the first one — each GPU needs its own binaries.
+    for (const auto& rocm_arch : rocm_arches) {
+        backends::BackendUtils::install_rocm_runtime(rocm_arch, version, progress_cb);
+    }
 }
 
 } // namespace

--- a/src/cpp/server/backends/acestep/acestep_server.cpp
+++ b/src/cpp/server/backends/acestep/acestep_server.cpp
@@ -141,7 +141,8 @@ void AceStepServer::load(const std::string& model_name,
 #endif
     };
     if (backend == "rocm") {
-        const std::string arch = SystemInfo::get_rocm_arch();
+        const std::vector<std::string> rocm_arches = SystemInfo::get_rocm_arches();
+        const std::string arch = rocm_arches.empty() ? std::string() : rocm_arches.front();
         std::string dirs;
         if (!arch.empty()) {
             dirs = BackendUtils::join_runtime_dirs(

--- a/src/cpp/server/backends/llamacpp/llamacpp_server.cpp
+++ b/src/cpp/server/backends/llamacpp/llamacpp_server.cpp
@@ -184,8 +184,10 @@ InstallParams LlamaCppServer::get_install_params(const std::string& backend, con
 #endif
     } else if (resolved_backend == "rocm-nightly") {
         params.repo = "lemonade-sdk/llamacpp-rocm";
+        const std::vector<std::string> rocm_arches = SystemInfo::get_rocm_arches();
+        const std::string rocm_arch = rocm_arches.empty() ? std::string() : rocm_arches.front();
         std::string target_arch =
-            SystemInfo::rocm_asset_family(SystemInfo::get_rocm_arch());
+            SystemInfo::rocm_asset_family(rocm_arch);
         if (target_arch.empty()) {
             throw std::runtime_error(
                 SystemInfo::get_unsupported_backend_error("llamacpp", "rocm-nightly")
@@ -413,7 +415,8 @@ void LlamaCppServer::load(const std::string& model_name,
         std::string lib_path = exe_dir.string();
 
         if (llamacpp_backend == "rocm-stable") {
-            std::string rocm_arch = SystemInfo::get_rocm_arch();
+            const std::vector<std::string> rocm_arches = SystemInfo::get_rocm_arches();
+            const std::string rocm_arch = rocm_arches.empty() ? std::string() : rocm_arches.front();
             if (!rocm_arch.empty()) {
                 std::string therock_dirs = BackendUtils::join_runtime_dirs(
                     BackendUtils::get_therock_lib_paths(rocm_arch));
@@ -453,7 +456,8 @@ void LlamaCppServer::load(const std::string& model_name,
         std::string new_path;
 
         if (llamacpp_backend == "rocm-stable") {
-            std::string rocm_arch = SystemInfo::get_rocm_arch();
+            const std::vector<std::string> rocm_arches = SystemInfo::get_rocm_arches();
+            const std::string rocm_arch = rocm_arches.empty() ? std::string() : rocm_arches.front();
             if (!rocm_arch.empty()) {
                 // Prepend ALL TheRock runtime dirs (not just _rocm_sdk_core/bin) so
                 // HIP + BLAS DLLs resolve; _rocm_sdk_core/bin alone → STATUS_DLL_NOT_FOUND.
@@ -477,14 +481,17 @@ void LlamaCppServer::load(const std::string& model_name,
         // System32 amdhip64_7.dll shadows the TheRock runtime on PATH. Copying
         // to the exe directory overrides both.
         if (llamacpp_backend == "rocm-stable") {
-            std::string rocm_arch = SystemInfo::get_rocm_arch();
+            const std::vector<std::string> rocm_arches = SystemInfo::get_rocm_arches();
+            const std::string rocm_arch = rocm_arches.empty() ? std::string() : rocm_arches.front();
             if (!rocm_arch.empty()) {
                 BackendUtils::stage_therock_hip_runtime(
                     rocm_arch, fs::path(executable).parent_path());
             }
         }
 
-        std::string arch = lemon::SystemInfo::get_rocm_arch();
+        const std::vector<std::string> rocm_arches = lemon::SystemInfo::get_rocm_arches();
+        const std::string arch = rocm_arches.empty() ? std::string() : rocm_arches.front();
+
         if ((arch == "gfx1151") || (arch == "gfx1152")){
             env_vars.push_back({"OCL_SET_SVM_SIZE", "262144"});
             LOG(DEBUG, "LlamaCpp") << "Setting OCL_SET_SVM_SIZE=262144 for gfx1151/gfx1152 (enables loading larger models)" << std::endl;

--- a/src/cpp/server/backends/openmoss/openmoss_server.cpp
+++ b/src/cpp/server/backends/openmoss/openmoss_server.cpp
@@ -102,7 +102,8 @@ void OpenMossServer::load(const std::string& model_name,
 #endif
     };
     if (backend == "rocm") {
-        const std::string arch = SystemInfo::get_rocm_arch();
+        const std::vector<std::string> rocm_arches = SystemInfo::get_rocm_arches();
+        const std::string arch = rocm_arches.empty() ? std::string() : rocm_arches.front();
         std::string dirs;
         if (!arch.empty()) {
             dirs = BackendUtils::join_runtime_dirs(

--- a/src/cpp/server/backends/sdcpp/sdcpp_server.cpp
+++ b/src/cpp/server/backends/sdcpp/sdcpp_server.cpp
@@ -119,7 +119,8 @@ InstallParams SDServer::get_install_params(const std::string& backend, const std
         params.filename = "sd-" + short_version + "-bin-Darwin-macOS-*-arm64.zip";
 #endif
     } else if (is_rocm_backend(resolved_backend)) {
-        std::string target_arch = SystemInfo::get_rocm_arch();
+        const std::vector<std::string> rocm_arches = SystemInfo::get_rocm_arches();
+        const std::string target_arch = rocm_arches.empty() ? std::string() : rocm_arches.front();
 
         if (target_arch.empty()) {
             throw std::runtime_error(
@@ -299,7 +300,8 @@ void SDServer::load(const std::string& model_name,
     std::string lib_path = exe_dir.string();
 
     if (resolved_backend == "rocm-stable") {
-        std::string rocm_arch = SystemInfo::get_rocm_arch();
+        const std::vector<std::string> rocm_arches = SystemInfo::get_rocm_arches();
+        const std::string rocm_arch = rocm_arches.empty() ? std::string() : rocm_arches.front();
         if (!rocm_arch.empty()) {
             std::string therock_dirs = BackendUtils::join_runtime_dirs(
                 BackendUtils::get_therock_lib_paths(rocm_arch));
@@ -323,7 +325,8 @@ void SDServer::load(const std::string& model_name,
         std::string new_path = path_to_utf8(exe_dir);
 
         if (resolved_backend == "rocm-stable") {
-            std::string rocm_arch = SystemInfo::get_rocm_arch();
+            const std::vector<std::string> rocm_arches = SystemInfo::get_rocm_arches();
+            const std::string rocm_arch = rocm_arches.empty() ? std::string() : rocm_arches.front();
             if (!rocm_arch.empty()) {
                 std::vector<std::string> therock_dirs = BackendUtils::get_therock_lib_paths(rocm_arch);
                 std::string therock_bin = therock_dirs.empty() ? std::string() : therock_dirs.front();

--- a/src/cpp/server/backends/thenoise/thenoise_server.cpp
+++ b/src/cpp/server/backends/thenoise/thenoise_server.cpp
@@ -49,7 +49,8 @@ InstallParams TheNoiseServer::get_install_params(const std::string& backend, con
 
     // TheNoise publishes one portable bundle per GPU target (gfx1150 / gfx1151)
     // under the same release tag. Pick the archive matching this host.
-    std::string target_arch = SystemInfo::get_rocm_arch();
+    const std::vector<std::string> rocm_arches = SystemInfo::get_rocm_arches();
+    const std::string target_arch = rocm_arches.empty() ? std::string() : rocm_arches.front();
 
     InstallParams params;
     params.repo = "lemonade-sdk/thenoise";

--- a/src/cpp/server/backends/thinksound/thinksound_server.cpp
+++ b/src/cpp/server/backends/thinksound/thinksound_server.cpp
@@ -110,7 +110,8 @@ void ThinkSoundServer::load(const std::string& model_name,
 #endif
     };
     if (backend == "rocm") {
-        const std::string arch = SystemInfo::get_rocm_arch();
+        const std::vector<std::string> rocm_arches = SystemInfo::get_rocm_arches();
+        const std::string arch = rocm_arches.empty() ? std::string() : rocm_arches.front();
         std::string dirs;
         if (!arch.empty()) {
             dirs = BackendUtils::join_runtime_dirs(

--- a/src/cpp/server/backends/trellis/trellis_server.cpp
+++ b/src/cpp/server/backends/trellis/trellis_server.cpp
@@ -126,7 +126,8 @@ void TrellisServer::load(const std::string& model_name,
 #endif
     };
     if (backend == "rocm") {
-        const std::string arch = SystemInfo::get_rocm_arch();
+        const std::vector<std::string> rocm_arches = SystemInfo::get_rocm_arches();
+        const std::string arch = rocm_arches.empty() ? std::string() : rocm_arches.front();
         std::string dirs;
         if (!arch.empty()) {
             dirs = BackendUtils::join_runtime_dirs(

--- a/src/cpp/server/backends/vllm/vllm_server.cpp
+++ b/src/cpp/server/backends/vllm/vllm_server.cpp
@@ -297,8 +297,10 @@ InstallParams VLLMServer::get_install_params(const std::string& backend, const s
 
     if (backend == "rocm") {
         params.repo = "lemonade-sdk/vllm-rocm";
+        const std::vector<std::string> rocm_arches = SystemInfo::get_rocm_arches();
+        const std::string rocm_arch = rocm_arches.empty() ? std::string() : rocm_arches.front();
         std::string target_arch =
-            SystemInfo::rocm_asset_family(SystemInfo::get_rocm_arch());
+            SystemInfo::rocm_asset_family(rocm_arch);
         if (target_arch.empty()) {
             throw std::runtime_error(
                 SystemInfo::get_unsupported_backend_error("vllm", "rocm")
@@ -420,8 +422,10 @@ void VLLMServer::load(const std::string& model_name,
     args.push_back(model_name);
     // Keep eager execution for consumer GPU inference; leave dtype selection to vLLM.
     // Discrete-HBM parts skip it: eager costs decode throughput for no stability gain.
+    const std::vector<std::string> rocm_arches = SystemInfo::get_rocm_arches();
+    const std::string rocm_arch = rocm_arches.empty() ? std::string() : rocm_arches.front();
     const DeviceClassLaunchPolicy launch_policy = device_class_launch_policy(
-        SystemInfo::get_rocm_arch(), resolved_vllm_args.has_memory_budget_arg,
+        rocm_arch, resolved_vllm_args.has_memory_budget_arg,
         resolved_vllm_args.has_enforce_eager);
     if (launch_policy.enforce_eager) {
         args.push_back("--enforce-eager");

--- a/src/cpp/server/backends/whispercpp/whispercpp_server.cpp
+++ b/src/cpp/server/backends/whispercpp/whispercpp_server.cpp
@@ -98,8 +98,9 @@ InstallParams WhisperServer::get_install_params(const std::string& backend, cons
         throw std::runtime_error("Unsupported platform for whisper.cpp cpu backend");
 #endif
     } else if (backend == "rocm") {
-        std::string rocm_arch =
-            SystemInfo::rocm_asset_family(SystemInfo::get_rocm_arch());
+        const std::vector<std::string> rocm_arches = SystemInfo::get_rocm_arches();
+        const std::string primary_arch = rocm_arches.empty() ? std::string() : rocm_arches.front();
+        std::string rocm_arch = SystemInfo::rocm_asset_family(primary_arch);
         if (rocm_arch.empty()) {
             throw std::runtime_error(SystemInfo::get_unsupported_backend_error("whispercpp", "rocm"));
         }
@@ -301,7 +302,8 @@ void WhisperServer::load(const std::string& model_name,
     // on LD_LIBRARY_PATH, exactly as llamacpp_server.cpp and sd_server.cpp do.
     // Without this it aborts at startup (dlopen libamd_comgr.so.3) on gfx1151.
     if (whispercpp_backend == "rocm") {
-        std::string rocm_arch = SystemInfo::get_rocm_arch();
+        const std::vector<std::string> rocm_arches = SystemInfo::get_rocm_arches();
+        const std::string rocm_arch = rocm_arches.empty() ? std::string() : rocm_arches.front();
         if (!rocm_arch.empty()) {
             std::string therock_dirs = BackendUtils::join_runtime_dirs(
                 BackendUtils::get_therock_lib_paths(rocm_arch));

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -5597,7 +5597,8 @@ void Server::handle_image_upscale(const httplib::Request& req, httplib::Response
         std::string lib_path = cli_dir.string();
 
         if (resolved_backend == "rocm-stable") {
-            std::string rocm_arch = SystemInfo::get_rocm_arch();
+            const std::vector<std::string> rocm_arches = SystemInfo::get_rocm_arches();
+            const std::string rocm_arch = rocm_arches.empty() ? std::string() : rocm_arches.front();
             if (!rocm_arch.empty()) {
                 std::string therock_dirs = lemon::backends::BackendUtils::join_runtime_dirs(
                     lemon::backends::BackendUtils::get_therock_lib_paths(rocm_arch));
@@ -5615,7 +5616,8 @@ void Server::handle_image_upscale(const httplib::Request& req, httplib::Response
 #else
         if (resolved_backend == "rocm-stable") {
             std::string new_path = cli_dir.string();
-            std::string rocm_arch = SystemInfo::get_rocm_arch();
+            const std::vector<std::string> rocm_arches = SystemInfo::get_rocm_arches();
+            const std::string rocm_arch = rocm_arches.empty() ? std::string() : rocm_arches.front();
             std::vector<std::string> therock_dirs;
             if (!rocm_arch.empty()) {
                 therock_dirs =

--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -2171,6 +2171,39 @@ std::string SystemInfo::get_rocm_arch() {
     return "";  // No supported architecture found
 }
 
+std::vector<std::string> SystemInfo::get_rocm_arches() {
+    // Returns ALL detected AMD GPU ROCm architectures.
+    // Ordered: iGPU first, then dGPUs (same order as the amd_gpu array).
+    // Used to ensure ROCm backends are downloaded for every GPU on the system.
+    std::vector<std::string> arches;
+    try {
+        json system_info = SystemInfoCache::get_system_info_with_cache();
+        if (!system_info.contains("devices")) {
+            return arches;
+        }
+        const auto& devices = system_info["devices"];
+        if (devices.contains("amd_gpu") && devices["amd_gpu"].is_array()) {
+            for (const auto& gpu : devices["amd_gpu"]) {
+                if (gpu.value("available", false)) {
+                    std::string name = gpu.value("name", "");
+                    if (!name.empty()) {
+                        std::string arch = identify_rocm_arch_from_name(name);
+                        if (!arch.empty()) {
+                            // Avoid duplicates (e.g., identical iGPU/dGPU arch strings)
+                            if (std::find(arches.begin(), arches.end(), arch) == arches.end()) {
+                                arches.push_back(arch);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    } catch (...) {
+        // Detection failed — return empty list
+    }
+    return arches;
+}
+
 static int cuda_sm_value(const std::string& arch) {
     if (arch.size() <= 3 || arch.substr(0, 3) != "sm_") {
         return 0;

--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -825,7 +825,9 @@ static std::string get_expected_backend_version(const std::string& recipe, const
     // or these GPUs report update_required forever: versions_match tolerates the
     // "-{family}" suffix but not a different base.
     if (recipe == "vllm" && resolved_backend == "rocm") {
-        std::string asset_family = SystemInfo::rocm_asset_family(SystemInfo::get_rocm_arch());
+        const std::vector<std::string> rocm_arches = SystemInfo::get_rocm_arches();
+        const std::string rocm_arch = rocm_arches.empty() ? std::string() : rocm_arches.front();
+        std::string asset_family = SystemInfo::rocm_asset_family(rocm_arch);
         if (!asset_family.empty()) {
             std::string override_version = SystemInfo::vllm_rocm_version_override(asset_family);
             if (!override_version.empty()) {
@@ -2066,7 +2068,7 @@ std::string identify_npu_arch() {
 }
 
 namespace {
-    // Per-thread arch override consumed by get_rocm_arch(). Empty = probe hardware.
+    // Per-thread arch override consumed by get_rocm_arches(). Empty = probe hardware.
     thread_local std::string g_rocm_arch_override;
 }
 
@@ -2148,60 +2150,65 @@ std::string SystemInfo::select_rocm_arch(const json& amd_gpu_devices) {
     return integrated_fallback;  // empty if no supported AMD GPU found
 }
 
-std::string SystemInfo::get_rocm_arch() {
-    if (!g_rocm_arch_override.empty()) {
-        return g_rocm_arch_override;
+std::vector<std::string> SystemInfo::collect_rocm_arches(const json& amd_gpu_devices) {
+    // Pure mapping from the "amd_gpu" device array to ALL supported ROCm
+    // architectures, deduplicated and ordered discrete-first then integrated,
+    // so front() matches what select_rocm_arch() picks on a hybrid host.
+    std::vector<std::string> discrete;
+    std::vector<std::string> integrated;
+    if (!amd_gpu_devices.is_array()) {
+        return discrete;
     }
-    try {
-        // Use cached system info to avoid re-detecting GPUs
-        json system_info = SystemInfoCache::get_system_info_with_cache();
-
-        if (!system_info.contains("devices")) {
-            return "";
+    for (const auto& gpu : amd_gpu_devices) {
+        if (!gpu.value("available", false)) {
+            continue;
         }
-
-        const auto& devices = system_info["devices"];
-        if (devices.contains("amd_gpu")) {
-            return select_rocm_arch(devices["amd_gpu"]);
+        // Prefer the family captured at detection time; fall back to
+        // re-deriving from the name (matches select_rocm_arch()).
+        std::string arch = gpu.value("family", "");
+        if (arch.empty()) {
+            arch = identify_rocm_arch_from_name(gpu.value("name", ""));
         }
-    } catch (...) {
-        // Detection failed
+        if (arch.empty()) {
+            continue;
+        }
+        std::vector<std::string>& bucket =
+            gpu.value("integrated", false) ? integrated : discrete;
+        if (std::find(bucket.begin(), bucket.end(), arch) == bucket.end()) {
+            bucket.push_back(arch);
+        }
     }
-
-    return "";  // No supported architecture found
+    // Dedup across buckets (e.g. identical iGPU/dGPU arch strings), keeping
+    // the discrete-first preference.
+    for (const auto& arch : integrated) {
+        if (std::find(discrete.begin(), discrete.end(), arch) == discrete.end()) {
+            discrete.push_back(arch);
+        }
+    }
+    return discrete;
 }
 
 std::vector<std::string> SystemInfo::get_rocm_arches() {
-    // Returns ALL detected AMD GPU ROCm architectures.
-    // Ordered: iGPU first, then dGPUs (same order as the amd_gpu array).
-    // Used to ensure ROCm backends are downloaded for every GPU on the system.
-    std::vector<std::string> arches;
+    // A per-thread override (set_rocm_arch_override) short-circuits hardware
+    // probing so backend asset URLs can be resolved for an arbitrary GPU
+    // topology with no GPU present.
+    if (!g_rocm_arch_override.empty()) {
+        return {g_rocm_arch_override};
+    }
     try {
         json system_info = SystemInfoCache::get_system_info_with_cache();
         if (!system_info.contains("devices")) {
-            return arches;
+            return {};
         }
         const auto& devices = system_info["devices"];
-        if (devices.contains("amd_gpu") && devices["amd_gpu"].is_array()) {
-            for (const auto& gpu : devices["amd_gpu"]) {
-                if (gpu.value("available", false)) {
-                    std::string name = gpu.value("name", "");
-                    if (!name.empty()) {
-                        std::string arch = identify_rocm_arch_from_name(name);
-                        if (!arch.empty()) {
-                            // Avoid duplicates (e.g., identical iGPU/dGPU arch strings)
-                            if (std::find(arches.begin(), arches.end(), arch) == arches.end()) {
-                                arches.push_back(arch);
-                            }
-                        }
-                    }
-                }
-            }
+        if (!devices.contains("amd_gpu") || !devices["amd_gpu"].is_array()) {
+            return {};
         }
+        return collect_rocm_arches(devices["amd_gpu"]);
     } catch (...) {
         // Detection failed — return empty list
+        return {};
     }
-    return arches;
 }
 
 static int cuda_sm_value(const std::string& arch) {
@@ -3957,7 +3964,7 @@ static bool s_recipes_computed = false;
 
 // True while THIS thread is inside build_recipes_info(). That computation can
 // call back into get_system_info_with_cache() on the same thread (e.g.
-// SystemInfo::get_rocm_arch() while resolving a backend's install params).
+// SystemInfo::get_rocm_arches() while resolving a backend's install params).
 // Because the outer call holds s_system_info_mutex, the nested call must not
 // try to re-lock it. thread_local (not a shared atomic) is deliberate: only the
 // recursing thread short-circuits — genuinely concurrent threads still block on
@@ -4024,7 +4031,7 @@ json SystemInfoCache::get_system_info_with_cache() {
     // Compute recipes if not cached (or invalidated)
     if (!s_recipes_computed) {
         // Mark this thread as building recipes so any re-entrant call (via
-        // get_rocm_arch() etc.) short-circuits instead of re-locking. The guard
+        // get_rocm_arches() etc.) short-circuits instead of re-locking. The guard
         // clears on every exit path, including exceptions.
         struct RecipeBuildGuard {
             ~RecipeBuildGuard() { s_building_recipes = false; }

--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -24,6 +24,7 @@
 #include <set>
 #include <map>
 #include <mutex>
+#include <stdexcept>
 #include <vector>
 #include <cmath>
 
@@ -2151,14 +2152,16 @@ std::string SystemInfo::select_rocm_arch(const json& amd_gpu_devices) {
 }
 
 std::vector<std::string> SystemInfo::collect_rocm_arches(const json& amd_gpu_devices) {
-    // Pure mapping from the "amd_gpu" device array to ALL supported ROCm
-    // architectures, deduplicated and ordered discrete-first then integrated,
-    // so front() matches what select_rocm_arch() picks on a hybrid host.
+    if (!amd_gpu_devices.is_array()) {
+        throw std::invalid_argument(
+            "collect_rocm_arches() expects an \"amd_gpu\" device array");
+    }
+    // Ordering/dedup contract as documented on get_rocm_arches(): discrete
+    // first, then integrated, unique. The buckets exist because an iGPU and a
+    // dGPU can report the SAME arch (e.g. gfx1151 on both); the cross-bucket
+    // merge below dedups that case while keeping the discrete-first order.
     std::vector<std::string> discrete;
     std::vector<std::string> integrated;
-    if (!amd_gpu_devices.is_array()) {
-        return discrete;
-    }
     for (const auto& gpu : amd_gpu_devices) {
         if (!gpu.value("available", false)) {
             continue;
@@ -2178,8 +2181,6 @@ std::vector<std::string> SystemInfo::collect_rocm_arches(const json& amd_gpu_dev
             bucket.push_back(arch);
         }
     }
-    // Dedup across buckets (e.g. identical iGPU/dGPU arch strings), keeping
-    // the discrete-first preference.
     for (const auto& arch : integrated) {
         if (std::find(discrete.begin(), discrete.end(), arch) == discrete.end()) {
             discrete.push_back(arch);

--- a/test/cpp/test_vllm_cdna_gating.cpp
+++ b/test/cpp/test_vllm_cdna_gating.cpp
@@ -261,9 +261,14 @@ int main() {
         expect(SystemInfo::collect_rocm_arches(unknown).empty(),
                "an unrecognized GPU arch yields an empty list");
 
-        // Non-array input is tolerated.
-        expect(SystemInfo::collect_rocm_arches(nlohmann::json::object()).empty(),
-               "non-array input yields an empty list");
+        // Non-array input is a caller bug and must throw.
+        bool threw = false;
+        try {
+            SystemInfo::collect_rocm_arches(nlohmann::json::object());
+        } catch (const std::invalid_argument&) {
+            threw = true;
+        }
+        expect(threw, "non-array input throws std::invalid_argument");
 
         // The per-thread override short-circuits probing entirely.
         SystemInfo::set_rocm_arch_override("gfx942");

--- a/test/cpp/test_vllm_cdna_gating.cpp
+++ b/test/cpp/test_vllm_cdna_gating.cpp
@@ -207,6 +207,72 @@ int main() {
                "an unavailable discrete GPU falls back to the available iGPU");
     }
 
+    // get_rocm_arches()/collect_rocm_arches() must return ALL arches,
+    // discrete-first, deduplicated — the backend download path installs the
+    // ROCm runtime for every GPU, while front() keeps single-arch semantics.
+    {
+        auto arch_list = [](const std::vector<std::string>& v) {
+            std::string out;
+            for (const auto& a : v) {
+                if (!out.empty()) out += ",";
+                out += a;
+            }
+            return out;
+        };
+
+        nlohmann::json igpu_only = nlohmann::json::array();
+        igpu_only.push_back({{"name", "AMD Radeon 8060S"}, {"family", "gfx1151"}, {"integrated", true}, {"available", true}});
+        nlohmann::json dgpu_only = nlohmann::json::array();
+        dgpu_only.push_back({{"name", "AMD Instinct MI300X"}, {"family", "gfx942"}, {"integrated", false}, {"available", true}});
+        nlohmann::json unavailable_dgpu = nlohmann::json::array();
+        unavailable_dgpu.push_back({{"name", "AMD Radeon 8060S"}, {"family", "gfx1151"}, {"integrated", true}, {"available", true}});
+        unavailable_dgpu.push_back({{"name", "AMD Instinct MI300X"}, {"family", "gfx942"}, {"integrated", false}, {"available", false}});
+
+        nlohmann::json hybrid = nlohmann::json::array();
+        hybrid.push_back({{"name", "AMD Radeon 8060S"}, {"family", "gfx1151"}, {"integrated", true}, {"available", true}});
+        hybrid.push_back({{"name", "AMD Instinct MI300X"}, {"family", "gfx942"}, {"integrated", false}, {"available", true}});
+        auto hybrid_arches = SystemInfo::collect_rocm_arches(hybrid);
+        expect(hybrid_arches.size() == 2 && hybrid_arches[0] == "gfx942" && hybrid_arches[1] == "gfx1151",
+               "hybrid iGPU(gfx1151)+dGPU(gfx942): BOTH arches returned, discrete first");
+
+        // Identical arch on iGPU and dGPU must be deduplicated.
+        nlohmann::json same_arch = nlohmann::json::array();
+        same_arch.push_back({{"name", "AMD Radeon 8060S"}, {"family", "gfx1151"}, {"integrated", true}, {"available", true}});
+        same_arch.push_back({{"name", "AMD Radeon RX 8000"}, {"family", "gfx1151"}, {"integrated", false}, {"available", true}});
+        auto same_arches = SystemInfo::collect_rocm_arches(same_arch);
+        expect(same_arches.size() == 1 && same_arches[0] == "gfx1151",
+               "identical iGPU/dGPU arch (gfx1151/gfx1151) is deduplicated to one entry");
+
+        expect(SystemInfo::collect_rocm_arches(igpu_only).size() == 1 &&
+               SystemInfo::collect_rocm_arches(igpu_only)[0] == "gfx1151",
+               "iGPU-only host lists just its integrated arch");
+        expect(SystemInfo::collect_rocm_arches(dgpu_only).size() == 1 &&
+               SystemInfo::collect_rocm_arches(dgpu_only)[0] == "gfx942",
+               "dGPU-only host lists just its discrete arch");
+
+        // Unavailable GPUs are skipped entirely.
+        auto unavail = SystemInfo::collect_rocm_arches(unavailable_dgpu);
+        expect(unavail.size() == 1 && unavail[0] == "gfx1151",
+               "unavailable discrete GPU is skipped, only the available iGPU is listed");
+
+        // A device with no recognizable arch is skipped, not fatal.
+        nlohmann::json unknown = nlohmann::json::array();
+        unknown.push_back({{"name", "AMD Something Unknown"}, {"family", ""}, {"integrated", false}, {"available", true}});
+        expect(SystemInfo::collect_rocm_arches(unknown).empty(),
+               "an unrecognized GPU arch yields an empty list");
+
+        // Non-array input is tolerated.
+        expect(SystemInfo::collect_rocm_arches(nlohmann::json::object()).empty(),
+               "non-array input yields an empty list");
+
+        // The per-thread override short-circuits probing entirely.
+        SystemInfo::set_rocm_arch_override("gfx942");
+        auto overridden = SystemInfo::get_rocm_arches();
+        SystemInfo::set_rocm_arch_override("");
+        expect(overridden.size() == 1 && overridden[0] == "gfx942",
+               "a set rocm arch override makes get_rocm_arches() return just that arch");
+    }
+
     // Status must resolve the SAME per-arch override install writes, or gfx942 reads
     // update_required forever (the RDNA pin cannot prefix-match the dcgpu base).
     {


### PR DESCRIPTION
Split from the closed stacked PR #2452 (first of four clean PRs).

Closes #2371 — multi-GPU systems only got ROCm for the first GPU arch.

Previously `get_rocm_arch()` returned only the first AMD GPU arch, so on systems with an iGPU and a dGPU of different architectures TheRock was only installed for one of them.

- `get_rocm_arches()` is now the single entry point, returning ALL detected AMD GPU ROCm architectures (deduplicated, discrete-first so `front()` preserves single-arch semantics)
- `install_therock_if_needed()` installs the ROCm runtime for every detected arch
- Per-thread arch override feeds `get_rocm_arches()` for asset-URL resolution without a GPU present
- Pure `collect_rocm_arches(json)` helper + unit coverage for ordering, dedup, skip and override behavior