### PR TITLE
Add TheNoise-based upscalers

### DIFF
--- a/docs/dev/backends-reference.md
+++ b/docs/dev/backends-reference.md
@@ -18,7 +18,7 @@ the generator instead. Prose outside the markers is preserved. -->
 | `openmoss` | OpenMOSS TTS | yes | no | cuda, rocm, vulkan |
 | `ryzenai-llm` | Ryzen AI LLM | no | yes | npu |
 | `sd-cpp` | StableDiffusion.cpp | yes | no | cpu, cuda, metal, rocm, vulkan |
-| `thenoise` | TheNoise ROCm (experimental) | yes | no | rocm |
+| `thenoise` | TheNoise ROCm | yes | no | rocm |
 | `thinksound` | ThinkSound | yes | no | cuda, rocm, vulkan |
 | `trellis` | TRELLIS.2 | yes | no | cuda, rocm, vulkan |
 | `vllm` | vLLM ROCm (experimental) | yes | yes | rocm |
@@ -135,7 +135,7 @@ the generator instead. Prose outside the markers is preserved. -->
 | `sampling_method` | — | ARGS | "" | Sampling method |
 | `flow_shift` | — | SIZE | 0.0 | Flow shift |
 
-#### `thenoise` — TheNoise ROCm (experimental)
+#### `thenoise` — TheNoise ROCm
 
 | Option | CLI flag | Type | Default | Description |
 |--------|----------|------|---------|-------------|

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -423,7 +423,7 @@ The following options are available depending on the recipe being used:
 | `--vllm BACKEND` | vLLM backend to use | Auto-detected |
 | `--vllm-args ARGS` | Custom arguments to pass to vllm-server | `""` |
 
-#### TheNoise ROCm (experimental) (`thenoise` recipe)
+#### TheNoise ROCm (`thenoise` recipe)
 
 | Option | Description | Default |
 |--------|-------------|---------|

--- a/docs/guide/configuration/README.md
+++ b/docs/guide/configuration/README.md
@@ -149,6 +149,7 @@ When `lemond` starts, effective configuration is resolved by deep-merging settin
   "thenoise": {
     "backend": "auto",
     "lora_dir": "",
+    "rocm_bin": "builtin",
     "upscaler_dir": ""
   },
   "thinksound": {

--- a/src/cpp/include/lemon/backends/sdcpp/sdcpp_server.h
+++ b/src/cpp/include/lemon/backends/sdcpp/sdcpp_server.h
@@ -48,8 +48,7 @@ public:
     // sd-cli binary's -M upscale mode as a subprocess.
     static std::string upscale_via_cli(
         const std::string& b64_image,
-        const std::string& upscale_model_path,
-        double upscale_factor = 0.0);
+        const std::string& upscale_model_path);
 
 private:
     // Precedence and fall-through are documented in build_extra_args().

--- a/src/cpp/include/lemon/backends/sdcpp/sdcpp_server.h
+++ b/src/cpp/include/lemon/backends/sdcpp/sdcpp_server.h
@@ -49,9 +49,7 @@ public:
     static std::string upscale_via_cli(
         const std::string& b64_image,
         const std::string& upscale_model_path,
-        const std::string& cli_exe_path,
-        const std::vector<std::pair<std::string, std::string>>& env_vars,
-        bool debug = false);
+        double upscale_factor = 0.0);
 
 private:
     // Precedence and fall-through are documented in build_extra_args().

--- a/src/cpp/include/lemon/backends/thenoise/thenoise.h
+++ b/src/cpp/include/lemon/backends/thenoise/thenoise.h
@@ -10,7 +10,7 @@ namespace thenoise {
 // links into both the lemonade CLI and lemond without a separate source file.
 inline const BackendDescriptor descriptor = {
     /*recipe*/          "thenoise",
-    /*display_name*/    "TheNoise ROCm (experimental)",
+    /*display_name*/    "TheNoise ROCm",
     /*binary*/          "thenoise",
     /*config_section*/  "thenoise",
     /*default_device*/  DEVICE_GPU,
@@ -48,7 +48,7 @@ inline const BackendDescriptor descriptor = {
     /*self_manages_downloads*/ false,
     /*takes_args*/      false,
     /*arg_variants*/    {},
-    /*bin_variants*/    {},
+    /*bin_variants*/    {"rocm"},
     /*config_extra*/    {{"lora_dir", ""}, {"upscaler_dir", ""}},
 };
 

--- a/src/cpp/include/lemon/backends/thenoise/thenoise_server.h
+++ b/src/cpp/include/lemon/backends/thenoise/thenoise_server.h
@@ -39,6 +39,11 @@ public:
     json image_edits(const json& request) override;
     json image_variations(const json& request) override;
 
+    static std::string upscale_via_cli(
+        const std::string& b64_image,
+        const std::string& upscale_model_path,
+        double upscale_factor = 0.0);
+
 private:
     // image_defaults from the currently loaded model's server_models.json entry.
     // Applied when a request doesn't specify size / steps / cfg_scale / etc.

--- a/src/cpp/include/lemon/backends/thenoise/thenoise_server.h
+++ b/src/cpp/include/lemon/backends/thenoise/thenoise_server.h
@@ -41,8 +41,7 @@ public:
 
     static std::string upscale_via_cli(
         const std::string& b64_image,
-        const std::string& upscale_model_path,
-        double upscale_factor = 0.0);
+        const std::string& upscale_model_path);
 
 private:
     // image_defaults from the currently loaded model's server_models.json entry.

--- a/src/cpp/resources/backend_versions.json
+++ b/src/cpp/resources/backend_versions.json
@@ -146,7 +146,7 @@
   },
   "thenoise": {
     "comment": "TheNoise release tag. The portable bundle publishes per-GPU-target archives (<tag>-gfxNNNN-x64.tar.gz) under this tag; the host arch picks the matching archive.",
-    "rocm": "thenoise-0.3.0-rocm7.14.0"
+    "rocm": "thenoise-0.4.0-rocm7.14.0"
   },
   "rocm_asset_families": {
     "comment": "Maps a concrete ROCm ISA (as detected on the device) to the family target name the GitHub release repos publish assets under. ISAs not listed here (e.g. gfx908, gfx90a, which ship as individual assets) are used verbatim. Add a new GPU's ISA here when its release asset is published under a family name.",

--- a/src/cpp/resources/backend_versions.json
+++ b/src/cpp/resources/backend_versions.json
@@ -146,7 +146,7 @@
   },
   "thenoise": {
     "comment": "TheNoise release tag. The portable bundle publishes per-GPU-target archives (<tag>-gfxNNNN-x64.tar.gz) under this tag; the host arch picks the matching archive.",
-    "rocm": "thenoise-0.4.0-rocm7.14.0"
+    "rocm": "thenoise-0.4.1-rocm7.14.0"
   },
   "rocm_asset_families": {
     "comment": "Maps a concrete ROCm ISA (as detected on the device) to the family target name the GitHub release repos publish assets under. ISAs not listed here (e.g. gfx908, gfx90a, which ship as individual assets) are used verbatim. Add a new GPU's ISA here when its release asset is published under a family name.",

--- a/src/cpp/resources/defaults.json
+++ b/src/cpp/resources/defaults.json
@@ -111,6 +111,7 @@
   "thenoise": {
     "backend": "auto",
     "lora_dir": "",
+    "rocm_bin": "builtin",
     "upscaler_dir": ""
   },
   "thinksound": {

--- a/src/cpp/resources/server_models.json
+++ b/src/cpp/resources/server_models.json
@@ -2292,7 +2292,7 @@
         ],
         "size": 0.067
     },
-    "RealESRGAN-4x-lsdir-TheNoise": {
+    "LSDIR-4x-TheNoise": {
         "checkpoints": {
             "main": "mikkoph/upscalers:esrgan/4x-lsdir-v1.safetensors"
         },
@@ -2304,7 +2304,7 @@
         ],
         "size": 0.067
     },
-    "RealESRGAN-4x-nmkd-TheNoise": {
+    "NMKD-Siax-CX-200k-TheNoise": {
         "checkpoints": {
             "main": "mikkoph/upscalers:esrgan/4x-nmkd-siax-cx-200k.safetensors"
         },
@@ -2328,7 +2328,7 @@
         ],
         "size": 0.067
     },
-    "RealESRGAN-4x-remacri-TheNoise": {
+    "Remacri-4x-TheNoise": {
         "checkpoints": {
             "main": "mikkoph/upscalers:esrgan/4x-remacri.safetensors"
         },

--- a/src/cpp/resources/server_models.json
+++ b/src/cpp/resources/server_models.json
@@ -2280,6 +2280,66 @@
         ],
         "size": 0.017
     },
+    "RealESRGAN-2xplus-TheNoise": {
+        "checkpoints": {
+            "main": "mikkoph/upscalers:esrgan/2x-real-esrgan-plus.safetensors"
+        },
+        "recipe": "thenoise",
+        "suggested": true,
+        "labels": [
+            "upscaling",
+            "image"
+        ],
+        "size": 0.067
+    },
+    "RealESRGAN-4x-lsdir-TheNoise": {
+        "checkpoints": {
+            "main": "mikkoph/upscalers:esrgan/4x-lsdir-v1.safetensors"
+        },
+        "recipe": "thenoise",
+        "suggested": true,
+        "labels": [
+            "upscaling",
+            "image"
+        ],
+        "size": 0.067
+    },
+    "RealESRGAN-4x-nmkd-TheNoise": {
+        "checkpoints": {
+            "main": "mikkoph/upscalers:esrgan/4x-nmkd-siax-cx-200k.safetensors"
+        },
+        "recipe": "thenoise",
+        "suggested": true,
+        "labels": [
+            "upscaling",
+            "image"
+        ],
+        "size": 0.067
+    },
+    "RealESRGAN-4xplus-TheNoise": {
+        "checkpoints": {
+            "main": "mikkoph/upscalers:esrgan/4x-real-esrgan-plus.safetensors"
+        },
+        "recipe": "thenoise",
+        "suggested": true,
+        "labels": [
+            "upscaling",
+            "image"
+        ],
+        "size": 0.067
+    },
+    "RealESRGAN-4x-remacri-TheNoise": {
+        "checkpoints": {
+            "main": "mikkoph/upscalers:esrgan/4x-remacri.safetensors"
+        },
+        "recipe": "thenoise",
+        "suggested": true,
+        "labels": [
+            "upscaling",
+            "image"
+        ],
+        "size": 0.067
+    },
     "Qwen3.5-0.8B-FP16-vLLM": {
         "checkpoint": "Qwen/Qwen3.5-0.8B",
         "recipe": "vllm",

--- a/src/cpp/server/backends/sdcpp/sdcpp_server.cpp
+++ b/src/cpp/server/backends/sdcpp/sdcpp_server.cpp
@@ -16,6 +16,7 @@
 #include <filesystem>
 #include <fstream>
 #include <chrono>
+#include <cstring>
 #include <random>
 #include <sstream>
 #include <set>
@@ -638,15 +639,101 @@ json SDServer::image_variations(const json& request) {
 std::string SDServer::upscale_via_cli(
     const std::string& b64_image,
     const std::string& upscale_model_path,
-    const std::string& cli_exe_path,
-    const std::vector<std::pair<std::string, std::string>>& env_vars,
-    bool debug) {
+    double /* upscale_factor */) {
 
-    if (!fs::exists(cli_exe_path)) {
+    std::string backend;
+    if (auto* cfg = RuntimeConfig::global()) {
+        json recipe_opts = cfg->recipe_options("");
+        if (recipe_opts.contains("sd-cpp_backend") &&
+            recipe_opts["sd-cpp_backend"].is_string()) {
+            backend = recipe_opts["sd-cpp_backend"].get<std::string>();
+        }
+    }
+    if (backend.empty()) {
+        auto supported = SystemInfo::get_supported_backends("sd-cpp");
+        backend = supported.backends.empty() ? "cpu" : supported.backends[0];
+    }
+
+    std::string exe_dir = BackendUtils::get_backend_binary_path(*sdcpp::spec(), backend);
+    std::filesystem::path cli_exe = std::filesystem::path(exe_dir).parent_path() /
+#ifdef _WIN32
+        "sd-cli.exe";
+#else
+        "sd-cli";
+#endif
+
+    if (!fs::exists(cli_exe)) {
         LOG(ERROR, "SDServer") << "sd-cli binary not found at: "
-            << cli_exe_path << std::endl;
+            << cli_exe.string() << std::endl;
         return "";
     }
+
+    std::vector<std::pair<std::string, std::string>> env_vars;
+    std::filesystem::path cli_dir = cli_exe.parent_path();
+
+    std::string resolved_backend = backend;
+    if (backend == "rocm") {
+        std::string channel = "stable";
+        if (auto* cfg = RuntimeConfig::global()) {
+            channel = cfg->rocm_channel_for_recipe("sd-cpp");
+        }
+        resolved_backend = "rocm-" + channel;
+    }
+#ifndef _WIN32
+    std::string lib_path = cli_dir.string();
+
+    if (resolved_backend == "rocm-stable") {
+        std::string rocm_arch = SystemInfo::get_rocm_arch();
+        if (!rocm_arch.empty()) {
+            std::string therock_dirs = BackendUtils::join_runtime_dirs(
+                BackendUtils::get_therock_lib_paths(rocm_arch));
+            if (!therock_dirs.empty()) {
+                lib_path = therock_dirs + ":" + lib_path;
+            }
+        }
+    }
+
+    const char* existing_ld_path = std::getenv("LD_LIBRARY_PATH");
+    if (existing_ld_path && strlen(existing_ld_path) > 0) {
+        lib_path = lib_path + ":" + std::string(existing_ld_path);
+    }
+    env_vars.push_back({"LD_LIBRARY_PATH", lib_path});
+#else
+    if (resolved_backend == "rocm-stable") {
+        std::string new_path = cli_dir.string();
+        std::string rocm_arch = SystemInfo::get_rocm_arch();
+        std::vector<std::string> therock_dirs;
+        if (!rocm_arch.empty()) {
+            therock_dirs =
+                BackendUtils::get_therock_lib_paths(rocm_arch);
+            for (auto it = therock_dirs.rbegin(); it != therock_dirs.rend(); ++it) {
+                if (!it->empty()) {
+                    new_path = *it + ";" + new_path;
+                }
+            }
+        }
+
+        const char* existing_path = std::getenv("PATH");
+        if (existing_path && strlen(existing_path) > 0) new_path += ";" + std::string(existing_path);
+        env_vars.push_back({"PATH", new_path});
+
+        if (!therock_dirs.empty()) {
+            fs::path therock_dll = fs::path(therock_dirs.front()) / "amdhip64_7.dll";
+            fs::path target_dll = cli_exe.parent_path() / "amdhip64_7.dll";
+            if (fs::exists(therock_dll)) {
+                std::error_code ec;
+                fs::copy_file(therock_dll, target_dll, fs::copy_options::overwrite_existing, ec);
+                if (!ec) {
+                    LOG(INFO, "SDServer") << "Copied amdhip64_7.dll from TheRock to "
+                        << path_to_utf8(target_dll) << std::endl;
+                } else {
+                    LOG(ERROR, "SDServer") << "Failed to copy amdhip64_7.dll: "
+                        << ec.message() << std::endl;
+                }
+            }
+        }
+    }
+#endif
 
     std::string raw = JsonUtils::base64_decode(b64_image);
 
@@ -709,7 +796,7 @@ std::string SDServer::upscale_via_cli(
     // inherit_output = true so subprocess stderr/stdout is visible in server
     // logs for debugging failed upscale operations
     auto proc = ProcessManager::start_process(
-        cli_exe_path, cli_args, "", true, false, env_vars);
+        cli_exe.string(), cli_args, "", true, false, env_vars);
 
     int exit_code = ProcessManager::wait_for_exit(proc, 300);
 
@@ -725,7 +812,7 @@ std::string SDServer::upscale_via_cli(
     } else {
         LOG(WARNING, "SDServer") << "ESRGAN upscale failed (exit code: "
             << exit_code << ", model: " << upscale_model_path
-            << ", cli: " << cli_exe_path << ")" << std::endl;
+            << ", cli: " << cli_exe.string() << ")" << std::endl;
     }
 
     return result;

--- a/src/cpp/server/backends/sdcpp/sdcpp_server.cpp
+++ b/src/cpp/server/backends/sdcpp/sdcpp_server.cpp
@@ -638,8 +638,7 @@ json SDServer::image_variations(const json& request) {
 
 std::string SDServer::upscale_via_cli(
     const std::string& b64_image,
-    const std::string& upscale_model_path,
-    double /* upscale_factor */) {
+    const std::string& upscale_model_path) {
 
     std::string backend;
     if (auto* cfg = RuntimeConfig::global()) {

--- a/src/cpp/server/backends/thenoise/thenoise_server.cpp
+++ b/src/cpp/server/backends/thenoise/thenoise_server.cpp
@@ -397,6 +397,7 @@ std::string TheNoiseServer::upscale_via_cli(
     const std::string& b64_image,
     const std::string& upscale_model_path) {
 
+    //ROCm is currently the only available backend. If other backends are added this needs to be parameterized accordingly.
     std::string exe_path = BackendUtils::get_backend_binary_path(*thenoise::spec(), "rocm");
 
     if (!fs::exists(exe_path)) {

--- a/src/cpp/server/backends/thenoise/thenoise_server.cpp
+++ b/src/cpp/server/backends/thenoise/thenoise_server.cpp
@@ -395,8 +395,7 @@ json TheNoiseServer::image_variations(const json& /* request */) {
 
 std::string TheNoiseServer::upscale_via_cli(
     const std::string& b64_image,
-    const std::string& upscale_model_path,
-    double upscale_factor) {
+    const std::string& upscale_model_path) {
 
     std::string exe_path = BackendUtils::get_backend_binary_path(*thenoise::spec(), "rocm");
 
@@ -462,12 +461,6 @@ std::string TheNoiseServer::upscale_via_cli(
         "--input", input_path.string(),
         "--out", output_path.string()
     };
-
-    // Omit the factor when the client didn't request one, so thenoise applies its default
-    if (upscale_factor > 0.0) {
-        args.push_back("--upscale-factor");
-        args.push_back(std::to_string(upscale_factor));
-    }
 
     std::vector<std::pair<std::string, std::string>> env_vars;
     auto proc = ProcessManager::start_process(

--- a/src/cpp/server/backends/thenoise/thenoise_server.cpp
+++ b/src/cpp/server/backends/thenoise/thenoise_server.cpp
@@ -7,9 +7,12 @@
 #include "lemon/utils/process_manager.h"
 #include "lemon/error_types.h"
 #include "lemon/system_info.h"
-#include <lemon/utils/aixlog.hpp>
+#include "lemon/utils/aixlog.hpp"
+#include "lemon/utils/json_utils.h"
+#include "lemon/utils/path_utils.h"
 #include <ctime>
 #include <filesystem>
+#include <fstream>
 #include <random>
 #include <set>
 #include <sstream>
@@ -388,6 +391,106 @@ json TheNoiseServer::image_variations(const json& /* request */) {
     return ErrorResponse::from_exception(
         UnsupportedOperationException("Image variations", "thenoise (text-to-image only)")
     );
+}
+
+std::string TheNoiseServer::upscale_via_cli(
+    const std::string& b64_image,
+    const std::string& upscale_model_path,
+    double upscale_factor) {
+
+    std::string exe_path = BackendUtils::get_backend_binary_path(*thenoise::spec(), "rocm");
+
+    if (!fs::exists(exe_path)) {
+        LOG(ERROR, "TheNoise") << "thenoise binary not found at: " << exe_path << std::endl;
+        return "";
+    }
+
+    std::string raw = JsonUtils::base64_decode(b64_image);
+
+    fs::path runtime_base = path_from_utf8(get_runtime_dir());
+    std::random_device rd;
+    std::uniform_int_distribution<unsigned int> dis(0, 0xFFFFFF);
+
+    fs::path temp_dir;
+    std::error_code ec;
+    for (int attempt = 0; attempt < 8; ++attempt) {
+        auto nonce = static_cast<unsigned long long>(
+            std::chrono::steady_clock::now().time_since_epoch().count());
+        std::ostringstream suffix;
+        suffix << "thenoise-upscale-" << nonce << "-" << std::hex << dis(rd);
+        fs::path candidate = runtime_base / suffix.str();
+
+        ec.clear();
+        if (fs::create_directory(candidate, ec)) {
+            temp_dir = candidate;
+            break;
+        }
+    }
+
+    if (temp_dir.empty()) {
+        LOG(ERROR, "TheNoise") << "Failed to create temporary directory for upscale" << std::endl;
+        return "";
+    }
+
+    fs::path input_path = temp_dir / "input.png";
+    fs::path output_path = temp_dir / "output.png";
+
+    struct TempFileGuard {
+        fs::path path;
+        bool recursive = false;
+        ~TempFileGuard() {
+            std::error_code ec;
+            if (recursive) {
+                fs::remove_all(path, ec);
+            } else {
+                fs::remove(path, ec);
+            }
+        }
+    };
+    TempFileGuard dir_guard{temp_dir, true};
+    TempFileGuard input_guard{input_path};
+    TempFileGuard output_guard{output_path};
+
+    {
+        std::ofstream out(input_path, std::ios::binary);
+        out.write(raw.data(), raw.size());
+    }
+
+    std::vector<std::string> args = {
+        "upscale",
+        "--pixel-upscaler", upscale_model_path,
+        "--input", input_path.string(),
+        "--out", output_path.string()
+    };
+
+    // Omit the factor when the client didn't request one, so thenoise applies its default
+    if (upscale_factor > 0.0) {
+        args.push_back("--upscale-factor");
+        args.push_back(std::to_string(upscale_factor));
+    }
+
+    std::vector<std::pair<std::string, std::string>> env_vars;
+    auto proc = ProcessManager::start_process(
+        exe_path, args, "", true, false, env_vars);
+
+    int exit_code = ProcessManager::wait_for_exit(proc, 300);
+
+    std::string result;
+    if (exit_code == 0 && fs::exists(output_path)) {
+        std::ifstream in(output_path, std::ios::binary);
+        std::string upscaled_data(
+            (std::istreambuf_iterator<char>(in)),
+            std::istreambuf_iterator<char>());
+        result = JsonUtils::base64_encode(upscaled_data);
+        LOG(INFO, "TheNoise") << "Upscale complete ("
+            << raw.size() << " -> " << upscaled_data.size() << " bytes)" << std::endl;
+    } else {
+        LOG(WARNING, "TheNoise") << "Upscale failed (exit code: "
+            << exit_code << ", model: " << upscale_model_path
+            << ", cli: " << exe_path << ")" << std::endl;
+    }
+
+    return result;
 }
 
 } // namespace backends

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -18,6 +18,7 @@
 #include "lemon/backends/backend_descriptor_registry.h"
 #include "lemon/backends/cloud/cloud_server.h"
 #include "lemon/backends/sdcpp/sdcpp_server.h"
+#include "lemon/backends/thenoise/thenoise_server.h"
 #include "lemon/backends/backend_utils.h"
 #include <cstring>
 #include "lemon/utils/conversation_fingerprint.h"
@@ -5526,7 +5527,7 @@ void Server::handle_image_upscale(const httplib::Request& req, httplib::Response
         }
 
         std::string upscale_model_path;
-        std::string backend;
+        std::string recipe;
         try {
             auto info = model_manager_->get_model_info(upscale_model_name);
 
@@ -5538,27 +5539,7 @@ void Server::handle_image_upscale(const httplib::Request& req, httplib::Response
             }
 
             upscale_model_path = info.resolved_path("main");
-
-            // Honor explicit config first (e.g. sdcpp.backend = "rocm").
-            // "auto" in config.json is mapped to "" by recipe_options().
-            auto recipe_opts = config_->recipe_options("");
-            if (recipe_opts.contains("sd-cpp_backend") &&
-                recipe_opts["sd-cpp_backend"].is_string()) {
-                backend = recipe_opts["sd-cpp_backend"].get<std::string>();
-            }
-
-            // Auto-detect best backend when not explicitly configured,
-            // matching the same logic SDServer::load() uses via
-            // RecipeOptions::get_option(). Without this, upscaling
-            // silently falls back to CPU even when ROCm/Vulkan is available.
-            if (backend.empty()) {
-                auto supported = SystemInfo::get_supported_backends("sd-cpp");
-                if (!supported.backends.empty()) {
-                    backend = supported.backends[0];
-                } else {
-                    backend = "cpu";
-                }
-            }
+            recipe = info.recipe;
         } catch (const std::exception& e) {
             res.status = 404;
             nlohmann::json error = {{"error", {
@@ -5569,106 +5550,41 @@ void Server::handle_image_upscale(const httplib::Request& req, httplib::Response
             return;
         }
 
-        // sd-server's HTTP API does not expose an upscaling endpoint.
-        // Upscaling is only available via the sd-cli binary's -M upscale mode,
-        // so we shell out to sd-cli as a subprocess. This also keeps upscaling
-        // as a separate request from generation, which lets the frontend show
-        // the original and upscaled images side by side with independent timing.
-        std::string exe_dir = lemon::backends::BackendUtils::get_backend_binary_path(
-            *lemon::backends::try_get_spec_for_recipe("sd-cpp"), backend);
-        std::filesystem::path cli_exe = std::filesystem::path(exe_dir).parent_path() /
-#ifdef _WIN32
-            "sd-cli.exe";
-#else
-            "sd-cli";
-#endif
+        // Optional client-requested upscale factor. Each backend applies it
+        // only when > 0; otherwise it uses its own default (thenoise omits the
+        // flag entirely).
+        double upscale_factor = 0.0;
+        if (request_json.contains("upscale_factor") && request_json["upscale_factor"].is_number()) {
+            upscale_factor = request_json["upscale_factor"].get<double>();
+        }
 
-        if (!std::filesystem::exists(cli_exe)) {
-            res.status = 500;
+        std::string b64_image = request_json["image"].get<std::string>();
+
+        // Upscaling is model-free: no model is loaded through the router, so we
+        // dispatch by recipe to each backend's shared upscale API, which shells
+        // out to its own CLI binary directly (backend selection, binary path,
+        // and runtime environment all live in the backend).
+        std::string upscaled;
+        if (recipe == "thenoise") {
+            upscaled = lemon::backends::TheNoiseServer::upscale_via_cli(
+                b64_image, upscale_model_path, upscale_factor);
+        } else if (recipe == "sd-cpp") {
+            upscaled = lemon::backends::SDServer::upscale_via_cli(
+                b64_image, upscale_model_path, upscale_factor);
+        } else {
+            res.status = 400;
             nlohmann::json error = {{"error", {
-                {"message", "sd-cpp backend not installed (sd-cli not found at: "
-                            + cli_exe.string() + ")"},
-                {"type", "server_error"}
+                {"message", "Upscale is not supported by recipe: " + recipe},
+                {"type", "invalid_request_error"}
             }}};
             res.set_content(error.dump(), "application/json");
             return;
         }
 
-        std::vector<std::pair<std::string, std::string>> env_vars;
-        std::filesystem::path cli_dir = cli_exe.parent_path();
-
-        std::string resolved_backend = backend;
-        if (backend == "rocm") {
-            std::string channel = "stable";
-            if (config_) {
-                channel = config_->rocm_channel_for_recipe("sd-cpp");
-            }
-            resolved_backend = "rocm-" + channel;
-        }
-#ifndef _WIN32
-        std::string lib_path = cli_dir.string();
-
-        if (resolved_backend == "rocm-stable") {
-            std::string rocm_arch = SystemInfo::get_rocm_arch();
-            if (!rocm_arch.empty()) {
-                std::string therock_dirs = lemon::backends::BackendUtils::join_runtime_dirs(
-                    lemon::backends::BackendUtils::get_therock_lib_paths(rocm_arch));
-                if (!therock_dirs.empty()) {
-                    lib_path = therock_dirs + ":" + lib_path;
-                }
-            }
-        }
-
-        const char* existing_ld_path = std::getenv("LD_LIBRARY_PATH");
-        if (existing_ld_path && strlen(existing_ld_path) > 0) {
-            lib_path = lib_path + ":" + std::string(existing_ld_path);
-        }
-        env_vars.push_back({"LD_LIBRARY_PATH", lib_path});
-#else
-        if (resolved_backend == "rocm-stable") {
-            std::string new_path = cli_dir.string();
-            std::string rocm_arch = SystemInfo::get_rocm_arch();
-            std::vector<std::string> therock_dirs;
-            if (!rocm_arch.empty()) {
-                therock_dirs =
-                    lemon::backends::BackendUtils::get_therock_lib_paths(rocm_arch);
-                for (auto it = therock_dirs.rbegin(); it != therock_dirs.rend(); ++it) {
-                    if (!it->empty()) {
-                        new_path = *it + ";" + new_path;
-                    }
-                }
-            }
-
-            const char* existing_path = std::getenv("PATH");
-            if (existing_path && strlen(existing_path) > 0) new_path += ";" + std::string(existing_path);
-            env_vars.push_back({"PATH", new_path});
-
-            if (!therock_dirs.empty()) {
-                fs::path therock_dll = fs::path(therock_dirs.front()) / "amdhip64_7.dll";
-                fs::path target_dll = cli_exe.parent_path() / "amdhip64_7.dll";
-                if (fs::exists(therock_dll)) {
-                    std::error_code ec;
-                    fs::copy_file(therock_dll, target_dll, fs::copy_options::overwrite_existing, ec);
-                    if (!ec) {
-                        LOG(INFO, "Server") << "Copied amdhip64_7.dll from TheRock to "
-                            << lemon::utils::path_to_utf8(target_dll) << std::endl;
-                    } else {
-                        LOG(ERROR, "Server") << "Failed to copy amdhip64_7.dll: "
-                            << ec.message() << std::endl;
-                    }
-                }
-            }
-        }
-#endif
-
-        std::string b64_image = request_json["image"].get<std::string>();
-        std::string upscaled = lemon::backends::SDServer::upscale_via_cli(
-            b64_image, upscale_model_path, cli_exe.string(), env_vars);
-
         if (upscaled.empty()) {
             res.status = 500;
             nlohmann::json error = {{"error", {
-                {"message", "ESRGAN upscale failed"},
+                {"message", "Upscale failed"},
                 {"type", "server_error"}
             }}};
             res.set_content(error.dump(), "application/json");

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -5550,14 +5550,6 @@ void Server::handle_image_upscale(const httplib::Request& req, httplib::Response
             return;
         }
 
-        // Optional client-requested upscale factor. Each backend applies it
-        // only when > 0; otherwise it uses its own default (thenoise omits the
-        // flag entirely).
-        double upscale_factor = 0.0;
-        if (request_json.contains("upscale_factor") && request_json["upscale_factor"].is_number()) {
-            upscale_factor = request_json["upscale_factor"].get<double>();
-        }
-
         std::string b64_image = request_json["image"].get<std::string>();
 
         // Upscaling is model-free: no model is loaded through the router, so we
@@ -5566,11 +5558,9 @@ void Server::handle_image_upscale(const httplib::Request& req, httplib::Response
         // and runtime environment all live in the backend).
         std::string upscaled;
         if (recipe == "thenoise") {
-            upscaled = lemon::backends::TheNoiseServer::upscale_via_cli(
-                b64_image, upscale_model_path, upscale_factor);
+            upscaled = lemon::backends::TheNoiseServer::upscale_via_cli(b64_image, upscale_model_path);
         } else if (recipe == "sd-cpp") {
-            upscaled = lemon::backends::SDServer::upscale_via_cli(
-                b64_image, upscale_model_path, upscale_factor);
+            upscaled = lemon::backends::SDServer::upscale_via_cli(b64_image, upscale_model_path);
         } else {
             res.status = 400;
             nlohmann::json error = {{"error", {


### PR DESCRIPTION
<!--
Before submitting this PR, please read:
- docs/dev/contribute.md
- docs/dev/philosophy.md
- AGENTS.md if you used an AI coding agent or AI-assisted workflow
- docs/dev/documentation.md if this PR changes user-facing or developer-facing documentation
-->

## Summary

Adds the ability to upscale images using TheNoise + adds additional upscaling models. Since the upscaling endpoint was hardcoded for sdcpp, a few changes were needed to sdcpp backend to move backend-specific code away from `server.cpp`.

Additionally I removed "experimental" from the backend's name and added the "rocm" bin variant to users can keep track of specific forks or "latest" like the other backends.

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

In image generation, select one of the upscaler models from this PR (-TheNoise suffix). Also tried the pre-existing models and both paths still work.

## Documentation

<!-- Select ONE of the following -->

- [x]  Documentation is affected and has been updated.

## Breaking Changes

- [x] This PR does not introduce breaking changes.

## AI-assisted contribution

Please select one:

- [x] I used AI tools for this PR.

If AI tools were used:

<!-- Only complete this section if you checked "I used AI tools for this PR" above -->

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.
