### PR TITLE
Retire undocumented /params, /log-level, /api/v1/test, and /status routes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@ All core endpoints are registered under **4 path prefixes**:
 - `/v0/` — Legacy short
 - `/v1/` — OpenAI SDK / LiteLLM compatibility
 
-**Core endpoints:** `chat/completions`, `completions`, `embeddings`, `reranking`, `models`, `models/{id}`, `health`, `pull`, `pull/variants`, `registry/search`, `load`, `unload`, `delete`, `params`, `install`, `uninstall`, `audio/transcriptions`, `audio/speech`, `images/generations`, `images/edits`, `images/variations`, `responses`, `stats`, `system-info`, `system-stats`, `log-level`, `logs/stream`, `jobs`, `jobs/{id}`, `jobs/{id}/pause`, `jobs/{id}/interrupt`, `jobs/{id}/resume`
+**Core endpoints:** `chat/completions`, `completions`, `embeddings`, `reranking`, `models`, `models/{id}`, `health`, `pull`, `pull/variants`, `registry/search`, `load`, `unload`, `delete`, `install`, `uninstall`, `audio/transcriptions`, `audio/speech`, `images/generations`, `images/edits`, `images/variations`, `responses`, `stats`, `system-info`, `system-stats`, `logs/stream`, `jobs`, `jobs/{id}`, `jobs/{id}/pause`, `jobs/{id}/interrupt`, `jobs/{id}/resume`
 
 **Job engine** (`POST jobs`, `GET jobs`, `GET/DELETE jobs/{id}`, `POST jobs/{id}/{pause,interrupt,resume}`): server-side sequences of ops (`system_info`, `system_stats`, `models`, `sleep`, `load`, `unload`, `chat`) with data passing, forward-only branching, and a pause/interrupt/resume lifecycle persisted across restart. Exclusive ops hold a Router slot so normal traffic queues. See `docs/dev/job-system.md` and `docs/dev/job-expression-language.md`.
 

--- a/docs/assets/persona-demo/developers/interfaces.js
+++ b/docs/assets/persona-demo/developers/interfaces.js
@@ -144,7 +144,7 @@
     { title: 'System', icon: 'monitor_heart', eps: [['GET', '/v1/system-info'], ['GET', '/v1/system-stats']] },
     { title: 'Models', icon: 'inventory_2', eps: [['POST', '/v1/pull'], ['POST', '/v1/load'], ['POST', '/v1/unload'], ['POST', '/v1/delete']] },
     { title: 'Backends', icon: 'memory', eps: [['POST', '/v1/install'], ['POST', '/v1/uninstall']] },
-    { title: 'Config & scale', icon: 'tune', eps: [['POST', '/v1/params'], ['POST', '/v1/cloud/auth'], ['POST', '/internal/set']] },
+    { title: 'Config & scale', icon: 'tune', eps: [['POST', '/v1/cloud/auth'], ['POST', '/internal/set'], ['GET', '/internal/config']] },
     { title: 'Lifecycle', icon: 'restart_alt', eps: [['GET', '/v1/health'], ['GET', '/v1/logs/stream'], ['POST', '/internal/shutdown']], wide: true }
   ];
 

--- a/src/app/src/renderer/LogsWindow.tsx
+++ b/src/app/src/renderer/LogsWindow.tsx
@@ -61,9 +61,7 @@ const LogsWindow: React.FC<LogsWindowProps> = ({ isVisible, height }) => {
       setIsInitialized(true);
 
       try {
-        // Using serverFetch with the full URL to reach the root-level /internal/config
-        // endpoint while benefiting from automatic authentication and init-waiting.
-        const response = await serverFetch(`${url}/internal/config`);
+        const response = await serverFetch('/internal/config');
         if (!response.ok) return;
 
         const config = await response.json();

--- a/src/app/src/renderer/LogsWindow.tsx
+++ b/src/app/src/renderer/LogsWindow.tsx
@@ -250,10 +250,10 @@ const LogsWindow: React.FC<LogsWindowProps> = ({ isVisible, height }) => {
     setIsSettingLogLevel(true);
 
     try {
-      const response = await serverFetch('/log-level', {
+      const response = await serverFetch('/internal/set', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ level: nextLevel }),
+        body: JSON.stringify({ log_level: nextLevel }),
       });
 
       if (!response.ok) {
@@ -261,8 +261,9 @@ const LogsWindow: React.FC<LogsWindowProps> = ({ isVisible, height }) => {
       }
 
       const data = await response.json();
-      if (isLogLevel(data.level)) {
-        setLogLevel(data.level);
+      const applied = data?.updated?.log_level;
+      if (isLogLevel(applied)) {
+        setLogLevel(applied);
       }
     } catch (error) {
       console.error('Failed to update log level:', error);

--- a/src/app/src/renderer/utils/serverConfig.ts
+++ b/src/app/src/renderer/utils/serverConfig.ts
@@ -310,17 +310,28 @@ class ServerConfig {
   }
 
   /**
+   * Resolve a relative endpoint against the current base URL. Root-level
+   * control endpoints (/internal/*) are not mounted under the /api/v1 prefix,
+   * so they resolve against the server base instead.
+   */
+  private resolveUrl(endpoint: string): string {
+    if (endpoint.startsWith('http')) {
+      return endpoint;
+    }
+    const path = endpoint.startsWith('/') ? endpoint : `/${endpoint}`;
+    return path.startsWith('/internal/')
+      ? `${this.getServerBaseUrl()}${path}`
+      : `${this.getApiBaseUrl()}${path}`;
+  }
+
+  /**
    * Wrapper for fetch that automatically discovers port on connection failures
    * (only attempts discovery in localhost mode)
    */
   async fetch(endpoint: string, opts?: RequestInit): Promise<Response> {
     await this.waitForInit();
 
-    const fullUrl = endpoint.startsWith('http')
-      ? endpoint
-      : endpoint.startsWith('/internal/')
-        ? `${this.getServerBaseUrl()}${endpoint}`
-        : `${this.getApiBaseUrl()}${endpoint.startsWith('/') ? endpoint : `/${endpoint}`}`;
+    const fullUrl = this.resolveUrl(endpoint);
 
     const options = { ...opts };
 
@@ -347,7 +358,7 @@ class ServerConfig {
         await this.discoverPort();
         const newUrl = endpoint.startsWith('http')
           ? endpoint.replace(/localhost:\d+/, `localhost:${this.port}`)
-          : `${this.getApiBaseUrl()}${endpoint.startsWith('/') ? endpoint : `/${endpoint}`}`;
+          : this.resolveUrl(endpoint);
 
         return await fetch(newUrl, options);
       } catch (retryError) {

--- a/src/cpp/include/lemon/server.h
+++ b/src/cpp/include/lemon/server.h
@@ -204,12 +204,10 @@ private:
     // loops without any keys still work.
     void handle_cloud_auth_set(const httplib::Request& req, httplib::Response& res);
     void handle_cloud_auth_clear(const httplib::Request& req, httplib::Response& res);
-    void handle_params(const httplib::Request& req, httplib::Response& res);
     void handle_metrics(const httplib::Request& req, httplib::Response& res);
     void handle_stats(const httplib::Request& req, httplib::Response& res);
     void handle_system_info(const httplib::Request& req, httplib::Response& res);
     void handle_system_stats(const httplib::Request& req, httplib::Response& res);
-    void handle_log_level(const httplib::Request& req, httplib::Response& res);
     void handle_shutdown(const httplib::Request& req, httplib::Response& res);
     void handle_simulate_vram_pressure(const httplib::Request& req, httplib::Response& res);
 

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -1157,7 +1157,7 @@ void Server::setup_routes(httplib::Server &web_server) {
         web_server.Post("/api/v1/" + endpoint, handler);
         web_server.Post("/v0/" + endpoint, handler);
         web_server.Post("/v1/" + endpoint, handler);
-        if (endpoint != "params" && endpoint != "jobs") {
+        if (endpoint != "jobs") {
             web_server.Get("/api/v0/" + endpoint, [](const httplib::Request&, httplib::Response& res) {
                 res.status = 405;
                 res.set_content("{\"error\": \"Method Not Allowed. Use POST for this endpoint\"}", "application/json");
@@ -1398,14 +1398,6 @@ void Server::setup_routes(httplib::Server &web_server) {
         handle_delete(req, res);
     });
 
-    register_post("params", [this](const httplib::Request& req, httplib::Response& res) {
-        handle_params(req, res);
-    });
-
-    register_get("params", [this](const httplib::Request& req, httplib::Response& res) {
-        handle_config_get(req, res);
-    });
-
     // Backend management endpoints
     register_post("install", [this](const httplib::Request& req, httplib::Response& res) {
         handle_install(req, res);
@@ -1430,10 +1422,6 @@ void Server::setup_routes(httplib::Server &web_server) {
 
     register_get("system-stats", [this](const httplib::Request& req, httplib::Response& res) {
         handle_system_stats(req, res);
-    });
-
-    register_post("log-level", [this](const httplib::Request& req, httplib::Response& res) {
-        handle_log_level(req, res);
     });
 
 
@@ -1514,12 +1502,6 @@ void Server::setup_routes(httplib::Server &web_server) {
     });
     web_server.Delete(R"(/v1/cloud/auth/(.+))", [this](const httplib::Request& req, httplib::Response& res) {
         handle_cloud_auth_clear(req, res);
-    });
-
-    // Test endpoint to verify POST works
-    web_server.Post("/api/v1/test", [](const httplib::Request& req, httplib::Response& res) {
-        LOG(INFO, "Server") << "TEST POST endpoint hit!" << std::endl;
-        res.set_content("{\"test\": \"ok\"}", "application/json");
     });
 
     // Register Ollama-compatible API routes
@@ -1629,10 +1611,7 @@ void Server::setup_static_files(httplib::Server &web_server) {
         res.set_content(html_template, "text/html");
     };
 
-    // Keep status page at /status endpoint
-    web_server.Get("/status", serve_index_html);
-
-    // Also serve index.html at /api/v1 for compatibility
+    // Serve index.html at /api/v1 for compatibility
     web_server.Get("/api/v1", serve_index_html);
 
     // Mount static files directory for status page assets (CSS, JS, images)
@@ -6811,32 +6790,6 @@ void Server::handle_cloud_auth_clear(const httplib::Request& req, httplib::Respo
     }
 }
 
-void Server::handle_params(const httplib::Request& req, httplib::Response& res) {
-    try {
-        auto body = nlohmann::json::parse(req.body);
-
-        // Delegate to RuntimeConfig — accepts all known recipe option keys
-        auto result = config_->set(body, [this](const json& applied) {
-            apply_config_side_effects(applied);
-        });
-        res.set_content(result.dump(), "application/json");
-    } catch (const nlohmann::json::parse_error& e) {
-        LOG(ERROR, "Server") << "ERROR in handle_params: invalid JSON: " << e.what() << std::endl;
-        res.status = 400;
-        nlohmann::json error = {{"error", "Invalid JSON in request body"}};
-        res.set_content(error.dump(), "application/json");
-    } catch (const std::invalid_argument& e) {
-        res.status = 400;
-        nlohmann::json error = {{"error", e.what()}};
-        res.set_content(error.dump(), "application/json");
-    } catch (const std::exception& e) {
-        LOG(ERROR, "Server") << "ERROR in handle_params: " << e.what() << std::endl;
-        res.status = 500;
-        nlohmann::json error = {{"error", e.what()}};
-        res.set_content(error.dump(), "application/json");
-    }
-}
-
 // Called by handle_pull when local_import=true
 // Parameters:
 //   - dest_path: Directory where model files are located (already copied/uploaded)
@@ -7082,31 +7035,6 @@ void Server::handle_system_stats(const httplib::Request& req, httplib::Response&
     stats["npu_percent"] = (npu_percent >= 0) ? nlohmann::json(npu_percent) : nlohmann::json();
 
     res.set_content(stats.dump(), "application/json");
-}
-
-void Server::handle_log_level(const httplib::Request& req, httplib::Response& res) {
-    try {
-        auto request_json = nlohmann::json::parse(req.body);
-
-        // Translate {"level":"debug"} -> config_->set({"log_level":"debug"})
-        json changes = {{"log_level", request_json["level"]}};
-        config_->set(changes, [this](const json& applied) {
-            apply_config_side_effects(applied);
-        });
-
-        // Return same response format for backward compatibility
-        nlohmann::json response = {{"status", "success"}, {"level", config_->log_level()}};
-        res.set_content(response.dump(), "application/json");
-    } catch (const std::invalid_argument& e) {
-        res.status = 400;
-        nlohmann::json error = {{"error", e.what()}};
-        res.set_content(error.dump(), "application/json");
-    } catch (const std::exception& e) {
-        LOG(ERROR, "Server") << "ERROR in handle_log_level: " << e.what() << std::endl;
-        res.status = 500;
-        nlohmann::json error = {{"error", e.what()}};
-        res.set_content(error.dump(), "application/json");
-    }
 }
 
 void Server::handle_simulate_vram_pressure(const httplib::Request& req, httplib::Response& res) {

--- a/src/cpp/tray/tray_ui.cpp
+++ b/src/cpp/tray/tray_ui.cpp
@@ -562,7 +562,7 @@ void TrayUI::on_change_context_size(int new_ctx_size) {
     recipe_options_["ctx_size"] = new_ctx_size;
     nlohmann::json body;
     body["ctx_size"] = new_ctx_size;
-    http_post("/api/v1/params", body.dump());
+    http_post("/internal/set", body.dump());
     build_menu();
 
     std::string label = (new_ctx_size >= 1024)

--- a/test/server_cli2.py
+++ b/test/server_cli2.py
@@ -734,9 +734,9 @@ sys.exit(0)
         )
         print(f"Config set output: {result.stdout}")
 
-        # 2. Query the params to verify it parsed correctly and merged
+        # 2. Read the config back to verify it parsed correctly and merged
         response = requests.get(
-            f"http://localhost:{PORT}/api/v1/params",
+            f"http://localhost:{PORT}/internal/config",
             headers=_auth_headers(),
             timeout=10,
         )
@@ -765,7 +765,7 @@ sys.exit(0)
 
             # Verify it is set to false on the server
             response = requests.get(
-                f"http://localhost:{PORT}/api/v1/params",
+                f"http://localhost:{PORT}/internal/config",
                 headers=_auth_headers(),
                 timeout=10,
             )
@@ -783,7 +783,7 @@ sys.exit(0)
                 ]
             )
             response = requests.get(
-                f"http://localhost:{PORT}/api/v1/params",
+                f"http://localhost:{PORT}/internal/config",
                 headers=_auth_headers(),
                 timeout=10,
             )

--- a/test/server_endpoints.py
+++ b/test/server_endpoints.py
@@ -239,6 +239,39 @@ class EndpointTests(ServerTestBase):
 
         session.close()
 
+    def test_000b_retired_endpoints_removed(self):
+        """Verify the retired routes stay gone on every prefix."""
+        session = requests.Session()
+        headers = _auth_headers()
+
+        for endpoint in ["params", "log-level", "test"]:
+            for prefix in ["/api/v0", "/api/v1", "/v0", "/v1"]:
+                url = f"http://localhost:{PORT}{prefix}/{endpoint}"
+                for response in (
+                    session.get(url, headers=headers, timeout=TIMEOUT_DEFAULT),
+                    session.post(
+                        url, json={}, headers=headers, timeout=TIMEOUT_DEFAULT
+                    ),
+                ):
+                    self.assertEqual(
+                        response.status_code,
+                        404,
+                        f"Retired endpoint {prefix}/{endpoint} still responds",
+                    )
+
+        response = session.get(
+            f"http://localhost:{PORT}/status", headers=headers, timeout=TIMEOUT_DEFAULT
+        )
+        self.assertEqual(response.status_code, 404, "Retired /status still responds")
+
+        # The legacy status page is still served at its documented location.
+        response = session.get(
+            f"http://localhost:{PORT}/api/v1", headers=headers, timeout=TIMEOUT_DEFAULT
+        )
+        self.assertEqual(response.status_code, 200, response.text)
+
+        session.close()
+
     def test_000a_register_model_definition_without_pull(self):
         """Register a user model definition without downloading its checkpoint."""
         canonical_name = f"user.RegisterEndpoint-{uuid.uuid4().hex[:8]}"

--- a/test/server_telemetry.py
+++ b/test/server_telemetry.py
@@ -27,7 +27,11 @@ from queue import Queue
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 import requests  # noqa: E402
-from utils.server_base import ServerTestBase, run_server_tests  # noqa: E402
+from utils.server_base import (  # noqa: E402
+    ServerTestBase,
+    _auth_headers,
+    run_server_tests,
+)
 from utils.test_models import (  # noqa: E402
     ENDPOINT_TEST_MODEL,
     PORT,
@@ -274,9 +278,23 @@ class TelemetryTestBase(ServerTestBase):
 
     _pull_base_model = False
 
+    _telemetry_snapshot = None
+
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+
+        # /internal/set persists to config.json, so the pre-test telemetry
+        # settings have to be captured and restored rather than just disabled.
+        # /internal/config reports the defaults-merged config, so the snapshot
+        # covers every key these tests write.
+        try:
+            res = cls._auth_get(f"http://localhost:{PORT}/internal/config")
+            if res.status_code == 200:
+                cls._telemetry_snapshot = res.json().get("telemetry")
+        except Exception:
+            pass
+
         cls.mock_port = find_free_port()
         cls.mock_server = MockOTLPServer(("127.0.0.1", cls.mock_port), MockOTLPHandler)
         cls.mock_thread = threading.Thread(target=cls.mock_server.serve_forever)
@@ -296,10 +314,18 @@ class TelemetryTestBase(ServerTestBase):
     @classmethod
     def tearDownClass(cls):
         try:
-            cls._auth_post(
-                f"http://localhost:{PORT}/internal/set",
-                {"telemetry": {"enabled": False}},
-            )
+            restored = False
+            if cls._telemetry_snapshot:
+                res = cls._auth_post(
+                    f"http://localhost:{PORT}/internal/set",
+                    {"telemetry": cls._telemetry_snapshot},
+                )
+                restored = res.status_code == 200
+            if not restored:
+                cls._auth_post(
+                    f"http://localhost:{PORT}/internal/set",
+                    {"telemetry": {"enabled": False}},
+                )
         except Exception:
             pass
         cls.mock_server.shutdown()
@@ -310,18 +336,12 @@ class TelemetryTestBase(ServerTestBase):
     @classmethod
     def _auth_post(cls, url, json_body, timeout=TIMEOUT_DEFAULT, headers=None):
         req_headers = dict(headers or {})
-        api_key = os.environ.get("LEMONADE_API_KEY")
-        if api_key:
-            req_headers["Authorization"] = f"Bearer {api_key}"
+        req_headers.update(_auth_headers())
         return requests.post(url, json=json_body, headers=req_headers, timeout=timeout)
 
     @classmethod
     def _auth_get(cls, url, timeout=TIMEOUT_DEFAULT):
-        headers = {}
-        api_key = os.environ.get("LEMONADE_API_KEY")
-        if api_key:
-            headers["Authorization"] = f"Bearer {api_key}"
-        return requests.get(url, headers=headers, timeout=timeout)
+        return requests.get(url, headers=_auth_headers(), timeout=timeout)
 
     def setUp(self):
         super().setUp()
@@ -1568,13 +1588,9 @@ class ReliabilityTests(TelemetryTestBase):
         )
 
         # Send a POST request to /internal/telemetry/flush and verify it returns 200 OK
-        headers = {}
-        api_key = os.environ.get("LEMONADE_API_KEY")
-        if api_key:
-            headers["Authorization"] = f"Bearer {api_key}"
-        res = requests.post(
+        res = self._auth_post(
             f"http://localhost:{PORT}/internal/telemetry/flush",
-            headers=headers,
+            None,
             timeout=5.0,
         )
         self.assertEqual(res.status_code, 200, res.text)

--- a/test/server_telemetry.py
+++ b/test/server_telemetry.py
@@ -2,7 +2,7 @@
 Integration tests for the OpenInference telemetry feature (Option B).
 
 Covers:
-- Configuration validation (POST /v1/params).
+- Configuration validation (POST /internal/set).
 - Out-of-band tracing for chat completions (non-streaming).
 - Out-of-band tracing for chat completions (streaming).
 - Trace context validation (span name, kind, attributes, traceId, spanId).
@@ -297,7 +297,7 @@ class TelemetryTestBase(ServerTestBase):
     def tearDownClass(cls):
         try:
             cls._auth_post(
-                f"http://localhost:{PORT}/api/v1/params",
+                f"http://localhost:{PORT}/internal/set",
                 {"telemetry": {"enabled": False}},
             )
         except Exception:
@@ -357,7 +357,7 @@ class TelemetryTestBase(ServerTestBase):
                 otlp_params[k] = v
 
         payload = {"telemetry": {**telemetry_params, "otlp": otlp_params}}
-        res = self._auth_post(f"http://localhost:{PORT}/api/v1/params", payload)
+        res = self._auth_post(f"http://localhost:{PORT}/internal/set", payload)
         self.assertEqual(res.status_code, 200, res.text)
 
     def _wait_for_span(self, span_name=None, timeout=5.0, queue=None):
@@ -456,54 +456,54 @@ class ConfigTests(TelemetryTestBase):
                 },
             }
         }
-        res = self._auth_post(f"http://localhost:{PORT}/api/v1/params", payload)
+        res = self._auth_post(f"http://localhost:{PORT}/internal/set", payload)
         self.assertEqual(res.status_code, 200, res.text)
 
         # Invalid: enabled is not a boolean
         payload = {"telemetry": {"enabled": "yes"}}
-        res = self._auth_post(f"http://localhost:{PORT}/api/v1/params", payload)
+        res = self._auth_post(f"http://localhost:{PORT}/internal/set", payload)
         self.assertEqual(res.status_code, 400)
         self.assertIn("enabled", res.json()["error"])
 
         # Invalid: endpoint is not a string
         payload = {"telemetry": {"otlp": {"endpoint": 123}}}
-        res = self._auth_post(f"http://localhost:{PORT}/api/v1/params", payload)
+        res = self._auth_post(f"http://localhost:{PORT}/internal/set", payload)
         self.assertEqual(res.status_code, 400)
         self.assertIn("endpoint", res.json()["error"])
 
         # Invalid: headers is not an object
         payload = {"telemetry": {"otlp": {"headers": "Bearer token"}}}
-        res = self._auth_post(f"http://localhost:{PORT}/api/v1/params", payload)
+        res = self._auth_post(f"http://localhost:{PORT}/internal/set", payload)
         self.assertEqual(res.status_code, 400)
         self.assertIn("headers", res.json()["error"])
 
         # Invalid: protocol is not a string
         payload = {"telemetry": {"otlp": {"protocol": 123}}}
-        res = self._auth_post(f"http://localhost:{PORT}/api/v1/params", payload)
+        res = self._auth_post(f"http://localhost:{PORT}/internal/set", payload)
         self.assertEqual(res.status_code, 400)
         self.assertIn("protocol", res.json()["error"])
 
         # Invalid: protocol value is not supported
         payload = {"telemetry": {"otlp": {"protocol": "http/xml"}}}
-        res = self._auth_post(f"http://localhost:{PORT}/api/v1/params", payload)
+        res = self._auth_post(f"http://localhost:{PORT}/internal/set", payload)
         self.assertEqual(res.status_code, 400)
         self.assertIn("protocol", res.json()["error"])
 
         # Invalid: max_retries is not an integer
         payload = {"telemetry": {"otlp": {"max_retries": "3"}}}
-        res = self._auth_post(f"http://localhost:{PORT}/api/v1/params", payload)
+        res = self._auth_post(f"http://localhost:{PORT}/internal/set", payload)
         self.assertEqual(res.status_code, 400)
         self.assertIn("max_retries", res.json()["error"])
 
         # Invalid: max_retries is negative
         payload = {"telemetry": {"otlp": {"max_retries": -1}}}
-        res = self._auth_post(f"http://localhost:{PORT}/api/v1/params", payload)
+        res = self._auth_post(f"http://localhost:{PORT}/internal/set", payload)
         self.assertEqual(res.status_code, 400)
         self.assertIn("max_retries", res.json()["error"])
 
         # Invalid: semantics is not an array
         payload = {"telemetry": {"otlp": {"semantics": "openinference"}}}
-        res = self._auth_post(f"http://localhost:{PORT}/api/v1/params", payload)
+        res = self._auth_post(f"http://localhost:{PORT}/internal/set", payload)
         self.assertEqual(res.status_code, 400)
         self.assertIn("semantics", res.json()["error"])
 
@@ -511,7 +511,7 @@ class ConfigTests(TelemetryTestBase):
         payload = {
             "telemetry": {"otlp": {"semantics": ["openinference", "custom_fmt"]}}
         }
-        res = self._auth_post(f"http://localhost:{PORT}/api/v1/params", payload)
+        res = self._auth_post(f"http://localhost:{PORT}/internal/set", payload)
         self.assertEqual(res.status_code, 400)
         self.assertIn("semantics", res.json()["error"])
 
@@ -527,8 +527,8 @@ class ConfigTests(TelemetryTestBase):
             res.json().get("updated", {}).get("telemetry", {}).get("enabled")
         )
 
-        # 2. Get params to verify it is disabled
-        res = self._auth_get(f"http://localhost:{PORT}/api/v1/params")
+        # 2. Read the config back to verify it is disabled
+        res = self._auth_get(f"http://localhost:{PORT}/internal/config")
         self.assertEqual(res.status_code, 200, res.text)
         self.assertFalse(res.json().get("telemetry", {}).get("enabled"))
 
@@ -542,8 +542,8 @@ class ConfigTests(TelemetryTestBase):
             res.json().get("updated", {}).get("telemetry", {}).get("enabled")
         )
 
-        # 4. Get params to verify it is enabled again
-        res = self._auth_get(f"http://localhost:{PORT}/api/v1/params")
+        # 4. Read the config back to verify it is enabled again
+        res = self._auth_get(f"http://localhost:{PORT}/internal/config")
         self.assertEqual(res.status_code, 200, res.text)
         self.assertTrue(res.json().get("telemetry", {}).get("enabled"))
 
@@ -584,7 +584,7 @@ class ConfigTests(TelemetryTestBase):
         self.assertEqual(res.status_code, 200, res.text)
 
         # 3. Verify settings are preserved
-        res = self._auth_get(f"http://localhost:{PORT}/api/v1/params")
+        res = self._auth_get(f"http://localhost:{PORT}/internal/config")
         self.assertEqual(res.status_code, 200)
         telemetry = res.json().get("telemetry", {})
         self.assertFalse(telemetry.get("enabled"))
@@ -600,7 +600,7 @@ class ConfigTests(TelemetryTestBase):
         self.assertEqual(res.status_code, 200)
 
         # 5. Verify settings are still preserved and semantics is still otel_genai
-        res = self._auth_get(f"http://localhost:{PORT}/api/v1/params")
+        res = self._auth_get(f"http://localhost:{PORT}/internal/config")
         self.assertEqual(res.status_code, 200)
         telemetry = res.json().get("telemetry", {})
         self.assertTrue(telemetry.get("enabled"))
@@ -609,7 +609,7 @@ class ConfigTests(TelemetryTestBase):
 
         # 6. Verify unknown telemetry keys are rejected
         res = self._auth_post(
-            f"http://localhost:{PORT}/api/v1/params",
+            f"http://localhost:{PORT}/internal/set",
             {"telemetry": {"unknown_field": True}},
         )
         self.assertEqual(res.status_code, 400)
@@ -617,7 +617,7 @@ class ConfigTests(TelemetryTestBase):
 
         # 7. Verify unknown OTLP keys are rejected
         res = self._auth_post(
-            f"http://localhost:{PORT}/api/v1/params",
+            f"http://localhost:{PORT}/internal/set",
             {"telemetry": {"otlp": {"unknown_otlp_field": "val"}}},
         )
         self.assertEqual(res.status_code, 400)
@@ -1295,7 +1295,7 @@ class ReliabilityTests(TelemetryTestBase):
                 }
             }
             res = self._auth_post(
-                f"http://localhost:{temp_port}/api/v1/params", config_payload
+                f"http://localhost:{temp_port}/internal/set", config_payload
             )
             self.assertEqual(res.status_code, 200, res.text)
 

--- a/test/utils/reset_server_state.py
+++ b/test/utils/reset_server_state.py
@@ -24,7 +24,9 @@ HOST_CANDIDATES = ("127.0.0.1", "localhost")
 
 
 def _auth_headers() -> dict:
-    api_key = os.environ.get("LEMONADE_API_KEY")
+    api_key = os.environ.get("LEMONADE_ADMIN_API_KEY") or os.environ.get(
+        "LEMONADE_API_KEY"
+    )
     if api_key:
         return {"Authorization": f"Bearer {api_key}"}
     return {}

--- a/test/utils/server_base.py
+++ b/test/utils/server_base.py
@@ -155,8 +155,15 @@ def wait_for_server(port=PORT, timeout=60):
 
 
 def _auth_headers():
-    """Return Authorization header if LEMONADE_API_KEY is set."""
-    api_key = os.environ.get("LEMONADE_API_KEY")
+    """Return Authorization header for the highest-privilege key that is set.
+
+    The admin key comes first because it authenticates against both the regular
+    API routes and /internal/*, while LEMONADE_API_KEY cannot reach /internal/*
+    when a distinct admin key is configured.
+    """
+    api_key = os.environ.get("LEMONADE_ADMIN_API_KEY") or os.environ.get(
+        "LEMONADE_API_KEY"
+    )
     if api_key:
         return {"Authorization": f"Bearer {api_key}"}
     return {}

--- a/test/validate_llamacpp.py
+++ b/test/validate_llamacpp.py
@@ -112,11 +112,11 @@ def get_hot_llamacpp_models(base_url):
 
 
 def set_rocm_channel(base_url, channel):
-    """Configure the ROCm channel in lemond via the params API."""
-    print(f"Setting rocm_channel={channel} via /params", flush=True)
+    """Configure the ROCm channel in lemond via the internal config API."""
+    print(f"Setting rocm_channel={channel} via /internal/set", flush=True)
     response, body = request_json(
         "POST",
-        f"{base_url}/params",
+        f"{base_url.rsplit('/api/v1', 1)[0]}/internal/set",
         timeout=TIMEOUT_DEFAULT,
         json={"rocm_channel": channel},
     )


### PR DESCRIPTION
## Background

These 4 endpoints accidentally made it into the modern lemonade codebase during the change from python to C++. I've been meaning to get rid of these for ages, but never got around to it.

Cleaning this up is an important part of ensuring we have accurate docs and practices.

## Summary

Retires four undocumented HTTP routes and moves their first-party callers onto the existing `/internal/*` config endpoints.

- `POST /{api/}v{0,1}/params` and `POST /{api/}v{0,1}/log-level` were thin wrappers over the same `RuntimeConfig::set()` that `POST /internal/set` calls; `GET /{api/}v{0,1}/params` was an alias of `GET /internal/config` that exposed the full config snapshot on the public prefix.
- `POST /api/v1/test` was a debug stub ("TEST POST endpoint hit!") with no callers, v1-only, breaking the quad-prefix invariant.
- `GET /status` was a second mount of the legacy status page; the page is still served at `GET /api/v1`.

Client migrations: the tray context-size menu (`tray_ui.cpp`) and the desktop app's log-level selector (`LogsWindow.tsx`) now `POST /internal/set`. `LogsWindow` already read the current level from `GET /internal/config`, so both directions now use one API.

@fl0rianr please note a minor change to GUI2 here.

Note: `/internal/set` persists to `config.json`, which `/params` and `/log-level` did not. The tray's context size and the app's log level now survive a restart — intended, but calling it out as an observable behavior change.

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_

- `cmake --build --preset default --target lemond` — clean.
- `npx tsc --noEmit` in `src/app` — clean.
- Ran `lemond` and confirmed `GET/POST /api/v1/params`, `/v1/params`, `/api/v1/log-level`, `/api/v1/test`, and `/status` all return 404, while `/api/v1`, `/api/v1/health`, `/app`, and `GET /internal/config` still return 200.
- Confirmed the replacement calls: `POST /internal/set {"ctx_size":8192}` and `POST /internal/set {"log_level":"debug"}` both return `{"status":"success","updated":{...}}`.
- Migrated `test/server_telemetry.py` (18 `/api/v1/params` call sites → `/internal/set` for writes, `/internal/config` for reads) and `test/validate_llamacpp.py`.
- **Not built locally:** `tray_ui.cpp` — the Linux tray target is gated off in my configuration (`REQUIRE_LINUX_TRAY=OFF`). The change there is a one-line endpoint string swap.

## Documentation

- [x] Documentation is affected and has been updated.

All four routes were undocumented; the only references were the endpoint list in `AGENTS.md`, which is updated here.

## Breaking Changes

- [x] This PR introduces breaking changes.

`/v1/params`, `/v1/log-level`, `/api/v1/test`, and `/status` are removed. None were documented, so no third-party integration should be relying on them, but any that is will need to move to `POST /internal/set` / `GET /internal/config` (admin-key gated when `LEMONADE_ADMIN_API_KEY` is set).

## AI-assisted contribution

Please select one:

- [x] I used AI tools for this PR.

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
