### PR TITLE
feat(server): size-filter streaming backends by working set, not full size

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2847,6 +2847,18 @@ if(BUILD_TESTING AND EXISTS "${_RECIPE_HIDING_TEST_SRC}")
     add_cpp_ci_test(RecipeHidingTest CI ON COMMAND test_recipe_hiding)
 endif()
 
+# Streaming memory filter: backends that stream the model from storage are
+# size-filtered on their resident working set vs the device pool, not full size.
+set(_STREAMING_MEM_FILTER_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_streaming_memory_filter.cpp")
+if(BUILD_TESTING AND EXISTS "${_STREAMING_MEM_FILTER_TEST_SRC}")
+    add_executable(test_streaming_memory_filter test/cpp/test_streaming_memory_filter.cpp)
+    target_link_libraries(test_streaming_memory_filter PRIVATE lemonade-server-core)
+    add_dependencies(test_streaming_memory_filter copy_resources)
+
+    include(CTest)
+    add_cpp_ci_test(StreamingMemoryFilterTest CI ON COMMAND test_streaming_memory_filter)
+endif()
+
 # Remote model registry source parsing, cache namespaces, snapshot fingerprints,
 # and persistence of ModelScope provenance in ModelInfo.
 set(_MODEL_REGISTRY_TEST_SRC

--- a/src/cpp/include/lemon/backends/backend_descriptor.h
+++ b/src/cpp/include/lemon/backends/backend_descriptor.h
@@ -114,6 +114,11 @@ struct BackendDescriptor {
     std::vector<std::string> bin_variants;         // each emits `<variant>_bin: "builtin"`
     nlohmann::json config_extra = nlohmann::json::object();  // fixed extras (e.g. prefer_system, image defaults)
 
+    // True if the backend streams the model from storage rather than loading it
+    // fully resident (ds4 --ssd-streaming); changes how it is size-filtered (see
+    // filter_models_by_backend in model_manager.cpp).
+    bool streams_model_from_storage = false;
+
     // The config.json section name for this backend, falling back to the recipe.
     std::string effective_config_section() const {
         return config_section.empty() ? recipe : config_section;

--- a/src/cpp/include/lemon/model_manager.h
+++ b/src/cpp/include/lemon/model_manager.h
@@ -104,6 +104,9 @@ struct ModelInfo {
     bool update_available = false; // Whether a newer remote-registry version exists
     std::optional<bool> auto_update = std::nullopt; // Optional per-model auto-update override
     double size = 0.0;   // Model size in GB
+    // Resident working set for a streaming backend; 0 = filter on full `size`.
+    // See streaming_working_set_gb() / filter_models_by_backend.
+    double min_resident_gb = 0.0;
     int64_t max_context_window = 0;  // Static model-supported text context, when known
 
     // GGUF architecture metadata (populated for llamacpp models, used for auto ctx_size)
@@ -299,6 +302,11 @@ public:
     static std::set<std::string> recipes_missing_all_models(
         const std::set<std::string>& size_filtered_recipes,
         const std::set<std::string>& visible_recipes);
+
+    // Memory-fit helpers for streaming backends (see filter_models_by_backend
+    // for the rationale). Pure and hardware-independent, so unit-tested directly.
+    static double streaming_working_set_gb(double min_resident_gb, double size_gb);
+    static bool streaming_model_exceeds_pool(double working_set_gb, double pool_gb);
 
     // Test-only raw view of the side table without a cache rebuild; prefer
     // recipes_with_all_models_filtered() everywhere else.

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -2814,6 +2814,7 @@ void ModelManager::build_cache() {
             continue;
         }
         info.size = JsonUtils::get_or_default<double>(value, "size", 0.0);
+        info.min_resident_gb = JsonUtils::get_or_default<double>(value, "min_resident_gb", 0.0);
         info.cloud_provider = JsonUtils::get_or_default<std::string>(value, "cloud_provider", "");
         info.system_prompt = JsonUtils::get_or_default<std::string>(value, "system_prompt", "");
         if (value.contains("auto_update") && value["auto_update"].is_boolean()) {
@@ -2892,6 +2893,7 @@ void ModelManager::build_cache() {
             continue;
         }
         info.size = JsonUtils::get_or_default<double>(value, "size", 0.0);
+        info.min_resident_gb = JsonUtils::get_or_default<double>(value, "min_resident_gb", 0.0);
         info.cloud_provider = JsonUtils::get_or_default<std::string>(value, "cloud_provider", "");
         info.system_prompt = JsonUtils::get_or_default<std::string>(value, "system_prompt", "");
         if (value.contains("auto_update") && value["auto_update"].is_boolean()) {
@@ -3558,10 +3560,28 @@ std::map<std::string, ModelInfo> ModelManager::filter_models_by_backend(
                            "Detected operating system: " + os_version + ".";
         }
 
-        // Filter out models that are too large for system RAM
-        // Heuristic: if model size > 80% of system RAM, filter it out
-        if (!filter_out && !user_controlled_model && system_ram_gb > 0.0 && info.size > 0.0) {
-            if (info.size > max_model_size_gb) {
+        // Filter out models too large to run on this machine.
+        if (!filter_out && !user_controlled_model && info.size > 0.0) {
+            const auto* desc = backends::descriptor_for(recipe);
+            if (desc && desc->streams_model_from_storage) {
+                // A streaming backend reads the model from disk on demand, so the
+                // full model need not fit in memory — only its resident working
+                // set, and only in the device's own pool. ROCm cannot address
+                // system RAM plus the iGPU carveout as one pool; it gets the
+                // larger of the pools (largest_mem_pool_gb), so that is the ceiling.
+                const double working_set = streaming_working_set_gb(info.min_resident_gb, info.size);
+                if (streaming_model_exceeds_pool(working_set, largest_mem_pool_gb)) {
+                    filter_out = true;
+                    size_filtered_recipes.insert(recipe);
+                    std::ostringstream oss;
+                    oss << std::fixed << std::setprecision(1);
+                    oss << "This model streams from disk but needs about " << working_set
+                        << " GB resident in GPU memory, and this device's largest memory "
+                        << "pool is only " << largest_mem_pool_gb << " GB.";
+                    filter_reason = oss.str();
+                }
+            } else if (system_ram_gb > 0.0 && info.size > max_model_size_gb) {
+                // Non-streaming: the whole model must fit (80% of system RAM).
                 filter_out = true;
                 size_filtered_recipes.insert(recipe);
                 std::ostringstream oss;
@@ -3621,6 +3641,15 @@ std::set<std::string> ModelManager::recipes_missing_all_models(
         }
     }
     return hidden;
+}
+
+double ModelManager::streaming_working_set_gb(double min_resident_gb, double size_gb) {
+    return min_resident_gb > 0.0 ? min_resident_gb : size_gb;
+}
+
+bool ModelManager::streaming_model_exceeds_pool(double working_set_gb, double pool_gb) {
+    // pool <= 0 means the device pool is unknown: don't hide on missing data.
+    return pool_gb > 0.0 && working_set_gb > pool_gb;
 }
 
 void ModelManager::set_cloud_registry(CloudProviderRegistry* registry) {

--- a/test/cpp/test_streaming_memory_filter.cpp
+++ b/test/cpp/test_streaming_memory_filter.cpp
@@ -1,0 +1,54 @@
+// Coverage for the pure memory-fit helpers used to size-filter streaming
+// backends (streams_model_from_storage). A streaming model is filtered on its
+// resident working set against the device's largest memory pool, not the full
+// model size against system RAM — because the model is read from disk on demand
+// and can legitimately exceed memory.
+
+#include "lemon/model_manager.h"
+
+#include <cstdio>
+
+using lemon::ModelManager;
+
+static int g_failures = 0;
+
+static void check(const std::string& name, bool ok) {
+    std::printf("%s %s\n", ok ? "PASS" : "FAIL", name.c_str());
+    if (!ok) ++g_failures;
+}
+
+int main() {
+    // working set: declared floor wins; fall back to full size when undeclared.
+    check("declared min_resident is the working set",
+          ModelManager::streaming_working_set_gb(16.0, 81.0) == 16.0);
+    check("no declared floor falls back to full size",
+          ModelManager::streaming_working_set_gb(0.0, 81.0) == 81.0);
+
+    // fit decision against the device pool.
+    check("working set within pool -> keep",
+          ModelManager::streaming_model_exceeds_pool(16.0, 64.0) == false);
+    check("working set equal to pool -> keep",
+          ModelManager::streaming_model_exceeds_pool(64.0, 64.0) == false);
+    check("working set above pool -> filter",
+          ModelManager::streaming_model_exceeds_pool(96.0, 64.0) == true);
+
+    // unknown pool (<=0) is missing data, not a reason to hide.
+    check("unknown pool never filters",
+          ModelManager::streaming_model_exceeds_pool(81.0, 0.0) == false);
+
+    // end-to-end of the two helpers: an 81 GB model with a 16 GB floor fits a
+    // 64 GB pool, but the same model with no declared floor does not.
+    check("81 GB model with 16 GB floor fits a 64 GB pool",
+          ModelManager::streaming_model_exceeds_pool(
+              ModelManager::streaming_working_set_gb(16.0, 81.0), 64.0) == false);
+    check("81 GB model with no floor does not fit a 64 GB pool",
+          ModelManager::streaming_model_exceeds_pool(
+              ModelManager::streaming_working_set_gb(0.0, 81.0), 64.0) == true);
+
+    if (g_failures == 0) {
+        std::printf("All streaming memory filter tests passed.\n");
+    } else {
+        std::printf("%d streaming memory filter test(s) failed.\n", g_failures);
+    }
+    return g_failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Replaces #3289. Per @superm1's [review](https://github.com/lemonade-sdk/lemonade/pull/3047#discussion_r3832551973), adding the iGPU carveout to physical memory is wrong for ROCm — you don't address system RAM **and** the carveout as one pool, you get the larger of the two (confirmed by an OOM repro: the ds4 model tops out ~48 GiB on a box that "fix" reported as 126 GB).

The real problem is that model-size filtering assumes **full residency**. For a backend that streams the model from storage on demand, the full model need not fit — only its resident working set, and only in the device's own memory pool. This adds that mechanism:

- `streams_model_from_storage` descriptor flag.
- per-model `min_resident_gb` (resident floor; falls back to `size` when unset).
- filter branch: streaming backends are filtered when `working_set > largest_mem_pool_gb` (the "larger of the two pools" @superm1 described); non-streaming backends keep the existing system-RAM check.
- pure helpers `streaming_working_set_gb` / `streaming_model_exceeds_pool` with unit coverage.

No backend sets the flag in this PR — it's the infrastructure a streaming backend (ds4, #3047) opts into, split out so the memory-accounting approach can be reviewed on its own.

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_

- New `StreamingMemoryFilterTest` (CI ON) covers the pure helpers: working-set selection (declared floor vs. fallback to full size) and the fit decision (within / equal / above pool, and unknown-pool = don't hide).
- Exercised end-to-end on a gfx1151 Strix Halo via the ds4 opt-in (kept on the #3047 branch): with an 81 GB model declaring a 16 GB floor it is **shown** (16 < 64 GB pool); with the floor forced above the pool it is **hidden** (`unavailable_recipes`), and a load attempt returns "streams from disk but needs about N GB resident … largest memory pool is only 64.0 GB."
- Inert on `main` (no backend sets the flag), so existing filtering behavior is unchanged.

## Documentation

- [x] Documentation is not affected by this change.

## Breaking Changes

- [x] This PR does not introduce breaking changes.

## AI-assisted contribution

- [x] I used AI tools for this PR.

Implemented with Claude Code (Opus 4.8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
