### PR TITLE
fix(openmoss): bump OpenMOSS TTS pin to v0.3.0 and re-enable CI

### DIFF
--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -1071,11 +1071,11 @@ jobs:
             extra_args: "--wrapped-server trellis"
             backends: "vulkan rocm"
             runner: [Windows, rocm, vulkan, lemon-prod]
-          # - name: tts-openmoss
-          #   script: server_tts_openmoss.py
-          #   extra_args: "--wrapped-server openmoss"
-          #   backends: "vulkan rocm"
-          #   runner: [Windows, rocm, vulkan, lemon-prod]
+          - name: tts-openmoss
+            script: server_tts_openmoss.py
+            extra_args: "--wrapped-server openmoss"
+            backends: "vulkan rocm"
+            runner: [Windows, rocm, vulkan, lemon-prod]
     env:
       LEMONADE_CI_MODE: "True"
       HF_TOKEN: ${{ secrets.HUGGINGFACE_ACCESS_TOKEN }}
@@ -1324,11 +1324,11 @@ jobs:
             extra_args: "--wrapped-server trellis"
             backends: "vulkan rocm"
             runner: [Linux, vulkan, rocm, lemon-prod]
-          # - name: tts-openmoss
-          #   script: server_tts_openmoss.py
-          #   extra_args: "--wrapped-server openmoss"
-          #   backends: "vulkan rocm"
-          #   runner: [Linux, vulkan, rocm, lemon-prod]
+          - name: tts-openmoss
+            script: server_tts_openmoss.py
+            extra_args: "--wrapped-server openmoss"
+            backends: "vulkan rocm"
+            runner: [Linux, vulkan, rocm, lemon-prod]
     env:
       LEMONADE_CI_MODE: "True"
       HF_TOKEN: ${{ secrets.HUGGINGFACE_ACCESS_TOKEN }}

--- a/src/cpp/resources/backend_versions.json
+++ b/src/cpp/resources/backend_versions.json
@@ -4,13 +4,13 @@
     "comment": "Expected SHA-256 of downloaded GitHub release assets, verified after download (see BackendUtils::lookup_expected_asset_hash). Keyed by checksums.github.<owner/repo>.<tag>.<asset>. Values are the sha256:<hex> digests GitHub publishes for each asset. Update alongside the matching version pin below.",
     "github": {
       "pwilkin/openmoss": {
-        "v0.1.3": {
-          "moss-tts-vulkan-linux-x64.tar.gz": "sha256:15e64803ed7f93e0459f4e3132346a83123e1de0b973702c2c0631ae32f55feb",
-          "moss-tts-vulkan-windows-x64.zip": "sha256:6cafdc45c53cc614427696bd369f44602e7881d3879f5acb48b5f92b339149b6",
-          "moss-tts-rocm-linux-x64.tar.gz": "sha256:6bf1dac5fc8511e6bc6d11ec55623e1d364db814242a5af7346f5b6feb6b0dad",
-          "moss-tts-rocm-windows-x64.zip": "sha256:c9178dfad4ddf51fc8d8df8d1412e65237ff364ca9ca8fc997c9c71f55d60827",
-          "moss-tts-cuda-linux-x64.tar.gz": "sha256:8662251a854bda4993a5f99e90ba02c176797bf22b1c5b3e89a0061b0a4b102a",
-          "moss-tts-cuda-windows-x64.zip": "sha256:2b2f5f4b6757d99acf621b43426483ab0bc4a70f1f13904c17deed09cac70969"
+        "v0.3.0": {
+          "moss-tts-vulkan-linux-x64.tar.gz": "sha256:1288a22295451d0e5d8bd707ef79ea324e1c7b5f1cd9bfbdab2167a388fe3af7",
+          "moss-tts-vulkan-windows-x64.zip": "sha256:709c5c67e76c4180a38c6516cf908665fa2df6613900298a7d2c58eba5914733",
+          "moss-tts-rocm-linux-x64.tar.gz": "sha256:0126df034ea8d18cb895ef39e639bf36a29c7a024a87ab9eaeadf1126ccfe80d",
+          "moss-tts-rocm-windows-x64.zip": "sha256:5b4f32862b6c52a52b01e937af11cf9f60f887da079bb0354cbb6ecc46e7fe72",
+          "moss-tts-cuda-linux-x64.tar.gz": "sha256:3a7a61852bd9fe16a14f262ff99e055739e7bc52c2727749d05f0b4664facb37",
+          "moss-tts-cuda-windows-x64.zip": "sha256:def68a7f35e6bd111ec4118f4e88835547f3af87efd5f3812ab1e505d1f38229"
         }
       },
       "pwilkin/acestep.cpp": {
@@ -186,9 +186,9 @@
     "cuda": "v0.4.3"
   },
   "openmoss": {
-    "vulkan": "v0.1.3",
-    "rocm-stable": "v0.1.3",
-    "cuda": "v0.1.3"
+    "vulkan": "v0.3.0",
+    "rocm-stable": "v0.3.0",
+    "cuda": "v0.3.0"
   },
   "clear_bin_if_lemonade_below": "9.4.0"
 }


### PR DESCRIPTION
## Summary

Re-enables the `tts-openmoss` integration tests disabled in #3291 by bumping the OpenMOSS backend pin from `v0.1.3` to `v0.3.0`.

The regression came from upstream data, not from Lemonade: on 2026-08-21 `ilintar/moss-tts-gguf` and `ilintar/moss-voicegen-gguf` were re-uploaded ("Replace F16 artifacts with BF16 and FP32 conversion"). The pinned `v0.1.3` binary only reads F16 codec sidecars, so every `/audio/speech` request died in the codec (`read_f16_to_host_: expected f16 for moss.codec.quantizer.q.0.oproj.wp0`) and surfaced as `500 generation produced no audio`. Upstream `v0.3.0` (`pwilkin/openmoss@6b3371a`, "fix: preserve BF16 model precision") teaches the codec loader to accept F16, BF16, and FP32 sidecars. Its server CLI and routes are unchanged, so no C++ changes are needed.

This is the minimal unblock; it takes only the version/checksum bump from #2863 and none of that PR's new models, voice registry, or capability changes.

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_ Ran `test/server_tts_openmoss.py` against a local `lemond` on a Strix Halo box, on both backends CI covers:

- `--wrapped-server openmoss --backend vulkan` — 11/11 OK
- `--wrapped-server openmoss --backend rocm` — 11/11 OK

The ROCm run downloaded the `v0.3.0` archive fresh, so the new ROCm checksum is verified end to end by `BackendUtils::lookup_expected_asset_hash`. All asset digests were taken from the GitHub release API and match the ones in #2863.

Labeled `ci:backends` so the backend matrices run on this PR.

## Documentation

- [x] Documentation is not affected by this change.
- [ ] Documentation is affected and has been updated.
- [ ] Documentation is affected but will be handled in a separate PR or issue.

## Breaking Changes

- [ ] This PR introduces breaking changes.
- [x] This PR does not introduce breaking changes.

## AI-assisted contribution

Please select one:

- [x] I used AI tools for this PR.
- [ ] I did not use AI tools for this PR.

If AI tools were used:

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
