### PR TITLE
fix: pre-load OOM memory warning + hard block at 2x headroom

### DIFF
--- a/src/cpp/include/lemon/model_manager.h
+++ b/src/cpp/include/lemon/model_manager.h
@@ -449,6 +449,7 @@ private:
     // Download from a JSON manifest
     void download_from_manifest(const json& manifest, std::map<std::string, std::string>& headers, DownloadProgressCallback progress_callback);
 
+
     // Download from the model's configured remote registry
     void download_from_registry(const ModelInfo& info,
                                    DownloadProgressCallback progress_callback = nullptr);

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -3378,6 +3378,7 @@ bool ModelManager::backend_self_manages_downloads(const std::string& recipe) con
     return desc && desc->self_manages_downloads;
 }
 
+
 void ModelManager::download_registered_model(const ModelInfo& info, bool do_not_upgrade, DownloadProgressCallback progress_callback) {
     // Serialize downloads per checkpoint repo. A second request for the same
     // repo (e.g. a client that timed out and retried /pull while the first
@@ -3567,6 +3568,7 @@ json ModelManager::fetch_collection_manifest(const std::string& repo_id,
         manifest_info.model_name = repo_id;
         manifest_info.checkpoints["main"] = repo_id;
         try {
+
             manifest_info.registry_source = source;
             download_from_registry(manifest_info, nullptr);
             manifest = read_cached_collection_manifest(cache_dir);
@@ -4810,6 +4812,7 @@ void ModelManager::download_from_manifest(const json& manifest, std::map<std::st
 //   - FLM backend: ✅ Downloads FLM models via 'flm pull' command
 //   - llama-server backend: ❌ Cannot download (expects GGUF files pre-cached)
 //   - ryzenai-server backend: ❌ Cannot download (expects ONNX files pre-cached)
+
 void ModelManager::download_from_registry(const ModelInfo& info,
                                           DownloadProgressCallback progress_callback) {
     const std::string main_repo_id = checkpoint_to_repo_id(info.checkpoint("main"));

--- a/src/cpp/server/router.cpp
+++ b/src/cpp/server/router.cpp
@@ -978,6 +978,27 @@ void Router::load_model(const std::string& model_name,
                                       canonical_model_name);
         }
 
+        // Pre-load OOM check: estimate if the model fits in available memory.
+        // Done AFTER eviction so freed VRAM/RAM is visible. Uses ModelInfo::size
+        // (file size in GB) as a rough proxy for load-time memory demand.
+        if (model_info.size > 0.0) {
+            constexpr double SAFETY_MARGIN = 0.9;
+            double available = get_available_memory_gb(
+                model_info.device & DEVICE_GPU ? DEVICE_GPU :
+                model_info.device & DEVICE_NPU ? DEVICE_NPU :
+                DEVICE_CPU);
+            double headroom = available * SAFETY_MARGIN;
+            if (model_info.size > headroom) {
+                LOG(WARNING, "Router") << "Model " << canonical_model_name
+                    << " requires ~" << model_info.size << " GB but only "
+                    << headroom << " GB available (safety margin " << SAFETY_MARGIN
+                    << "). Consider freeing memory or reducing ctx_size." << std::endl;
+                // Log only — don't block; the OS will handle OOM if it occurs.
+                // Many models load smaller than their file size (quantization
+                // mapped in pages), and the auto-tune below may reduce ctx_size.
+            }
+        }
+
         // Auto-tune: resolve ctx_size = -1 → computed from memory + arch metadata
         // Done AFTER eviction so that freed VRAM/RAM is visible to the memory query.
         int64_t auto_ctx = resolve_auto_ctx_size(effective_options, model_info);

--- a/src/cpp/server/router.cpp
+++ b/src/cpp/server/router.cpp
@@ -981,6 +981,10 @@ void Router::load_model(const std::string& model_name,
         // Pre-load OOM check: estimate if the model fits in available memory.
         // Done AFTER eviction so freed VRAM/RAM is visible. Uses ModelInfo::size
         // (file size in GB) as a rough proxy for load-time memory demand.
+        // When the model far exceeds available memory (more than 2x headroom),
+        // reject the load with a clear error rather than letting the OS OOM killer
+        // kill the entire process. Smaller overruns may still succeed due to
+        // page-mapped quantization, so those are logged as warnings only.
         if (model_info.size > 0.0) {
             constexpr double SAFETY_MARGIN = 0.9;
             double available = get_available_memory_gb(
@@ -988,14 +992,19 @@ void Router::load_model(const std::string& model_name,
                 model_info.device & DEVICE_NPU ? DEVICE_NPU :
                 DEVICE_CPU);
             double headroom = available * SAFETY_MARGIN;
-            if (model_info.size > headroom) {
+            if (model_info.size > headroom * 2.0) {
+                is_loading_ = false;
+                load_cv_.notify_all();
+                throw std::runtime_error(
+                    "Model '" + canonical_model_name + "' requires ~" +
+                    std::to_string(model_info.size) + " GB but only " +
+                    std::to_string(headroom) + " GB available. "
+                    "Free memory by unloading other models or reducing ctx_size.");
+            } else if (model_info.size > headroom) {
                 LOG(WARNING, "Router") << "Model " << canonical_model_name
                     << " requires ~" << model_info.size << " GB but only "
                     << headroom << " GB available (safety margin " << SAFETY_MARGIN
                     << "). Consider freeing memory or reducing ctx_size." << std::endl;
-                // Log only — don't block; the OS will handle OOM if it occurs.
-                // Many models load smaller than their file size (quantization
-                // mapped in pages), and the auto-tune below may reduce ctx_size.
             }
         }
 


### PR DESCRIPTION
Split from the closed stacked PR #2452 (fourth of four clean PRs).

Addresses #1804 — large model loads that can't fit now fail fast with a clear error instead of hanging or being OOM-killed.

**Pre-load check** (`router.cpp`): compares `model_info.size` against `get_available_memory_gb()` for the target device (after eviction, so freed VRAM/RAM is visible).

- Model fits with < 2x headroom: warn-only (GGUF file size ≠ load-time memory; auto-tune ctx_size may still fit it)
- Model exceeds 2x headroom: reject the load with a clear `runtime_error` instead of letting the OS OOM killer kill the whole process