### PR TITLE
fix(system_info): safely extract numeric compute_capability in GPU detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2281,6 +2281,9 @@ if(BUILD_TESTING AND EXISTS "${_SYSTEM_INFO_HELPERS_TEST_SRC}")
     target_include_directories(test_system_info_helpers PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/server
     )
+    target_link_libraries(test_system_info_helpers PRIVATE
+        nlohmann_json::nlohmann_json
+    )
     add_cpp_ci_test(SystemInfoHelpersTest CI ON COMMAND test_system_info_helpers)
 endif()
 

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -8,6 +8,7 @@
 #include <lemon/utils/process_manager.h>
 #include <lemon/utils/path_utils.h>
 #include <lemon/system_info.h>
+#include "system_info_utils.h"
 #include <lemon/backends/backend_descriptor_registry.h>
 #include <lemon/backends/backend_registry.h>
 #include <lemon/backends/backend_utils.h>
@@ -3511,7 +3512,7 @@ std::map<std::string, ModelInfo> ModelManager::filter_models_by_backend(
                     if (gpu.value("available", false)) {
                         std::string name = gpu.value("name", "unknown");
                         std::string family = gpu.value("family", "");
-                        std::string cc = gpu.value("compute_capability", "");
+                        std::string cc = system_info_detail::extract_compute_capability(gpu);
                         std::string suffix;
                         if (!cc.empty()) suffix = " (compute " + cc + ", " + (family.empty() ? "unsupported arch" : family) + ")";
                         else if (!family.empty()) suffix = " (" + family + ")";

--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -1413,7 +1413,7 @@ json SystemInfo::build_recipes_info(const json& devices) {
                         std::string detected_compute_cap;
                         for (const auto& gpu : devices["nvidia_gpu"]) {
                             if (!gpu.value("available", false)) continue;
-                            std::string cc = gpu.value("compute_capability", "");
+                            std::string cc = system_info_detail::extract_compute_capability(gpu);
                             if (!cc.empty()) {
                                 detected_compute_cap = cc;
                                 break;

--- a/src/cpp/server/system_info_utils.h
+++ b/src/cpp/server/system_info_utils.h
@@ -7,13 +7,28 @@
 #include <exception>
 #include <filesystem>
 #include <fstream>
+#include <nlohmann/json.hpp>
 #include <set>
-#include <system_error>
 #include <string>
+#include <system_error>
 #include <utility>
 #include <vector>
 
 namespace lemon::system_info_detail {
+
+inline std::string extract_compute_capability(const nlohmann::json& gpu) {
+    if (!gpu.is_object() || !gpu.contains("compute_capability")) {
+        return "";
+    }
+    const auto& val = gpu["compute_capability"];
+    if (val.is_string()) {
+        return val.get<std::string>();
+    }
+    if (val.is_number()) {
+        return val.dump();
+    }
+    return "";
+}
 
 inline const std::set<std::string>& cuda_supported_archs() {
     static const std::set<std::string> archs = {

--- a/test/cpp/test_system_info_helpers.cpp
+++ b/test/cpp/test_system_info_helpers.cpp
@@ -19,6 +19,7 @@
 using lemon::system_info_detail::compute_cap_to_sm;
 using lemon::system_info_detail::cuda_supported_archs;
 using lemon::system_info_detail::device_matches_constraint;
+using lemon::system_info_detail::extract_compute_capability;
 using lemon::system_info_detail::gfx_target_version_to_arch;
 using lemon::system_info_detail::identify_cuda_arch_from_name;
 using lemon::system_info_detail::rocm_device_memory_from_sysfs;
@@ -132,6 +133,25 @@ static bool expect_device_memory(const char* name,
 
 int main() {
     int failures = 0;
+
+    const std::vector<std::pair<nlohmann::json, std::string>> extract_cases = {
+        {nlohmann::json{{"compute_capability", "8.9"}}, "8.9"},
+        {nlohmann::json{{"compute_capability", "8.6"}}, "8.6"},
+        {nlohmann::json{{"compute_capability", 8.9}}, "8.9"},
+        {nlohmann::json{{"compute_capability", 8.0}}, "8.0"},
+        {nlohmann::json{{"compute_capability", 8}}, "8"},
+        {nlohmann::json{{"other", "value"}}, ""},
+        {nlohmann::json{{"compute_capability", nullptr}}, ""},
+        {nlohmann::json{{"compute_capability", true}}, ""},
+        {nlohmann::json{{"compute_capability", nlohmann::json::array()}}, ""},
+        {nlohmann::json{{"compute_capability", nlohmann::json::object()}}, ""},
+        {nlohmann::json("not an object"), ""},
+    };
+    for (size_t i = 0; i < extract_cases.size(); ++i) {
+        const auto& [gpu_json, expected] = extract_cases[i];
+        const std::string name = "extract_compute_capability case " + std::to_string(i);
+        failures += !expect_string(name.c_str(), extract_compute_capability(gpu_json), expected);
+    }
 
     const std::vector<std::pair<std::string, std::string>> compute_cap_cases = {
         {"7.5", "sm_75"},


### PR DESCRIPTION
## Summary

- Safely extracts `compute_capability` from GPU device JSON to prevent `[json.exception.type_error.302]` exceptions when the value is numeric (e.g. `8.9` as float or integer).
- Implements `lemon::system_info_detail::extract_compute_capability()` in `system_info_utils.h` and uses it across `system_info.cpp` and `model_manager.cpp`.

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_
- Added C++ unit tests to `test_system_info_helpers.cpp` covering string (`"8.9"`, `"8.6"`), numeric float (`8.9`, `8.0`), integer (`8`), and invalid/null JSON inputs.
- Verified test suite:
  ```bash
  cmake --build --preset default --target test_system_info_helpers
  ctest --test-dir build -R '^SystemInfoHelpersTest$' --output-on-failure
  ```
- Built full server target:
  ```bash
  cmake --build --preset default --target lemond
  ```
- Ran `cpp-ci-tests` suite.

## Documentation

- [x] Documentation is not affected by this change.
- [ ] Documentation is affected and has been updated.
- [ ] Documentation is affected but will be handled in a separate PR or issue.

## Breaking Changes

- [ ] This PR introduces breaking changes.
- [x] This PR does not introduce breaking changes.

## AI-assisted contribution

- [x] I used AI tools for this PR.
- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.