### PR TITLE
thenoise: respect the user configurable "Model Options"

### DIFF
--- a/src/cpp/include/lemon/backends/thenoise/thenoise_server.h
+++ b/src/cpp/include/lemon/backends/thenoise/thenoise_server.h
@@ -40,16 +40,11 @@ public:
     json image_variations(const json& request) override;
 
 private:
-    // image_defaults from the currently loaded model's server_models.json entry.
-    // Applied when a request doesn't specify size / steps / cfg_scale / etc.
-    ImageDefaults image_defaults_;
-
-    // Build the /text2image request body. Precedence: request -> image_defaults_
-    // -> recipe_options_.
+    // Precedence and fall-through are documented in build_request().
     nlohmann::json build_request(const nlohmann::json& request) const;
 
-    // Resolve the output size from `size: "WxH"`, `width`/`height`, or
-    // image_defaults. Returns "" if nothing can be resolved.
+    // Resolve the output size from `size: "WxH"`, `width`/`height`, or the
+    // effective recipe options. Returns "" if nothing can be resolved.
     std::string resolve_size(const nlohmann::json& request) const;
 };
 

--- a/src/cpp/server/backends/thenoise/thenoise_server.cpp
+++ b/src/cpp/server/backends/thenoise/thenoise_server.cpp
@@ -73,8 +73,6 @@ void TheNoiseServer::load(const std::string& model_name,
     LOG(INFO, "TheNoise") << "Loading model: " << model_name << std::endl;
     LOG(DEBUG, "TheNoise") << "Per-model settings: " << options.to_log_string() << std::endl;
 
-    image_defaults_ = model_info.image_defaults;
-
     std::string backend = options.get_option("thenoise_backend");
     if (backend.empty()) {
         backend = "rocm";
@@ -178,7 +176,6 @@ void TheNoiseServer::unload() {
         LOG(INFO, "TheNoise") << "Stopping server (PID: " << handle.pid << ")" << std::endl;
         utils::ProcessManager::stop_process(handle);
     }
-    image_defaults_ = ImageDefaults{};
 }
 
 // ICompletionServer implementation - not supported for image generation
@@ -209,17 +206,21 @@ std::string TheNoiseServer::resolve_size(const json& request) const {
         return std::to_string(request["width"].get<int>()) + "x"
              + std::to_string(request["height"].get<int>());
     }
-    if (image_defaults_.has_defaults) {
-        return std::to_string(image_defaults_.width) + "x"
-             + std::to_string(image_defaults_.height);
-    }
-    return "";
+    // Fall back to the effective recipe options (ladder in build_request()).
+    // Return "" when unset so thenoise picks its own native defaults.
+    if (!recipe_options_.has_option("width") || !recipe_options_.has_option("height")) return "";
+    int w = static_cast<int>(recipe_options_.get_option("width"));
+    int h = static_cast<int>(recipe_options_.get_option("height"));
+    if (w <= 0 || h <= 0) return "";
+    return std::to_string(w) + "x" + std::to_string(h);
 }
-
 json TheNoiseServer::build_request(const json& request) const {
     // thenoise /text2image accepts the shared model-agnostic params directly.
-    // Precedence for each value: request override -> model image_defaults
-    // -> recipe_options.
+    // Per-value precedence, highest → lowest: per-request body fields, then the
+    // effective recipe options, which already fold user-saved > model
+    // recipe_options > image_defaults > architecture > global config (via
+    // RecipeOptions::merge_precedence_layers / inherit); a value absent from
+    // every layer is omitted, letting thenoise apply its own defaults.
     json body;
 
     body["prompt"] = request.value("prompt", "");
@@ -227,12 +228,6 @@ json TheNoiseServer::build_request(const json& request) const {
     auto resolve_int = [&](const std::string& key, int fallback) -> int {
         if (request.contains(key) && request[key].is_number_integer()) {
             return request[key].get<int>();
-        }
-        return fallback;
-    };
-    auto resolve_float = [&](const std::string& key, float fallback) -> float {
-        if (request.contains(key) && request[key].is_number()) {
-            return request[key].get<float>();
         }
         return fallback;
     };
@@ -248,6 +243,15 @@ json TheNoiseServer::build_request(const json& request) const {
         }
         return fallback;
     };
+    auto option_int = [&](const std::string& key) -> int {
+        return recipe_options_.has_option(key) ? static_cast<int>(recipe_options_.get_option(key)) : 0;
+    };
+    auto option_float = [&](const std::string& key) -> float {
+        return recipe_options_.has_option(key) ? static_cast<float>(recipe_options_.get_option(key)) : 0.0f;
+    };
+    auto option_string = [&](const std::string& key) -> std::string {
+        return recipe_options_.has_option(key) ? recipe_options_.get_option(key).get<std::string>() : "";
+    };
 
     // size -> width / height
     std::string size = resolve_size(request);
@@ -260,28 +264,24 @@ json TheNoiseServer::build_request(const json& request) const {
     }
 
     // negative_prompt
-    std::string negative_prompt = resolve_string("negative_prompt",
-        recipe_options_.get_option("negative_prompt"));
+    std::string negative_prompt = resolve_string("negative_prompt", option_string("negative_prompt"));
     if (!negative_prompt.empty()) {
         body["negative_prompt"] = negative_prompt;
     }
 
     // steps
-    int steps = image_defaults_.has_defaults
-                  ? image_defaults_.steps
-                  : static_cast<int>(recipe_options_.get_option("steps"));
-    steps = resolve_int("steps", steps);
+    int steps = resolve_int("steps", option_int("steps"));
     if (steps > 0) {
         body["steps"] = steps;
     }
 
     // cfg_scale -> guidance_scale
-    float cfg_scale = image_defaults_.has_defaults
-                              ? image_defaults_.cfg_scale
-                              : static_cast<float>(recipe_options_.get_option("cfg_scale"));
-    cfg_scale = resolve_float("cfg_scale", cfg_scale);
-    if (cfg_scale > 0.0f) {
-        body["guidance_scale"] = cfg_scale;
+    // 0.0 is a valid explicit value (disables CFG guidance); only omit the key
+    // when it is absent from every layer so thenoise applies its own default.
+    if (request.contains("cfg_scale") && request["cfg_scale"].is_number()) {
+        body["guidance_scale"] = request["cfg_scale"].get<float>();
+    } else if (recipe_options_.has_option("cfg_scale")) {
+        body["guidance_scale"] = option_float("cfg_scale");
     }
 
     // seed stays as-is; negative means "random" for thenoise. We still emit a
@@ -292,7 +292,7 @@ json TheNoiseServer::build_request(const json& request) const {
     }
 
     // sampler
-    std::string sampler = resolve_string("sampler", recipe_options_.get_option("sampler"));
+    std::string sampler = resolve_string("sampler", option_string("sampler"));
     if (!sampler.empty()) {
         body["sampler"] = sampler;
     }
@@ -305,15 +305,19 @@ json TheNoiseServer::build_request(const json& request) const {
     }
 
     // film_grain
-    float film_grain = static_cast<float>(recipe_options_.get_option("film_grain"));
-    film_grain = resolve_float("film_grain", film_grain);
+    float film_grain = option_float("film_grain");
+    film_grain = request.contains("film_grain") && request["film_grain"].is_number()
+                     ? request["film_grain"].get<float>()
+                     : film_grain;
     if (film_grain > 0.0f) {
         body["film_grain"] = film_grain;
     }
 
     // sharpening
-    float sharpening = static_cast<float>(recipe_options_.get_option("sharpening"));
-    sharpening = resolve_float("sharpening", sharpening);
+    float sharpening = option_float("sharpening");
+    sharpening = request.contains("sharpening") && request["sharpening"].is_number()
+                     ? request["sharpening"].get<float>()
+                     : sharpening;
     if (sharpening > 0.0f) {
         body["sharpening"] = sharpening;
     }


### PR DESCRIPTION
## Summary

Port the recipe-option precedence changes from #2845 (Stable Diffusion) to the TheNoise image-generation backend, which shares the same request-building pattern.

TheNoise previously snapshotted `image_defaults` from `server_models.json` at load time and used it as a fallback layer between per-request fields and `recipe_options_`, which meant user-configurable "Model Options" were silently overridden by registry Image Defaults. TheNoise now consumes the effective `RecipeOptions` that the router already merges (`user-saved > model recipe_options > image_defaults > architecture > global config` via `RecipeOptions::merge_precedence_layers` / `inherit`) and omits unset values so thenoise applies its own defaults.

Two deliberate behavior refinements carried over from #2845:

- Explicit `cfg_scale: 0.0` in a request is now forwarded as `guidance_scale: 0.0` (a valid value — it disables CFG guidance) instead of being swallowed by a `> 0.0` guard.
- `guidance_scale` is only sent when set somewhere in the precedence ladder; previously the descriptor default was always forwarded, even when the user never configured anything.

Fixes #

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_

- `cmake --build --preset default --target lemond -- -j24` builds cleanly.
- `ctest -L cpp-ci -R RecipeOptions` passes (`RecipeOptionsPrecedence`).
- Full behavioral coverage requires an ROCm gfx1150/gfx1151 host: `python test/server_thenoise.py`.

## Documentation

- [x] Documentation is not affected by this change.
- [ ] Documentation is affected and has been updated.
- [ ] Documentation is affected but will be handled in a separate PR or issue.

## Breaking Changes

- [ ] This PR introduces breaking changes.
- [x] This PR does not introduce breaking changes.

Requests with no explicit options resolve to the same values as before (Image Defaults still apply as the lowest non-empty layer); only explicit user-saved Model Options now correctly take precedence, and explicit 0.0 CFG requests are honored instead of dropped.

## AI-assisted contribution

Please select one:

- [x] I used AI tools for this PR.
- [ ] I did not use AI tools for this PR.

If AI tools were used:

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.