### PR TITLE
fix(gui): associate remote download progress with checkpoints

### DIFF
--- a/src/app/src/components/ModelManager.tsx
+++ b/src/app/src/components/ModelManager.tsx
@@ -12,7 +12,7 @@ import {
   isCompatibleHuggingFaceVariantResult,
 } from '../features/models/huggingFaceSearch';
 import { DEFAULT_CONTEXT_SIZE } from '../modelConfiguration';
-import { DownloadListItem, activeDownloadForModel, downloadStore } from '../features/downloadManager/downloadStore';
+import { DownloadListItem, activeDownloadForModel, downloadStore, isDownloadActive } from '../features/downloadManager/downloadStore';
 import { ModelListPanel, capabilityTagIconTarget, modelIsCustom, modelMatchesBackends, modelMatchesTags, modelMatchesTasks } from './ModelListPanel';
 import type { FilterTab, PrimaryFilter } from './ModelListPanel';
 import { ModelNavRail } from './ModelNavRail';
@@ -1073,6 +1073,7 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
   const [loadError, setLoadError] = useState<{ modelName: string; message: string } | null>(null);
   const [pulling, setPulling] = useState<Record<string, number>>({});  // model -> percent
   const [downloadItems, setDownloadItems] = useState<DownloadListItem[]>(() => downloadStore.snapshot());
+  const unknownActiveModelDownloadsRef = useRef<Set<string>>(new Set());
   const pullAbortRef = useRef<Record<string, AbortController>>({});
   const [selectedDetailModelId, setSelectedDetailModelId] = useState<string | null>(null);
   const [mobileDetailOpen, setMobileDetailOpen] = useState(false);
@@ -2283,6 +2284,21 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
     }
     return merged;
   }, [visibleServerModels, loadedModels]);
+
+  useEffect(() => {
+    const knownNames = new Set(visibleServerModels.map(model => customModelNameKey(modelName(model))));
+    const unknownActiveIds = new Set(
+      downloadItems
+        .filter(item => item.downloadType === 'model' && isDownloadActive(item))
+        .filter(item => !knownNames.has(customModelNameKey(item.modelName)))
+        .map(item => item.id),
+    );
+    const appeared = [...unknownActiveIds].some(
+      id => !unknownActiveModelDownloadsRef.current.has(id),
+    );
+    unknownActiveModelDownloadsRef.current = unknownActiveIds;
+    if (appeared) void refresh();
+  }, [downloadItems, refresh, visibleServerModels]);
 
   const omniComponentOptions = useMemo(() => {
     const roles: Record<OmniComponentRole, OmniComponentOption[]> = {

--- a/src/app/src/components/ModelManager.tsx
+++ b/src/app/src/components/ModelManager.tsx
@@ -1527,23 +1527,23 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
       const source = String((model as any).registry_source || (model as any).source || '').toLowerCase();
       return !source || source === provider;
     };
+    const activeDownloadForRegisteredModel = (model: ModelInfo): DownloadListItem | undefined => {
+      const name = modelName(model);
+      return activeDownloadForModel(downloadItems, name)
+        || activeDownloadForModel(downloadItems, `user.${name}`);
+    };
     const registered = allModels.find(model => {
       const checkpoint = modelCheckpoint(model);
       return sourceMatches(model)
         && (checkpoint === modelId || checkpoint.startsWith(`${modelId}:`))
-        && Boolean(activeDownloadForModel(downloadItems, modelName(model)));
+        && Boolean(activeDownloadForRegisteredModel(model));
     });
     if (registered) {
       const name = modelName(registered);
-      const download = activeDownloadForModel(downloadItems, name);
+      const download = activeDownloadForRegisteredModel(registered);
       if (download) return { modelName: name, percent: download.percent, downloadId: download.id };
     }
 
-    for (const variant of variants?.variants || []) {
-      const name = resolveRemoteModelName(provider, modelId, variant.name, variants?.recipe || '', variants);
-      const download = activeDownloadForModel(downloadItems, name);
-      if (download) return { modelName: name, percent: download.percent, downloadId: download.id };
-    }
     return null;
   };
 

--- a/src/app/tests/remote-download-association.spec.ts
+++ b/src/app/tests/remote-download-association.spec.ts
@@ -1,0 +1,119 @@
+import { expect, test, type Page } from '@playwright/test';
+
+const activeRepository = 'unsloth/Llama-3.2-3B-Instruct-GGUF';
+const collidingRepository = 'example/Llama-3.2-3B-Instruct-GGUF';
+const localModelName = 'Llama-3.2-3B-Instruct-GGUF-Q4_K_M';
+
+async function mockCatalogWithCollidingNames(page: Page, registerCheckpoint = true): Promise<void> {
+  await page.route('**/api/v1/health**', route =>
+    route.fulfill({ json: { status: 'ok', version: 'test', all_models_loaded: [] } }),
+  );
+  await page.route('**/api/v1/system-info**', route => route.fulfill({ json: {} }));
+  await page.route('**/api/v1/models**', route =>
+    route.fulfill({
+      json: {
+        data: registerCheckpoint ? [{
+          id: localModelName,
+          name: localModelName,
+          checkpoint: `${activeRepository}:Q4_K_M`,
+          source: 'huggingface',
+          registry_source: 'huggingface',
+          labels: ['chat'],
+          recipe: 'llamacpp',
+          downloaded: false,
+        }] : [],
+      },
+    }),
+  );
+  await page.route('**/api/v1/downloads**', route =>
+    route.fulfill({
+      json: {
+        downloads: [{
+          id: `model:user.${localModelName}`,
+          type: 'model',
+          model_name: `user.${localModelName}`,
+          status: 'downloading',
+          running: true,
+          file: 'model.gguf',
+          file_index: 1,
+          total_files: 1,
+          bytes_downloaded: 420,
+          bytes_total: 1000,
+          percent: 42,
+        }],
+      },
+    }),
+  );
+  await page.route('**huggingface.co/api/models**', route =>
+    route.fulfill({
+      json: [activeRepository, collidingRepository].map((id, index) => ({
+        id,
+        modelId: id,
+        likes: 10 - index,
+        downloads: 100 - index,
+        tags: ['gguf', 'text-generation'],
+        pipeline_tag: 'text-generation',
+      })),
+    }),
+  );
+  await page.route('**/api/v1/pull/variants?**', route => {
+    const checkpoint = new URL(route.request().url()).searchParams.get('checkpoint') || '';
+    return route.fulfill({
+      json: {
+        checkpoint,
+        source: 'huggingface',
+        recipe: 'llamacpp',
+        repo_kind: 'gguf',
+        suggested_name: 'Llama-3.2-3B-Instruct-GGUF',
+        suggested_labels: ['chat'],
+        mmproj_files: [],
+        variants: [{
+          name: 'Q4_K_M',
+          primary_file: 'model-Q4_K_M.gguf',
+          files: ['model-Q4_K_M.gguf'],
+          sharded: false,
+          size_bytes: 1000,
+        }],
+      },
+    });
+  });
+}
+
+async function openCollidingSearch(page: Page): Promise<void> {
+  await page.goto('/');
+  await page.locator('.titlebar__nav').getByText('Models', { exact: true }).click();
+  await page.locator('#model-list-search').fill('llama 3.2');
+  await expect(page.locator('.zone--hf .workspace-list-row')).toHaveCount(2);
+}
+
+test('remote progress belongs only to the repository registered for the download', async ({ page }) => {
+  await mockCatalogWithCollidingNames(page);
+  await openCollidingSearch(page);
+
+  const activeRow = page.locator('.zone--hf .workspace-list-row').filter({ hasText: activeRepository });
+  const collidingRow = page.locator('.zone--hf .workspace-list-row').filter({ hasText: collidingRepository });
+
+  await expect(activeRow).toContainText('Downloading 42%');
+  await expect(activeRow.getByRole('button', { name: `Cancel download of ${activeRepository}` })).toBeVisible();
+  await expect(collidingRow).not.toContainText('Downloading');
+  await expect(collidingRow.getByRole('button', { name: `Cancel download of ${collidingRepository}` })).toHaveCount(0);
+
+  // The association must also survive a reload, when component-local pull state is gone
+  // and the UI reconstructs progress solely from the server snapshots.
+  await page.reload();
+  await page.locator('.titlebar__nav').getByText('Models', { exact: true }).click();
+  await page.locator('#model-list-search').fill('llama 3.2');
+
+  await expect(activeRow).toContainText('Downloading 42%');
+  await expect(collidingRow).not.toContainText('Downloading');
+});
+
+test('remote progress is not guessed from a generated name without a checkpoint association', async ({ page }) => {
+  await mockCatalogWithCollidingNames(page, false);
+  await openCollidingSearch(page);
+
+  const rows = page.locator('.zone--hf .workspace-list-row');
+  await expect(rows.filter({ hasText: activeRepository })).not.toContainText('Downloading');
+  await expect(rows.filter({ hasText: collidingRepository })).not.toContainText('Downloading');
+  await expect(rows.getByRole('button', { name: /Cancel download of/ })).toHaveCount(0);
+});

--- a/src/app/tests/remote-download-association.spec.ts
+++ b/src/app/tests/remote-download-association.spec.ts
@@ -4,31 +4,48 @@ const activeRepository = 'unsloth/Llama-3.2-3B-Instruct-GGUF';
 const collidingRepository = 'example/Llama-3.2-3B-Instruct-GGUF';
 const localModelName = 'Llama-3.2-3B-Instruct-GGUF-Q4_K_M';
 
-async function mockCatalogWithCollidingNames(page: Page, registerCheckpoint = true): Promise<void> {
+type CatalogState = {
+  registerCheckpoint: boolean;
+  registrationSource: 'huggingface' | 'modelscope';
+  downloadActive: boolean;
+};
+
+async function mockCatalogWithCollidingNames(
+  page: Page,
+  options: Partial<CatalogState> = {},
+): Promise<{ state: CatalogState; modelRequests: () => number }> {
+  const state: CatalogState = {
+    registerCheckpoint: true,
+    registrationSource: 'huggingface',
+    downloadActive: true,
+    ...options,
+  };
+  let modelRequestCount = 0;
   await page.route('**/api/v1/health**', route =>
     route.fulfill({ json: { status: 'ok', version: 'test', all_models_loaded: [] } }),
   );
   await page.route('**/api/v1/system-info**', route => route.fulfill({ json: {} }));
-  await page.route('**/api/v1/models**', route =>
-    route.fulfill({
+  await page.route('**/api/v1/models**', route => {
+    modelRequestCount += 1;
+    return route.fulfill({
       json: {
-        data: registerCheckpoint ? [{
+        data: state.registerCheckpoint ? [{
           id: localModelName,
           name: localModelName,
           checkpoint: `${activeRepository}:Q4_K_M`,
-          source: 'huggingface',
-          registry_source: 'huggingface',
+          source: state.registrationSource,
+          registry_source: state.registrationSource,
           labels: ['chat'],
           recipe: 'llamacpp',
           downloaded: false,
         }] : [],
       },
-    }),
-  );
+    });
+  });
   await page.route('**/api/v1/downloads**', route =>
     route.fulfill({
       json: {
-        downloads: [{
+        downloads: state.downloadActive ? [{
           id: `model:user.${localModelName}`,
           type: 'model',
           model_name: `user.${localModelName}`,
@@ -40,7 +57,7 @@ async function mockCatalogWithCollidingNames(page: Page, registerCheckpoint = tr
           bytes_downloaded: 420,
           bytes_total: 1000,
           percent: 42,
-        }],
+        }] : [],
       },
     }),
   );
@@ -77,6 +94,7 @@ async function mockCatalogWithCollidingNames(page: Page, registerCheckpoint = tr
       },
     });
   });
+  return { state, modelRequests: () => modelRequestCount };
 }
 
 async function openCollidingSearch(page: Page): Promise<void> {
@@ -109,11 +127,39 @@ test('remote progress belongs only to the repository registered for the download
 });
 
 test('remote progress is not guessed from a generated name without a checkpoint association', async ({ page }) => {
-  await mockCatalogWithCollidingNames(page, false);
+  await mockCatalogWithCollidingNames(page, { registerCheckpoint: false });
   await openCollidingSearch(page);
 
   const rows = page.locator('.zone--hf .workspace-list-row');
   await expect(rows.filter({ hasText: activeRepository })).not.toContainText('Downloading');
   await expect(rows.filter({ hasText: collidingRepository })).not.toContainText('Downloading');
   await expect(rows.getByRole('button', { name: /Cancel download of/ })).toHaveCount(0);
+});
+
+test('remote progress ignores a checkpoint registered by another provider', async ({ page }) => {
+  await mockCatalogWithCollidingNames(page, { registrationSource: 'modelscope' });
+  await openCollidingSearch(page);
+
+  const rows = page.locator('.zone--hf .workspace-list-row');
+  await expect(rows.filter({ hasText: activeRepository })).not.toContainText('Downloading');
+  await expect(rows.filter({ hasText: collidingRepository })).not.toContainText('Downloading');
+});
+
+test('a newly discovered external download refreshes a stale model registry', async ({ page }) => {
+  const catalog = await mockCatalogWithCollidingNames(page, {
+    registerCheckpoint: false,
+    downloadActive: false,
+  });
+  await openCollidingSearch(page);
+  const modelRequestsBeforeDownload = catalog.modelRequests();
+
+  catalog.state.registerCheckpoint = true;
+  catalog.state.downloadActive = true;
+  await page.evaluate(() => window.dispatchEvent(new Event('focus')));
+
+  const activeRow = page.locator('.zone--hf .workspace-list-row').filter({ hasText: activeRepository });
+  const collidingRow = page.locator('.zone--hf .workspace-list-row').filter({ hasText: collidingRepository });
+  await expect.poll(catalog.modelRequests).toBeGreaterThan(modelRequestsBeforeDownload);
+  await expect(activeRow).toContainText('Downloading 42%');
+  await expect(collidingRow).not.toContainText('Downloading');
 });


### PR DESCRIPTION
Remote Hugging Face results could show another repository's download progress when both generated the same local model name. Restore progress only when the registered source and checkpoint identify that repository, while handling the server's internal `user.` name prefix.

Fixes #3296

Tests:
- focused Playwright regression, including reload and an unassociated name collision
- `npm run typecheck`
- `npm run build:renderer:prod`
- pre-commit

Screenshots:

Before:

<img width="1440" height="1000" alt="ISSUE-3296-REPRO" src="https://github.com/user-attachments/assets/9798359a-8e68-497a-acc5-b001b7b89686" />


After:

<img width="1440" height="1000" alt="ISSUE-3296-PATCHED-RELOADED" src="https://github.com/user-attachments/assets/6cf92f7f-376a-4ef5-af70-a75f28f8072c" />

