### PR TITLE
fix: model-level resume for interrupted HF downloads

### DIFF
--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -4834,6 +4834,41 @@ void ModelManager::download_from_registry(const ModelInfo& info,
     repositories.emplace(main_repo_id, registry.fetch_repository(main_repo_id));
 
     std::map<std::string, std::vector<std::string>> files_to_download;
+
+    // Resume fast-path: if a download manifest exists, resume downloading
+    // incomplete files instead of re-fetching the HF API and rebuilding the
+    // file list. This handles the common case of a network interruption.
+    {
+        fs::path model_cache_path = path_from_utf8(get_hf_cache_dir()) / repo_id_to_cache_dir_name(main_repo_id);
+        fs::path manifest_path = model_cache_path / "snapshots" / ".download_manifest.json";
+        if (!safe_exists(manifest_path)) {
+            manifest_path = model_cache_path / ".download_manifest.json";
+        }
+        if (safe_exists(manifest_path)) {
+            try {
+                json manifest = JsonUtils::load_from_file(path_to_utf8(manifest_path));
+                if (manifest.contains("files") && manifest["files"].is_array() && !manifest["files"].empty()) {
+                    LOG(INFO, "ModelManager") << "Resuming interrupted download from existing manifest"
+                                              << std::endl;
+                    std::map<std::string, std::string> headers;
+                    const char* hf_token = std::getenv("HF_TOKEN");
+                    if (hf_token && hf_token[0]) {
+                        headers["Authorization"] = "Bearer " + std::string(hf_token);
+                    }
+                    download_from_manifest(manifest, headers, progress_callback);
+                    if (fs::exists(manifest_path)) {
+                        fs::remove(manifest_path);
+                    }
+                    return;
+                }
+            } catch (...) {
+                // Stale manifest — fall through to fresh download
+                LOG(WARNING, "ModelManager") << "Failed to resume from manifest, starting fresh download"
+                                             << std::endl;
+            }
+        }
+    }
+
     std::vector<std::string> main_repo_files;
     for (const auto& file : repositories.at(main_repo_id).files) {
         if (!file.directory) main_repo_files.push_back(file.path);


### PR DESCRIPTION
Split from the closed stacked PR #2452 (second of four clean PRs).

Fixes #1546.

Before fetching the HF API and rebuilding the file list, check for an existing `.download_manifest.json` with incomplete files. If found, resume downloading from the partial state instead of starting over. Avoids re-downloading already-completed files after a network interruption or Ctrl-C during model pull.

(Per-file retry/resume already exists on main; this adds the model-level manifest fast-path on top.)