### PR TITLE
ci: resolve newest llama.cpp b[NUM] tag instead of releases/latest

### DIFF
--- a/.github/workflows/validate_llamacpp.yml
+++ b/.github/workflows/validate_llamacpp.yml
@@ -49,7 +49,18 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          RELEASE=$(gh api repos/ggml-org/llama.cpp/releases/latest --jq '.tag_name')
+          # ggml-org/llama.cpp now publishes semver milestone releases (vX.Y.Z)
+          # as `releases/latest`; those are tag-only and carry no binaries (just
+          # a nightly-tag.txt pointing at the corresponding build). All binary
+          # assets live under the `b[NUM]` nightly tags, which the asset checks
+          # and pin updates below expect. Resolve the newest `b[NUM]` release
+          # instead of `releases/latest` so the resolved tag always has assets.
+          RELEASE=$(gh api "repos/ggml-org/llama.cpp/releases?per_page=100" \
+            --jq '[.[] | select(.draft == false and (.tag_name | test("^b[0-9]+$"))) | .tag_name][0]')
+          if [ -z "$RELEASE" ]; then
+            echo "::error::Could not resolve a b[NUM] llama.cpp release tag."
+            exit 1
+          fi
           echo "Latest llama.cpp release: $RELEASE"
           echo "release=$RELEASE" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Problem

The `Validate New llama.cpp Release` scheduled workflow fails every run:

```
Invalid GGML_RELEASE: 'v0.2.0'
```

Root cause: `ggml-org/llama.cpp` now publishes semver **milestone** releases (`vX.Y.Z`) as `releases/latest`. These are tag-only — the only asset is `nightly-tag.txt` pointing at the corresponding `b[NUM]` build. All binary assets (the `llama-{tag}-bin-*` families this workflow validates) live under the `b[NUM]` nightly tags.

The workflow's `get-latest-releases` job resolves `releases/latest` → `v0.2.0`, then `require_release()` rejects it because the validator (correctly) only accepts `^b[0-9]+$`. The run dies before any asset verification happens.

## Fix

In the `Get latest llama.cpp release` step, resolve the newest non-draft `b[NUM]` release tag from the releases list instead of `releases/latest`:

```bash
RELEASE=$(gh api "repos/ggml-org/llama.cpp/releases?per_page=100" \
  --jq '[.[] | select(.draft == false and (.tag_name | test("^b[0-9]+$"))) | .tag_name][0]')
```

This preserves the workflow's historical behavior — before ggml-org introduced semver milestones, `releases/latest` *was* the newest `b[NUM]` tag. The other two repos (`lemonade-sdk/llamacpp-rocm`, `lemonade-sdk/llama.cpp`) still publish `b[NUM]` as their latest release and are untouched.

## Verification

- Repo query resolves to `b10603` (the current newest build) — stable across repeated calls
- Resolved tag passes the existing `^b[0-9]+$` validator
- Asset checks and pin-update jobs are unchanged; they operate on the resolved `b[NUM]` tag as before

## Impact

Unblocks the weekly auto-update for `ggml-org/llama.cpp` pins (the workflow has been failing since the `v0.2.0` milestone was published 2026-08-21).