### PR TITLE
MCP: expose canonical Lemonade capability hub

### DIFF
--- a/.github/workflows/mcp-smoke-test.yml
+++ b/.github/workflows/mcp-smoke-test.yml
@@ -1,8 +1,8 @@
 name: MCP Smoke Test
 
-# Smoke-tests all 5 MCP tools (lemonade_list_models, lemonade_chat,
-# lemonade_transcribe_audio, lemonade_generate_image, lemonade_omni) via two
-# independent build paths: a native CMake build and a Docker image build.
+# Smoke-tests the canonical MCP tool catalog plus core inference/discovery
+# paths via two independent build paths: a native CMake build and a Docker
+# image build.
 # Either job failing fails the workflow.
 
 on:
@@ -11,6 +11,7 @@ on:
       - "src/cpp/server/mcp_server.cpp"
       - "src/cpp/include/lemon/mcp_server.h"
       - "src/cpp/server/server.cpp"
+      - "src/cpp/include/lemon/server.h"
       - "src/cpp/server/router.cpp"
       - "src/cpp/server/model_manager.cpp"
       - "src/cpp/resources/server_models.json"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ All core endpoints are registered under **4 path prefixes**:
 
 **Anthropic-compatible endpoint:** `POST /api/messages` — supports message completion, tool use, and SSE streaming.
 
-**MCP gateway endpoint:** `POST /mcp` — Model Context Protocol (Streamable HTTP transport, spec `2025-06-18`). Single JSON-RPC 2.0 endpoint exposing 5 tools (`lemonade_list_models`, `lemonade_chat`, `lemonade_transcribe_audio`, `lemonade_generate_image`, `lemonade_omni`). GET returns 405.
+**MCP gateway endpoint:** `POST /mcp` — Model Context Protocol (Streamable HTTP transport, spec `2025-06-18`). `tools/list` is the canonical runtime catalogue for Lemonade MCP tool names, descriptions, and input schemas; keep the human-readable contract in [`docs/api/mcp.md`](docs/api/mcp.md) instead of duplicating a static tool list here. Server-owned MCP actions delegate to the same Lemonade implementation as the corresponding APIs. GET returns 405.
 
 **WebSocket Realtime API**: OpenAI-compatible Realtime protocol for real-time audio transcription. `/realtime` and `/logs/stream` accept WebSocket upgrades directly on the main HTTP port; a dedicated listener on an OS-assigned port (9000+, exposed via the `websocket_port` field in the `/health` response) also remains for backward compatibility.
 

--- a/docs/api/mcp.md
+++ b/docs/api/mcp.md
@@ -232,7 +232,7 @@ Passing a non-collection model (e.g. a plain LLM) returns `isError: true` with a
 ## Canonical capability hub
 
 `tools/list` is the runtime source of truth for Lemonade tool names, descriptions, and input schemas.
-Lemonade App and other MCP clients are assumend to consume that catalog.
+Lemonade App and other MCP clients are assumed to consume that catalog.
 UI-only metadata such as icons, ordering, grouping, attachment selection, and rendering can remain local to the host.
 
 | Tool | Server capability |

--- a/docs/api/mcp.md
+++ b/docs/api/mcp.md
@@ -22,6 +22,16 @@ curl -s http://localhost:13305/mcp \
     -d '{"jsonrpc":"2.0","id":1,"method":"ping"}'
 ```
 
+### Lifecycle tool safety
+
+Model and backend lifecycle tools are intentionally part of the default `tools/list`
+catalog so MCP remains the complete server capability contract. They use the same
+API authentication boundary as the corresponding REST endpoints. Their MCP
+`annotations` describe read-only, destructive, and open-world behavior so hosts can
+apply their own approval UX or policy. These annotations, and `confirm: true` on
+`lemonade_delete_model`, are safety metadata and accident guards, not authorization
+boundaries.
+
 ## Supported methods
 
 | Method | Purpose |

--- a/docs/api/mcp.md
+++ b/docs/api/mcp.md
@@ -1,6 +1,6 @@
 # MCP Gateway
 
-Lemonade exposes its inference capabilities as a Model Context Protocol (MCP) server, so any MCP-compatible client (GitHub Copilot, Claude Desktop, MCP Inspector, Cursor, the `mcp` Python client, etc.) can call your locally running models as tools.
+Lemonade exposes its inference and model-management capabilities as a Model Context Protocol (MCP) server, so any MCP-compatible client (GitHub Copilot, Claude Desktop, MCP Inspector, Cursor, the `mcp` Python client, etc.) can call your locally running models as tools.
 
 The gateway implements the **MCP "Streamable HTTP" transport** (spec version `2025-06-18`) with the `tools` capability only. All traffic flows through a single endpoint:
 
@@ -34,7 +34,7 @@ curl -s http://localhost:13305/mcp \
 
 ## Tools
 
-All tools auto-load (and download, if missing) the requested model on first call, exactly like `POST /v1/chat/completions`. Errors are returned as MCP results with `"isError": true` rather than JSON-RPC errors, matching the spec's guidance for tool failures.
+Inference tools auto-load (and download, when explicitly permitted) models through the existing server paths. Model-management tools are thin adapters over the same lifecycle implementation used by Lemonade's REST APIs. Errors are returned as MCP results with `"isError": true` rather than JSON-RPC errors, matching the spec's guidance for tool failures.
 
 ### `lemonade_list_models`
 
@@ -51,6 +51,87 @@ Discover what's loaded, what's downloaded, and what's recommended. Call this fir
 ```
 
 Returns a summary text block plus a JSON-stringified text block with `{loaded, available, suggested_to_pull, recommended_chat_model}`.
+
+
+### `lemonade_get_model_info`
+
+Get detailed metadata for one exact model ID returned by `lemonade_list_models`.
+The result is backed by the same model record used by Lemonade's REST model APIs,
+including recipe, local/download state, collection components, recipe options,
+and Router metadata when present.
+
+```json
+{
+  "name": "lemonade_get_model_info",
+  "arguments": {"model_name": "Qwen3-1.7B-GGUF"}
+}
+```
+
+### `lemonade_load_model`
+
+Explicitly load one model through the same implementation as `POST /v1/load`.
+The model name is exact. Known registry models may be downloaded by the normal
+load path when they are not local yet. `collection.router` models remain virtual:
+loading them acknowledges readiness without creating a Router backend process.
+
+Recipe-specific options can be passed in the `options` object. They apply only
+to this load; this MCP tool does not persist them.
+
+```json
+{
+  "name": "lemonade_load_model",
+  "arguments": {
+    "model_name": "Qwen3-1.7B-GGUF",
+    "ctx_size": 8192,
+    "options": {"llamacpp_backend": "vulkan"}
+  }
+}
+```
+
+### `lemonade_unload_model`
+
+Unload exactly one named model through the same implementation as
+`POST /v1/unload`. Unlike the raw REST endpoint, the MCP schema requires
+`model_name`; omitting it cannot trigger the REST empty-name "unload all"
+behavior.
+
+```json
+{
+  "name": "lemonade_unload_model",
+  "arguments": {"model_name": "Qwen3-1.7B-GGUF"}
+}
+```
+
+### `lemonade_pull_model`
+
+Download or register a model through the same implementation as `POST /v1/pull`.
+For a built-in model, pass the exact model ID. For a custom remote model, use a
+`user.*` model ID plus the checkpoint and recipe fields accepted by `/pull`.
+The MCP call is synchronous, so large downloads can take a long time.
+
+```json
+{
+  "name": "lemonade_pull_model",
+  "arguments": {"model_name": "Qwen3-1.7B-GGUF"}
+}
+```
+
+### `lemonade_delete_model`
+
+Delete exactly one existing model through the same implementation as
+`POST /v1/delete`. This is destructive and requires `confirm: true`. If the
+model is loaded, the existing server implementation unloads it before deleting
+its local files/definition.
+
+```json
+{
+  "name": "lemonade_delete_model",
+  "arguments": {
+    "model_name": "user.my-model",
+    "confirm": true
+  }
+}
+```
 
 ### `lemonade_chat`
 
@@ -147,6 +228,54 @@ If the planner emits app-defined tool calls (those you passed in via `tools`/`to
 
 Passing a non-collection model (e.g. a plain LLM) returns `isError: true` with a hint to use `lemonade_chat`.
 
+
+## Canonical capability hub
+
+`tools/list` is the runtime source of truth for Lemonade tool names, descriptions, and input schemas.
+Lemonade App and other MCP clients are assumend to consume that catalog.
+UI-only metadata such as icons, ordering, grouping, attachment selection, and rendering can remain local to the host.
+
+| Tool | Server capability |
+|---|---|
+| `lemonade_list_models` | Model discovery |
+| `lemonade_get_model_info` | Detailed model record |
+| `lemonade_load_model` | Explicit load |
+| `lemonade_unload_model` | Explicit single-model unload |
+| `lemonade_get_loaded_models` | Current residency |
+| `lemonade_get_server_health` | Health and runtime limits |
+| `lemonade_pull_model` | Download/register model |
+| `lemonade_delete_model` | Destructive model delete (`confirm=true`) |
+| `lemonade_get_system_info` | Hardware + recipe/backend state |
+| `lemonade_list_backends` | Backend-focused system-info view |
+| `lemonade_install_backend` | Backend install/update |
+| `lemonade_generate_image` | Text-to-image |
+| `lemonade_edit_image` | Explicit-image edit |
+| `lemonade_generate_audio` | Music/SFX generation |
+| `lemonade_text_to_speech` | TTS |
+| `lemonade_transcribe_audio` | Speech-to-text |
+| `lemonade_generate_3d` | Image-to-3D GLB |
+| `lemonade_chat` | LLM chat completion |
+| `lemonade_omni` | Omni collection orchestration |
+
+The media contracts are server contracts, not conversation contracts. For
+example, `lemonade_edit_image`, `lemonade_transcribe_audio`, and
+`lemonade_generate_3d` require the host to send the actual image/audio input;
+"use the latest attachment" remains GUI/host adaptation and is not encoded in
+`tools/list`.
+
+### Additional server-adapter tools
+
+- `lemonade_get_loaded_models`, `lemonade_get_server_health`,
+  `lemonade_get_system_info`, and `lemonade_list_backends` are read-only views
+  over existing server state.
+- `lemonade_install_backend` delegates to `POST /api/v1/install` and is
+  synchronous through MCP.
+- `lemonade_generate_audio`, `lemonade_text_to_speech`, and
+  `lemonade_generate_3d` delegate to their existing `/api/v1` generation paths
+  and return generated bytes in MCP content/structured data.
+- `lemonade_edit_image` shares the same post-parse image-edit execution helper
+  as the multipart REST endpoint, avoiding a second image-edit implementation.
+
 ## Error model
 
 | Code | Meaning |
@@ -165,7 +294,7 @@ Tool-level failures (bad arguments, model load errors, backend exceptions) are r
 - No session resumption (`Mcp-Session-Id` header is not issued).
 - `resources/*` and `prompts/*` capabilities are not implemented.
 - Streaming chat output is not exposed via MCP — `stream=true` is ignored. Use `POST /v1/chat/completions` directly for streamed tokens.
-- Embeddings and text-to-speech are not currently exposed as MCP tools; use the OpenAI-compatible endpoints (`/v1/embeddings`, `/v1/audio/speech`) for those.
+- Embeddings are not currently exposed as an MCP tool; use the OpenAI-compatible `/v1/embeddings` endpoint.
 
 ## Quick test with curl
 

--- a/docs/assets/persona-demo.css
+++ b/docs/assets/persona-demo.css
@@ -1913,8 +1913,8 @@ html[data-md-color-scheme="zest-dark"] .hp-slide.is-active .hp-slide-demo {
 
 /* ======================================================================
    "Add as an MCP server": a client's MCP-server settings panel. Shows the
-   lemonade entry added to mcp.json (highlighted), a connected status, and the
-   five tools the gateway exposes (staggered in, as if discovered on connect).
+   lemonade entry added to mcp.json (highlighted), a connected status, and a
+   representative sample of discovered tools (staggered in on connect).
    ====================================================================== */
 /* The content sits in a 16:9 panel floating over the (scrimmed) app window, in two
    columns: the mcp.json config on the left, the connected status + tools on the

--- a/docs/assets/persona-demo/people/apps.js
+++ b/docs/assets/persona-demo/people/apps.js
@@ -87,10 +87,11 @@
   }
 
   // "Add as an MCP server": a generic client's MCP-server settings panel showing the
-  // lemonade entry being added to mcp.json (highlighted), a connected status, and the
-  // tools it exposes. Mirrors the real /mcp gateway (Streamable HTTP) -- see
-  // docs/api/mcp.md: five tools, JSON-RPC over a single POST /mcp endpoint.
+  // lemonade entry being added to mcp.json (highlighted), a connected status, and a
+  // representative sample of discovered tools. The real /mcp gateway exposes its
+  // canonical catalog through tools/list over the single POST /mcp endpoint.
   function mcpDemo() {
+    // Keep the visual compact: this is a sample, not the canonical catalog.
     var tools = [
       { icon: 'forum', name: 'lemonade_chat', tag: 'chat completion' },
       { icon: 'image', name: 'lemonade_generate_image', tag: 'image generation' },
@@ -130,7 +131,7 @@
             '<button class="hp-mcp-add-btn" type="button"><span class="material-symbols-outlined">add</span>Add server</button>' +
           '</div>' +
           '<div class="hp-mcp-col hp-mcp-col-tools">' +
-            '<div class="hp-mcp-status"><span class="hp-mcp-dot"></span>Connected · 5 tools</div>' +
+            '<div class="hp-mcp-status"><span class="hp-mcp-dot"></span>Connected · tools discovered</div>' +
             '<div class="hp-mcp-tools">' + toolRows + '</div>' +
           '</div>' +
         '</div>' +

--- a/src/cpp/include/lemon/mcp_server.h
+++ b/src/cpp/include/lemon/mcp_server.h
@@ -22,8 +22,11 @@ using json = nlohmann::json;
 class McpServer : public std::enable_shared_from_this<McpServer> {
 public:
     using EnsureLoadedFn = std::function<void(const std::string&)>;
+    using ServerToolFn =
+        std::function<json(const std::string&, const json&)>;
 
-    McpServer(Router* router, ModelManager* model_manager, EnsureLoadedFn ensure_loaded);
+    McpServer(Router* router, ModelManager* model_manager,
+              EnsureLoadedFn ensure_loaded, ServerToolFn server_tool);
     ~McpServer();
 
     // Must be called on a shared_ptr instance — handlers capture shared_from_this().
@@ -76,6 +79,7 @@ private:
     Router* router_;
     ModelManager* model_manager_;
     EnsureLoadedFn ensure_loaded_;
+    ServerToolFn server_tool_;
 };
 
 }  // namespace lemon

--- a/src/cpp/include/lemon/server.h
+++ b/src/cpp/include/lemon/server.h
@@ -185,6 +185,8 @@ private:
     void handle_unload(const httplib::Request& req, httplib::Response& res);
     void handle_pin(const httplib::Request& req, httplib::Response& res);
     void handle_delete(const httplib::Request& req, httplib::Response& res);
+    nlohmann::json handle_mcp_server_tool(
+        const std::string& tool_name, const nlohmann::json& arguments);
     void handle_cleanup_cache(const httplib::Request& req, httplib::Response& res);
     void handle_aliases_get(const httplib::Request& req, httplib::Response& res);
     void handle_aliases_add(const httplib::Request& req, httplib::Response& res);
@@ -292,6 +294,8 @@ private:
     // Image endpoint handlers (OpenAI /v1/images/* compatible)
     void handle_image_generations(const httplib::Request& req, httplib::Response& res);
     void handle_image_edits(const httplib::Request& req, httplib::Response& res);
+    void handle_image_edit_json(const nlohmann::json& request_json,
+                                httplib::Response& res);
     void handle_image_variations(const httplib::Request& req, httplib::Response& res);
     void handle_image_upscale(const httplib::Request& req, httplib::Response& res);
 

--- a/src/cpp/server/mcp_server.cpp
+++ b/src/cpp/server/mcp_server.cpp
@@ -215,10 +215,12 @@ std::string unique_token() {
 
 }  // namespace
 
-McpServer::McpServer(Router* router, ModelManager* model_manager, EnsureLoadedFn ensure_loaded)
+McpServer::McpServer(Router* router, ModelManager* model_manager,
+                     EnsureLoadedFn ensure_loaded, ServerToolFn server_tool)
     : router_(router),
       model_manager_(model_manager),
-      ensure_loaded_(std::move(ensure_loaded)) {}
+      ensure_loaded_(std::move(ensure_loaded)),
+      server_tool_(std::move(server_tool)) {}
 
 McpServer::~McpServer() = default;
 
@@ -390,6 +392,24 @@ json McpServer::handle_tools_call(const json& params, const json& id) {
             result = tool_omni(arguments);
         } else if (tool_name == "lemonade_list_models") {
             result = tool_list_models(arguments);
+        } else if (tool_name == "lemonade_get_model_info" ||
+                   tool_name == "lemonade_load_model" ||
+                   tool_name == "lemonade_unload_model" ||
+                   tool_name == "lemonade_get_loaded_models" ||
+                   tool_name == "lemonade_get_server_health" ||
+                   tool_name == "lemonade_pull_model" ||
+                   tool_name == "lemonade_delete_model" ||
+                   tool_name == "lemonade_get_system_info" ||
+                   tool_name == "lemonade_list_backends" ||
+                   tool_name == "lemonade_install_backend" ||
+                   tool_name == "lemonade_edit_image" ||
+                   tool_name == "lemonade_generate_audio" ||
+                   tool_name == "lemonade_text_to_speech" ||
+                   tool_name == "lemonade_generate_3d") {
+            if (!server_tool_) {
+                throw std::runtime_error("Lemonade server tools are not configured");
+            }
+            result = server_tool_(tool_name, arguments);
         } else {
             // Per MCP spec, unknown-tool errors are isError=true results, not JSON-RPC errors.
             result = {
@@ -1160,6 +1180,271 @@ json McpServer::tools_descriptor() {
                 {"properties", {
                     {"include_available", {{"type", "boolean"}}},
                     {"include_suggested", {{"type", "boolean"}}},
+                }},
+            }},
+        },
+        {
+            {"name", "lemonade_get_model_info"},
+            {"description",
+             "Get the server's detailed record for one exact model ID returned "
+             "by lemonade_list_models. Returns the same model metadata used by "
+             "the REST model APIs, including recipe, download state, components, "
+             "recipe options, and Router metadata when present."},
+            {"inputSchema", {
+                {"type", "object"},
+                {"required", json::array({"model_name"})},
+                {"additionalProperties", false},
+                {"properties", {
+                    {"model_name", {{"type", "string"},
+                                    {"description", "Exact model ID from lemonade_list_models."}}},
+                }},
+            }},
+        },
+        {
+            {"name", "lemonade_load_model"},
+            {"description",
+             "Explicitly load a Lemonade model using the same implementation as "
+             "POST /v1/load. The model_name must be exact. A known registry model "
+             "that is not local may be downloaded by the existing load path. "
+             "collection.router models are virtual and are acknowledged without "
+             "starting a Router backend process. `options` contains ephemeral "
+             "recipe-specific load options such as llamacpp_backend or "
+             "llamacpp_device; they are not persisted by this MCP tool."},
+            {"inputSchema", {
+                {"type", "object"},
+                {"required", json::array({"model_name"})},
+                {"additionalProperties", false},
+                {"properties", {
+                    {"model_name", {{"type", "string"},
+                                    {"description", "Exact model ID from lemonade_list_models."}}},
+                    {"ctx_size", {{"type", "integer"},
+                                  {"description", "Optional context size. Use -1 for automatic sizing."}}},
+                    {"pinned", {{"type", "boolean"},
+                                {"description", "Optional residency pin state for this load."}}},
+                    {"options", {{"type", "object"},
+                                 {"additionalProperties", true},
+                                 {"description", "Optional recipe-specific load options. Applied only to this load; model/model_name/save_options/pinned are not allowed here."}}},
+                }},
+            }},
+        },
+        {
+            {"name", "lemonade_unload_model"},
+            {"description",
+             "Unload exactly one named model using the same implementation as "
+             "POST /v1/unload. model_name is mandatory: this MCP tool never "
+             "exposes the REST endpoint's empty-name unload-all behavior."},
+            {"inputSchema", {
+                {"type", "object"},
+                {"required", json::array({"model_name"})},
+                {"additionalProperties", false},
+                {"properties", {
+                    {"model_name", {{"type", "string"},
+                                    {"description", "Exact model ID to unload."}}},
+                }},
+            }},
+        },
+        {
+            {"name", "lemonade_pull_model"},
+            {"description",
+             "Download or register a model using the same implementation as "
+             "POST /v1/pull. For a built-in/registered model, pass its exact "
+             "model_name. For a custom remote model, pass a user.* model_name "
+             "plus checkpoint and recipe. This call is synchronous and may take "
+             "a long time for large model downloads."},
+            {"inputSchema", {
+                {"type", "object"},
+                {"required", json::array({"model_name"})},
+                {"additionalProperties", false},
+                {"properties", {
+                    {"model_name", {{"type", "string"},
+                                    {"description", "Exact registered model ID, or user.* ID for a new custom model."}}},
+                    {"checkpoint", {{"type", "string"},
+                                    {"description", "Optional remote repository/checkpoint selector accepted by /pull."}}},
+                    {"recipe", {{"type", "string"},
+                                {"description", "Recipe required when registering a custom checkpoint."}}},
+                    {"source", {{"type", "string"},
+                                {"description", "Optional remote registry source, for example huggingface or modelscope."}}},
+                    {"do_not_upgrade", {{"type", "boolean"},
+                                        {"description", "Skip upgrading an already-cached registered model."}}},
+                }},
+            }},
+        },
+        {
+            {"name", "lemonade_delete_model"},
+            {"description",
+             "Delete exactly one model using the same implementation as POST "
+             "/v1/delete. This is destructive. The model_name must identify an "
+             "existing model exactly and confirm must be true. A loaded model is "
+             "unloaded first, matching the REST endpoint."},
+            {"inputSchema", {
+                {"type", "object"},
+                {"required", json::array({"model_name", "confirm"})},
+                {"additionalProperties", false},
+                {"properties", {
+                    {"model_name", {{"type", "string"},
+                                    {"description", "Exact existing model ID to delete."}}},
+                    {"confirm", {{"type", "boolean"},
+                                 {"enum", json::array({true})},
+                                 {"description", "Must be true to execute deletion."}}},
+                }},
+            }},
+        },
+        {
+            {"name", "lemonade_get_loaded_models"},
+            {"description",
+             "List the models currently loaded in Lemonade, including runtime "
+             "recipe/type/device information reported by the server. Use this "
+             "when the question is specifically about current residency; use "
+             "lemonade_list_models for broader discovery."},
+            {"inputSchema", {
+                {"type", "object"},
+                {"additionalProperties", false},
+                {"properties", json::object()},
+            }},
+        },
+        {
+            {"name", "lemonade_get_server_health"},
+            {"description",
+             "Return Lemonade server health and runtime limits using the same "
+             "implementation as GET /api/v1/health."},
+            {"inputSchema", {
+                {"type", "object"},
+                {"additionalProperties", false},
+                {"properties", json::object()},
+            }},
+        },
+        {
+            {"name", "lemonade_get_system_info"},
+            {"description",
+             "Return Lemonade hardware and recipe/backend capability information "
+             "using the same implementation as GET /api/v1/system-info."},
+            {"inputSchema", {
+                {"type", "object"},
+                {"additionalProperties", false},
+                {"properties", json::object()},
+            }},
+        },
+        {
+            {"name", "lemonade_list_backends"},
+            {"description",
+             "List Lemonade recipes/backends and their installation/support "
+             "state. This is the backend-focused view of the canonical "
+             "/api/v1/system-info data."},
+            {"inputSchema", {
+                {"type", "object"},
+                {"additionalProperties", false},
+                {"properties", json::object()},
+            }},
+        },
+        {
+            {"name", "lemonade_install_backend"},
+            {"description",
+             "Install or update one Lemonade recipe/backend through the same "
+             "implementation as POST /api/v1/install. The MCP call is "
+             "synchronous; use lemonade_list_backends first to inspect support "
+             "and current state."},
+            {"inputSchema", {
+                {"type", "object"},
+                {"required", json::array({"recipe", "backend"})},
+                {"additionalProperties", false},
+                {"properties", {
+                    {"recipe", {{"type", "string"}}},
+                    {"backend", {{"type", "string"}}},
+                    {"force", {{"type", "boolean"},
+                               {"description", "Override an unsupported-state guard when the underlying API permits it."}}},
+                }},
+            }},
+        },
+        {
+            {"name", "lemonade_edit_image"},
+            {"description",
+             "Edit an explicitly supplied image with a Lemonade image model. "
+             "The host/client must provide `image` as raw base64 or a data:image "
+             "URL; conversation attachment selection remains a host concern. "
+             "When model is omitted, the server reuses a loaded/downloaded image model."},
+            {"inputSchema", {
+                {"type", "object"},
+                {"required", json::array({"prompt", "image"})},
+                {"additionalProperties", false},
+                {"properties", {
+                    {"prompt", {{"type", "string"}}},
+                    {"image", {{"type", "string"},
+                               {"description", "Base64 image bytes or a data:image/...;base64 URL."}}},
+                    {"model", {{"type", "string"}}},
+                    {"size", {{"type", "string"}}},
+                    {"steps", {{"type", "integer"}, {"minimum", 1}}},
+                    {"cfg_scale", {{"type", "number"}}},
+                    {"seed", {{"type", "integer"}}},
+                    {"n", {{"type", "integer"}, {"minimum", 1}, {"maximum", 10}}},
+                }},
+            }},
+        },
+        {
+            {"name", "lemonade_generate_audio"},
+            {"description",
+             "Generate music or a sound effect with a Lemonade audio-generation "
+             "model using the same server generation path as POST "
+             "/api/v1/audio/generations. When model is omitted, reuse a "
+             "loaded/downloaded audio-generation model."},
+            {"inputSchema", {
+                {"type", "object"},
+                {"required", json::array({"prompt"})},
+                {"additionalProperties", false},
+                {"properties", {
+                    {"prompt", {{"type", "string"}}},
+                    {"model", {{"type", "string"}}},
+                    {"duration", {{"type", "number"}}},
+                    {"steps", {{"type", "integer"}, {"minimum", 1}}},
+                    {"cfg", {{"type", "number"}}},
+                    {"seed", {{"type", "integer"}}},
+                    {"lyrics", {{"type", "string"}}},
+                    {"vocal_language", {{"type", "string"}}},
+                    {"response_format", {{"type", "string"}}},
+                }},
+            }},
+        },
+        {
+            {"name", "lemonade_text_to_speech"},
+            {"description",
+             "Convert text to speech using the same server generation path as "
+             "POST /api/v1/audio/speech. When model is omitted, reuse a "
+             "loaded/downloaded TTS model."},
+            {"inputSchema", {
+                {"type", "object"},
+                {"required", json::array({"input"})},
+                {"additionalProperties", false},
+                {"properties", {
+                    {"input", {{"type", "string"}}},
+                    {"model", {{"type", "string"}}},
+                    {"voice", {{"type", "string"}}},
+                    {"speed", {{"type", "number"}}},
+                    {"response_format", {{"type", "string"}}},
+                }},
+            }},
+        },
+        {
+            {"name", "lemonade_generate_3d"},
+            {"description",
+             "Create a GLB from an explicitly supplied image using the same "
+             "server generation path as POST /api/v1/3d/generations. The "
+             "current server API is image-to-3D; prompt-to-image-to-3D "
+             "orchestration remains a follow-up capability rather than hidden "
+             "GUI-only behavior. When model is omitted, reuse a loaded/downloaded 3D model."},
+            {"inputSchema", {
+                {"type", "object"},
+                {"required", json::array({"image"})},
+                {"additionalProperties", false},
+                {"properties", {
+                    {"image", {{"type", "string"},
+                               {"description", "Base64 image bytes or a data:image/...;base64 URL."}}},
+                    {"model", {{"type", "string"}}},
+                    {"resolution", {{"type", "integer"},
+                                    {"enum", json::array({512, 1024, 1536})}}},
+                    {"bg_removal", {{"type", "string"},
+                                    {"enum", json::array({"threshold", "birefnet"})}}},
+                    {"seed", {{"type", "integer"}}},
+                    {"uv", {{"type", "string"},
+                            {"enum", json::array({"box", "xatlas"})}}},
                 }},
             }},
         },

--- a/src/cpp/server/mcp_server.cpp
+++ b/src/cpp/server/mcp_server.cpp
@@ -1168,6 +1168,11 @@ json McpServer::tools_descriptor() {
     return json::array({
         {
             {"name", "lemonade_list_models"},
+            {"annotations", {
+                {"readOnlyHint", true},
+                {"destructiveHint", false},
+                {"openWorldHint", false},
+            }},
             {"description",
              "List models known to the Lemonade server. ALWAYS call this "
              "first if you don't already know the exact model name to use "
@@ -1185,6 +1190,11 @@ json McpServer::tools_descriptor() {
         },
         {
             {"name", "lemonade_get_model_info"},
+            {"annotations", {
+                {"readOnlyHint", true},
+                {"destructiveHint", false},
+                {"openWorldHint", false},
+            }},
             {"description",
              "Get the server's detailed record for one exact model ID returned "
              "by lemonade_list_models. Returns the same model metadata used by "
@@ -1202,6 +1212,11 @@ json McpServer::tools_descriptor() {
         },
         {
             {"name", "lemonade_load_model"},
+            {"annotations", {
+                {"readOnlyHint", false},
+                {"destructiveHint", false},
+                {"openWorldHint", true},
+            }},
             {"description",
              "Explicitly load a Lemonade model using the same implementation as "
              "POST /v1/load. The model_name must be exact. A known registry model "
@@ -1229,6 +1244,11 @@ json McpServer::tools_descriptor() {
         },
         {
             {"name", "lemonade_unload_model"},
+            {"annotations", {
+                {"readOnlyHint", false},
+                {"destructiveHint", false},
+                {"openWorldHint", false},
+            }},
             {"description",
              "Unload exactly one named model using the same implementation as "
              "POST /v1/unload. model_name is mandatory: this MCP tool never "
@@ -1245,6 +1265,11 @@ json McpServer::tools_descriptor() {
         },
         {
             {"name", "lemonade_pull_model"},
+            {"annotations", {
+                {"readOnlyHint", false},
+                {"destructiveHint", false},
+                {"openWorldHint", true},
+            }},
             {"description",
              "Download or register a model using the same implementation as "
              "POST /v1/pull. For a built-in/registered model, pass its exact "
@@ -1271,6 +1296,11 @@ json McpServer::tools_descriptor() {
         },
         {
             {"name", "lemonade_delete_model"},
+            {"annotations", {
+                {"readOnlyHint", false},
+                {"destructiveHint", true},
+                {"openWorldHint", false},
+            }},
             {"description",
              "Delete exactly one model using the same implementation as POST "
              "/v1/delete. This is destructive. The model_name must identify an "
@@ -1291,6 +1321,11 @@ json McpServer::tools_descriptor() {
         },
         {
             {"name", "lemonade_get_loaded_models"},
+            {"annotations", {
+                {"readOnlyHint", true},
+                {"destructiveHint", false},
+                {"openWorldHint", false},
+            }},
             {"description",
              "List the models currently loaded in Lemonade, including runtime "
              "recipe/type/device information reported by the server. Use this "
@@ -1304,6 +1339,11 @@ json McpServer::tools_descriptor() {
         },
         {
             {"name", "lemonade_get_server_health"},
+            {"annotations", {
+                {"readOnlyHint", true},
+                {"destructiveHint", false},
+                {"openWorldHint", false},
+            }},
             {"description",
              "Return Lemonade server health and runtime limits using the same "
              "implementation as GET /api/v1/health."},
@@ -1315,6 +1355,11 @@ json McpServer::tools_descriptor() {
         },
         {
             {"name", "lemonade_get_system_info"},
+            {"annotations", {
+                {"readOnlyHint", true},
+                {"destructiveHint", false},
+                {"openWorldHint", false},
+            }},
             {"description",
              "Return Lemonade hardware and recipe/backend capability information "
              "using the same implementation as GET /api/v1/system-info."},
@@ -1326,6 +1371,11 @@ json McpServer::tools_descriptor() {
         },
         {
             {"name", "lemonade_list_backends"},
+            {"annotations", {
+                {"readOnlyHint", true},
+                {"destructiveHint", false},
+                {"openWorldHint", false},
+            }},
             {"description",
              "List Lemonade recipes/backends and their installation/support "
              "state. This is the backend-focused view of the canonical "
@@ -1338,6 +1388,11 @@ json McpServer::tools_descriptor() {
         },
         {
             {"name", "lemonade_install_backend"},
+            {"annotations", {
+                {"readOnlyHint", false},
+                {"destructiveHint", true},
+                {"openWorldHint", true},
+            }},
             {"description",
              "Install or update one Lemonade recipe/backend through the same "
              "implementation as POST /api/v1/install. The MCP call is "

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -1211,7 +1211,8 @@ nlohmann::json Server::handle_mcp_server_tool(
 
     auto call_binary_handler = [this](const nlohmann::json& body,
                                       JsonHandler handler,
-                                      const std::string& label) {
+                                      const std::string& label,
+                                      const std::string& fallback_mime_type) {
         httplib::Request request;
         request.method = "POST";
         request.body = body.dump();
@@ -1221,10 +1222,15 @@ nlohmann::json Server::handle_mcp_server_tool(
         if (response.status >= 400) {
             return mcp_model_http_result(response);
         }
-        const std::string mime_type = response.get_header_value("Content-Type");
+        std::string mime_type = response.get_header_value("Content-Type");
+        if (mime_type.empty()) {
+            mime_type = fallback_mime_type.empty()
+                ? "application/octet-stream"
+                : fallback_mime_type;
+        }
         const std::string encoded = utils::JsonUtils::base64_encode(response.body);
         nlohmann::json payload = {
-            {"mime_type", mime_type.empty() ? "application/octet-stream" : mime_type},
+            {"mime_type", mime_type},
             {"data_base64", encoded},
         };
         nlohmann::json content = nlohmann::json::array();
@@ -1503,7 +1509,7 @@ nlohmann::json Server::handle_mcp_server_tool(
                 if (arguments.contains(key)) body[key] = arguments[key];
             }
             return call_binary_handler(
-                body, &Server::handle_audio_generations, "Generated audio.");
+                body, &Server::handle_audio_generations, "Generated audio.", "audio/wav");
         }
 
         if (tool_name == "lemonade_text_to_speech") {
@@ -1517,8 +1523,23 @@ nlohmann::json Server::handle_mcp_server_tool(
             for (const char* key : {"voice", "speed", "response_format"}) {
                 if (arguments.contains(key)) body[key] = arguments[key];
             }
+            std::string fallback_mime_type = "audio/mpeg";
+            const std::string response_format =
+                body.value("response_format", std::string("mp3"));
+            if (response_format == "wav") {
+                fallback_mime_type = "audio/wav";
+            } else if (response_format == "opus") {
+                fallback_mime_type = "audio/ogg";
+            } else if (response_format == "aac") {
+                fallback_mime_type = "audio/aac";
+            } else if (response_format == "flac") {
+                fallback_mime_type = "audio/flac";
+            } else if (response_format == "pcm") {
+                fallback_mime_type = "audio/l16";
+            }
             return call_binary_handler(
-                body, &Server::handle_audio_speech, "Generated speech audio.");
+                body, &Server::handle_audio_speech, "Generated speech audio.",
+                fallback_mime_type);
         }
 
         if (tool_name == "lemonade_generate_3d") {
@@ -1533,7 +1554,8 @@ nlohmann::json Server::handle_mcp_server_tool(
                 if (arguments.contains(key)) body[key] = arguments[key];
             }
             return call_binary_handler(
-                body, &Server::handle_3d_generations, "Generated GLB model.");
+                body, &Server::handle_3d_generations, "Generated GLB model.",
+                "model/gltf-binary");
         }
 
         return mcp_model_tool_result({{"error", "Unknown Lemonade server tool: " + tool_name}}, true);

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -350,6 +350,99 @@ nlohmann::json get_model_storage_stats(const std::string& model_storage_path) {
     };
 }
 
+std::string mcp_model_result_text(const nlohmann::json& payload) {
+    if (payload.is_object()) {
+        auto error = payload.find("error");
+        if (error != payload.end()) {
+            if (error->is_string()) return error->get<std::string>();
+            if (error->is_object()) {
+                auto message = error->find("message");
+                if (message != error->end() && message->is_string()) {
+                    return message->get<std::string>();
+                }
+            }
+        }
+        auto message = payload.find("message");
+        if (message != payload.end() && message->is_string()) {
+            return message->get<std::string>();
+        }
+    }
+    if (payload.is_string()) return payload.get<std::string>();
+    return payload.dump();
+}
+
+nlohmann::json mcp_model_tool_result(nlohmann::json payload,
+                                     bool is_error,
+                                     const std::string& message = "") {
+    nlohmann::json structured = payload.is_object()
+        ? payload
+        : nlohmann::json{{"result", std::move(payload)}};
+    const std::string text = message.empty()
+        ? mcp_model_result_text(structured)
+        : message;
+    return {
+        {"content", nlohmann::json::array({{
+            {"type", "text"},
+            {"text", text},
+        }})},
+        {"structuredContent", std::move(structured)},
+        {"isError", is_error},
+    };
+}
+
+nlohmann::json mcp_model_http_result(const httplib::Response& response) {
+    nlohmann::json payload;
+    if (response.body.empty()) {
+        payload = nlohmann::json::object();
+    } else {
+        try {
+            payload = nlohmann::json::parse(response.body);
+        } catch (const std::exception&) {
+            payload = {{"body", response.body}};
+        }
+    }
+    if (!payload.is_object()) {
+        payload = {{"result", std::move(payload)}};
+    }
+    if (response.status > 0) {
+        payload["http_status"] = response.status;
+    }
+    return mcp_model_tool_result(std::move(payload), response.status >= 400);
+}
+
+void validate_mcp_model_arguments(
+        const nlohmann::json& arguments,
+        const std::set<std::string>& allowed) {
+    if (!arguments.is_object()) {
+        throw std::invalid_argument("Tool arguments must be an object");
+    }
+    for (const auto& [key, value] : arguments.items()) {
+        (void)value;
+        if (allowed.count(key) == 0) {
+            throw std::invalid_argument("Unknown argument: " + key);
+        }
+    }
+}
+
+std::string required_mcp_model_string(const nlohmann::json& arguments,
+                                      const char* key) {
+    auto value = arguments.find(key);
+    if (value == arguments.end() || !value->is_string()) {
+        throw std::invalid_argument(std::string("Missing or non-string argument: ") + key);
+    }
+    std::string result = value->get<std::string>();
+    result.erase(result.begin(), std::find_if(result.begin(), result.end(), [](unsigned char ch) {
+        return !std::isspace(ch);
+    }));
+    result.erase(std::find_if(result.rbegin(), result.rend(), [](unsigned char ch) {
+        return !std::isspace(ch);
+    }).base(), result.end());
+    if (result.empty()) {
+        throw std::invalid_argument(std::string("Argument must not be empty: ") + key);
+    }
+    return result;
+}
+
 } // namespace
 
 
@@ -1092,6 +1185,363 @@ httplib::Server::HandlerResponse Server::authenticate_request(const httplib::Req
 }
 
 
+
+nlohmann::json Server::handle_mcp_server_tool(
+        const std::string& tool_name,
+        const nlohmann::json& arguments) {
+    using JsonHandler = void (Server::*)(const httplib::Request&, httplib::Response&);
+
+    auto call_json_handler = [this](const nlohmann::json& body, JsonHandler handler) {
+        httplib::Request request;
+        request.method = "POST";
+        request.body = body.dump();
+        request.headers.emplace("Content-Type", "application/json");
+        httplib::Response response;
+        (this->*handler)(request, response);
+        return mcp_model_http_result(response);
+    };
+
+    auto call_get_handler = [this](JsonHandler handler) {
+        httplib::Request request;
+        request.method = "GET";
+        httplib::Response response;
+        (this->*handler)(request, response);
+        return mcp_model_http_result(response);
+    };
+
+    auto call_binary_handler = [this](const nlohmann::json& body,
+                                      JsonHandler handler,
+                                      const std::string& label) {
+        httplib::Request request;
+        request.method = "POST";
+        request.body = body.dump();
+        request.headers.emplace("Content-Type", "application/json");
+        httplib::Response response;
+        (this->*handler)(request, response);
+        if (response.status >= 400) {
+            return mcp_model_http_result(response);
+        }
+        const std::string mime_type = response.get_header_value("Content-Type");
+        const std::string encoded = utils::JsonUtils::base64_encode(response.body);
+        nlohmann::json payload = {
+            {"mime_type", mime_type.empty() ? "application/octet-stream" : mime_type},
+            {"data_base64", encoded},
+        };
+        nlohmann::json content = nlohmann::json::array();
+        if (mime_type.rfind("audio/", 0) == 0) {
+            content.push_back({
+                {"type", "audio"},
+                {"data", encoded},
+                {"mimeType", mime_type},
+            });
+        } else if (mime_type.rfind("image/", 0) == 0) {
+            content.push_back({
+                {"type", "image"},
+                {"data", encoded},
+                {"mimeType", mime_type},
+            });
+        } else {
+            content.push_back({
+                {"type", "text"},
+                {"text", label},
+            });
+        }
+        return nlohmann::json{
+            {"content", std::move(content)},
+            {"structuredContent", std::move(payload)},
+            {"isError", false},
+        };
+    };
+
+    auto resolve_media_model = [this](const nlohmann::json& args,
+                                      ModelType type,
+                                      const char* type_name) -> std::string {
+        if (args.contains("model")) {
+            if (!args["model"].is_string()) {
+                throw std::invalid_argument("model must be a string");
+            }
+            std::string model = args["model"].get<std::string>();
+            if (!model.empty()) return model;
+        }
+        const std::string wanted_type = model_type_to_string(type);
+        for (const auto& loaded : router_->get_all_loaded_models()) {
+            if (loaded.value("type", std::string()) == wanted_type) {
+                const std::string model = loaded.value("model_name", std::string());
+                if (!model.empty()) return model;
+            }
+        }
+        for (const auto& [name, info] : model_manager_->get_downloaded_models()) {
+            if (info.type == type) return name;
+        }
+        throw std::invalid_argument(
+            std::string("No loaded/downloaded ") + type_name +
+            " model is available; pass an explicit model or pull one first");
+    };
+
+    try {
+        if (tool_name == "lemonade_get_model_info") {
+            validate_mcp_model_arguments(arguments, {"model_name"});
+            const std::string requested = required_mcp_model_string(arguments, "model_name");
+            if (!model_manager_->model_exists(requested)) {
+                return mcp_model_tool_result({
+                    {"error", "Model not found: " + requested},
+                    {"model_name", requested},
+                }, true);
+            }
+            const std::string model_name = model_manager_->resolve_model_name(requested);
+            const ModelInfo info = model_manager_->get_model_info(model_name);
+            const std::string public_name = model_manager_->get_public_model_name(model_name);
+            const std::string response_name = public_name.empty() ? requested : public_name;
+            nlohmann::json payload = model_info_to_json(response_name, info);
+            payload["model_name"] = response_name;
+            return mcp_model_tool_result(std::move(payload), false);
+        }
+
+        if (tool_name == "lemonade_load_model") {
+            validate_mcp_model_arguments(
+                arguments, {"model_name", "ctx_size", "pinned", "options"});
+            nlohmann::json body = {
+                {"model_name", required_mcp_model_string(arguments, "model_name")},
+                {"save_options", false},
+            };
+
+            if (arguments.contains("ctx_size")) {
+                if (!arguments["ctx_size"].is_number_integer()) {
+                    throw std::invalid_argument("ctx_size must be an integer");
+                }
+                body["ctx_size"] = arguments["ctx_size"];
+            }
+            if (arguments.contains("pinned")) {
+                if (!arguments["pinned"].is_boolean()) {
+                    throw std::invalid_argument("pinned must be a boolean");
+                }
+                body["pinned"] = arguments["pinned"];
+            }
+            if (arguments.contains("options")) {
+                if (!arguments["options"].is_object()) {
+                    throw std::invalid_argument("options must be an object");
+                }
+                for (const auto& [key, value] : arguments["options"].items()) {
+                    if (key == "model" || key == "model_name" ||
+                        key == "save_options" || key == "pinned") {
+                        throw std::invalid_argument(
+                            "options must contain recipe options only; reserved key: " + key);
+                    }
+                    if (key == "ctx_size" && arguments.contains("ctx_size")) {
+                        throw std::invalid_argument(
+                            "ctx_size must be provided either at top level or in options, not both");
+                    }
+                    body[key] = value;
+                }
+            }
+            return call_json_handler(body, &Server::handle_load);
+        }
+
+        if (tool_name == "lemonade_unload_model") {
+            validate_mcp_model_arguments(arguments, {"model_name"});
+            const nlohmann::json body = {
+                {"model_name", required_mcp_model_string(arguments, "model_name")},
+            };
+            return call_json_handler(body, &Server::handle_unload);
+        }
+
+        if (tool_name == "lemonade_pull_model") {
+            validate_mcp_model_arguments(
+                arguments,
+                {"model_name", "checkpoint", "recipe", "source", "do_not_upgrade"});
+            nlohmann::json body = {
+                {"model_name", required_mcp_model_string(arguments, "model_name")},
+                {"stream", false},
+            };
+            for (const char* key : std::vector<const char*>{"checkpoint", "recipe", "source"}) {
+                if (!arguments.contains(key)) continue;
+                if (!arguments[key].is_string()) {
+                    throw std::invalid_argument(std::string(key) + " must be a string");
+                }
+                body[key] = arguments[key];
+            }
+            if (arguments.contains("do_not_upgrade")) {
+                if (!arguments["do_not_upgrade"].is_boolean()) {
+                    throw std::invalid_argument("do_not_upgrade must be a boolean");
+                }
+                body["do_not_upgrade"] = arguments["do_not_upgrade"];
+            }
+            return call_json_handler(body, &Server::handle_pull);
+        }
+
+        if (tool_name == "lemonade_delete_model") {
+            validate_mcp_model_arguments(arguments, {"model_name", "confirm"});
+            const std::string requested = required_mcp_model_string(arguments, "model_name");
+            if (!arguments.contains("confirm") || !arguments["confirm"].is_boolean() ||
+                !arguments["confirm"].get<bool>()) {
+                return mcp_model_tool_result({
+                    {"error", "Deletion requires confirm=true"},
+                    {"model_name", requested},
+                    {"required", "confirm=true"},
+                }, true);
+            }
+
+            if (!model_manager_->model_exists(requested)) {
+                return mcp_model_tool_result({
+                    {"error", "Model not found: " + requested},
+                    {"model_name", requested},
+                }, true);
+            }
+            return call_json_handler(
+                nlohmann::json{{"model_name", requested}}, &Server::handle_delete);
+        }
+
+        if (tool_name == "lemonade_get_loaded_models") {
+            validate_mcp_model_arguments(arguments, {});
+            nlohmann::json models = router_->get_all_loaded_models();
+            return mcp_model_tool_result({
+                {"models", models},
+                {"count", models.size()},
+            }, false);
+        }
+
+        if (tool_name == "lemonade_get_server_health") {
+            validate_mcp_model_arguments(arguments, {});
+            return call_get_handler(&Server::handle_health);
+        }
+
+        if (tool_name == "lemonade_get_system_info") {
+            validate_mcp_model_arguments(arguments, {});
+            return call_get_handler(&Server::handle_system_info);
+        }
+
+        if (tool_name == "lemonade_list_backends") {
+            validate_mcp_model_arguments(arguments, {});
+            httplib::Request request;
+            request.method = "GET";
+            httplib::Response response;
+            handle_system_info(request, response);
+            if (response.status >= 400) return mcp_model_http_result(response);
+            nlohmann::json system_info = nlohmann::json::parse(response.body);
+            nlohmann::json payload = {
+                {"recipes", system_info.value("recipes", nlohmann::json::object())},
+                {"unavailable_recipes", system_info.value(
+                    "unavailable_recipes", nlohmann::json::array())},
+                {"no_fetch_executables", system_info.value("no_fetch_executables", false)},
+            };
+            return mcp_model_tool_result(std::move(payload), false);
+        }
+
+        if (tool_name == "lemonade_install_backend") {
+            validate_mcp_model_arguments(arguments, {"recipe", "backend", "force"});
+            nlohmann::json body = {
+                {"recipe", required_mcp_model_string(arguments, "recipe")},
+                {"backend", required_mcp_model_string(arguments, "backend")},
+                {"stream", false},
+            };
+            if (arguments.contains("force")) {
+                if (!arguments["force"].is_boolean()) {
+                    throw std::invalid_argument("force must be a boolean");
+                }
+                body["force"] = arguments["force"];
+            }
+            return call_json_handler(body, &Server::handle_install);
+        }
+
+        if (tool_name == "lemonade_edit_image") {
+            validate_mcp_model_arguments(
+                arguments, {"prompt", "image", "model", "size", "steps",
+                            "cfg_scale", "seed", "n"});
+            nlohmann::json body;
+            body["model"] = resolve_media_model(arguments, ModelType::IMAGE, "image");
+            body["prompt"] = required_mcp_model_string(arguments, "prompt");
+            std::string image = required_mcp_model_string(arguments, "image");
+            const auto comma = image.find(',');
+            if (image.rfind("data:", 0) == 0) {
+                if (comma == std::string::npos) {
+                    throw std::invalid_argument("image data URL is missing its base64 payload");
+                }
+                image = image.substr(comma + 1);
+            }
+            body["image_data"] = image;
+            body["image_filename"] = "image.png";
+            for (const char* key : {"size", "steps", "cfg_scale", "seed", "n"}) {
+                if (arguments.contains(key)) body[key] = arguments[key];
+            }
+            httplib::Response response;
+            handle_image_edit_json(body, response);
+            if (response.status >= 400) return mcp_model_http_result(response);
+            nlohmann::json payload = nlohmann::json::parse(response.body);
+            nlohmann::json content = nlohmann::json::array();
+            if (payload.contains("data") && payload["data"].is_array()) {
+                for (const auto& item : payload["data"]) {
+                    if (item.contains("b64_json") && item["b64_json"].is_string()) {
+                        content.push_back({
+                            {"type", "image"},
+                            {"data", item["b64_json"]},
+                            {"mimeType", "image/png"},
+                        });
+                    }
+                }
+            }
+            if (content.empty()) {
+                content.push_back({{"type", "text"}, {"text", "Image edit completed."}});
+            }
+            return {
+                {"content", std::move(content)},
+                {"structuredContent", std::move(payload)},
+                {"isError", false},
+            };
+        }
+
+        if (tool_name == "lemonade_generate_audio") {
+            validate_mcp_model_arguments(
+                arguments, {"prompt", "model", "duration", "steps", "cfg", "seed",
+                            "lyrics", "vocal_language", "response_format"});
+            nlohmann::json body = {
+                {"model", resolve_media_model(
+                    arguments, ModelType::AUDIO_GENERATION, "audio-generation")},
+                {"prompt", required_mcp_model_string(arguments, "prompt")},
+            };
+            for (const char* key : {"duration", "steps", "cfg", "seed", "lyrics",
+                                    "vocal_language", "response_format"}) {
+                if (arguments.contains(key)) body[key] = arguments[key];
+            }
+            return call_binary_handler(
+                body, &Server::handle_audio_generations, "Generated audio.");
+        }
+
+        if (tool_name == "lemonade_text_to_speech") {
+            validate_mcp_model_arguments(
+                arguments, {"input", "model", "voice", "speed", "response_format"});
+            nlohmann::json body = {
+                {"model", resolve_media_model(arguments, ModelType::TTS, "TTS")},
+                {"input", required_mcp_model_string(arguments, "input")},
+                {"stream", false},
+            };
+            for (const char* key : {"voice", "speed", "response_format"}) {
+                if (arguments.contains(key)) body[key] = arguments[key];
+            }
+            return call_binary_handler(
+                body, &Server::handle_audio_speech, "Generated speech audio.");
+        }
+
+        if (tool_name == "lemonade_generate_3d") {
+            validate_mcp_model_arguments(
+                arguments, {"image", "model", "resolution", "bg_removal", "seed", "uv"});
+            nlohmann::json body = {
+                {"model", resolve_media_model(arguments, ModelType::MESH, "3D")},
+                {"image", required_mcp_model_string(arguments, "image")},
+                {"response_format", "glb"},
+            };
+            for (const char* key : {"resolution", "bg_removal", "seed", "uv"}) {
+                if (arguments.contains(key)) body[key] = arguments[key];
+            }
+            return call_binary_handler(
+                body, &Server::handle_3d_generations, "Generated GLB model.");
+        }
+
+        return mcp_model_tool_result({{"error", "Unknown Lemonade server tool: " + tool_name}}, true);
+    } catch (const std::exception& e) {
+        return mcp_model_tool_result({{"error", e.what()}}, true);
+    }
+}
+
 void Server::setup_routes(httplib::Server &web_server) {
     // Add pre-routing handler to log ALL incoming requests (except health checks)
     web_server.set_pre_routing_handler([this](const httplib::Request& req, httplib::Response& res) {
@@ -1532,7 +1982,10 @@ void Server::setup_routes(httplib::Server &web_server) {
     auto mcp_server = std::make_shared<McpServer>(
         router_.get(),
         model_manager_.get(),
-        [this](const std::string& m) { auto_load_model_if_needed(m); });
+        [this](const std::string& m) { auto_load_model_if_needed(m); },
+        [this](const std::string& tool_name, const json& arguments) {
+            return handle_mcp_server_tool(tool_name, arguments);
+        });
     mcp_server->register_routes(web_server);
 
     // Setup static file serving for web UI
@@ -5297,6 +5750,35 @@ bool Server::load_image_model(const nlohmann::json& request_json, httplib::Respo
     return true;
 }
 
+void Server::handle_image_edit_json(
+        const nlohmann::json& request_json,
+        httplib::Response& res) {
+    if (!request_json.contains("prompt") || !request_json["prompt"].is_string()) {
+        res.status = 400;
+        res.set_content(nlohmann::json{{"error", {
+            {"message", "Missing or non-string 'prompt' field in request"},
+            {"type", "invalid_request_error"}
+        }}}.dump(), "application/json");
+        return;
+    }
+    if (!request_json.contains("image_data") || !request_json["image_data"].is_string()) {
+        res.status = 400;
+        res.set_content(nlohmann::json{{"error", {
+            {"message", "Missing image data"},
+            {"type", "invalid_request_error"}
+        }}}.dump(), "application/json");
+        return;
+    }
+    if (!load_image_model(request_json, res)) return;
+
+    auto response = router_->image_edits(request_json);
+    if (response.contains("error")) {
+        LOG(ERROR, "Server") << "Image edits backend error: " << response.dump() << std::endl;
+        res.status = 500;
+    }
+    res.set_content(response.dump(), "application/json");
+}
+
 void Server::handle_image_edits(const httplib::Request& req, httplib::Response& res) {
     try {
         LOG(INFO, "Server") << "POST /api/v1/images/edits" << std::endl;
@@ -5401,24 +5883,7 @@ void Server::handle_image_edits(const httplib::Request& req, httplib::Response& 
             }
         }
 
-        if (!request_json.contains("prompt")) {
-            res.status = 400;
-            nlohmann::json error = {{"error", {
-                {"message", "Missing 'prompt' field in request"},
-                {"type", "invalid_request_error"}
-            }}};
-            res.set_content(error.dump(), "application/json");
-            return;
-        }
-
-        if (!load_image_model(request_json, res)) return;
-
-        auto response = router_->image_edits(request_json);
-        if (response.contains("error")) {
-            LOG(ERROR, "Server") << "Image edits backend error: " << response.dump() << std::endl;
-            res.status = 500;
-        }
-        res.set_content(response.dump(), "application/json");
+        handle_image_edit_json(request_json, res);
 
     } catch (const nlohmann::json::exception& e) {
         LOG(ERROR, "Server") << "JSON parse error in handle_image_edits: " << e.what() << std::endl;

--- a/test/server_mcp.py
+++ b/test/server_mcp.py
@@ -3,8 +3,10 @@ Integration tests for the MCP gateway endpoint (POST /mcp).
 
 Requires a Lemonade server to already be running on port 13305.
 
-Covers the JSON-RPC 2.0 envelope plus the four tools exposed by the gateway:
-- lemonade_list_models
+Covers the JSON-RPC 2.0 envelope plus inference and model-management tools:
+- lemonade_list_models / lemonade_get_model_info
+- lemonade_load_model / lemonade_unload_model
+- lemonade_pull_model / lemonade_delete_model
 - lemonade_chat
 - lemonade_transcribe_audio   (smoke-tested via schema only; needs Whisper)
 - lemonade_generate_image     (smoke-tested via schema only; needs SD)
@@ -52,6 +54,44 @@ def _post(payload, timeout=TIMEOUT_DEFAULT):
         headers=_auth_headers(),
         timeout=timeout,
     )
+
+
+def _call_tool(name, arguments, request_id=100, timeout=TIMEOUT_DEFAULT):
+    """Call one MCP tool and return the decoded tool result."""
+    response = _post(
+        {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": "tools/call",
+            "params": {"name": name, "arguments": arguments},
+        },
+        timeout=timeout,
+    )
+    response.raise_for_status()
+    return response.json()["result"]
+
+
+MCP_HUB_EXPECTED_TOOLS = {
+    "lemonade_list_models",
+    "lemonade_get_model_info",
+    "lemonade_load_model",
+    "lemonade_unload_model",
+    "lemonade_get_loaded_models",
+    "lemonade_get_server_health",
+    "lemonade_pull_model",
+    "lemonade_delete_model",
+    "lemonade_get_system_info",
+    "lemonade_list_backends",
+    "lemonade_install_backend",
+    "lemonade_generate_image",
+    "lemonade_edit_image",
+    "lemonade_generate_audio",
+    "lemonade_text_to_speech",
+    "lemonade_transcribe_audio",
+    "lemonade_generate_3d",
+    "lemonade_chat",
+    "lemonade_omni",
+}
 
 
 class McpGatewayTests(ServerTestBase):
@@ -225,13 +265,7 @@ class McpGatewayTests(ServerTestBase):
         body = response.json()
         tools = body["result"]["tools"]
         names = {tool["name"] for tool in tools}
-        expected = {
-            "lemonade_list_models",
-            "lemonade_chat",
-            "lemonade_transcribe_audio",
-            "lemonade_generate_image",
-            "lemonade_omni",
-        }
+        expected = MCP_HUB_EXPECTED_TOOLS
         self.assertTrue(expected.issubset(names), f"missing tools: {expected - names}")
         for tool in tools:
             self.assertIn("description", tool)
@@ -246,9 +280,149 @@ class McpGatewayTests(ServerTestBase):
         self.assertIn("model", omni["inputSchema"]["properties"])
         self.assertIn("output_dir", omni["inputSchema"]["properties"])
 
+        unload = next(t for t in tools if t["name"] == "lemonade_unload_model")
+        self.assertEqual(unload["inputSchema"].get("required"), ["model_name"])
+        delete = next(t for t in tools if t["name"] == "lemonade_delete_model")
+        self.assertEqual(
+            set(delete["inputSchema"].get("required", [])), {"model_name", "confirm"}
+        )
+        self.assertEqual(
+            delete["inputSchema"]["properties"]["confirm"].get("enum"), [True]
+        )
+
+        install = next(t for t in tools if t["name"] == "lemonade_install_backend")
+        self.assertEqual(
+            set(install["inputSchema"].get("required", [])), {"recipe", "backend"}
+        )
+        edit = next(t for t in tools if t["name"] == "lemonade_edit_image")
+        self.assertEqual(
+            set(edit["inputSchema"].get("required", [])), {"prompt", "image"}
+        )
+        model3d = next(t for t in tools if t["name"] == "lemonade_generate_3d")
+        self.assertEqual(model3d["inputSchema"].get("required"), ["image"])
+        self.assertEqual(
+            model3d["inputSchema"]["properties"]["bg_removal"].get("enum"),
+            ["threshold", "birefnet"],
+        )
+
     # ---------------------------------------------------------------------
     # tools/call error paths
     # ---------------------------------------------------------------------
+
+    def test_024_get_model_info_tool(self):
+        """Named model detail is available through MCP without a duplicate listing tool."""
+        result = _call_tool(
+            "lemonade_get_model_info",
+            {"model_name": ENDPOINT_TEST_MODEL},
+            request_id=24,
+        )
+        self.assertFalse(result["isError"], msg=str(result))
+        self.assertEqual(result["structuredContent"]["model_name"], ENDPOINT_TEST_MODEL)
+        self.assertIn("recipe", result["structuredContent"])
+
+    def test_025_unload_requires_explicit_model_name(self):
+        """Missing model_name must never fall through to REST's unload-all behavior."""
+        base = f"http://localhost:{PORT}/api/v1"
+        load = requests.post(
+            f"{base}/load",
+            json={"model_name": ENDPOINT_TEST_MODEL},
+            headers=_auth_headers(),
+            timeout=TIMEOUT_MODEL_OPERATION,
+        )
+        self.assertEqual(load.status_code, 200, load.text)
+
+        result = _call_tool("lemonade_unload_model", {}, request_id=25)
+        self.assertTrue(result["isError"], msg=str(result))
+
+        health = requests.get(
+            f"{base}/health", headers=_auth_headers(), timeout=TIMEOUT_DEFAULT
+        )
+        self.assertEqual(health.status_code, 200, health.text)
+        loaded = {item["model_name"] for item in health.json()["all_models_loaded"]}
+        self.assertIn(ENDPOINT_TEST_MODEL, loaded)
+
+    def test_026_load_and_unload_tools(self):
+        """Explicit MCP load/unload round-trips through the existing server handlers."""
+        loaded = _call_tool(
+            "lemonade_load_model", {"model_name": ENDPOINT_TEST_MODEL}, request_id=26
+        )
+        self.assertFalse(loaded["isError"], msg=str(loaded))
+        self.assertEqual(loaded["structuredContent"]["status"], "success")
+
+        unloaded = _call_tool(
+            "lemonade_unload_model", {"model_name": ENDPOINT_TEST_MODEL}, request_id=27
+        )
+        self.assertFalse(unloaded["isError"], msg=str(unloaded))
+        self.assertEqual(unloaded["structuredContent"]["status"], "success")
+
+    def test_027_pull_existing_model_tool(self):
+        """Pull reuses /pull; the already-cached endpoint model makes this deterministic."""
+        result = _call_tool(
+            "lemonade_pull_model",
+            {"model_name": ENDPOINT_TEST_MODEL, "do_not_upgrade": True},
+            request_id=28,
+            timeout=TIMEOUT_MODEL_OPERATION,
+        )
+        self.assertFalse(result["isError"], msg=str(result))
+
+    def test_028_delete_requires_confirmation(self):
+        """Delete is exact and requires confirm=true before calling the REST handler."""
+        canonical_name = f"user.McpDelete-{uuid.uuid4().hex[:8]}"
+        base = f"http://localhost:{PORT}/api/v1"
+        try:
+            register = requests.post(
+                f"{base}/pull",
+                json={
+                    "model_name": canonical_name,
+                    "recipe": "collection.omni",
+                    "components": [ENDPOINT_TEST_MODEL],
+                },
+                headers=_auth_headers(),
+                timeout=TIMEOUT_MODEL_OPERATION,
+            )
+            self.assertEqual(register.status_code, 200, register.text)
+
+            refused = _call_tool(
+                "lemonade_delete_model",
+                {"model_name": canonical_name, "confirm": False},
+                request_id=29,
+            )
+            self.assertTrue(refused["isError"], msg=str(refused))
+
+            still_there = _call_tool(
+                "lemonade_get_model_info", {"model_name": canonical_name}, request_id=30
+            )
+            self.assertFalse(still_there["isError"], msg=str(still_there))
+
+            deleted = _call_tool(
+                "lemonade_delete_model",
+                {"model_name": canonical_name, "confirm": True},
+                request_id=31,
+                timeout=TIMEOUT_MODEL_OPERATION,
+            )
+            self.assertFalse(deleted["isError"], msg=str(deleted))
+        finally:
+            try:
+                requests.post(
+                    f"{base}/delete",
+                    json={"model_name": canonical_name},
+                    headers=_auth_headers(),
+                    timeout=TIMEOUT_DEFAULT,
+                )
+            except Exception:
+                pass
+
+    def test_012_all_advertised_tools_have_dispatch(self):
+        """Every tools/list entry must resolve to a real tools/call dispatch."""
+        listed = _post({"jsonrpc": "2.0", "id": 120, "method": "tools/list"}).json()[
+            "result"
+        ]["tools"]
+        self.assertEqual({tool["name"] for tool in listed}, MCP_HUB_EXPECTED_TOOLS)
+        for index, tool in enumerate(listed, start=121):
+            result = _call_tool(tool["name"], {}, request_id=index)
+            text = json.dumps(result)
+            self.assertNotIn("Unknown tool:", text, msg=tool["name"])
+            self.assertNotIn("Unknown Lemonade server tool:", text, msg=tool["name"])
 
     def test_013_list_models_emits_prefixed_collection_id(self):
         """lemonade_list_models emits the canonical `user.` collection id (issue #2788).

--- a/test/server_mcp.py
+++ b/test/server_mcp.py
@@ -417,7 +417,14 @@ class McpGatewayTests(ServerTestBase):
         listed = _post({"jsonrpc": "2.0", "id": 120, "method": "tools/list"}).json()[
             "result"
         ]["tools"]
-        self.assertEqual({tool["name"] for tool in listed}, MCP_HUB_EXPECTED_TOOLS)
+        listed_names = {tool["name"] for tool in listed}
+        self.assertTrue(
+            MCP_HUB_EXPECTED_TOOLS.issubset(listed_names),
+            msg=(
+                "Missing expected MCP tools: "
+                f"{sorted(MCP_HUB_EXPECTED_TOOLS - listed_names)}"
+            ),
+        )
         for index, tool in enumerate(listed, start=121):
             result = _call_tool(tool["name"], {}, request_id=index)
             text = json.dumps(result)

--- a/test/server_mcp.py
+++ b/test/server_mcp.py
@@ -425,6 +425,73 @@ class McpGatewayTests(ServerTestBase):
                 f"{sorted(MCP_HUB_EXPECTED_TOOLS - listed_names)}"
             ),
         )
+        by_name = {tool["name"]: tool for tool in listed}
+        expected_annotations = {
+            "lemonade_list_models": {
+                "readOnlyHint": True,
+                "destructiveHint": False,
+                "openWorldHint": False,
+            },
+            "lemonade_get_model_info": {
+                "readOnlyHint": True,
+                "destructiveHint": False,
+                "openWorldHint": False,
+            },
+            "lemonade_load_model": {
+                "readOnlyHint": False,
+                "destructiveHint": False,
+                "openWorldHint": True,
+            },
+            "lemonade_unload_model": {
+                "readOnlyHint": False,
+                "destructiveHint": False,
+                "openWorldHint": False,
+            },
+            "lemonade_get_loaded_models": {
+                "readOnlyHint": True,
+                "destructiveHint": False,
+                "openWorldHint": False,
+            },
+            "lemonade_get_server_health": {
+                "readOnlyHint": True,
+                "destructiveHint": False,
+                "openWorldHint": False,
+            },
+            "lemonade_pull_model": {
+                "readOnlyHint": False,
+                "destructiveHint": False,
+                "openWorldHint": True,
+            },
+            "lemonade_delete_model": {
+                "readOnlyHint": False,
+                "destructiveHint": True,
+                "openWorldHint": False,
+            },
+            "lemonade_get_system_info": {
+                "readOnlyHint": True,
+                "destructiveHint": False,
+                "openWorldHint": False,
+            },
+            "lemonade_list_backends": {
+                "readOnlyHint": True,
+                "destructiveHint": False,
+                "openWorldHint": False,
+            },
+            "lemonade_install_backend": {
+                "readOnlyHint": False,
+                "destructiveHint": True,
+                "openWorldHint": True,
+            },
+        }
+        for name, expected in expected_annotations.items():
+            annotations = by_name[name].get("annotations", {})
+            for key, value in expected.items():
+                self.assertEqual(
+                    annotations.get(key),
+                    value,
+                    msg=f"{name} annotation {key}: {annotations}",
+                )
+
         for index, tool in enumerate(listed, start=121):
             result = _call_tool(tool["name"], {}, request_id=index)
             text = json.dumps(result)

--- a/test/server_mcp_smoke.py
+++ b/test/server_mcp_smoke.py
@@ -1,14 +1,15 @@
 """
-MCP gateway smoke tests — exercises each of the 5 MCP tools end-to-end.
+MCP gateway smoke tests — validates the canonical tool catalog and core inference paths.
 
 Two modes:
 
-* **Fast mode (default, used in CI)** — exercises each tool's dispatcher and
-  validation path. Only downloads a ~180 MB GGUF for the chat tool. Whisper,
+* **Fast mode (default, used in CI)** — validates the canonical `tools/list`
+  catalog, then exercises the core inference/discovery paths. Only downloads
+  a ~180 MB GGUF for the chat tool. Whisper,
   Stable Diffusion, and Omni are checked via their structured-error paths so
   the workflow stays runnable on a vanilla ubuntu-latest runner.
 
-* **Live mode (local opt-in)** — per-tool flags trigger real inference using
+* **Live mode (local opt-in)** — per-inference flags trigger real inference using
   the models recommended in `docs/api/mcp.md`. Use these when you want
   end-to-end confidence on your own machine without burning GitHub minutes.
 
@@ -16,10 +17,10 @@ Usage:
     # Fast mode (CI default)
     python test/server_mcp_smoke.py
 
-    # Run every tool live with the doc-recommended models (multi-GB download)
+    # Run every inference smoke live with the doc-recommended models (multi-GB download)
     python test/server_mcp_smoke.py --full
 
-    # Opt into individual tools
+    # Opt into individual inference smokes
     python test/server_mcp_smoke.py --live-transcribe --live-image
     python test/server_mcp_smoke.py --live-omni --omni-model LMX-Omni-5.5B-Lite
 
@@ -47,6 +48,28 @@ DEFAULT_CHAT_MODEL = "Qwen3-1.7B-GGUF"
 DEFAULT_TRANSCRIBE_MODEL = "Whisper-Large-v3-Turbo"
 DEFAULT_IMAGE_MODEL = "SDXL-Turbo"
 DEFAULT_OMNI_MODEL = "LMX-Omni-5.5B-Lite"
+
+MCP_HUB_REQUIRED_TOOLS = {
+    "lemonade_list_models",
+    "lemonade_get_model_info",
+    "lemonade_load_model",
+    "lemonade_unload_model",
+    "lemonade_get_loaded_models",
+    "lemonade_get_server_health",
+    "lemonade_pull_model",
+    "lemonade_delete_model",
+    "lemonade_get_system_info",
+    "lemonade_list_backends",
+    "lemonade_install_backend",
+    "lemonade_generate_image",
+    "lemonade_edit_image",
+    "lemonade_generate_audio",
+    "lemonade_text_to_speech",
+    "lemonade_transcribe_audio",
+    "lemonade_generate_3d",
+    "lemonade_chat",
+    "lemonade_omni",
+}
 
 # Live tools can pull multi-GB models and run real inference; give them room.
 LIVE_PULL_TIMEOUT = 1800  # 30 min
@@ -186,6 +209,26 @@ def make_silent_wav(duration_s=1, sample_rate=16000):
 # ---------------------------------------------------------------------------
 # Fast-mode smokes (default; what CI runs).
 # ---------------------------------------------------------------------------
+
+
+def smoke_catalog(mcp_url, _cfg):
+    """tools/list must expose the canonical hub; future additional tools are allowed."""
+    payload = {"jsonrpc": "2.0", "id": 0, "method": "tools/list"}
+    response = _post(mcp_url, payload, timeout=60)
+    assert (
+        response.status_code == 200
+    ), f"HTTP {response.status_code}: {response.text[:300]}"
+    body = response.json()
+    tools = body.get("result", {}).get("tools")
+    assert isinstance(tools, list), f"tools/list returned no tool array: {body}"
+    names = [tool.get("name") for tool in tools]
+    assert all(
+        isinstance(name, str) and name for name in names
+    ), f"invalid tool name: {names}"
+    assert len(names) == len(set(names)), f"duplicate tool names: {names}"
+    missing = MCP_HUB_REQUIRED_TOOLS - set(names)
+    assert not missing, f"missing canonical MCP tools: {sorted(missing)}"
+    detail(f"{len(names)} tools advertised; canonical hub present")
 
 
 def smoke_list_models(mcp_url, _cfg):
@@ -366,7 +409,10 @@ def build_plan(args):
     live_image = args.full or args.live_image
     live_omni = args.full or args.live_omni
 
-    smokes = [("lemonade_list_models", smoke_list_models)]
+    smokes = [
+        ("tools/list catalog", smoke_catalog),
+        ("lemonade_list_models", smoke_list_models),
+    ]
 
     # Chat: live mode uses the doc-recommended model; fast mode uses tiny.
     if live_chat:
@@ -439,7 +485,7 @@ def main():
     live.add_argument(
         "--full",
         action="store_true",
-        help="Enable live mode for every tool (equivalent to all --live-* flags).",
+        help="Enable live mode for every inference smoke (equivalent to all --live-* flags).",
     )
     live.add_argument(
         "--live-chat",


### PR DESCRIPTION
## Summary

Expand `/mcp` into the canonical Lemonade capability hub so clients can discover server-owned tool contracts through `tools/list` and execute them through `tools/call`.

This exposes model management, system/backend management, and multimodal capabilities while reusing the existing server/API implementation instead of duplicating business logic. It also prepares GUI3 to consume Lemonade capabilities dynamically rather than maintaining a separate tool contract.

Fixes #3275
Related to #3274

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_

- `python test/server_mcp.py`
- 24 tests passed in 33.789s
- Verified the complete MCP tool catalogue is exposed through `tools/list`
- Verified advertised tools have matching `tools/call` dispatch

## Documentation

- [x] Documentation is affected and has been updated.
- [ ] Documentation is not affected by this change.

## Breaking Changes

- [x] This PR does not introduce breaking changes.

## AI-assisted contribution

- [x] I used AI tools for this PR.

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.