### PR TITLE
fix(vllm): scale gpu-memory-utilization to free memory on shared-memory devices

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1166,7 +1166,7 @@ if(BUILD_TESTING AND EXISTS "${VLLM_ARG_RESOLVER_TEST_SOURCE}")
         src/cpp/server/backends/vllm/vllm_arg_resolver.cpp
     )
     target_link_libraries(test_vllm_arg_resolver PRIVATE nlohmann_json::nlohmann_json)
-    add_cpp_ci_test(vllm_arg_resolver CI OFF COMMAND test_vllm_arg_resolver)
+    add_cpp_ci_test(vllm_arg_resolver CI ON COMMAND test_vllm_arg_resolver)
 endif()
 
 set(LLAMACPP_REQUEST_TEST_SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_llamacpp_request.cpp")

--- a/src/cpp/include/lemon/backends/vllm/vllm_arg_resolver.h
+++ b/src/cpp/include/lemon/backends/vllm/vllm_arg_resolver.h
@@ -43,5 +43,10 @@ DeviceClassLaunchPolicy device_class_launch_policy(const std::string& arch,
                                                    bool has_memory_budget_arg,
                                                    bool has_enforce_eager = false);
 
+// The --gpu-memory-utilization to emit alongside the shared-memory kv-cache cap, or a
+// negative value to leave vLLM's own default in place. `global_vram_usage_pct` is
+// used/total in [0, 1] (SystemInfo::get_global_vram_usage_pct), or negative if unknown.
+double shared_memory_gpu_utilization(double global_vram_usage_pct);
+
 } // namespace backends
 } // namespace lemon

--- a/src/cpp/include/lemon/backends/vllm/vllm_arg_resolver.h
+++ b/src/cpp/include/lemon/backends/vllm/vllm_arg_resolver.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <nlohmann/json.hpp>
 #include <string>
 #include <vector>
@@ -43,10 +44,13 @@ DeviceClassLaunchPolicy device_class_launch_policy(const std::string& arch,
                                                    bool has_memory_budget_arg,
                                                    bool has_enforce_eager = false);
 
-// The --gpu-memory-utilization to emit alongside the shared-memory kv-cache cap, or a
-// negative value to leave vLLM's own default in place. `global_vram_usage_pct` is
-// used/total in [0, 1] (SystemInfo::get_global_vram_usage_pct), or negative if unknown.
-double shared_memory_gpu_utilization(double global_vram_usage_pct);
+constexpr uint64_t kKvCacheCapBytes = 4ULL << 30;
+constexpr const char* kKvCacheCapArg = "4G";
+
+// The --gpu-memory-utilization for a device holding `free_bytes` of `total_bytes`, or a
+// negative value to leave vLLM's own default in place. Both must describe the one device
+// vLLM will run on; the definition explains why.
+double shared_memory_gpu_utilization(uint64_t free_bytes, uint64_t total_bytes);
 
 } // namespace backends
 } // namespace lemon

--- a/src/cpp/include/lemon/system_info.h
+++ b/src/cpp/include/lemon/system_info.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <vector>
 #include <nlohmann/json.hpp>
@@ -159,7 +160,16 @@ public:
 
     // Global GPU memory pressure across all processes (used/total in [0,1]),
     // or -1.0 if no source is available. Used by the dynamic VRAM eviction engine.
+    // Folds every GPU in the machine into one worst-case number, so it must not be read
+    // as a measurement of any single device -- see get_rocm_device_memory().
     static double get_global_vram_usage_pct();
+
+    // Free and total bytes the ROCm runtime exposes for the GPU whose ISA is `arch`
+    // (e.g. "gfx1151"). False unless exactly one GPU matches and both values are
+    // readable.
+    static bool get_rocm_device_memory(const std::string& arch,
+                                       uint64_t& free_bytes,
+                                       uint64_t& total_bytes);
 };
 
 // Windows implementation

--- a/src/cpp/server/backends/vllm/vllm_arg_resolver.cpp
+++ b/src/cpp/server/backends/vllm/vllm_arg_resolver.cpp
@@ -3,6 +3,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cmath>
 #include <map>
 #include <regex>
 #include <set>
@@ -356,24 +357,40 @@ DeviceClassLaunchPolicy device_class_launch_policy(const std::string& arch,
     };
 }
 
-double shared_memory_gpu_utilization(double global_vram_usage_pct) {
+double shared_memory_gpu_utilization(uint64_t free_bytes, uint64_t total_bytes) {
     // vLLM refuses to start unless `gpu_memory_utilization` of the *total* pool is free,
-    // a pre-flight check the kv-cache cap does not relax. On a device whose memory is
-    // shared with the rest of the system, scaling the request down to what is actually
-    // free keeps a co-tenant process from blocking a model that comfortably fits.
+    // a pre-flight check the kv-cache cap does not relax. Scaling the request down to
+    // what this device has free keeps a co-tenant process from blocking a model that
+    // fits; a machine-wide pressure reading would not, since it can describe a GPU vLLM
+    // never touches.
     constexpr double vllm_default = 0.92;
+    // vLLM re-reads free memory after this process does; without a margin the request
+    // races the very reading it was derived from.
     constexpr double headroom = 0.05;
-    constexpr double minimum = 0.10;
 
-    // Rejects NaN as well as out-of-range readings.
-    if (!(global_vram_usage_pct >= 0.0) || global_vram_usage_pct > 1.0) {
+    if (total_bytes == 0 || free_bytes > total_bytes) {
         return -1.0;
     }
-    const double available = 1.0 - global_vram_usage_pct - headroom;
-    if (available >= vllm_default) {
+
+    const double free_fraction =
+        static_cast<double>(free_bytes) / static_cast<double>(total_bytes);
+    // A device with room to spare keeps the budget vLLM chose for itself.
+    if (free_fraction >= vllm_default) {
         return -1.0;
     }
-    return std::max(minimum, available);
+
+    // Truncated rather than rounded to two decimals, because the flag is emitted at that
+    // precision and rounding up would ask for memory the reading says is not there.
+    const double available = std::floor((free_fraction - headroom) * 100.0) / 100.0;
+
+    // A budget below the cap emitted beside it cannot hold even the cache, and vLLM's own
+    // error names the byte counts -- better than a request known in advance to fail.
+    if (available <= 0.0 ||
+        static_cast<double>(total_bytes) * available <=
+            static_cast<double>(kKvCacheCapBytes)) {
+        return -1.0;
+    }
+    return available;
 }
 
 } // namespace backends

--- a/src/cpp/server/backends/vllm/vllm_arg_resolver.cpp
+++ b/src/cpp/server/backends/vllm/vllm_arg_resolver.cpp
@@ -356,5 +356,25 @@ DeviceClassLaunchPolicy device_class_launch_policy(const std::string& arch,
     };
 }
 
+double shared_memory_gpu_utilization(double global_vram_usage_pct) {
+    // vLLM refuses to start unless `gpu_memory_utilization` of the *total* pool is free,
+    // a pre-flight check the kv-cache cap does not relax. On a device whose memory is
+    // shared with the rest of the system, scaling the request down to what is actually
+    // free keeps a co-tenant process from blocking a model that comfortably fits.
+    constexpr double vllm_default = 0.92;
+    constexpr double headroom = 0.05;
+    constexpr double minimum = 0.10;
+
+    // Rejects NaN as well as out-of-range readings.
+    if (!(global_vram_usage_pct >= 0.0) || global_vram_usage_pct > 1.0) {
+        return -1.0;
+    }
+    const double available = 1.0 - global_vram_usage_pct - headroom;
+    if (available >= vllm_default) {
+        return -1.0;
+    }
+    return std::max(minimum, available);
+}
+
 } // namespace backends
 } // namespace lemon

--- a/src/cpp/server/backends/vllm/vllm_server.cpp
+++ b/src/cpp/server/backends/vllm/vllm_server.cpp
@@ -15,6 +15,7 @@
 #include <lemon/utils/aixlog.hpp>
 #include <algorithm>
 #include <chrono>
+#include <cstdint>
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
@@ -421,8 +422,9 @@ void VLLMServer::load(const std::string& model_name,
     args.push_back(model_name);
     // Keep eager execution for consumer GPU inference; leave dtype selection to vLLM.
     // Discrete-HBM parts skip it: eager costs decode throughput for no stability gain.
+    const std::string rocm_arch = SystemInfo::get_rocm_arch();
     const DeviceClassLaunchPolicy launch_policy = device_class_launch_policy(
-        SystemInfo::get_rocm_arch(), resolved_vllm_args.has_memory_budget_arg,
+        rocm_arch, resolved_vllm_args.has_memory_budget_arg,
         resolved_vllm_args.has_enforce_eager);
     if (launch_policy.enforce_eager) {
         args.push_back("--enforce-eager");
@@ -473,20 +475,26 @@ void VLLMServer::load(const std::string& model_name,
     // Discrete-HBM GPUs get vLLM's native budgeting instead of a fixed cap.
     if (launch_policy.cap_kv_cache) {
         args.push_back("--kv-cache-memory-bytes");
-        args.push_back("4G");
+        args.push_back(kKvCacheCapArg);
 
         // The cap above bounds what vLLM uses, but not what it demands be free before it
-        // will start. Track the free share of the pool so a co-tenant process can't
-        // reject a model that fits.
-        const double utilization =
-            shared_memory_gpu_utilization(SystemInfo::get_global_vram_usage_pct());
-        if (utilization > 0.0) {
-            std::ostringstream formatted;
-            formatted << std::fixed << std::setprecision(2) << utilization;
-            LOG(DEBUG, "vLLM") << "Scaling --gpu-memory-utilization to "
-                               << formatted.str() << " for available memory" << std::endl;
-            args.push_back("--gpu-memory-utilization");
-            args.push_back(formatted.str());
+        // will start, so a co-tenant process can still reject a model that fits.
+        uint64_t free_bytes = 0;
+        uint64_t total_bytes = 0;
+        if (SystemInfo::get_rocm_device_memory(rocm_arch, free_bytes, total_bytes)) {
+            const double utilization =
+                shared_memory_gpu_utilization(free_bytes, total_bytes);
+            if (utilization > 0.0) {
+                constexpr uint64_t mib = 1024 * 1024;
+                std::ostringstream formatted;
+                formatted << std::fixed << std::setprecision(2) << utilization;
+                LOG(DEBUG, "vLLM") << "Scaling --gpu-memory-utilization to "
+                                   << formatted.str() << "; " << rocm_arch << " has "
+                                   << (free_bytes / mib) << " MiB of "
+                                   << (total_bytes / mib) << " MiB free" << std::endl;
+                args.push_back("--gpu-memory-utilization");
+                args.push_back(formatted.str());
+            }
         }
     }
 

--- a/src/cpp/server/backends/vllm/vllm_server.cpp
+++ b/src/cpp/server/backends/vllm/vllm_server.cpp
@@ -18,6 +18,7 @@
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
+#include <iomanip>
 #include <random>
 #include <regex>
 #include <sstream>
@@ -473,6 +474,20 @@ void VLLMServer::load(const std::string& model_name,
     if (launch_policy.cap_kv_cache) {
         args.push_back("--kv-cache-memory-bytes");
         args.push_back("4G");
+
+        // The cap above bounds what vLLM uses, but not what it demands be free before it
+        // will start. Track the free share of the pool so a co-tenant process can't
+        // reject a model that fits.
+        const double utilization =
+            shared_memory_gpu_utilization(SystemInfo::get_global_vram_usage_pct());
+        if (utilization > 0.0) {
+            std::ostringstream formatted;
+            formatted << std::fixed << std::setprecision(2) << utilization;
+            LOG(DEBUG, "vLLM") << "Scaling --gpu-memory-utilization to "
+                               << formatted.str() << " for available memory" << std::endl;
+            args.push_back("--gpu-memory-utilization");
+            args.push_back(formatted.str());
+        }
     }
 
     // Emitted as its own argv element, never through vllm_args: that tokenizer strips quotes

--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -1818,20 +1818,12 @@ std::string identify_rocm_arch_from_name(const std::string& device_name) {
     // Linux will pass the ISA from KFD, transform it to what the rest of lemonade expects
     if (!device_lower.empty() &&
         std::all_of(device_lower.begin(), device_lower.end(), ::isdigit)) {
-        int v;
-        try {
-            v = std::stoi(device_lower);
-        } catch (const std::exception& e) {
+        std::string arch = system_info_detail::gfx_target_version_to_arch(device_lower);
+        if (arch.empty()) {
             throw std::runtime_error(
-                "Failed to parse gfx_target_version '" + device_lower + "': " + e.what());
+                "Failed to parse gfx_target_version '" + device_lower + "'");
         }
-        int major = v / 10000;
-        int minor = (v / 100) % 100;
-        int step  = v % 100;
-
-        char buf[16];
-        std::snprintf(buf, sizeof(buf), "gfx%d%x%x", major, minor, step);
-        return std::string(buf);
+        return arch;
     }
 
     if (device_lower.find("radeon") == std::string::npos &&
@@ -4258,6 +4250,14 @@ double SystemInfo::get_global_vram_usage_pct() {
 #endif
 
     return highest_ratio;
+}
+
+bool SystemInfo::get_rocm_device_memory(const std::string& arch,
+                                        uint64_t& free_bytes,
+                                        uint64_t& total_bytes) {
+    return system_info_detail::rocm_device_memory_from_sysfs(
+        "/sys/class/kfd/kfd/topology/nodes", "/sys/class/drm",
+        arch, free_bytes, total_bytes);
 }
 
 } // namespace lemon

--- a/src/cpp/server/system_info_utils.h
+++ b/src/cpp/server/system_info_utils.h
@@ -2,7 +2,13 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cstdint>
+#include <cstdio>
+#include <exception>
+#include <filesystem>
+#include <fstream>
 #include <set>
+#include <system_error>
 #include <string>
 #include <utility>
 #include <vector>
@@ -118,6 +124,121 @@ inline std::string identify_cuda_arch_from_name(const std::string& device_name) 
         }
     }
     return "";
+}
+
+// KFD publishes a GPU's ISA as packed decimal (110501 -> gfx1151), where the minor and
+// step fields are hex nibbles. Empty when the value is not a decimal integer; the CPU
+// node's 0 yields the unmatchable "gfx000" rather than an error.
+inline std::string gfx_target_version_to_arch(const std::string& gfx_target_version) {
+    if (gfx_target_version.empty() ||
+        !std::all_of(gfx_target_version.begin(), gfx_target_version.end(),
+                     [](unsigned char c) { return std::isdigit(c) != 0; })) {
+        return "";
+    }
+
+    int packed = 0;
+    try {
+        packed = std::stoi(gfx_target_version);
+    } catch (const std::exception&) {
+        return "";
+    }
+
+    char buf[16];
+    std::snprintf(buf, sizeof(buf), "gfx%d%x%x",
+                  packed / 10000, (packed / 100) % 100, packed % 100);
+    return std::string(buf);
+}
+
+// Reads the amdgpu driver's own per-device accounting under `kfd_nodes_dir` (KFD
+// topology) and `drm_dir` (/sys/class/drm). Both are world-readable, unlike the libdrm
+// probe elsewhere in this file's callers, which needs O_RDWR on a render node and so
+// answers wrongly for a service account outside the `render` group.
+//
+// Reports nothing unless exactly one GPU matches: two of the same ISA leave no way to say
+// which one a launch lands on, and guessing would size against the wrong device.
+inline bool rocm_device_memory_from_sysfs(const std::filesystem::path& kfd_nodes_dir,
+                                          const std::filesystem::path& drm_dir,
+                                          const std::string& arch,
+                                          uint64_t& free_bytes,
+                                          uint64_t& total_bytes) {
+    namespace fs = std::filesystem;
+
+    if (arch.empty()) {
+        return false;
+    }
+
+    std::error_code ec;
+    if (!fs::is_directory(kfd_nodes_dir, ec)) {
+        return false;
+    }
+
+    std::string wanted = arch;
+    std::transform(wanted.begin(), wanted.end(), wanted.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+
+    std::vector<std::string> matching_render_minors;
+    for (fs::directory_iterator it(kfd_nodes_dir, ec), end; it != end && !ec;
+         it.increment(ec)) {
+        std::ifstream props(it->path() / "properties");
+        if (!props.is_open()) {
+            continue;
+        }
+
+        std::string line;
+        std::string gfx_target_version;
+        std::string drm_render_minor;
+        while (std::getline(props, line)) {
+            const size_t space = line.find(' ');
+            if (space == std::string::npos) {
+                continue;
+            }
+            const std::string key = line.substr(0, space);
+            std::string value = line.substr(space + 1);
+            const size_t end_of_value = value.find_last_not_of(" \t\n\r");
+            value = end_of_value == std::string::npos
+                ? ""
+                : value.substr(0, end_of_value + 1);
+
+            if (key == "gfx_target_version") {
+                gfx_target_version = value;
+            } else if (key == "drm_render_minor") {
+                drm_render_minor = value;
+            }
+        }
+
+        // drm_render_minor -1 marks a GPU with no render node, which no userspace
+        // runtime can open. The CPU node needs no special case: its packed version of 0
+        // cannot match a real ISA.
+        if (drm_render_minor.empty() || drm_render_minor == "-1") {
+            continue;
+        }
+        if (gfx_target_version_to_arch(gfx_target_version) == wanted) {
+            matching_render_minors.push_back(drm_render_minor);
+        }
+    }
+
+    if (matching_render_minors.size() != 1) {
+        return false;
+    }
+
+    auto read_u64 = [](const fs::path& path, uint64_t& value) {
+        std::ifstream file(path);
+        return file.is_open() && static_cast<bool>(file >> value);
+    };
+
+    const fs::path device_dir =
+        drm_dir / ("renderD" + matching_render_minors.front()) / "device";
+    uint64_t used = 0;
+    uint64_t total = 0;
+    if (!read_u64(device_dir / "mem_info_vram_used", used) ||
+        !read_u64(device_dir / "mem_info_vram_total", total) ||
+        total == 0 || used > total) {
+        return false;
+    }
+
+    free_bytes = total - used;
+    total_bytes = total;
+    return true;
 }
 
 }  // namespace lemon::system_info_detail

--- a/test/cpp/test_system_info_helpers.cpp
+++ b/test/cpp/test_system_info_helpers.cpp
@@ -7,7 +7,10 @@
 
 #include "system_info_utils.h"
 
+#include <cstdint>
 #include <cstdio>
+#include <filesystem>
+#include <fstream>
 #include <set>
 #include <string>
 #include <utility>
@@ -16,7 +19,9 @@
 using lemon::system_info_detail::compute_cap_to_sm;
 using lemon::system_info_detail::cuda_supported_archs;
 using lemon::system_info_detail::device_matches_constraint;
+using lemon::system_info_detail::gfx_target_version_to_arch;
 using lemon::system_info_detail::identify_cuda_arch_from_name;
+using lemon::system_info_detail::rocm_device_memory_from_sysfs;
 
 static bool expect_string(const char* name,
                           const std::string& actual,
@@ -46,6 +51,83 @@ static bool expect_membership(const char* name,
                               bool expected) {
     const bool actual = cuda_supported_archs().count(arch) > 0;
     return expect_bool(name, actual, expected);
+}
+
+namespace fs = std::filesystem;
+
+// A throwaway copy of the two world-readable sysfs trees the ROCm memory probe reads,
+// so the topology walk is exercised with no GPU present.
+class FakeSysfs {
+public:
+    explicit FakeSysfs(const std::string& tag)
+        : root_(fs::temp_directory_path() / ("lemonade_sysfs_" + tag)) {
+        fs::remove_all(root_);
+        fs::create_directories(kfd_nodes());
+        fs::create_directories(drm());
+    }
+
+    ~FakeSysfs() {
+        std::error_code ec;
+        fs::remove_all(root_, ec);
+    }
+
+    FakeSysfs(const FakeSysfs&) = delete;
+    FakeSysfs& operator=(const FakeSysfs&) = delete;
+
+    fs::path kfd_nodes() const { return root_ / "kfd_nodes"; }
+    fs::path drm() const { return root_ / "drm"; }
+
+    void add_node(const std::string& node_id,
+                  const std::string& gfx_target_version,
+                  const std::string& drm_render_minor) const {
+        const fs::path node = kfd_nodes() / node_id;
+        fs::create_directories(node);
+        std::ofstream props(node / "properties");
+        props << "cpu_cores_count 0\n"
+              << "gfx_target_version " << gfx_target_version << "\n"
+              << "drm_render_minor " << drm_render_minor << "\n";
+    }
+
+    void add_memory(const std::string& drm_render_minor,
+                    const std::string& used,
+                    const std::string& total) const {
+        const fs::path device = drm() / ("renderD" + drm_render_minor) / "device";
+        fs::create_directories(device);
+        std::ofstream(device / "mem_info_vram_used") << used << "\n";
+        std::ofstream(device / "mem_info_vram_total") << total << "\n";
+    }
+
+private:
+    fs::path root_;
+};
+
+static bool expect_device_memory(const char* name,
+                                 const FakeSysfs& sysfs,
+                                 const std::string& arch,
+                                 bool expected_found,
+                                 uint64_t expected_free = 0,
+                                 uint64_t expected_total = 0) {
+    uint64_t free_bytes = 0;
+    uint64_t total_bytes = 0;
+    const bool found = rocm_device_memory_from_sysfs(
+        sysfs.kfd_nodes(), sysfs.drm(), arch, free_bytes, total_bytes);
+
+    bool ok = found == expected_found;
+    if (ok && found) {
+        ok = free_bytes == expected_free && total_bytes == expected_total;
+    }
+    std::printf("[%s] %s\n", ok ? "PASS" : "FAIL", name);
+    if (!ok) {
+        std::printf("  got:  found=%s free=%llu total=%llu\n"
+                    "  want: found=%s free=%llu total=%llu\n",
+                    found ? "true" : "false",
+                    static_cast<unsigned long long>(free_bytes),
+                    static_cast<unsigned long long>(total_bytes),
+                    expected_found ? "true" : "false",
+                    static_cast<unsigned long long>(expected_free),
+                    static_cast<unsigned long long>(expected_total));
+    }
+    return ok;
 }
 
 int main() {
@@ -148,6 +230,114 @@ int main() {
     failures += !expect_bool(
         "does not match any wildcard family",
         device_matches_constraint("gfx1151", {"gfx103X", "gfx110X"}), false);
+
+    // KFD publishes a GPU's ISA as packed decimal, with hex minor and step nibbles.
+    failures += !expect_string(
+        "gfx_target_version 110501 is gfx1151",
+        gfx_target_version_to_arch("110501"), "gfx1151");
+    failures += !expect_string(
+        "gfx_target_version 90010 is gfx90a, whose step is a hex nibble",
+        gfx_target_version_to_arch("90010"), "gfx90a");
+    failures += !expect_string(
+        "gfx_target_version 120001 is gfx1201",
+        gfx_target_version_to_arch("120001"), "gfx1201");
+    failures += !expect_string(
+        "gfx_target_version 90402 is gfx942",
+        gfx_target_version_to_arch("90402"), "gfx942");
+    // Preserved from the original inline conversion: 0 formats rather than erroring, and
+    // the result cannot collide with a real ISA, so the CPU node needs no special case.
+    failures += !expect_string(
+        "the CPU node's zero version yields an unmatchable ISA",
+        gfx_target_version_to_arch("0"), "gfx000");
+    failures += !expect_string(
+        "an already-formatted ISA is not a packed version",
+        gfx_target_version_to_arch("gfx1151"), "");
+    failures += !expect_string(
+        "an empty version has no ISA",
+        gfx_target_version_to_arch(""), "");
+
+    {
+        // 27.07 of 32.0 GiB free: the reading from the gfx1151 merge-queue failures.
+        FakeSysfs sysfs("single");
+        sysfs.add_node("0", "0", "-1");
+        sysfs.add_node("1", "110501", "128");
+        sysfs.add_memory("128", "5292500582", "34359738368");
+        failures += !expect_device_memory(
+            "a single matching GPU reports its own free and total bytes",
+            sysfs, "gfx1151", true, 34359738368ULL - 5292500582ULL, 34359738368ULL);
+        failures += !expect_device_memory(
+            "an ISA absent from the topology is not reported",
+            sysfs, "gfx942", false);
+        failures += !expect_device_memory(
+            "an empty ISA is not reported",
+            sysfs, "", false);
+    }
+
+    {
+        // A machine-wide pressure reading would return the exhausted card here. Sizing a
+        // launch against that number is what this probe exists to avoid.
+        FakeSysfs sysfs("hybrid");
+        sysfs.add_node("0", "0", "-1");
+        sysfs.add_node("1", "110501", "128");
+        sysfs.add_node("2", "110000", "129");
+        sysfs.add_memory("128", "0", "34359738368");
+        sysfs.add_memory("129", "17179869184", "17179869184");
+        failures += !expect_device_memory(
+            "an exhausted second GPU does not affect the requested one",
+            sysfs, "gfx1151", true, 34359738368ULL, 34359738368ULL);
+    }
+
+    {
+        FakeSysfs sysfs("duplicate");
+        sysfs.add_node("1", "110501", "128");
+        sysfs.add_node("2", "110501", "129");
+        sysfs.add_memory("128", "0", "34359738368");
+        sysfs.add_memory("129", "0", "34359738368");
+        failures += !expect_device_memory(
+            "two GPUs of one ISA are ambiguous and go unreported",
+            sysfs, "gfx1151", false);
+    }
+
+    {
+        FakeSysfs sysfs("norender");
+        sysfs.add_node("1", "110501", "-1");
+        failures += !expect_device_memory(
+            "a GPU with no render node goes unreported",
+            sysfs, "gfx1151", false);
+    }
+
+    {
+        FakeSysfs sysfs("unreadable");
+        sysfs.add_node("1", "110501", "128");
+        failures += !expect_device_memory(
+            "a missing memory reading goes unreported",
+            sysfs, "gfx1151", false);
+    }
+
+    {
+        FakeSysfs sysfs("zerototal");
+        sysfs.add_node("1", "110501", "128");
+        sysfs.add_memory("128", "0", "0");
+        failures += !expect_device_memory(
+            "a zero total goes unreported",
+            sysfs, "gfx1151", false);
+    }
+
+    {
+        FakeSysfs sysfs("overused");
+        sysfs.add_node("1", "110501", "128");
+        sysfs.add_memory("128", "34359738369", "34359738368");
+        failures += !expect_device_memory(
+            "used exceeding total goes unreported",
+            sysfs, "gfx1151", false);
+    }
+
+    {
+        FakeSysfs sysfs("empty");
+        failures += !expect_device_memory(
+            "an empty topology goes unreported",
+            sysfs, "gfx1151", false);
+    }
 
     std::printf("\n%d failures\n", failures);
     return failures == 0 ? 0 : 1;

--- a/test/cpp/test_vllm_arg_resolver.cpp
+++ b/test/cpp/test_vllm_arg_resolver.cpp
@@ -5,6 +5,7 @@
 #include "lemon/backends/vllm/vllm_arg_resolver.h"
 
 #include <cmath>
+#include <cstdint>
 #include <cstdio>
 #include <exception>
 #include <string>
@@ -115,8 +116,17 @@ static bool expect_error(const char* name,
     return false;
 }
 
-static bool expect_utilization(const char* name, double usage_pct, double expected) {
-    double actual = shared_memory_gpu_utilization(usage_pct);
+static constexpr uint64_t gib = 1024ULL * 1024ULL * 1024ULL;
+
+static uint64_t gib_of(double count) {
+    return static_cast<uint64_t>(count * static_cast<double>(gib));
+}
+
+static bool expect_utilization(const char* name,
+                               uint64_t free_bytes,
+                               uint64_t total_bytes,
+                               double expected) {
+    double actual = shared_memory_gpu_utilization(free_bytes, total_bytes);
     // A negative expectation only asserts "omit the flag", not an exact value.
     bool ok = expected < 0.0 ? actual < 0.0 : std::fabs(actual - expected) < 1e-9;
     std::printf("[%s] %s\n  got:  %.4f\n  want: %.4f\n",
@@ -328,23 +338,55 @@ int main() {
         true,
         "gptq");
 
-    // shared_memory_gpu_utilization scales vLLM's startup free-memory demand to what is
-    // actually free, so a co-tenant process cannot reject a model that fits.
+    // shared_memory_gpu_utilization scales vLLM's startup free-memory demand to what the
+    // device itself has free, so a co-tenant process cannot reject a model that fits.
+
+    // The gfx1151 CI case, verbatim from the failing run: 27.07 of 32.0 GiB free, which
+    // vLLM's 0.92 default (29.44 GiB) rejects. 0.79 asks for 25.28 GiB, which fits.
     failures += !expect_utilization(
-        "an idle pool leaves vLLM's own default in place", 0.02, -1.0);
+        "the observed CI reading yields a request that fits",
+        gib_of(27.07), gib_of(32.0), 0.79);
+
+    // Same reading: 0.7959 truncates to 0.79 rather than rounding to 0.80, because the
+    // flag is emitted at two decimals and rounding up would spend the headroom.
+    failures += !expect_utilization(
+        "the emitted value truncates rather than rounding past what is free",
+        gib_of(27.07), gib_of(32.0), 0.79);
 
     failures += !expect_utilization(
-        "no usable reading leaves vLLM's own default in place", -1.0, -1.0);
+        "an idle device leaves vLLM's own default in place",
+        gib_of(31.5), gib_of(32.0), -1.0);
+
+    // vLLM's pre-flight passes at exactly 0.92 free, so there is nothing to correct.
+    failures += !expect_utilization(
+        "a device vLLM's default exactly fits keeps that default",
+        gib_of(92.0), gib_of(100.0), -1.0);
 
     failures += !expect_utilization(
-        "an out-of-range reading leaves vLLM's own default in place", 1.5, -1.0);
-
-    // The gfx1151 CI case: ~4.9 of 32 GiB held by another process.
-    failures += !expect_utilization(
-        "a busy pool scales the request below what is free", 0.154, 1.0 - 0.154 - 0.05);
+        "a device just below the default is scaled down",
+        gib_of(58.0), gib_of(64.0), 0.85);
 
     failures += !expect_utilization(
-        "an exhausted pool clamps to the floor rather than going negative", 1.0, 0.10);
+        "no usable reading leaves vLLM's own default in place", 0, 0, -1.0);
+
+    failures += !expect_utilization(
+        "a nonsensical reading leaves vLLM's own default in place",
+        gib_of(48.0), gib_of(32.0), -1.0);
+
+    failures += !expect_utilization(
+        "an exhausted device leaves vLLM's own default in place",
+        0, gib_of(32.0), -1.0);
+
+    // 4 GiB free of 32 GiB scales to 0.07, a 2.24 GiB budget that cannot hold the 4 GiB
+    // kv-cache cap emitted beside it. vLLM's own error names the byte counts instead.
+    failures += !expect_utilization(
+        "a budget too small for the kv-cache cap leaves vLLM's own default in place",
+        gib_of(4.0), gib_of(32.0), -1.0);
+
+    // The same 12.5% free share of a large pool is 17.92 GiB, which clears the cap.
+    failures += !expect_utilization(
+        "the same free share on a large pool is still worth requesting",
+        gib_of(32.0), gib_of(256.0), 0.07);
 
     std::printf("\n%d failures\n", failures);
     return failures == 0 ? 0 : 1;

--- a/test/cpp/test_vllm_arg_resolver.cpp
+++ b/test/cpp/test_vllm_arg_resolver.cpp
@@ -4,6 +4,7 @@
 
 #include "lemon/backends/vllm/vllm_arg_resolver.h"
 
+#include <cmath>
 #include <cstdio>
 #include <exception>
 #include <string>
@@ -11,6 +12,7 @@
 
 using lemon::backends::VLLMArgResolution;
 using lemon::backends::resolve_vllm_args;
+using lemon::backends::shared_memory_gpu_utilization;
 using nlohmann::json;
 
 static json test_config() {
@@ -111,6 +113,15 @@ static bool expect_error(const char* name,
 
     std::printf("[FAIL] %s\n  expected error containing: %s\n", name, expected_substring.c_str());
     return false;
+}
+
+static bool expect_utilization(const char* name, double usage_pct, double expected) {
+    double actual = shared_memory_gpu_utilization(usage_pct);
+    // A negative expectation only asserts "omit the flag", not an exact value.
+    bool ok = expected < 0.0 ? actual < 0.0 : std::fabs(actual - expected) < 1e-9;
+    std::printf("[%s] %s\n  got:  %.4f\n  want: %.4f\n",
+                ok ? "PASS" : "FAIL", name, actual, expected);
+    return ok;
 }
 
 int main() {
@@ -316,6 +327,24 @@ int main() {
         resolve_vllm_args("Qwen3.5-4B-vLLM", "Qwen/Qwen3.5-4B", test_config(), "--quantization gptq"),
         true,
         "gptq");
+
+    // shared_memory_gpu_utilization scales vLLM's startup free-memory demand to what is
+    // actually free, so a co-tenant process cannot reject a model that fits.
+    failures += !expect_utilization(
+        "an idle pool leaves vLLM's own default in place", 0.02, -1.0);
+
+    failures += !expect_utilization(
+        "no usable reading leaves vLLM's own default in place", -1.0, -1.0);
+
+    failures += !expect_utilization(
+        "an out-of-range reading leaves vLLM's own default in place", 1.5, -1.0);
+
+    // The gfx1151 CI case: ~4.9 of 32 GiB held by another process.
+    failures += !expect_utilization(
+        "a busy pool scales the request below what is free", 0.154, 1.0 - 0.154 - 0.05);
+
+    failures += !expect_utilization(
+        "an exhausted pool clamps to the floor rather than going negative", 1.0, 0.10);
 
     std::printf("\n%d failures\n", failures);
     return failures == 0 ? 0 : 1;


### PR DESCRIPTION
## Summary

vLLM refuses to start unless `gpu_memory_utilization` of the **total** memory pool is free. The `--kv-cache-memory-bytes 4G` cap that shared-memory devices already get bounds what vLLM *uses*, but not what it *demands be free*, so the default 0.92 still applies at startup. On a 32 GiB gfx1151 any co-tenant process holding more than ~2.5 GiB rejects a 4B model that fits with room to spare.

This scales `--gpu-memory-utilization` to the free share of **the device vLLM will actually run on**, read from the amdgpu driver's own per-device accounting. An idle device keeps vLLM's own default; an explicit user `--gpu-memory-utilization` and discrete-HBM parts are untouched.

This is the intermittent `Validate vllm (rocm)` failure in the merge queue. Three runs, each with the identical reading `Free memory on device cuda:0 (27.07/32.0 GiB) on startup is less than desired GPU memory utilization (0.92, 29.44 GiB)` in its `server-logs-rocm` artifact:

- [Aug 25 14:35](https://github.com/lemonade-sdk/lemonade/actions/runs/32860463383/job/97845930366)
- [Aug 25 05:33](https://github.com/lemonade-sdk/lemonade/actions/runs/32813275201/job/97698221197)
- [Aug 25 01:29](https://github.com/lemonade-sdk/lemonade/actions/runs/32797764433/job/97653926622)

That reading now yields 0.79 — 25.28 GiB requested against 27.07 GiB free — which loads.

### Why the reading is per-device

`SystemInfo::get_global_vram_usage_pct()` is the eviction engine's machine-wide pressure signal. It folds every GPU in the box into one worst-case ratio, and its APU branch falls back to the dedicated VRAM carve-out whenever its libdrm probe cannot open a render node — reachable in normal deployments, since `lemond.service` runs as `User=lemonade` and the postinst only adds that user to `render` when the group already exists. Either path can describe a device vLLM never touches, which would clamp the request low enough to fail loads that succeed today.

`SystemInfo::get_rocm_device_memory(arch, ...)` instead reads the single GPU matching the ISA the launch policy was derived from, through world-readable KFD topology and sysfs — no render-node access required. It reports nothing unless exactly one GPU matches, so an ambiguous or unreadable topology leaves vLLM on its own default rather than on another device's numbers.

The emitted value only steps in where vLLM's default would actually be rejected, truncates rather than rounds so it never asks for more than is free, and is withheld entirely when the resulting budget could not hold the 4 GiB cache cap emitted beside it — vLLM's own pre-flight names the byte counts in that case, which is a better diagnostic than a request known in advance to fail.

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [ ] I kept refactoring separate unless it is required for this change.

_Scope note:_ the per-device probe (`system_info_utils.h`, `system_info.h`, `test_system_info_helpers.cpp`) is new surface this fix requires — the codebase had no per-device memory reading. Two smaller items are judgment calls, easy to drop on request: `identify_rocm_arch_from_name()` now shares the packed-decimal gfx conversion with the probe instead of duplicating it (behavior preserved, including `"0"` → `"gfx000"`), and the CMake change below.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_ `cmake --build --preset windows --target cpp-ci-tests lemond`, then `ctest --test-dir build -C Release -L cpp-ci` — 57/57 pass.

- 13 cases in `test_vllm_arg_resolver` pin literal values rather than restating the formula: the observed CI reading, the truncation boundary (0.7959 must emit 0.79, never 0.80), vLLM's exact 0.92 threshold, an exhausted device, a nonsensical reading, and the kv-cap floor on both a small and a large pool.
- 20 cases in `test_system_info_helpers` drive the sysfs probe against a fixture topology: a single match, an exhausted second GPU that must not influence the result, duplicate ISAs, a GPU with no render node, and missing / zero / inconsistent readings.

`add_cpp_ci_test(vllm_arg_resolver ...)` moves from `CI OFF` to `CI ON`. The target compiles only `vllm_arg_resolver.cpp` plus nlohmann and needs no GPU or backend; without it these regression tests never execute in CI, leaving the flake this PR targets unguarded. The `OFF` appears to date from the bulk helper migration in #2877 rather than a deliberate exclusion.

Removing the `#ifdef __linux__` in favour of a path-parameterized probe means the logic now compiles and is unit-tested on every platform, not only on Linux builds.

_Not verified locally:_ that sysfs `mem_info_vram_total` equals the total vLLM reports on gfx1151 — that needs the runner, so `Validate vllm (rocm)` is the real check. A mismatch would make the sysfs total the smaller of the two, which lowers the emitted request further below vLLM's default; it can therefore leave the flake unfixed but cannot introduce a new failure.

## Documentation

- [x] Documentation is not affected by this change.

## Breaking Changes

- [x] This PR does not introduce breaking changes.

## AI-assisted contribution

- [x] I used AI tools for this PR.

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.
