### PR TITLE
fix: ensure content+role fields always present in streaming deltas for OpenAI compat

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3118,6 +3118,14 @@ if(BUILD_TESTING AND EXISTS "${_STREAMING_PROXY_CANCEL_TEST_SRC}")
     add_cpp_ci_test(StreamingProxyCancelTest CI OFF COMMAND test_streaming_proxy_cancel)
 endif()
 
+set(_STREAMING_PROXY_REASONING_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_streaming_proxy_reasoning_content.cpp")
+if(BUILD_TESTING AND EXISTS "${_STREAMING_PROXY_REASONING_TEST_SRC}")
+    add_executable(test_streaming_proxy_reasoning_content
+        test/cpp/test_streaming_proxy_reasoning_content.cpp)
+    target_link_libraries(test_streaming_proxy_reasoning_content PRIVATE lemonade-server-core)
+    add_cpp_ci_test(StreamingProxyReasoningContentTest CI ON COMMAND test_streaming_proxy_reasoning_content)
+endif()
+
 set(_STREAMING_HEARTBEAT_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_streaming_heartbeat.cpp")
 if(BUILD_TESTING AND EXISTS "${_STREAMING_HEARTBEAT_TEST_SRC}")
     add_executable(test_streaming_heartbeat test/cpp/test_streaming_heartbeat.cpp)

--- a/src/cpp/include/lemon/streaming_proxy.h
+++ b/src/cpp/include/lemon/streaming_proxy.h
@@ -68,6 +68,14 @@ public:
 
     static void process_sse_lines(std::string& line_buffer, std::function<void(const std::string&)> line_callback);
 
+    // Normalize streaming chat.completion.chunk SSE deltas for OpenAI API
+    // compatibility. Injects `role: "assistant"` on assistant deltas that
+    // omit it, and `content: ""` when a delta carries reasoning_content but
+    // no content — clients like @ai-sdk/openai-compatible reset the
+    // connection when content is expected but absent (#1370). Non-chat SSE
+    // lines pass through unchanged.
+    static std::string normalize_chat_completion_chunk(const std::string& sse_chunk);
+
     static TelemetryData parse_telemetry(const std::string& buffer);
 
     // Extract telemetry from a complete (non-streaming) response body or a

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -3819,6 +3819,15 @@ void Server::handle_chat_completions(const httplib::Request& req, httplib::Respo
                 auto& first_choice = response["choices"][0];
                 if (first_choice.contains("message")) {
                     auto& message = first_choice["message"];
+                    // Ensure content field is present alongside reasoning_content:
+                    // standard OpenAI-compatible clients expect content to always
+                    // be present (#1370).
+                    const bool has_reasoning = message.contains("reasoning_content") &&
+                                               message["reasoning_content"].is_string();
+                    const bool has_content = message.contains("content") && !message["content"].is_null();
+                    if (has_reasoning && !has_content) {
+                        message["content"] = "";
+                    }
                     if (message.contains("tool_calls")) {
                         LOG(DEBUG, "Server") << "Response contains tool_calls: " << message["tool_calls"].dump() << std::endl;
                     } else {

--- a/src/cpp/server/streaming_proxy.cpp
+++ b/src/cpp/server/streaming_proxy.cpp
@@ -11,6 +11,96 @@ namespace lemon {
 
 namespace {
 
+// Normalize a single `data: {...}` SSE line for chat.completion.chunk
+// objects. Applies two fixes for OpenAI API compliance (#1370):
+//
+// 1. Role normalization: some backends emit null or missing `delta.role` on
+//    content chunks. Injects `"role": "assistant"` when the delta contains
+//    assistant-type fields (content, reasoning_content, thinking, tool_calls,
+//    function_call) but role is absent or null.
+//
+// 2. Content normalization: backends that emit `reasoning_content` often omit
+//    the standard `content` field entirely. Injects `"content": ""` to
+//    prevent OpenAI-compatible clients (e.g. @ai-sdk/openai-compatible) from
+//    resetting the connection when content is expected but absent.
+std::string normalize_data_line(const std::string& line) {
+    const std::string prefix = "data: ";
+    if (line.rfind(prefix, 0) != 0) {
+        return line;
+    }
+
+    // Preserve trailing \r if present (some SSE implementations send \r\n)
+    std::string suffix;
+    std::string payload = line.substr(prefix.size());
+    if (!payload.empty() && payload.back() == '\r') {
+        suffix = "\r";
+        payload.pop_back();
+    }
+
+    if (payload.empty() || payload == "[DONE]") {
+        return line;
+    }
+
+    try {
+        auto chunk = json::parse(payload);
+        // Only normalize chat.completion.chunk objects — leave text_completion,
+        // error frames, and other SSE events untouched.
+        if (!chunk.is_object() ||
+            !chunk.contains("object") ||
+            !chunk["object"].is_string() ||
+            chunk["object"].get<std::string>() != "chat.completion.chunk" ||
+            !chunk.contains("choices") ||
+            !chunk["choices"].is_array()) {
+            return line;
+        }
+
+        bool changed = false;
+        for (auto& choice : chunk["choices"]) {
+            if (!choice.is_object() || !choice.contains("delta") || !choice["delta"].is_object()) {
+                continue;
+            }
+
+            auto& delta = choice["delta"];
+
+            // --- Fix 1: Role normalization ---
+            const bool role_is_null = delta.contains("role") && delta["role"].is_null();
+            const bool role_is_missing = !delta.contains("role");
+            const bool has_assistant_delta =
+                delta.contains("content") ||
+                delta.contains("reasoning_content") ||
+                delta.contains("thinking") ||
+                delta.contains("tool_calls") ||
+                delta.contains("function_call");
+
+            if (role_is_null || (role_is_missing && has_assistant_delta)) {
+                delta["role"] = "assistant";
+                changed = true;
+            }
+
+            // --- Fix 2: Content normalization ---
+            // If delta has reasoning_content but content is missing or null,
+            // inject empty content string for OpenAI compatibility.
+            const bool has_reasoning = delta.contains("reasoning_content") &&
+                                       delta["reasoning_content"].is_string();
+            const bool has_content = delta.contains("content") && !delta["content"].is_null();
+
+            if (has_reasoning && !has_content) {
+                delta["content"] = "";
+                changed = true;
+            }
+        }
+
+        if (!changed) {
+            return line;
+        }
+
+        return prefix + chunk.dump() + suffix;
+    } catch (...) {
+        // Malformed JSON — pass through unchanged
+        return line;
+    }
+}
+
 void extract_telemetry_from_chunk(const nlohmann::json& chunk, StreamingProxy::TelemetryData& telemetry) {
     nlohmann::json usage;
     if (chunk.contains("usage")) {
@@ -79,6 +169,28 @@ void extract_telemetry_from_chunk(const nlohmann::json& chunk, StreamingProxy::T
 
 } // namespace
 
+// Normalize every `data: {...}` line in a raw SSE chunk (which may contain
+// zero, one, or many lines) for OpenAI chat-completion compatibility. See
+// normalize_data_line() above.
+std::string StreamingProxy::normalize_chat_completion_chunk(const std::string& sse_chunk) {
+    std::string output;
+    size_t pos = 0;
+
+    while (pos < sse_chunk.size()) {
+        size_t newline = sse_chunk.find('\n', pos);
+        if (newline == std::string::npos) {
+            output += normalize_data_line(sse_chunk.substr(pos));
+            break;
+        }
+
+        output += normalize_data_line(sse_chunk.substr(pos, newline - pos));
+        output.push_back('\n');
+        pos = newline + 1;
+    }
+
+    return output;
+}
+
 
 void StreamingProxy::forward_sse_stream(
     const std::string& backend_url,
@@ -140,9 +252,6 @@ void StreamingProxy::forward_sse_stream(
                 return true;
             }
 
-            line_buffer.append(data, length);
-            process_sse_lines(line_buffer, process_line);
-
             std::string chunk(data, length);
             if (!has_first_token && chunk.find("data: ") != std::string::npos) {
                 has_first_token = true;
@@ -154,8 +263,33 @@ void StreamingProxy::forward_sse_stream(
                 has_done_marker = true;
             }
 
-            if (!sink.write(data, length)) {
-                return false;
+            // Accumulate bytes and flush only complete (newline-terminated) lines:
+            // each complete line feeds telemetry extraction, then is normalized
+            // for OpenAI compatibility before being forwarded to the client
+            // (#1370). Partial trailing lines stay buffered for the next chunk.
+            line_buffer.append(chunk);
+            std::string output;
+            size_t pos = 0;
+            size_t newline;
+            while ((newline = line_buffer.find('\n', pos)) != std::string::npos) {
+                std::string line = line_buffer.substr(pos, newline - pos + 1);
+                std::string telemetry_line = line;
+                if (!telemetry_line.empty() && telemetry_line.back() == '\n') {
+                    telemetry_line.pop_back();
+                }
+                if (!telemetry_line.empty() && telemetry_line.back() == '\r') {
+                    telemetry_line.pop_back();
+                }
+                process_line(telemetry_line);
+                output.append(StreamingProxy::normalize_chat_completion_chunk(line));
+                pos = newline + 1;
+            }
+            line_buffer.erase(0, pos);
+
+            if (!output.empty()) {
+                if (!sink.write(output.data(), output.size())) {
+                    return false; // Client disconnected
+                }
             }
 
             return true;

--- a/test/cpp/test_streaming_proxy_reasoning_content.cpp
+++ b/test/cpp/test_streaming_proxy_reasoning_content.cpp
@@ -1,0 +1,193 @@
+#include "lemon/streaming_proxy.h"
+#include <cassert>
+#include <iostream>
+#include <nlohmann/json.hpp>
+#include <sstream>
+#include <string>
+
+using json = nlohmann::json;
+
+static json parse_first_data_json(const std::string& sse) {
+    const std::string prefix = "data: ";
+    auto start = sse.find(prefix);
+    assert(start != std::string::npos);
+    start += prefix.size();
+    auto end = sse.find('\n', start);
+    assert(end != std::string::npos);
+    return json::parse(sse.substr(start, end - start));
+}
+
+// ===== Role normalization tests =====
+
+static void test_null_role_is_normalized() {
+    std::string input =
+        "data: {\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hi\",\"role\":null},\"finish_reason\":null}]}\n\n";
+
+    std::string output = lemon::StreamingProxy::normalize_chat_completion_chunk(input);
+    auto chunk = parse_first_data_json(output);
+
+    assert(chunk["choices"][0]["delta"]["role"] == "assistant");
+    assert(chunk["choices"][0]["delta"]["content"] == "hi");
+}
+
+static void test_missing_role_on_content_delta_is_added() {
+    std::string input =
+        "data: {\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hi\"},\"finish_reason\":null}]}\n\n";
+
+    std::string output = lemon::StreamingProxy::normalize_chat_completion_chunk(input);
+    auto chunk = parse_first_data_json(output);
+
+    assert(chunk["choices"][0]["delta"]["role"] == "assistant");
+}
+
+static void test_empty_delta_chunk_role_is_not_mutated() {
+    // A finish-reason-only delta (no assistant payload) should not get a role added.
+    std::string input =
+        "data: {\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n";
+    assert(lemon::StreamingProxy::normalize_chat_completion_chunk(input) == input);
+}
+
+static void test_done_marker_and_non_chat_chunks_are_preserved() {
+    std::string done = "data: [DONE]\n\n";
+    assert(lemon::StreamingProxy::normalize_chat_completion_chunk(done) == done);
+
+    std::string completion =
+        "data: {\"object\":\"text_completion\",\"choices\":[{\"index\":0,\"text\":\"hi\"}]}\n\n";
+    assert(lemon::StreamingProxy::normalize_chat_completion_chunk(completion) == completion);
+}
+
+// ===== Reasoning content normalization tests =====
+
+static void test_reasoning_content_without_content_gets_empty_content() {
+    std::string input =
+        "data: {\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"reasoning_content\":\"Let me think...\"},\"finish_reason\":null}]}\n\n";
+
+    std::string output = lemon::StreamingProxy::normalize_chat_completion_chunk(input);
+    auto chunk = parse_first_data_json(output);
+
+    assert(chunk["choices"][0]["delta"]["reasoning_content"] == "Let me think...");
+    assert(chunk["choices"][0]["delta"]["content"] == "");
+}
+
+static void test_reasoning_content_with_null_content_gets_empty_content() {
+    std::string input =
+        "data: {\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"reasoning_content\":\"hmm\",\"content\":null},\"finish_reason\":null}]}\n\n";
+
+    std::string output = lemon::StreamingProxy::normalize_chat_completion_chunk(input);
+    auto chunk = parse_first_data_json(output);
+
+    assert(chunk["choices"][0]["delta"]["reasoning_content"] == "hmm");
+    assert(chunk["choices"][0]["delta"]["content"] == "");
+}
+
+static void test_normal_content_delta_gets_role_added() {
+    // Content with no role gets role: assistant injected (role normalization)
+    std::string input =
+        "data: {\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hello\"},\"finish_reason\":null}]}\n\n";
+    std::string output = lemon::StreamingProxy::normalize_chat_completion_chunk(input);
+    auto chunk = parse_first_data_json(output);
+    assert(chunk["choices"][0]["delta"]["content"] == "Hello");
+    assert(chunk["choices"][0]["delta"]["role"] == "assistant");
+}
+
+static void test_content_and_reasoning_together_is_not_content_mutated() {
+    // Both content and reasoning_content present — content should not be touched
+    // Role gets added (role normalization) since none was present
+    std::string input =
+        "data: {\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"The\",\"reasoning_content\":\"thinking\"},\"finish_reason\":null}]}\n\n";
+    auto output = lemon::StreamingProxy::normalize_chat_completion_chunk(input);
+    auto chunk = parse_first_data_json(output);
+    assert(chunk["choices"][0]["delta"]["content"] == "The");
+    assert(chunk["choices"][0]["delta"]["reasoning_content"] == "thinking");
+    assert(chunk["choices"][0]["delta"]["role"] == "assistant");
+}
+
+// ===== Combined edge cases =====
+
+static void test_carriage_return_is_preserved() {
+    std::string input =
+        "data: {\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"reasoning_content\":\"hmm\"},\"finish_reason\":null}]}\r\n\r\n";
+    std::string output = lemon::StreamingProxy::normalize_chat_completion_chunk(input);
+    auto chunk = parse_first_data_json(output);
+    assert(chunk["choices"][0]["delta"]["reasoning_content"] == "hmm");
+    assert(chunk["choices"][0]["delta"]["content"] == "");
+    assert(output.size() >= 2 && output[output.size() - 2] == '\r');
+}
+
+static void test_multi_choice_handling() {
+    std::string input =
+        "data: {\"object\":\"chat.completion.chunk\",\"choices\":["
+        "{\"index\":0,\"delta\":{\"reasoning_content\":\"think\"},\"finish_reason\":null},"
+        "{\"index\":1,\"delta\":{\"content\":\"Hello\"},\"finish_reason\":null}"
+        "]}\n\n";
+    std::string output = lemon::StreamingProxy::normalize_chat_completion_chunk(input);
+    auto chunk = parse_first_data_json(output);
+    // Choice 0: reasoning + content injection + role
+    assert(chunk["choices"][0]["delta"]["reasoning_content"] == "think");
+    assert(chunk["choices"][0]["delta"]["content"] == "");
+    assert(chunk["choices"][0]["delta"]["role"] == "assistant");
+    // Choice 1: unchanged (already has content)
+    assert(!chunk["choices"][1]["delta"].contains("reasoning_content"));
+    assert(chunk["choices"][1]["delta"]["content"] == "Hello");
+}
+
+static void test_multiple_lines() {
+    std::string input =
+        "data: {\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\"},\"finish_reason\":null}]}\n"
+        "data: {\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"reasoning_content\":\"Let me\"},\"finish_reason\":null}]}\n"
+        "data: {\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"reasoning_content\":\" think\"},\"finish_reason\":null}]}\n"
+        "data: {\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"The answer is\"},\"finish_reason\":null}]}\n"
+        "data: [DONE]\n";
+
+    std::string output = lemon::StreamingProxy::normalize_chat_completion_chunk(input);
+    
+    std::istringstream stream(output);
+    std::string line;
+    int line_num = 0;
+    while (std::getline(stream, line)) {
+        if (line.find("data: ") != 0) continue;
+        std::string payload = line.substr(6);
+        if (payload == "[DONE]") break;
+        
+        auto chunk = json::parse(payload);
+        auto& delta = chunk["choices"][0]["delta"];
+        
+        if (line_num == 0) {
+            // Role delta — unchanged
+            assert(delta["role"] == "assistant");
+        } else if (line_num >= 1 && line_num <= 2) {
+            // Reasoning deltas — should have content: "" AND role: assistant
+            assert(delta.contains("reasoning_content"));
+            assert(delta["content"] == "");
+            assert(delta["role"] == "assistant");
+        } else if (line_num == 3) {
+            // Content delta — unchanged
+            assert(delta["content"] == "The answer is");
+            assert(!delta.contains("reasoning_content"));
+        }
+        line_num++;
+    }
+    assert(line_num >= 4);
+}
+
+int main() {
+    // Role normalization
+    test_null_role_is_normalized();
+    test_missing_role_on_content_delta_is_added();
+    test_empty_delta_chunk_role_is_not_mutated();
+    test_done_marker_and_non_chat_chunks_are_preserved();
+
+    // Reasoning content normalization
+    test_reasoning_content_without_content_gets_empty_content();
+    test_reasoning_content_with_null_content_gets_empty_content();
+    test_normal_content_delta_gets_role_added();
+    test_content_and_reasoning_together_is_not_content_mutated();
+
+    // Combined edge cases
+    test_carriage_return_is_preserved();
+    test_multi_choice_handling();
+    test_multiple_lines();
+
+    std::cout << "all streaming proxy normalization tests passed\n";
+    return 0;
+}


### PR DESCRIPTION
Split from the closed stacked PR #2452 (third of four clean PRs).

Closes #1370 — OpenCode / @ai-sdk/openai-compatible streaming crash when reasoning models emit `reasoning_content` without `content`.

**Streaming proxy** (`streaming_proxy.cpp`): intercepts each SSE `data: {...}` line in `forward_sse_stream()`; injects `content: ""` when `reasoning_content` is present without content, and `role: "assistant"` when null/missing on assistant deltas. Only applies to `chat.completion.chunk` objects — non-chat SSE passthrough.

**Non-streaming REST** (`server.cpp`): same content injection on the response message.

Notes: the `thinking` → `enable_thinking` normalization half of the original fix already exists on main via `normalize_thinking_controls`, so it is not duplicated here.

Unit tests: role normalization, reasoning content normalization, CRLF, multi-choice, multi-line streams (11 cases).