### PR TITLE
Require 2 reviewers for breaking changes

### DIFF
--- a/docs/dev/contribute.md
+++ b/docs/dev/contribute.md
@@ -68,7 +68,7 @@ __Please do not use AI to write issues__. If you feel an issue is important enou
 3. A "ready for review" non-draft PR is a signal that it is ready for human review.
 4. Evaluate the PR for scope:
     - minor features and fixes should have any 1 reviewer.
-    - major features, refactors, new backends, security-related issues, etc. should have 2 reviewers including 1 subject area expert.
+    - major features, breaking changes, refactors, new backends, security-related issues, etc. should have 2 reviewers including 1 subject area expert.
     - project scope expansion, re-architecture, design language changes, etc. should have @jeremyfowers review.
 5. Evaluate the PR for which subject areas it impacts, and request review from a subject area expert in the maintainers table below.
 


### PR DESCRIPTION
The triage bot was getting confused on "minor changes" like cli flags that happened to incur breaking changes.

<!--
Before submitting this PR, please read:
- docs/dev/contribute.md
- docs/dev/philosophy.md
- AGENTS.md if you used an AI coding agent or AI-assisted workflow
- docs/dev/documentation.md if this PR changes user-facing or developer-facing documentation
-->

## Summary

<!--
What does this PR change? Keep it short and specific.
For bug fixes, link the related issue and/or include exact reproduction steps.
For new features, explain how the feature works and what use case it supports.
-->

Fixes #<!-- issue number -->

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## AI-assisted contribution

Please select one:

- [ ] I used AI tools for this PR.
- [x] I did not use AI tools for this PR.

