### PR TITLE
fix(gui3): refine Tauri window control icons

### DIFF
--- a/src/app/src/App.tsx
+++ b/src/app/src/App.tsx
@@ -1156,7 +1156,7 @@ const App: React.FC = () => {
                 aria-label="Minimize"
                 title="Minimize"
               >
-                <Icon name="minimize-2" size={14} />
+                <Icon name="minus" size={15} className="titlebar__window-icon" />
               </button>
               <button
                 className="titlebar__window-btn"
@@ -1165,7 +1165,7 @@ const App: React.FC = () => {
                 aria-label="Maximize"
                 title="Maximize"
               >
-                <Icon name="maximize-2" size={14} />
+                <Icon name="square" size={15} className="titlebar__window-icon" />
               </button>
               <button
                 className="titlebar__window-btn titlebar__window-btn--close"
@@ -1174,7 +1174,7 @@ const App: React.FC = () => {
                 aria-label="Cancel"
                 title="Cancel"
               >
-                <Icon name="x" size={14} />
+                <Icon name="x" size={15} className="titlebar__window-icon" />
               </button>
             </>
           )}

--- a/src/app/src/App.tsx
+++ b/src/app/src/App.tsx
@@ -1150,7 +1150,7 @@ const App: React.FC = () => {
           {isDesktop && (
             <>
               <button
-                className="titlebar__window-btn"
+                className="titlebar__window-btn titlebar__window-btn--minimize"
                 data-tauri-drag-region="false"
                 onClick={() => window.api?.minimizeWindow?.()}
                 aria-label="Minimize"

--- a/src/app/src/components/Icon.tsx
+++ b/src/app/src/components/Icon.tsx
@@ -18,8 +18,8 @@ export type IconName =
   | 'sliders-horizontal' | 'flame' | 'wrench' | 'brain' | 'rocket' | 'pin'
   | 'star' | 'hugging-face' | 'cloud' | 'cloud-off' | 'user-round-cog' | 'router'
   | 'speech' | 'book-open' | 'newspaper' | 'github' | 'discord' | 'funnel' | 'info'
-  | 'thermometer' | 'gem' | 'gauge' | 'timer' | 'hard-drive' | 'library' | 'scan-eye' | 'minimize-2'
-  | 'panel-left-close' | 'panel-left-open' | 'maximize-2' | 'brain-off' | 'brain-cog' | 'brain-circuit' | 'wrench-off' | 'terminal-square' | 'settings' | 'layers'
+  | 'thermometer' | 'gem' | 'gauge' | 'timer' | 'hard-drive' | 'library' | 'scan-eye' | 'minus' | 'minimize-2'
+  | 'panel-left-close' | 'panel-left-open' | 'square' | 'maximize-2' | 'brain-off' | 'brain-cog' | 'brain-circuit' | 'wrench-off' | 'terminal-square' | 'settings' | 'layers'
   | 'menu' | 'flask-conical' | 'external-link'
   | 'model-details';
 

--- a/src/app/src/components/localIcons.tsx
+++ b/src/app/src/components/localIcons.tsx
@@ -198,6 +198,10 @@ export const LOCAL_ICON_DEFINITIONS: Record<string, LocalIconDefinition> = {
     "viewBox": "0 0 24 24",
     "body": "<path d=\"m14 10 7-7\"></path><path d=\"M20 10h-6V4\"></path><path d=\"m3 21 7-7\"></path><path d=\"M4 14h6v6\"></path>"
   },
+  "minus": {
+    "viewBox": "0 0 24 24",
+    "body": "<path d=\"M5.5 12h13\"></path>"
+  },
   "moon": {
     "viewBox": "0 0 24 24",
     "body": "<path d=\"M20.985 12.486a9 9 0 1 1-9.473-9.472c.405-.022.617.46.402.803a6 6 0 0 0 8.268 8.268c.344-.215.825-.004.803.401\"></path>"
@@ -285,6 +289,10 @@ export const LOCAL_ICON_DEFINITIONS: Record<string, LocalIconDefinition> = {
   "speech": {
     "viewBox": "0 0 24 24",
     "body": "<path d=\"M8.8 20v-4.1l1.9.2a2.3 2.3 0 0 0 2.164-2.1V8.3A5.37 5.37 0 0 0 2 8.25c0 2.8.656 3.054 1 4.55a5.77 5.77 0 0 1 .029 2.758L2 20\"></path><path d=\"M19.8 17.8a7.5 7.5 0 0 0 .003-10.603\"></path><path d=\"M17 15a3.5 3.5 0 0 0-.025-4.975\"></path>"
+  },
+  "square": {
+    "viewBox": "0 0 24 24",
+    "body": "<rect width=\"14\" height=\"14\" x=\"5\" y=\"5\" rx=\"0.5\"></rect>"
   },
   "stop": {
     "viewBox": "0 0 24 24",

--- a/src/app/src/styles/styles.css
+++ b/src/app/src/styles/styles.css
@@ -511,6 +511,14 @@ input[type="checkbox"]:disabled {
   color: var(--text-primary);
 }
 
+.titlebar__window-icon {
+  stroke-width: 1.5;
+}
+
+.titlebar__window-icon[data-icon='x'] {
+  transform: scale(0.9);
+}
+
 .titlebar__window-btn--close:hover {
   background: var(--danger);
   color: var(--danger-on);
@@ -11948,6 +11956,10 @@ a.backend-card__version:focus-visible {
   .titlebar.titlebar--desktop {
     column-gap: var(--space-1);
     padding-inline: var(--space-2);
+  }
+
+  .titlebar--desktop .titlebar__brand {
+    margin-inline-start: var(--space-1);
   }
 
   .titlebar--desktop .titlebar__right,

--- a/src/app/src/styles/styles.css
+++ b/src/app/src/styles/styles.css
@@ -543,9 +543,6 @@ input[type="checkbox"]:disabled {
   stroke-width: 1.5;
 }
 
-.titlebar__window-icon[data-icon='x'] {
-}
-
 .titlebar__window-btn--close:hover {
   background: var(--danger);
   color: var(--danger-on);

--- a/src/app/src/styles/styles.css
+++ b/src/app/src/styles/styles.css
@@ -544,7 +544,6 @@ input[type="checkbox"]:disabled {
 }
 
 .titlebar__window-icon[data-icon='x'] {
-  transform: scale(0.9);
 }
 
 .titlebar__window-btn--close:hover {

--- a/src/app/src/styles/styles.css
+++ b/src/app/src/styles/styles.css
@@ -472,6 +472,12 @@ input[type="checkbox"]:disabled {
   color: var(--text-primary);
 }
 
+.titlebar--desktop .titlebar__utilities-toggle,
+.titlebar--desktop .titlebar__utilities-toggle:hover,
+.titlebar--desktop .titlebar__utilities-toggle[aria-expanded="true"] {
+  border-color: transparent;
+}
+
 .titlebar__utility-label { display: none; }
 .titlebar__utility-status,
 .titlebar__utility-value { display: none; }
@@ -504,6 +510,28 @@ input[type="checkbox"]:disabled {
   color: var(--text-secondary);
   transition: background var(--duration-fast) var(--ease-out),
               color var(--duration-fast) var(--ease-out);
+}
+
+.titlebar--desktop .titlebar__window-btn--minimize {
+  position: relative;
+}
+
+.titlebar--desktop .titlebar__window-btn--minimize::before {
+  content: '';
+  position: absolute;
+  inset-block-start: 50%;
+  inset-inline-start: -1px;
+  width: 1px;
+  height: 25px;
+  border-radius: var(--radius-pill);
+  background: linear-gradient(
+    to bottom,
+    transparent 0%,
+    color-mix(in srgb, var(--border-strong) 70%, transparent) 50%,
+    transparent 100%
+  );
+  transform: translateY(-50%);
+  pointer-events: none;
 }
 
 .titlebar__window-btn:hover {

--- a/src/app/tests/features.spec.ts
+++ b/src/app/tests/features.spec.ts
@@ -841,11 +841,6 @@ test.describe('Lemonade UI — Feature Parity', () => {
       await expect(icon).toHaveAttribute('width', '15');
       await expect(icon).toHaveAttribute('height', '15');
     }
-    await expect(windowButtons.nth(2).locator('[data-icon="x"]')).toHaveCSS(
-      'transform',
-      'matrix(0.9, 0, 0, 0.9, 0, 0)',
-    );
-
     let brandLeft: number | null = null;
     for (const width of [1321, 1280, 901, 900, 821, 800, 769, 768, 480, 400]) {
       await page.setViewportSize({ width, height: 800 });

--- a/src/app/tests/features.spec.ts
+++ b/src/app/tests/features.spec.ts
@@ -824,12 +824,27 @@ test.describe('Lemonade UI — Feature Parity', () => {
     const right = page.locator('.titlebar__right');
     const search = page.locator('.titlebar__search');
     const windowButtons = page.locator('.titlebar__window-btn');
+    const brandIcon = page.locator('.titlebar__brand-icon');
+    const mobileMenuButton = page.locator('.workspace-mobile-menu-button');
 
     await expect(titlebar).toHaveClass(/titlebar--desktop/);
     await expect(page.getByRole('button', { name: 'Apps', exact: true })).toHaveClass(/is-active/);
     await expect(windowButtons).toHaveCount(3);
+    await expect(windowButtons.nth(0).locator('[data-icon="minus"]')).toHaveCount(1);
+    await expect(windowButtons.nth(1).locator('[data-icon="square"]')).toHaveCount(1);
+    await expect(windowButtons.nth(2).locator('[data-icon="x"]')).toHaveCount(1);
+    for (const iconName of ['minus', 'square', 'x']) {
+      const icon = windowButtons.locator(`[data-icon="${iconName}"]`);
+      await expect(icon).toHaveAttribute('width', '15');
+      await expect(icon).toHaveAttribute('height', '15');
+    }
+    await expect(windowButtons.nth(2).locator('[data-icon="x"]')).toHaveCSS(
+      'transform',
+      'matrix(0.9, 0, 0, 0.9, 0, 0)',
+    );
 
-    for (const width of [1321, 1280, 900, 821, 800, 769, 480, 400]) {
+    let brandLeft: number | null = null;
+    for (const width of [1321, 1280, 901, 900, 821, 800, 769, 768, 480, 400]) {
       await page.setViewportSize({ width, height: 800 });
       await page.waitForTimeout(250);
 
@@ -857,6 +872,11 @@ test.describe('Lemonade UI — Feature Parity', () => {
       }
 
       if (width >= 769) {
+        const brandBox = await brandIcon.boundingBox();
+        expect(brandBox, `brand icon box at ${width}px`).not.toBeNull();
+        brandLeft ??= brandBox!.x;
+        expect(brandBox!.x, `brand icon moved at ${width}px`).toBeCloseTo(brandLeft, 1);
+
         const searchBox = await search.boundingBox();
         expect(searchBox, `Apps search box at ${width}px`).not.toBeNull();
         if (width === 1321) {
@@ -866,6 +886,12 @@ test.describe('Lemonade UI — Feature Parity', () => {
           expect(searchBox!.width, `Apps search did not compact at ${width}px`)
             .toBeLessThanOrEqual(32);
         }
+      } else {
+        await expect(brandIcon).toBeHidden();
+        await expect(mobileMenuButton).toBeVisible();
+        const menuButtonBox = await mobileMenuButton.boundingBox();
+        expect(menuButtonBox, `mobile menu box at ${width}px`).not.toBeNull();
+        expect(menuButtonBox!.x, `brand/menu handoff moved at ${width}px`).toBeCloseTo(brandLeft!, 1);
       }
     }
 

--- a/src/app/tests/features.spec.ts
+++ b/src/app/tests/features.spec.ts
@@ -824,12 +824,15 @@ test.describe('Lemonade UI — Feature Parity', () => {
     const right = page.locator('.titlebar__right');
     const search = page.locator('.titlebar__search');
     const windowButtons = page.locator('.titlebar__window-btn');
+    const minimizeButton = page.getByRole('button', { name: 'Minimize', exact: true });
+    const appControls = page.getByRole('button', { name: 'App controls', exact: true });
     const brandIcon = page.locator('.titlebar__brand-icon');
     const mobileMenuButton = page.locator('.workspace-mobile-menu-button');
 
     await expect(titlebar).toHaveClass(/titlebar--desktop/);
     await expect(page.getByRole('button', { name: 'Apps', exact: true })).toHaveClass(/is-active/);
     await expect(windowButtons).toHaveCount(3);
+    await expect(minimizeButton).toHaveClass(/titlebar__window-btn--minimize/);
     await expect(windowButtons.nth(0).locator('[data-icon="minus"]')).toHaveCount(1);
     await expect(windowButtons.nth(1).locator('[data-icon="square"]')).toHaveCount(1);
     await expect(windowButtons.nth(2).locator('[data-icon="x"]')).toHaveCount(1);
@@ -863,6 +866,25 @@ test.describe('Lemonade UI — Feature Parity', () => {
         .toBeLessThanOrEqual(titlebarBox!.x + titlebarBox!.width);
 
       const minimumWindowButtonWidth = width <= 480 ? 30 : width <= 900 ? 32 : 34;
+      const dividerStyle = await minimizeButton.evaluate(element => {
+        const style = getComputedStyle(element, '::before');
+        return {
+          content: style.content,
+          width: style.width,
+          height: style.height,
+          insetInlineStart: style.insetInlineStart,
+          backgroundImage: style.backgroundImage,
+          pointerEvents: style.pointerEvents,
+        };
+      });
+      expect(dividerStyle.content, `window divider content at ${width}px`).toBe('""');
+      expect(dividerStyle.width, `window divider width at ${width}px`).toBe('1px');
+      expect(dividerStyle.height, `window divider height at ${width}px`).toBe('25px');
+      expect(dividerStyle.insetInlineStart, `window divider offset at ${width}px`).toBe('-1px');
+      expect(dividerStyle.backgroundImage, `window divider gradient missing at ${width}px`)
+        .toContain('linear-gradient');
+      expect(dividerStyle.pointerEvents, `window divider intercepts input at ${width}px`).toBe('none');
+
       const windowButtonBoxes = await windowButtons.evaluateAll(buttons => (
         buttons.map(button => button.getBoundingClientRect().width)
       ));
@@ -889,6 +911,8 @@ test.describe('Lemonade UI — Feature Parity', () => {
       } else {
         await expect(brandIcon).toBeHidden();
         await expect(mobileMenuButton).toBeVisible();
+        await expect(appControls).toBeVisible();
+        await expect(appControls).toHaveCSS('border-top-color', 'rgba(0, 0, 0, 0)');
         const menuButtonBox = await mobileMenuButton.boundingBox();
         expect(menuButtonBox, `mobile menu box at ${width}px`).not.toBeNull();
         expect(menuButtonBox!.x, `brand/menu handoff moved at ${width}px`).toBeCloseTo(brandLeft!, 1);
@@ -910,7 +934,13 @@ test.describe('Lemonade UI — Feature Parity', () => {
     await page.waitForSelector('.titlebar');
 
     const appControls = page.getByRole('button', { name: 'App controls', exact: true });
+    await expect(page.locator('.titlebar__window-btn--minimize')).toHaveCount(0);
     await expect(appControls).toBeVisible();
+    const browserAppControlsBorder = await appControls.evaluate(element => (
+      getComputedStyle(element).borderTopColor
+    ));
+    expect(browserAppControlsBorder).not.toBe('rgba(0, 0, 0, 0)');
+    expect(browserAppControlsBorder).not.toBe('transparent');
     await expect(appControls.locator('[data-icon="sliders-horizontal"]')).toBeVisible();
     await appControls.click();
     await expect(page.locator('.titlebar__utility-menu').getByRole('status')).toHaveAccessibleName(/Server (connected|connecting|offline)/i);

--- a/src/app/tests/icon-library.runtime.cjs
+++ b/src/app/tests/icon-library.runtime.cjs
@@ -24,7 +24,6 @@ assert.match(localIconSource, /"github"/);
 assert.match(localIconSource, /"discord"/);
 assert.match(stylesSource, /\.composer__tools-toggle\s*\{[\s\S]*?display:\s*inline-flex;[\s\S]*?white-space:\s*nowrap;/);
 assert.match(stylesSource, /\.titlebar__window-icon\s*\{[\s\S]*?stroke-width:\s*1\.5;/);
-assert.match(stylesSource, /\.titlebar__window-icon\[data-icon='x'\]\s*\{[\s\S]*?transform:\s*scale\(0\.9\);/);
 assert.match(localIconSource, /"minus":\s*\{[\s\S]*?"body":\s*"<path d=\\"M5\.5 12h13\\"><\/path>"/);
 assert.match(localIconSource, /"square":\s*\{[\s\S]*?"body":\s*"<rect width=\\"14\\" height=\\"14\\" x=\\"5\\" y=\\"5\\" rx=\\"0\.5\\"><\/rect>"/);
 assert.match(appSource, /onClick=\{\(\) => window\.api\?\.minimizeWindow\?\.\(\)\}[\s\S]*?<Icon name="minus" size=\{15\} className="titlebar__window-icon" \/>/);

--- a/src/app/tests/icon-library.runtime.cjs
+++ b/src/app/tests/icon-library.runtime.cjs
@@ -6,6 +6,7 @@ const root = path.resolve(__dirname, '..');
 const pkg = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8'));
 const iconSource = fs.readFileSync(path.join(root, 'src/components/Icon.tsx'), 'utf8');
 const localIconSource = fs.readFileSync(path.join(root, 'src/components/localIcons.tsx'), 'utf8');
+const appSource = fs.readFileSync(path.join(root, 'src/App.tsx'), 'utf8');
 const chatSource = fs.readFileSync(path.join(root, 'src/components/ChatView.tsx'), 'utf8');
 const markdownSource = fs.readFileSync(path.join(root, 'src/components/MarkdownMessage.tsx'), 'utf8');
 const stylesSource = fs.readFileSync(path.join(root, 'src/styles/styles.css'), 'utf8');
@@ -22,10 +23,17 @@ assert.match(localIconSource, /"hugging-face"/);
 assert.match(localIconSource, /"github"/);
 assert.match(localIconSource, /"discord"/);
 assert.match(stylesSource, /\.composer__tools-toggle\s*\{[\s\S]*?display:\s*inline-flex;[\s\S]*?white-space:\s*nowrap;/);
+assert.match(stylesSource, /\.titlebar__window-icon\s*\{[\s\S]*?stroke-width:\s*1\.5;/);
+assert.match(stylesSource, /\.titlebar__window-icon\[data-icon='x'\]\s*\{[\s\S]*?transform:\s*scale\(0\.9\);/);
+assert.match(localIconSource, /"minus":\s*\{[\s\S]*?"body":\s*"<path d=\\"M5\.5 12h13\\"><\/path>"/);
+assert.match(localIconSource, /"square":\s*\{[\s\S]*?"body":\s*"<rect width=\\"14\\" height=\\"14\\" x=\\"5\\" y=\\"5\\" rx=\\"0\.5\\"><\/rect>"/);
+assert.match(appSource, /onClick=\{\(\) => window\.api\?\.minimizeWindow\?\.\(\)\}[\s\S]*?<Icon name="minus" size=\{15\} className="titlebar__window-icon" \/>/);
+assert.match(appSource, /onClick=\{\(\) => window\.api\?\.maximizeWindow\?\.\(\)\}[\s\S]*?<Icon name="square" size=\{15\} className="titlebar__window-icon" \/>/);
+assert.match(appSource, /onClick=\{\(\) => window\.api\?\.closeWindow\?\.\(\)\}[\s\S]*?<Icon name="x" size=\{15\} className="titlebar__window-icon" \/>/);
 assert.doesNotMatch(chatSource, /<svg\b/);
 assert.doesNotMatch(markdownSource, /const\s+(?:COPY|CHECK)_ICON/);
 
-const iconNameBlock = iconSource.match(/export type IconName =([\s\S]*?);\n\ninterface IconProps/)[1];
+const iconNameBlock = iconSource.match(/export type IconName =([\s\S]*?);\r?\n\r?\ninterface IconProps/)[1];
 const iconNames = [...iconNameBlock.matchAll(/'([^']+)'/g)].map((match) => match[1]);
 for (const iconName of iconNames) {
   assert.match(localIconSource, new RegExp(`"${iconName.replace(/[.*+?^${}()|[\\]\\]/g, '\\$&')}"\\s*:`));

--- a/src/app/tests/ui-regression-contracts.runtime.cjs
+++ b/src/app/tests/ui-regression-contracts.runtime.cjs
@@ -78,7 +78,12 @@ assert.match(sources.app, /<span className="titlebar__brand-name">lemonade<\/spa
 assert.match(sources.app, /type="search"[\s\S]*?role="combobox"[\s\S]*?aria-expanded=\{navigationSearchOpen\}/);
 assert.match(sources.app, /aria-activedescendant=/);
 assert.match(sources.app, /className=\{`titlebar\$\{isDesktop \? ' titlebar--desktop' : ''\}`\}/);
+assert.match(sources.app, /className="titlebar__window-btn titlebar__window-btn--minimize"[\s\S]*?onClick=\{\(\) => window\.api\?\.minimizeWindow\?\.\(\)\}[\s\S]*?aria-label="Minimize"/);
 assert.match(styles, /\.titlebar\s*\{[\s\S]*?grid-template-columns:\s*minmax\(0, 1fr\) auto minmax\(0, 1fr\)/);
+assert.match(styles, /\.titlebar__utilities-toggle\s*\{[\s\S]*?border:\s*1px solid var\(--border-subtle\)/);
+assert.match(styles, /\.titlebar--desktop \.titlebar__utilities-toggle,[\s\S]*?\.titlebar--desktop \.titlebar__utilities-toggle:hover,[\s\S]*?\.titlebar--desktop \.titlebar__utilities-toggle\[aria-expanded="true"\]\s*\{\s*border-color:\s*transparent/);
+assert.match(styles, /\.titlebar--desktop \.titlebar__window-btn--minimize\s*\{\s*position:\s*relative/);
+assert.match(styles, /\.titlebar--desktop \.titlebar__window-btn--minimize::before\s*\{[\s\S]*?content:\s*'';[\s\S]*?position:\s*absolute;[\s\S]*?inset-inline-start:\s*-1px;[\s\S]*?width:\s*1px;[\s\S]*?height:\s*25px;[\s\S]*?background:\s*linear-gradient\([\s\S]*?transparent 0%,[\s\S]*?color-mix\(in srgb, var\(--border-strong\) 70%, transparent\) 50%,[\s\S]*?transparent 100%[\s\S]*?pointer-events:\s*none/);
 assert.match(styles, /@media \(max-width: 900px\)[\s\S]*?\.titlebar\.titlebar--desktop\s*\{[\s\S]*?column-gap:\s*var\(--space-1\)/);
 assert.match(styles, /@media \(max-width: 900px\)[\s\S]*?\.titlebar--desktop \.titlebar__brand\s*\{[\s\S]*?margin-inline-start:\s*var\(--space-1\)/);
 assert.match(styles, /@media \(max-width: 820px\)[\s\S]*?\.titlebar--desktop \.titlebar__nav\s*\{[\s\S]*?transform:\s*translateX\(clamp\(-44px, calc\(\(100vw - 820px\) \* 0\.2\), 0px\)\)/);

--- a/src/app/tests/ui-regression-contracts.runtime.cjs
+++ b/src/app/tests/ui-regression-contracts.runtime.cjs
@@ -80,6 +80,7 @@ assert.match(sources.app, /aria-activedescendant=/);
 assert.match(sources.app, /className=\{`titlebar\$\{isDesktop \? ' titlebar--desktop' : ''\}`\}/);
 assert.match(styles, /\.titlebar\s*\{[\s\S]*?grid-template-columns:\s*minmax\(0, 1fr\) auto minmax\(0, 1fr\)/);
 assert.match(styles, /@media \(max-width: 900px\)[\s\S]*?\.titlebar\.titlebar--desktop\s*\{[\s\S]*?column-gap:\s*var\(--space-1\)/);
+assert.match(styles, /@media \(max-width: 900px\)[\s\S]*?\.titlebar--desktop \.titlebar__brand\s*\{[\s\S]*?margin-inline-start:\s*var\(--space-1\)/);
 assert.match(styles, /@media \(max-width: 820px\)[\s\S]*?\.titlebar--desktop \.titlebar__nav\s*\{[\s\S]*?transform:\s*translateX\(clamp\(-44px, calc\(\(100vw - 820px\) \* 0\.2\), 0px\)\)/);
 assert.match(styles, /\.titlebar--desktop \.titlebar__right,[\s\S]*?\.titlebar--desktop \.titlebar__utility-menu\s*\{\s*gap:\s*var\(--space-1\)/);
 assert.match(styles, /@media \(max-width: 480px\)[\s\S]*?\.titlebar\.titlebar--desktop\s*\{[\s\S]*?grid-template-columns:\s*minmax\(0, 1fr\) auto minmax\(0, 1fr\)/);


### PR DESCRIPTION
## Summary

- Replace the Tauri titlebar's diagonal minimize/maximize arrows with the selected compact minus and square glyphs, and optically balance the close icon.
- Keep all window handlers, drag-region attributes, hover behavior, button order, accessibility labels, and hit targets unchanged.
- Keep the lemon brand anchored at one horizontal position through desktop widths, then hand off at the same position to the circular mobile menu at 768px.

Fixes #3320

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_

- `npm.cmd run typecheck`
- `npm.cmd run test:icons` — 87 registered icon contracts passed.
- `npm.cmd run test:ui-regressions`
- `npm.cmd run build:renderer`
- `playwright.cmd test tests/features.spec.ts --project=functional --grep "Tauri Apps titlebar"` — 1/1 passed using Microsoft Edge. The rendered test covers 1321, 1280, 901, 900, 821, 800, 769, 768, 480, and 400px; it verifies icon identity and geometry, the selected X scale, stationary brand/menu handoff, control containment, unchanged hit-area widths, and titlebar non-overlap.
- Rendered all three proposed control sets in the native Tauri/WebView2 development app and verified the selected compact set with the slightly enlarged X.

## Documentation

- [x] Documentation is not affected by this change.
- [ ] Documentation is affected and has been updated.
- [ ] Documentation is affected but will be handled in a separate PR or issue.

## Breaking Changes

- [ ] This PR introduces breaking changes.
- [x] This PR does not introduce breaking changes.

## AI-assisted contribution

Please select one:

- [x] I used AI tools for this PR.
- [ ] I did not use AI tools for this PR.

If AI tools were used:

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.