### PR TITLE
feat(windows): report VRAM and GPU usage in status bar via PDH

### DIFF
--- a/src/cpp/server/platform/metrics_windows.cpp
+++ b/src/cpp/server/platform/metrics_windows.cpp
@@ -1,8 +1,45 @@
 #include <lemon/system_metrics_platform.h>
 #include <windows.h>
+#include <chrono>
 #include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <mutex>
+#include <string>
+#include <vector>
+#include <pdh.h>
+#include <pdhmsg.h>
+#pragma comment(lib, "pdh.lib")
 
 namespace lemon {
+
+namespace {
+
+// PDH counter paths are localized by the OS, so building a path from the
+// English counter names ("GPU Engine", "Utilization Percentage", ...) breaks
+// on non-English Windows. Resolve the current-locale string from the canonical
+// English name via its stable performance-index: the index is machine-specific
+// but locale-neutral, and PdhLookupPerfIndexByName accepts the English name
+// regardless of the OS language.
+std::string localized_perf_name(const char* english_name) {
+    DWORD index = 0;
+    if (PdhLookupPerfIndexByNameA(NULL, english_name, &index) != ERROR_SUCCESS ||
+        index == 0) {
+        return english_name;
+    }
+    DWORD len = 0;
+    if (PdhLookupPerfNameByIndexA(NULL, index, NULL, &len) != PDH_MORE_DATA) {
+        return english_name;
+    }
+    std::string buf(len, '\0');
+    if (PdhLookupPerfNameByIndexA(NULL, index, buf.data(), &len) != ERROR_SUCCESS) {
+        return english_name;
+    }
+    buf.resize(std::strlen(buf.c_str()));
+    return buf;
+}
+
+} // namespace
 
 class WindowsMetricsPlatform : public SystemMetricsPlatform {
 public:
@@ -61,19 +98,178 @@ public:
     }
 
     double get_gpu_usage() override {
-        // GPU usage monitoring not implemented for Windows
-        return -1.0;
+        std::lock_guard<std::mutex> lock(pdh_mutex_);
+        if (!ensure_query()) {
+            return -1.0;
+        }
+        collect_if_stale();
+        return cached_gpu_usage_;
     }
 
     double get_vram_usage_gb() override {
-        // VRAM monitoring not implemented for Windows
-        return -1.0;
+        std::lock_guard<std::mutex> lock(pdh_mutex_);
+        if (!ensure_query()) {
+            return -1.0;
+        }
+        collect_if_stale();
+        return cached_vram_gb_;
     }
 
     double get_npu_utilization() override {
         // NPU monitoring not implemented for Windows
         return -1.0;
     }
+
+    ~WindowsMetricsPlatform() override {
+        if (query_ != NULL) {
+            PdhCloseQuery(query_);
+            query_ = NULL;
+        }
+    }
+
+private:
+    // Build the query and counters once. Returns false if no usable counters
+    // exist (e.g. no GPU present).
+    bool ensure_query() {
+        if (initialized_) {
+            return !gpu_counters_.empty() || !vram_counters_.empty();
+        }
+        initialized_ = true;
+
+        PDH_HQUERY query = NULL;
+        if (PdhOpenQuery(NULL, 0, &query) != ERROR_SUCCESS) {
+            return false;
+        }
+
+        // PDH instead of DXGI QueryVideoMemoryInfo: the latter reports
+        // CurrentUsage=0 on AMD iGPU drivers, hiding the status bar line.
+        const std::string gpu_obj = localized_perf_name("GPU Engine");
+        const std::string gpu_ctr = localized_perf_name("Utilization Percentage");
+        const std::string mem_obj = localized_perf_name("GPU Adapter Memory");
+        const std::string mem_ctr = localized_perf_name("Dedicated Usage");
+
+        add_counters(query, gpu_obj, gpu_ctr, true, gpu_counters_);
+        add_counters(query, mem_obj, mem_ctr, false, vram_counters_);
+
+        if (gpu_counters_.empty() && vram_counters_.empty()) {
+            PdhCloseQuery(query);
+            return false;
+        }
+
+        query_ = query;
+        return true;
+    }
+
+    void add_counters(PDH_HQUERY query, const std::string& object,
+                     const std::string& counter, bool all_instances,
+                     std::vector<PDH_HCOUNTER>& out) {
+        DWORD counter_buf_len = 0;
+        DWORD instance_buf_len = 0;
+        PDH_STATUS st = PdhEnumObjectItemsA(NULL, NULL, object.c_str(),
+                                            NULL, &counter_buf_len,
+                                            NULL, &instance_buf_len,
+                                            PERF_DETAIL_WIZARD, 0);
+        if (st != PDH_MORE_DATA || instance_buf_len == 0) {
+            return;
+        }
+
+        std::vector<char> counters_buf(counter_buf_len);
+        std::vector<char> instances_buf(instance_buf_len);
+        st = PdhEnumObjectItemsA(NULL, NULL, object.c_str(),
+                                 counters_buf.data(), &counter_buf_len,
+                                 instances_buf.data(), &instance_buf_len,
+                                 PERF_DETAIL_WIZARD, 0);
+        if (st != ERROR_SUCCESS) {
+            return;
+        }
+
+        for (char* name = instances_buf.data(); *name; name += strlen(name) + 1) {
+            if (!all_instances && strncmp(name, "luid_", 5) != 0) {
+                continue;
+            }
+            char path[512];
+            _snprintf_s(path, sizeof(path), _TRUNCATE, "\\%s(%s)\\%s",
+                        object.c_str(), name, counter.c_str());
+            PDH_HCOUNTER handle = NULL;
+            if (PdhAddCounterA(query, path, 0, &handle) == ERROR_SUCCESS) {
+                out.push_back(handle);
+            }
+        }
+    }
+
+    // PDH rate counters (GPU utilization) measure activity between successive
+    // PdhCollectQueryData calls; the app's own polling interval supplies the
+    // delta. Re-collect at most once per kCollectDebounceMs so the rate is not
+    // zeroed by the back-to-back gpu/vram reads in a single metrics pass.
+    void collect_if_stale() {
+        const auto now = std::chrono::steady_clock::now();
+        const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+            now - last_collect_);
+        if (elapsed.count() < kCollectDebounceMs) {
+            return;
+        }
+        if (PdhCollectQueryData(query_) != ERROR_SUCCESS) {
+            return;
+        }
+        last_collect_ = now;
+
+        cached_gpu_usage_ = read_max_double(gpu_counters_);
+        cached_vram_gb_ = read_sum_bytes(vram_counters_);
+    }
+
+    double read_max_double(const std::vector<PDH_HCOUNTER>& counters) {
+        if (counters.empty()) {
+            return -1.0;
+        }
+        double max_usage = -1.0;
+        PDH_FMT_COUNTERVALUE value{};
+        for (PDH_HCOUNTER counter : counters) {
+            if (PdhGetFormattedCounterValue(
+                    counter, PDH_FMT_DOUBLE | PDH_FMT_NOCAP100, NULL, &value) ==
+                    ERROR_SUCCESS &&
+                value.doubleValue > max_usage) {
+                max_usage = value.doubleValue;
+            }
+        }
+        if (max_usage < 0) {
+            return -1.0;
+        }
+        return std::round(max_usage * 10.0) / 10.0;
+    }
+
+    double read_sum_bytes(const std::vector<PDH_HCOUNTER>& counters) {
+        if (counters.empty()) {
+            return -1.0;
+        }
+        double total_bytes = 0.0;
+        bool any = false;
+        PDH_FMT_COUNTERVALUE value{};
+        for (PDH_HCOUNTER counter : counters) {
+            if (PdhGetFormattedCounterValue(
+                    counter, PDH_FMT_LARGE | PDH_FMT_NOCAP100, NULL, &value) ==
+                    ERROR_SUCCESS &&
+                value.largeValue > 0) {
+                total_bytes += static_cast<double>(value.largeValue);
+                any = true;
+            }
+        }
+        if (!any) {
+            return -1.0;
+        }
+        double gb = total_bytes / (1024.0 * 1024.0 * 1024.0);
+        return std::round(gb * 10.0) / 10.0;
+    }
+
+    static constexpr int64_t kCollectDebounceMs = 100;
+
+    PDH_HQUERY query_ = NULL;
+    std::vector<PDH_HCOUNTER> gpu_counters_;
+    std::vector<PDH_HCOUNTER> vram_counters_;
+    double cached_gpu_usage_ = -1.0;
+    double cached_vram_gb_ = -1.0;
+    std::chrono::steady_clock::time_point last_collect_{};
+    bool initialized_ = false;
+    std::mutex pdh_mutex_;
 };
 
 std::unique_ptr<SystemMetricsPlatform> create_metrics_platform() {


### PR DESCRIPTION
## Summary

Implement `get_vram_usage_gb()` and `get_gpu_usage()` for Windows in `metrics_windows.cpp` using PDH performance counters (the source Task Manager uses). The status bar already renders VRAM/GPU% when `/system-stats` returns a non-null value, so no frontend change is needed.

- VRAM -> `GPU Adapter Memory(<luid>)\Dedicated Usage` (summed per LUID)
- GPU% -> `GPU Engine(<instance>)\Utilization Percentage` (max across engines)

Previously these returned `-1.0` on Windows, so the VRAM and GPU lines stayed hidden in the status bar.

Fixes #3317 

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_ Built `lemond` on Windows (Radeon 8060S / Strix Halo). Confirmed the status bar now shows `VRAM: 62.6 GB` and `GPU: 70.8 %`.
<img width="478" height="35" alt="image" src="https://github.com/user-attachments/assets/924e4971-3238-44ac-a18f-a069e5f90e6a" />

## Documentation

- [x] Documentation is not affected by this change.

## Breaking Changes

- [x] This PR does not introduce breaking changes.

## AI-assisted contribution

- [x] I used AI tools for this PR.
- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.