### PR TITLE
ci(vllm): keep the HF model cache outside the workspace

### DIFF
--- a/.github/workflows/validate_vllm.yml
+++ b/.github/workflows/validate_vllm.yml
@@ -140,6 +140,16 @@ jobs:
           python-version: '3.10'
           requirements-file: 'test/requirements.txt'
 
+      - name: Set HF_HOME environment variable
+        run: |
+          # Persistent HF cache outside the workspace so model weights survive across
+          # jobs. The checkout clean wipes untracked workspace files (#2103), and the
+          # step below points HOME into the workspace, so the default cache location
+          # would be re-downloaded on every run.
+          HF_HOME="$HOME/.cache/lemonade-ci/huggingface"
+          mkdir -p "$HF_HOME"
+          echo "HF_HOME=$HF_HOME" >> "$GITHUB_ENV"
+
       - name: Run validation with lemond
         env:
           HOME: ${{ github.workspace }}/.home


### PR DESCRIPTION
## Summary

The vLLM validate job re-downloads the 9.3 GB model on every run. Its `Run validation` step sets `HOME` to `${{ github.workspace }}/.home`, so the HF cache lands inside the workspace, which `actions/checkout` with `clean: true` wipes on the next run. The logs show a cold start every time: `Cache built: 125 total, 0 downloaded`, then a 2-minute weight download before the load is even attempted.

This points `HF_HOME` at the persistent location the release workflow already uses (`cpp_server_build_test_release.yml`, added for #2103). The vLLM backend tarball is deliberately left uncached: this workflow exists to validate backend releases, so re-fetching it each run is the point.

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_ Confirmed lemond honors `HF_HOME` by running the same binary with the same lemonade cache dir against two `HF_HOME` values: an empty dir reports `Cache built: 136 total, 0 downloaded`, the populated one reports `136 total, 32 downloaded`. `path_utils.cpp:239` resolves the hub cache as `$HF_HOME/hub`. The workflow YAML parses and passes the repo's workflow linters.

## Documentation

- [x] Documentation is not affected by this change.

## Breaking Changes

- [x] This PR does not introduce breaking changes.

## AI-assisted contribution

- [x] I used AI tools for this PR.

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.
