### PR TITLE
docs: document POST /internal/simulate-vram-pressure

### DIFF
--- a/docs/dev/getting-started.md
+++ b/docs/dev/getting-started.md
@@ -630,6 +630,7 @@ Internal endpoints accept connections from any address, so first-party clients o
 | `POST` | `/internal/pin` | Pin or unpin a loaded model |
 | `POST` | `/internal/models/sync` | Sync/update downloaded models to the latest version (async or dry-run) |
 | `GET`  | `/internal/models/sync/status` | Retrieve status/progress of background model synchronization |
+| `POST` | `/internal/simulate-vram-pressure` | Test hook: synchronously run one eviction-engine evaluation |
 
 #### `POST /internal/set`
 
@@ -687,6 +688,31 @@ Returns the canonical default configuration — the values a brand-new `config.j
 ```bash
 curl http://localhost:13305/internal/config/defaults
 ```
+
+#### `POST /internal/simulate-vram-pressure`
+
+Test/admin hook for the [dynamic VRAM management](../guide/configuration/multi-model.md) path. Fires the VRAM pressure callback the eviction engine registers, synchronously and on the calling thread, without waiting for — or depending on — a real VRAM reading. The response returns only after the eviction pass has finished, which is what lets a test assert on the outcome instead of polling.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `pct` | number | No | The VRAM utilization to report, as a fraction in `[0, 1]`. Defaults to `0.0`. A value of `-1` requests an idle-only evaluation instead. |
+
+Behavior by `pct`:
+
+- **`pct >= auto_evict_threshold_pct`** — runs a pressure eviction pass, evicting the best candidate as if the monitor had observed that utilization.
+- **`0 <= pct < auto_evict_threshold_pct`** — no eviction, matching what the real monitor does below the threshold.
+- **`pct == -1`** — runs one idle-only evaluation: the same sweep the engine's background timer performs, evicting or downsizing models that are past their idle timeouts.
+
+The pass honors every normal protection: pinned models are never touched, models whose `auto_evict` option is off are skipped, and an active exclusive job session defers the evaluation entirely.
+
+**Example:**
+```bash
+curl -X POST http://localhost:13305/internal/simulate-vram-pressure \
+  -H "Content-Type: application/json" \
+  -d '{"pct": 0.95}'
+```
+
+Returns `{"status": "ok"}` whenever the request is well-formed — including when nothing was evicted — or `400` with an `error` field if the body is not valid JSON or `pct` is not a number.
 
 ### Dependencies
 

--- a/docs/dev/getting-started.md
+++ b/docs/dev/getting-started.md
@@ -699,12 +699,16 @@ Test/admin hook for the [dynamic VRAM management](../guide/configuration/multi-m
 
 Behavior by `pct`:
 
-- **`pct >= auto_evict_threshold_pct`** — runs one evaluation with pressure eviction enabled. A model already past its hard idle timeout takes priority; otherwise the highest-scoring eligible eviction candidate is selected.
+- **`pct >= auto_evict_threshold_pct`** — runs one evaluation with pressure eviction enabled. The first eligible model encountered in loaded-model order that is already past its `evict_idle_timeout` is selected immediately; if none has reached that timeout, the highest-scoring eligible pressure candidate is selected.
 - **`0 <= pct < auto_evict_threshold_pct`** — the callback returns without running an eviction-engine evaluation, so this does not force an idle-timeout sweep.
-- **`pct == -1`** — runs one idle-only evaluation: the same sweep the engine's background timer performs, evicting or downsizing models that are past their idle timeouts.
+- **`pct == -1`** — runs one idle-only evaluation, the same sweep used by the engine's background timer. Models past `evict_idle_timeout` can be evicted, while ready models past `downsize_idle_timeout` can be downsized.
 - **Other negative numeric values** — are accepted by the HTTP handler but do not trigger an evaluation.
 
-The evaluation respects the normal protections: pinned models are never touched, models whose `auto_evict` option is off are skipped, models currently in use are not selected for eviction, and an active exclusive job session defers the evaluation entirely.
+Eligibility starts with the global `auto_evict` setting and is overridden by a model's boolean `auto_evict` option when present. A per-model `false` therefore excludes that model even when the global setting is on; a per-model `true` can opt that model in even when the global setting is off.
+
+For pressure selection, the eviction score is `idle_time_ms / (load_duration_ms * evict_weight_factor)`. Higher scores are more disposable: longer-idle and faster-loading models rank higher, while a larger `evict_weight_factor` protects a model. If the recorded load duration is not positive, the engine uses `1000 ms`; a non-positive weight factor is treated as `1.0`.
+
+Pinned models are never auto-evicted or downsized, and models currently in use are not selected for eviction. If an exclusive job session is active when an evaluation begins, the evaluation is skipped and the hook does not reschedule it. The endpoint still returns `200`, so a successful response means the callback completed, not necessarily that an evaluation ran.
 
 **Example:**
 ```bash
@@ -713,7 +717,7 @@ curl -X POST http://localhost:13305/internal/simulate-vram-pressure \
   -d '{"pct": 0.95}'
 ```
 
-Returns `{"status": "ok"}` after the callback completes for a valid JSON object when `pct` is absent or numeric, including when nothing was evicted. Returns `400` with an `error` field if the body is invalid JSON, is not a JSON object, or contains a non-numeric `pct`.
+Returns `{"status": "ok"}` after the callback completes for a valid JSON object when `pct` is absent or numeric, including when no evaluation ran or nothing was evicted. Returns `400` with an `error` field if the body is invalid JSON, is not a JSON object, or contains a non-numeric `pct`.
 
 ### Dependencies
 

--- a/docs/dev/getting-started.md
+++ b/docs/dev/getting-started.md
@@ -630,7 +630,7 @@ Internal endpoints accept connections from any address, so first-party clients o
 | `POST` | `/internal/pin` | Pin or unpin a loaded model |
 | `POST` | `/internal/models/sync` | Sync/update downloaded models to the latest version (async or dry-run) |
 | `GET`  | `/internal/models/sync/status` | Retrieve status/progress of background model synchronization |
-| `POST` | `/internal/simulate-vram-pressure` | Test hook: synchronously run one eviction-engine evaluation |
+| `POST` | `/internal/simulate-vram-pressure` | Test/admin hook: synchronously simulate a VRAM-pressure callback |
 
 #### `POST /internal/set`
 
@@ -691,19 +691,20 @@ curl http://localhost:13305/internal/config/defaults
 
 #### `POST /internal/simulate-vram-pressure`
 
-Test/admin hook for the [dynamic VRAM management](../guide/configuration/multi-model.md) path. Fires the VRAM pressure callback the eviction engine registers, synchronously and on the calling thread, without waiting for — or depending on — a real VRAM reading. The response returns only after the eviction pass has finished, which is what lets a test assert on the outcome instead of polling.
+Test/admin hook for the [dynamic VRAM management](../guide/configuration/multi-model.md) path. Fires the VRAM pressure callback the eviction engine registers, synchronously and on the calling thread, without waiting for — or depending on — a real VRAM reading. The response returns only after the callback and any resulting eviction-engine evaluation have finished. When `pct` triggers an evaluation, a test can therefore assert on the outcome immediately instead of polling.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `pct` | number | No | The VRAM utilization to report, as a fraction in `[0, 1]`. Defaults to `0.0`. A value of `-1` requests an idle-only evaluation instead. |
+| `pct` | number | No | Simulated VRAM utilization. Pressure simulations normally use a fraction in `[0, 1]`; numeric values are not range-validated. Defaults to `0.0`. Exactly `-1` requests an idle-only evaluation instead. |
 
 Behavior by `pct`:
 
-- **`pct >= auto_evict_threshold_pct`** — runs a pressure eviction pass, evicting the best candidate as if the monitor had observed that utilization.
-- **`0 <= pct < auto_evict_threshold_pct`** — no eviction, matching what the real monitor does below the threshold.
+- **`pct >= auto_evict_threshold_pct`** — runs one evaluation with pressure eviction enabled. A model already past its hard idle timeout takes priority; otherwise the highest-scoring eligible eviction candidate is selected.
+- **`0 <= pct < auto_evict_threshold_pct`** — the callback returns without running an eviction-engine evaluation, so this does not force an idle-timeout sweep.
 - **`pct == -1`** — runs one idle-only evaluation: the same sweep the engine's background timer performs, evicting or downsizing models that are past their idle timeouts.
+- **Other negative numeric values** — are accepted by the HTTP handler but do not trigger an evaluation.
 
-The pass honors every normal protection: pinned models are never touched, models whose `auto_evict` option is off are skipped, and an active exclusive job session defers the evaluation entirely.
+The evaluation respects the normal protections: pinned models are never touched, models whose `auto_evict` option is off are skipped, models currently in use are not selected for eviction, and an active exclusive job session defers the evaluation entirely.
 
 **Example:**
 ```bash
@@ -712,7 +713,7 @@ curl -X POST http://localhost:13305/internal/simulate-vram-pressure \
   -d '{"pct": 0.95}'
 ```
 
-Returns `{"status": "ok"}` whenever the request is well-formed — including when nothing was evicted — or `400` with an `error` field if the body is not valid JSON or `pct` is not a number.
+Returns `{"status": "ok"}` after the callback completes for a valid JSON object when `pct` is absent or numeric, including when nothing was evicted. Returns `400` with an `error` field if the body is invalid JSON, is not a JSON object, or contains a non-numeric `pct`.
 
 ### Dependencies
 


### PR DESCRIPTION
## Summary

`POST /internal/simulate-vram-pressure` was the one `/internal/*` endpoint missing from the internal endpoints table in `docs/dev/getting-started.md`. It synchronously fires the eviction engine's VRAM pressure callback, which is how `test/server_eviction.py` and `test/server_pinning.py` get a deterministic eviction pass without a real VRAM reading. Documents the `pct` semantics — including the `-1` idle-only evaluation that the tests use — and notes that pinned models, `auto_evict: false` models, and active exclusive job sessions are all still respected.

Docs only; no code changes.

cc @clemperorpenguin — you added this endpoint in #2183 as part of dynamic VRAM management, so please confirm the `pct` semantics (threshold comparison vs. the `-1` idle-only path) read correctly.

Fixes #<!-- issue number -->

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_

- Against a running `lemond`: `{"pct": 0.95}`, `{"pct": -1.0}`, and `{}` all return `200 {"status": "ok"}`; a non-JSON body and `{"pct": "x"}` both return `400` with an `error` field — matching what the section documents.
- The three `pct` branches were traced through `EvictionEngine::on_vram_pressure` / `evaluate_servers`, and the protections (pinned, per-model `auto_evict`, `exclusive_active_`) read off `evaluate_servers` directly.
- The `-1` idle-only behavior matches how `test/server_eviction.py` uses it (`IDLE_EVALUATION_PCT = -1.0`, `_evaluate_idle_now`).

## Documentation

- [x] Documentation is affected and has been updated.

## Breaking Changes

- [x] This PR does not introduce breaking changes.

## AI-assisted contribution

Please select one:

- [x] I used AI tools for this PR.

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
