### PR TITLE
Handle llama.cpp new release scheme

### DIFF
--- a/src/cpp/server/backend_manager.cpp
+++ b/src/cpp/server/backend_manager.cpp
@@ -736,10 +736,29 @@ void BackendManager::install_backend(const std::string& recipe, const std::strin
     const bool backend_install_dir_existed_before = fs::exists(backend_install_dir);
 
     bool completion_reported = false;
+    bool backend_committed = false;
+
+    auto handle_install_failure = [&](const std::string& message) -> bool {
+        if (backend_committed || !has_existing_backend || force) {
+            if (!backend_install_dir_existed_before) {
+                std::error_code cleanup_ec;
+                fs::remove_all(backend_install_dir, cleanup_ec);
+            }
+            return false;
+        }
+        LOG(WARNING, "BackendManager")
+            << "Backend update for " << recipe << ":" << resolved_backend
+            << " failed (" << message << "); falling back to installed backend";
+        report_backend_ready(recipe, resolved_backend, progress_cb);
+        return true;
+    };
 
     try {
         backends::BackendUtils::install_from_github(
             *spec, params.version, params.repo, params.filename, resolved_backend, backend_progress_cb);
+        // install_from_github only returns after atomically swapping the new
+        // backend into place; from here on the working install is the new one.
+        backend_committed = true;
 
         const int logical_total_files = backend_total_files + static_cast<int>(runtime_steps.size());
         for (size_t i = 0; i < runtime_steps.size(); ++i) {
@@ -807,34 +826,10 @@ void BackendManager::install_backend(const std::string& recipe, const std::strin
             progress_cb(complete_progress);
         }
     } catch (const std::exception& e) {
-        // A failed backend update must not block model loading when a usable
-        // backend was already installed: log and fall back to the existing
-        // binary.
-        if (has_existing_backend && !force) {
-            LOG(WARNING, "BackendManager")
-                << "Backend update for " << recipe << ":" << resolved_backend
-                << " failed (" << e.what() << "); falling back to installed backend";
-            report_backend_ready(recipe, resolved_backend, progress_cb);
-            return;
-        }
-
-        if (!backend_install_dir_existed_before) {
-            std::error_code cleanup_ec;
-            fs::remove_all(backend_install_dir, cleanup_ec);
-        }
+        if (handle_install_failure(e.what())) return;
         throw;
     } catch (...) {
-        if (has_existing_backend && !force) {
-            LOG(WARNING, "BackendManager")
-                << "Backend update for " << recipe << ":" << resolved_backend
-                << " failed; falling back to installed backend";
-            report_backend_ready(recipe, resolved_backend, progress_cb);
-            return;
-        }
-        if (!backend_install_dir_existed_before) {
-            std::error_code cleanup_ec;
-            fs::remove_all(backend_install_dir, cleanup_ec);
-        }
+        if (handle_install_failure("unknown")) return;
         throw;
     }
 }

--- a/src/cpp/server/backend_manager.cpp
+++ b/src/cpp/server/backend_manager.cpp
@@ -802,9 +802,31 @@ void BackendManager::install_backend(const std::string& recipe, const std::strin
             complete_progress.complete = true;
             progress_cb(complete_progress);
         }
+    } catch (const std::exception& e) {
+        // A failed backend update must not block model loading when a usable
+        // backend was already installed: log and fall back to the existing
+        // binary.
+        if (has_existing_backend && !force) {
+            LOG(WARNING, "BackendManager")
+                << "Backend update for " << recipe << ":" << resolved_backend
+                << " failed (" << e.what() << "); falling back to installed backend";
+            report_backend_ready(recipe, resolved_backend, progress_cb);
+            return;
+        }
+
+        if (!backend_install_dir_existed_before) {
+            std::error_code cleanup_ec;
+            fs::remove_all(backend_install_dir, cleanup_ec);
+        }
+        throw;
     } catch (...) {
-        // If the backend was newly created and a required runtime fails, roll
-        // back the backend so the status does not look ready with missing deps.
+        if (has_existing_backend && !force) {
+            LOG(WARNING, "BackendManager")
+                << "Backend update for " << recipe << ":" << resolved_backend
+                << " failed; falling back to installed backend";
+            report_backend_ready(recipe, resolved_backend, progress_cb);
+            return;
+        }
         if (!backend_install_dir_existed_before) {
             std::error_code cleanup_ec;
             fs::remove_all(backend_install_dir, cleanup_ec);

--- a/src/cpp/server/backend_manager.cpp
+++ b/src/cpp/server/backend_manager.cpp
@@ -415,7 +415,8 @@ std::string BackendManager::fetch_latest_github_tag(const std::string& repo,
         return "";
     }
 
-    const std::string url = "https://api.github.com/repos/" + repo + "/releases/latest";
+    // Include pre-releases to handle the new release scheme of llama.cpp
+    const std::string url = "https://api.github.com/repos/" + repo + "/releases?per_page=1";
 
     LOG(DEBUG, "BackendManager") << "Resolving 'latest' for " << repo << " via " << url << std::endl;
     utils::HttpResponse resp;
@@ -442,8 +443,11 @@ std::string BackendManager::fetch_latest_github_tag(const std::string& repo,
 
     std::string tag;
     try {
-        auto body = json::parse(resp.body);
-        tag = body.at("tag_name").get<std::string>();
+        auto releases = json::parse(resp.body);
+        if (!releases.is_array() || releases.empty()) {
+            throw std::runtime_error("expected a non-empty JSON array of releases");
+        }
+        tag = releases[0]["tag_name"].get<std::string>();
     } catch (const std::exception& e) {
         if (throw_on_failure) {
             throw std::runtime_error(


### PR DESCRIPTION
## Summary

Fixes two issues:

1. if backend update fails but a previous version is installed, this doesn't block the model from launching anymore. A warnign is logged and the prev version is used. This is not strictly related to llamacpp but is a nice fallback.
2. resolve latest release on GitHub including pre-releases. Of course if the version is resolved for the brief period when the vSEMVER is the latest release this will fail (it doesn't have assets), but point 1. saves the day until the next bBUILDNUM release drops.

This could be probably be extended, but then we'd need llamacpp-specific rules. I think since the current behavior completely breaks `llamacpp.vulkan_bin=latest` it is a good idea to merge this and then eventually refine the approach later.

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

Use llamacpp and see that new released are picked up correctly.

## Documentation

- [x] Documentation is not affected by this change.

## Breaking Changes

- [x] This PR does not introduce breaking changes.

## AI-assisted contribution

Please select one:

- [x] I used AI tools for this PR.

If AI tools were used:

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.
