### PR TITLE
MCP: expose remote model search and pull variant discovery

### DIFF
--- a/.github/workflows/mcp-smoke-test.yml
+++ b/.github/workflows/mcp-smoke-test.yml
@@ -22,6 +22,7 @@ on:
       - "setup.sh"
       - "test/server_mcp_smoke.py"
       - "test/server_mcp.py"
+      - "test/server_mcp_remote_discovery.py"
       - ".github/workflows/mcp-smoke-test.yml"
   push:
     branches: ["main"]
@@ -104,6 +105,10 @@ jobs:
       - name: Run MCP smoke tests against CMake build
         run: |
           python test/server_mcp_smoke.py --host 127.0.0.1 --port 13305
+
+      - name: Run deterministic MCP remote discovery tests
+        run: |
+          python test/server_mcp_remote_discovery.py --lemond ./build/lemond
 
       - name: Shut down lemond
         if: always()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ All core endpoints are registered under **4 path prefixes**:
 
 **Anthropic-compatible endpoint:** `POST /api/messages` — supports message completion, tool use, and SSE streaming.
 
-**MCP gateway endpoint:** `POST /mcp` — Model Context Protocol (Streamable HTTP transport, spec `2025-06-18`). Single JSON-RPC 2.0 endpoint exposing 5 tools (`lemonade_list_models`, `lemonade_chat`, `lemonade_transcribe_audio`, `lemonade_generate_image`, `lemonade_omni`). GET returns 405.
+**MCP gateway endpoint:** `POST /mcp` — Model Context Protocol (Streamable HTTP transport, spec `2025-06-18`). Single JSON-RPC 2.0 endpoint exposing 7 tools (`lemonade_list_models`, `lemonade_search_models`, `lemonade_get_pull_variants`, `lemonade_chat`, `lemonade_transcribe_audio`, `lemonade_generate_image`, `lemonade_omni`). GET returns 405.
 
 **WebSocket Realtime API**: OpenAI-compatible Realtime protocol for real-time audio transcription. `/realtime` and `/logs/stream` accept WebSocket upgrades directly on the main HTTP port; a dedicated listener on an OS-assigned port (9000+, exposed via the `websocket_port` field in the `/health` response) also remains for backward compatibility.
 

--- a/docs/api/mcp.md
+++ b/docs/api/mcp.md
@@ -34,7 +34,7 @@ curl -s http://localhost:13305/mcp \
 
 ## Tools
 
-All tools auto-load (and download, if missing) the requested model on first call, exactly like `POST /v1/chat/completions`. Errors are returned as MCP results with `"isError": true` rather than JSON-RPC errors, matching the spec's guidance for tool failures.
+Inference tools keep their existing registered-model load/download semantics. Remote discovery tools only inspect external registries and never pull, register, or load a model. Tool failures are returned as MCP results with `"isError": true` rather than JSON-RPC errors, matching the spec's guidance for tool failures.
 
 ### `lemonade_list_models`
 
@@ -50,7 +50,40 @@ Discover what's loaded, what's downloaded, and what's recommended. Call this fir
 }
 ```
 
-Returns a summary text block plus a JSON-stringified text block with `{loaded, available, suggested_to_pull, recommended_chat_model}`.
+Returns a summary text block plus a JSON-stringified text block with `{loaded, available, suggested_to_pull, recommended_chat_model}`. These are models already known to Lemonade; remote registry search is intentionally separate.
+
+### `lemonade_search_models`
+
+Search Hugging Face or ModelScope for remote repository candidates when the requested model is not already registered in Lemonade. A candidate is only a repository reference; searching does not register, download, or load it.
+
+```json
+{
+  "name": "lemonade_search_models",
+  "arguments": {
+    "query": "qwen coder",
+    "source": "huggingface",
+    "limit": 20
+  }
+}
+```
+
+The human-readable `content` stays short. Machine-readable repository metadata is returned in `structuredContent` as `{query, source, total, candidates}`. Candidate fields come from Lemonade's existing registry normalization; MCP does not perform its own Hugging Face or ModelScope parsing.
+
+### `lemonade_get_pull_variants`
+
+After choosing a remote repository, inspect the exact variants Lemonade can pull. This calls the same server-side variant discovery as `GET /v1/pull/variants`, so split GGUFs, folder groups, companion files, sizes, and other supported repository kinds keep the REST endpoint's semantics.
+
+```json
+{
+  "name": "lemonade_get_pull_variants",
+  "arguments": {
+    "checkpoint": "owner/repo",
+    "source": "huggingface"
+  }
+}
+```
+
+The complete pull-variant response is returned unchanged in `structuredContent`. The tool never chooses a quantization and never starts a pull.
 
 ### `lemonade_chat`
 

--- a/src/cpp/include/lemon/mcp_server.h
+++ b/src/cpp/include/lemon/mcp_server.h
@@ -44,6 +44,8 @@ private:
     json tool_generate_image(const json& arguments);
     json tool_omni(const json& arguments);
     json tool_list_models(const json& arguments);
+    json tool_search_models(const json& arguments);
+    json tool_get_pull_variants(const json& arguments);
 
     // Resolve which model a tool should use when `model` is omitted. Precedence:
     //   1. an explicit `model` argument always wins;

--- a/src/cpp/server/mcp_server.cpp
+++ b/src/cpp/server/mcp_server.cpp
@@ -3,6 +3,7 @@
 #include <atomic>
 #include <cctype>
 #include <chrono>
+#include <cstdint>
 #include <exception>
 #include <filesystem>
 #include <fstream>
@@ -17,7 +18,10 @@
 #include <lemon/utils/aixlog.hpp>
 
 #include "lemon/collection_orchestrator.h"
+#include "lemon/hf_variants.h"
+#include "lemon/model_registry.h"
 #include "lemon/model_types.h"
+#include "lemon/runtime_config.h"
 #include "lemon/utils/json_utils.h"
 #include "lemon/utils/path_utils.h"
 #include "lemon/version.h"
@@ -58,6 +62,43 @@ std::string extract_string_arg(const json& args, const char* key) {
         throw std::runtime_error(std::string("Missing or non-string argument: ") + key);
     }
     return args[key].get<std::string>();
+}
+
+std::string trim_ascii_whitespace(std::string value) {
+    const auto first = value.find_first_not_of(" \t\r\n");
+    if (first == std::string::npos) return "";
+    const auto last = value.find_last_not_of(" \t\r\n");
+    return value.substr(first, last - first + 1);
+}
+
+std::string extract_registry_source(const json& arguments) {
+    if (!arguments.contains("source")) return "huggingface";
+    if (!arguments["source"].is_string()) {
+        throw std::runtime_error("`source` must be a string");
+    }
+    const std::string source = arguments["source"].get<std::string>();
+    if (source != "huggingface" && source != "modelscope") {
+        throw std::runtime_error(
+            "`source` must be either 'huggingface' or 'modelscope'");
+    }
+    return source;
+}
+
+json tool_error_result(const std::string& message,
+                       json structured = json::object()) {
+    json result = {
+        {"content", json::array({json{{"type", "text"}, {"text", message}}})},
+        {"isError", true},
+    };
+    if (!structured.empty()) {
+        result["structuredContent"] = std::move(structured);
+    }
+    return result;
+}
+
+bool lemond_is_offline() {
+    const RuntimeConfig* config = RuntimeConfig::global();
+    return config != nullptr && config->offline();
 }
 
 // Some MCP clients (notably Claude Desktop) emit chat messages in Anthropic's
@@ -390,6 +431,10 @@ json McpServer::handle_tools_call(const json& params, const json& id) {
             result = tool_omni(arguments);
         } else if (tool_name == "lemonade_list_models") {
             result = tool_list_models(arguments);
+        } else if (tool_name == "lemonade_search_models") {
+            result = tool_search_models(arguments);
+        } else if (tool_name == "lemonade_get_pull_variants") {
+            result = tool_get_pull_variants(arguments);
         } else {
             // Per MCP spec, unknown-tool errors are isError=true results, not JSON-RPC errors.
             result = {
@@ -1144,6 +1189,127 @@ json McpServer::tool_list_models(const json& arguments) {
     };
 }
 
+json McpServer::tool_search_models(const json& arguments) {
+    const std::string query = trim_ascii_whitespace(
+        extract_string_arg(arguments, "query"));
+    if (query.size() < 3) {
+        return tool_error_result(
+            "`query` must contain at least 3 non-whitespace characters.");
+    }
+
+    const std::string source_name = extract_registry_source(arguments);
+    const auto source = parse_remote_registry_source(source_name);
+
+    std::size_t limit = 12;
+    if (arguments.contains("limit")) {
+        if (!arguments["limit"].is_number_integer() &&
+            !arguments["limit"].is_number_unsigned()) {
+            return tool_error_result("`limit` must be an integer from 1 to 50.");
+        }
+        if (arguments["limit"].is_number_unsigned()) {
+            const auto requested = arguments["limit"].get<std::uint64_t>();
+            if (requested < 1 || requested > 50) {
+                return tool_error_result("`limit` must be an integer from 1 to 50.");
+            }
+            limit = static_cast<std::size_t>(requested);
+        } else {
+            const auto requested = arguments["limit"].get<std::int64_t>();
+            if (requested < 1 || requested > 50) {
+                return tool_error_result("`limit` must be an integer from 1 to 50.");
+            }
+            limit = static_cast<std::size_t>(requested);
+        }
+    }
+
+    if (lemond_is_offline()) {
+        return tool_error_result(
+            "Remote model search is unavailable while Lemond is in offline mode.",
+            {{"code", "lemond_offline"}});
+    }
+
+    RegistrySearchResponse search;
+    try {
+        search = search_registry_models(source, query, limit, false);
+    } catch (const RegistrySearchError& e) {
+        return tool_error_result(
+            std::string("Registry search failed: ") + e.what(),
+            {{"source", source_name},
+             {"upstream_status_code", e.status_code()}});
+    }
+
+    json candidates = json::array();
+    for (const auto& model : search.results) {
+        candidates.push_back({
+            {"checkpoint", model.repo_id},
+            {"display_name", model.display_name},
+            {"source", remote_registry_source_name(model.source)},
+            {"repository_type", model.repository_type},
+            {"description", model.description},
+            {"tags", model.tags},
+            {"task", model.task},
+            {"downloads", model.downloads},
+            {"likes", model.likes},
+            {"has_gguf", model.has_gguf},
+        });
+    }
+
+    const std::size_t found = candidates.size();
+    json payload = {
+        {"query", query},
+        {"source", remote_registry_source_name(source)},
+        {"total", search.total},
+        {"candidates", std::move(candidates)},
+    };
+    return json{
+        {"content", json::array({text_content_block(
+            "Found " + std::to_string(found) + " remote repositories.")})},
+        {"structuredContent", std::move(payload)},
+        {"isError", false},
+    };
+}
+
+json McpServer::tool_get_pull_variants(const json& arguments) {
+    const std::string checkpoint = trim_ascii_whitespace(
+        extract_string_arg(arguments, "checkpoint"));
+    if (checkpoint.empty()) {
+        return tool_error_result("`checkpoint` must not be empty.");
+    }
+
+    const std::string source_name = extract_registry_source(arguments);
+    const auto source = parse_remote_registry_source(source_name);
+
+    if (lemond_is_offline()) {
+        return tool_error_result(
+            "Pull-variant discovery is unavailable while Lemond is in offline mode.",
+            {{"code", "lemond_offline"}});
+    }
+
+    bool not_found = false;
+    json payload = fetch_pull_variants(checkpoint, source_name, not_found);
+    if (not_found) {
+        return tool_error_result(
+            "Checkpoint '" + checkpoint + "' was not found on " +
+                remote_registry_display_name(source) + ".",
+            {{"checkpoint", checkpoint}, {"source", source_name}});
+    }
+    if (!payload.is_object() || !payload.contains("variants") ||
+        !payload["variants"].is_array()) {
+        return tool_error_result(
+            "Pull-variant discovery returned a malformed server response.",
+            {{"checkpoint", checkpoint}, {"source", source_name}});
+    }
+
+    const std::size_t found = payload["variants"].size();
+    const bool gguf = payload.value("repo_kind", std::string()) == "gguf";
+    const std::string noun = gguf ? " GGUF variants." : " pull variants.";
+    return json{
+        {"content", json::array({text_content_block(
+            "Found " + std::to_string(found) + noun)})},
+        {"structuredContent", std::move(payload)},
+        {"isError", false},
+    };
+}
+
 json McpServer::tools_descriptor() {
     return json::array({
         {
@@ -1160,6 +1326,47 @@ json McpServer::tools_descriptor() {
                 {"properties", {
                     {"include_available", {{"type", "boolean"}}},
                     {"include_suggested", {{"type", "boolean"}}},
+                }},
+            }},
+        },
+        {
+            {"name", "lemonade_search_models"},
+            {"description",
+             "Search remote registries for candidate repositories. Use this "
+             "when the requested model is not already registered in Lemonade "
+             "and an external repository must be discovered. Returned "
+             "repositories are candidates, not registered Lemonade models; "
+             "inspect pull variants before choosing what to install."},
+            {"inputSchema", {
+                {"type", "object"},
+                {"required", json::array({"query"})},
+                {"properties", {
+                    {"query", {{"type", "string"}, {"minLength", 3}}},
+                    {"source", {{"type", "string"},
+                                {"enum", json::array({"huggingface", "modelscope"})},
+                                {"default", "huggingface"}}},
+                    {"limit", {{"type", "integer"},
+                               {"minimum", 1}, {"maximum", 50}, {"default", 12}}},
+                }},
+            }},
+        },
+        {
+            {"name", "lemonade_get_pull_variants"},
+            {"description",
+             "Inspect the installable variants of a chosen remote repository "
+             "using Lemonade's existing pull-variant discovery. Use this after "
+             "choosing a remote repository and before pulling when multiple "
+             "quantizations/files may exist. Variant groups, shards, files, "
+             "and sizes are preserved exactly as the server reports them; no "
+             "variant is selected automatically."},
+            {"inputSchema", {
+                {"type", "object"},
+                {"required", json::array({"checkpoint"})},
+                {"properties", {
+                    {"checkpoint", {{"type", "string"}, {"minLength", 1}}},
+                    {"source", {{"type", "string"},
+                                {"enum", json::array({"huggingface", "modelscope"})},
+                                {"default", "huggingface"}}},
                 }},
             }},
         },

--- a/test/server_mcp.py
+++ b/test/server_mcp.py
@@ -220,13 +220,15 @@ class McpGatewayTests(ServerTestBase):
         self.assertEqual(body["result"], {})
 
     def test_012_tools_list(self):
-        """tools/list must include the five gateway tools, each with a schema."""
+        """tools/list must include all seven gateway tools, each with a schema."""
         response = _post({"jsonrpc": "2.0", "id": 3, "method": "tools/list"})
         body = response.json()
         tools = body["result"]["tools"]
         names = {tool["name"] for tool in tools}
         expected = {
             "lemonade_list_models",
+            "lemonade_search_models",
+            "lemonade_get_pull_variants",
             "lemonade_chat",
             "lemonade_transcribe_audio",
             "lemonade_generate_image",

--- a/test/server_mcp_remote_discovery.py
+++ b/test/server_mcp_remote_discovery.py
@@ -1,104 +1,21 @@
 #!/usr/bin/env python3
-"""Deterministic end-to-end tests for MCP remote model discovery.
+"""Deterministic MCP contract tests for remote model discovery.
 
-A local HTTP fixture stands in for Hugging Face via HF_ENDPOINT, and this test
-starts its own lemond instance on an ephemeral port. No external registry or
-model download is required.
+This test starts an isolated lemond instance and exercises the MCP discovery
+descriptors, validation, and offline handling without making remote registry
+requests. While registry transport and response normalization are covered separately
+by the C++ model-registry tests.
 """
 
 import argparse
-import json
 import os
 import socket
 import subprocess
 import tempfile
-import threading
 import time
-from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
-from urllib.parse import parse_qs, urlparse
 
 import requests
-
-SEARCH_RESULTS = [
-    {
-        "id": "acme/Qwen-Coder-GGUF",
-        "downloads": 1234,
-        "likes": 42,
-        "tags": ["gguf", "text-generation"],
-        "pipeline_tag": "text-generation",
-    },
-    {
-        "id": "acme/Qwen-Coder-Alt-GGUF",
-        "downloads": 321,
-        "likes": 7,
-        "tags": ["gguf"],
-        "pipeline_tag": "text-generation",
-    },
-]
-
-REPOSITORIES = {
-    "acme/Qwen-Coder-GGUF": {
-        "sha": "0123456789abcdef",
-        "siblings": [
-            {
-                "rfilename": "Qwen-Coder-Q4_K_M-00001-of-00002.gguf",
-                "size": 100,
-            },
-            {
-                "rfilename": "Qwen-Coder-Q4_K_M-00002-of-00002.gguf",
-                "size": 200,
-            },
-            {"rfilename": "Qwen-Coder-Q8_0.gguf", "size": 400},
-            {"rfilename": "README.md", "size": 20},
-        ],
-    },
-    "acme/No-GGUF": {
-        "sha": "fedcba9876543210",
-        "siblings": [{"rfilename": "README.md", "size": 20}],
-    },
-    "acme/Malformed": {"sha": "badbadbad"},
-}
-
-
-class RegistryFixtureHandler(BaseHTTPRequestHandler):
-    server_version = "LemonadeRegistryFixture/1"
-
-    def log_message(self, _format, *_args):
-        return
-
-    def _send_json(self, status, payload):
-        body = json.dumps(payload).encode("utf-8")
-        self.send_response(status)
-        self.send_header("Content-Type", "application/json")
-        self.send_header("Content-Length", str(len(body)))
-        self.end_headers()
-        self.wfile.write(body)
-
-    def do_GET(self):
-        parsed = urlparse(self.path)
-        if parsed.path == "/api/models":
-            params = parse_qs(parsed.query)
-            query = params.get("search", [""])[0]
-            if query == "rate limit":
-                self._send_json(429, {"error": "mock rate limit"})
-                return
-            limit = int(params.get("limit", ["12"])[0])
-            self.server.last_search_limit = limit
-            self._send_json(200, SEARCH_RESULTS[:limit])
-            return
-
-        prefix = "/api/models/"
-        if parsed.path.startswith(prefix):
-            repo_id = parsed.path[len(prefix) :]
-            payload = REPOSITORIES.get(repo_id)
-            if payload is None:
-                self._send_json(404, {"error": "repository not found"})
-            else:
-                self._send_json(200, payload)
-            return
-
-        self._send_json(404, {"error": "fixture path not found"})
 
 
 def free_port():
@@ -149,222 +66,159 @@ def assert_tool_error(result, contains=None):
 
 
 def run_tests(lemond):
-    registry = ThreadingHTTPServer(("127.0.0.1", 0), RegistryFixtureHandler)
-    registry.last_search_limit = None
-    registry_thread = threading.Thread(target=registry.serve_forever, daemon=True)
-    registry_thread.start()
+    with tempfile.TemporaryDirectory(prefix="lemonade-mcp-remote-") as temp_dir:
+        port = free_port()
+        dead_registry_port = free_port()
+        base_url = f"http://127.0.0.1:{port}"
+        mcp_url = f"{base_url}/mcp"
+        env = os.environ.copy()
+        # Keep any startup-time registry checks on loopback while preserving the
+        # production HTTPS-only transport policy. No registry server is started.
+        dead_registry = f"https://127.0.0.1:{dead_registry_port}"
+        env["HF_ENDPOINT"] = dead_registry
+        env["MODELSCOPE_ENDPOINT"] = dead_registry
+        env.pop("LEMONADE_API_KEY", None)
+        env.pop("LEMONADE_ADMIN_API_KEY", None)
+        log_path = Path(temp_dir) / "lemond.log"
+        cache_dir = Path(temp_dir) / "cache"
+        cache_dir.mkdir()
 
-    try:
-        with tempfile.TemporaryDirectory(prefix="lemonade-mcp-remote-") as temp_dir:
-            port = free_port()
-            base_url = f"http://127.0.0.1:{port}"
-            mcp_url = f"{base_url}/mcp"
-            env = os.environ.copy()
-            env["HF_ENDPOINT"] = f"http://127.0.0.1:{registry.server_port}"
-            env.pop("LEMONADE_API_KEY", None)
-            env.pop("LEMONADE_ADMIN_API_KEY", None)
-            log_path = Path(temp_dir) / "lemond.log"
-            cache_dir = Path(temp_dir) / "cache"
-            cache_dir.mkdir()
+        with log_path.open("w", encoding="utf-8") as log_file:
+            process = subprocess.Popen(
+                [
+                    str(lemond),
+                    str(cache_dir),
+                    "--host",
+                    "127.0.0.1",
+                    "--port",
+                    str(port),
+                ],
+                env=env,
+                stdout=log_file,
+                stderr=subprocess.STDOUT,
+                text=True,
+            )
 
-            with log_path.open("w", encoding="utf-8") as log_file:
-                process = subprocess.Popen(
-                    [
-                        str(lemond),
-                        str(cache_dir),
-                        "--host",
-                        "127.0.0.1",
-                        "--port",
-                        str(port),
-                    ],
-                    env=env,
-                    stdout=log_file,
-                    stderr=subprocess.STDOUT,
-                    text=True,
+            try:
+                wait_ready(base_url, process)
+
+                # Put the isolated server in offline mode before exercising the
+                # discovery tools. Validation happens before the offline guard,
+                # so both paths remain covered without a registry transport mock.
+                offline = requests.post(
+                    f"{base_url}/internal/set",
+                    json={"offline": True},
+                    timeout=10,
                 )
+                assert offline.status_code == 200, offline.text
 
-                try:
-                    wait_ready(base_url, process)
+                listed = requests.post(
+                    mcp_url,
+                    json={"jsonrpc": "2.0", "id": 2, "method": "tools/list"},
+                    timeout=10,
+                ).json()
+                tools = {tool["name"]: tool for tool in listed["result"]["tools"]}
+                assert "lemonade_search_models" in tools
+                assert "lemonade_get_pull_variants" in tools
 
-                    listed = requests.post(
-                        mcp_url,
-                        json={"jsonrpc": "2.0", "id": 2, "method": "tools/list"},
-                        timeout=10,
-                    ).json()
-                    names = {tool["name"] for tool in listed["result"]["tools"]}
-                    assert "lemonade_search_models" in names
-                    assert "lemonade_get_pull_variants" in names
+                search_schema = tools["lemonade_search_models"]["inputSchema"]
+                assert search_schema["type"] == "object"
+                assert search_schema["required"] == ["query"]
+                search_props = search_schema["properties"]
+                assert search_props["query"]["minLength"] == 3
+                assert search_props["source"]["enum"] == [
+                    "huggingface",
+                    "modelscope",
+                ]
+                assert search_props["source"]["default"] == "huggingface"
+                assert search_props["limit"]["minimum"] == 1
+                assert search_props["limit"]["maximum"] == 50
+                assert search_props["limit"]["default"] == 12
 
-                    assert_tool_error(
-                        tool_call(mcp_url, "lemonade_search_models", {}), "query"
-                    )
-                    assert_tool_error(
-                        tool_call(mcp_url, "lemonade_search_models", {"query": "  q "}),
-                        "at least 3",
-                    )
-                    assert_tool_error(
-                        tool_call(
-                            mcp_url,
-                            "lemonade_search_models",
-                            {"query": "qwen coder", "source": "other"},
-                        ),
-                        "source",
-                    )
-                    assert_tool_error(
-                        tool_call(
-                            mcp_url,
-                            "lemonade_search_models",
-                            {"query": "qwen coder", "limit": 0},
-                        ),
-                        "limit",
-                    )
+                variants_schema = tools["lemonade_get_pull_variants"]["inputSchema"]
+                assert variants_schema["type"] == "object"
+                assert variants_schema["required"] == ["checkpoint"]
+                variants_props = variants_schema["properties"]
+                assert variants_props["checkpoint"]["minLength"] == 1
+                assert variants_props["source"]["enum"] == [
+                    "huggingface",
+                    "modelscope",
+                ]
+                assert variants_props["source"]["default"] == "huggingface"
 
-                    offline = requests.post(
-                        f"{base_url}/internal/set",
-                        json={"offline": True},
-                        timeout=10,
-                    )
-                    assert offline.status_code == 200, offline.text
-                    offline_search = tool_call(
-                        mcp_url,
-                        "lemonade_search_models",
-                        {"query": "qwen coder"},
-                    )
-                    assert_tool_error(offline_search, "offline")
-                    assert (
-                        offline_search["structuredContent"]["code"] == "lemond_offline"
-                    )
-                    offline_variants = tool_call(
-                        mcp_url,
-                        "lemonade_get_pull_variants",
-                        {"checkpoint": "acme/Qwen-Coder-GGUF"},
-                    )
-                    assert_tool_error(offline_variants, "offline")
-                    assert (
-                        offline_variants["structuredContent"]["code"]
-                        == "lemond_offline"
-                    )
-                    online = requests.post(
-                        f"{base_url}/internal/set",
-                        json={"offline": False},
-                        timeout=10,
-                    )
-                    assert online.status_code == 200, online.text
-
-                    search = tool_call(
+                assert_tool_error(
+                    tool_call(mcp_url, "lemonade_search_models", {}), "query"
+                )
+                assert_tool_error(
+                    tool_call(mcp_url, "lemonade_search_models", {"query": "  q "}),
+                    "at least 3",
+                )
+                assert_tool_error(
+                    tool_call(
                         mcp_url,
                         "lemonade_search_models",
-                        {"query": "qwen coder", "source": "huggingface", "limit": 1},
-                    )
-                    assert search.get("isError") is False, search
-                    assert registry.last_search_limit == 1
-                    structured = search.get("structuredContent")
-                    assert isinstance(structured, dict), search
-                    assert structured["query"] == "qwen coder"
-                    assert structured["source"] == "huggingface"
-                    assert len(structured["candidates"]) == 1
-                    candidate = structured["candidates"][0]
-                    assert candidate["checkpoint"] == "acme/Qwen-Coder-GGUF"
-                    assert candidate["downloads"] == 1234
-                    assert candidate["likes"] == 42
-                    assert candidate["tags"] == ["gguf", "text-generation"]
-                    assert len(search["content"]) == 1
-                    assert (
-                        search["content"][0]["text"] == "Found 1 remote repositories."
-                    )
-
-                    assert_tool_error(
-                        tool_call(mcp_url, "lemonade_get_pull_variants", {}),
-                        "checkpoint",
-                    )
-
-                    variants = tool_call(
+                        {"query": "qwen coder", "source": "other"},
+                    ),
+                    "source",
+                )
+                assert_tool_error(
+                    tool_call(
+                        mcp_url,
+                        "lemonade_search_models",
+                        {"query": "qwen coder", "limit": 0},
+                    ),
+                    "limit",
+                )
+                assert_tool_error(
+                    tool_call(mcp_url, "lemonade_get_pull_variants", {}),
+                    "checkpoint",
+                )
+                assert_tool_error(
+                    tool_call(
                         mcp_url,
                         "lemonade_get_pull_variants",
                         {
                             "checkpoint": "acme/Qwen-Coder-GGUF",
-                            "source": "huggingface",
+                            "source": "other",
                         },
-                    )
-                    assert variants.get("isError") is False, variants
-                    structured = variants.get("structuredContent")
-                    assert structured["checkpoint"] == "acme/Qwen-Coder-GGUF"
-                    assert structured["source"] == "huggingface"
-                    assert structured["repo_kind"] == "gguf"
-                    assert len(structured["variants"]) == 2
-                    by_name = {item["name"]: item for item in structured["variants"]}
-                    q4 = by_name["Q4_K_M"]
-                    assert q4["primary_file"] == "Qwen-Coder-Q4_K_M-00001-of-00002.gguf"
-                    assert q4["files"] == [
-                        "Qwen-Coder-Q4_K_M-00001-of-00002.gguf",
-                        "Qwen-Coder-Q4_K_M-00002-of-00002.gguf",
-                    ]
-                    assert q4["sharded"] is True
-                    assert q4["size_bytes"] == 300
-                    q8 = by_name["Q8_0"]
-                    assert q8["primary_file"] == "Qwen-Coder-Q8_0.gguf"
-                    assert q8["size_bytes"] == 400
-                    assert "selected_variant" not in structured
-                    assert variants["content"][0]["text"] == "Found 2 GGUF variants."
+                    ),
+                    "source",
+                )
 
-                    rate_limited = tool_call(
-                        mcp_url,
-                        "lemonade_search_models",
-                        {"query": "rate limit", "source": "huggingface"},
-                    )
-                    assert_tool_error(rate_limited, "registry search failed")
-                    assert (
-                        rate_limited["structuredContent"]["upstream_status_code"] == 429
-                    )
+                offline_search = tool_call(
+                    mcp_url,
+                    "lemonade_search_models",
+                    {"query": "qwen coder"},
+                )
+                assert_tool_error(offline_search, "offline")
+                assert offline_search["structuredContent"]["code"] == "lemond_offline"
 
-                    assert_tool_error(
-                        tool_call(
-                            mcp_url,
-                            "lemonade_get_pull_variants",
-                            {"checkpoint": "acme/Does-Not-Exist"},
-                        ),
-                        "not found",
-                    )
-                    assert_tool_error(
-                        tool_call(
-                            mcp_url,
-                            "lemonade_get_pull_variants",
-                            {"checkpoint": "acme/No-GGUF"},
-                        ),
-                        "no supported model files",
-                    )
-                    assert_tool_error(
-                        tool_call(
-                            mcp_url,
-                            "lemonade_get_pull_variants",
-                            {"checkpoint": "acme/Malformed"},
-                        ),
-                        "siblings",
-                    )
-                except Exception:
-                    log_file.flush()
-                    print("\n--- lemond log ---", file=os.sys.stderr)
-                    print(log_path.read_text(encoding="utf-8"), file=os.sys.stderr)
-                    raise
-                finally:
+                offline_variants = tool_call(
+                    mcp_url,
+                    "lemonade_get_pull_variants",
+                    {"checkpoint": "acme/Qwen-Coder-GGUF"},
+                )
+                assert_tool_error(offline_variants, "offline")
+                assert offline_variants["structuredContent"]["code"] == "lemond_offline"
+            except Exception:
+                log_file.flush()
+                print("\n--- lemond log ---", file=os.sys.stderr)
+                print(log_path.read_text(encoding="utf-8"), file=os.sys.stderr)
+                raise
+            finally:
+                try:
+                    requests.post(f"{base_url}/internal/shutdown", timeout=2)
+                except requests.RequestException:
+                    pass
+                try:
+                    process.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    process.terminate()
                     try:
-                        requests.post(f"{base_url}/internal/shutdown", timeout=2)
-                    except requests.RequestException:
-                        pass
-                    try:
-                        process.wait(timeout=5)
+                        process.wait(timeout=3)
                     except subprocess.TimeoutExpired:
-                        process.terminate()
-                        try:
-                            process.wait(timeout=3)
-                        except subprocess.TimeoutExpired:
-                            process.kill()
-                            process.wait(timeout=3)
-
-    finally:
-        registry.shutdown()
-        registry.server_close()
-        registry_thread.join(timeout=2)
+                        process.kill()
+                        process.wait(timeout=3)
 
 
 def main():

--- a/test/server_mcp_remote_discovery.py
+++ b/test/server_mcp_remote_discovery.py
@@ -1,0 +1,384 @@
+#!/usr/bin/env python3
+"""Deterministic end-to-end tests for MCP remote model discovery.
+
+A local HTTP fixture stands in for Hugging Face via HF_ENDPOINT, and this test
+starts its own lemond instance on an ephemeral port. No external registry or
+model download is required.
+"""
+
+import argparse
+import json
+import os
+import socket
+import subprocess
+import tempfile
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+
+import requests
+
+SEARCH_RESULTS = [
+    {
+        "id": "acme/Qwen-Coder-GGUF",
+        "downloads": 1234,
+        "likes": 42,
+        "tags": ["gguf", "text-generation"],
+        "pipeline_tag": "text-generation",
+    },
+    {
+        "id": "acme/Qwen-Coder-Alt-GGUF",
+        "downloads": 321,
+        "likes": 7,
+        "tags": ["gguf"],
+        "pipeline_tag": "text-generation",
+    },
+]
+
+REPOSITORIES = {
+    "acme/Qwen-Coder-GGUF": {
+        "sha": "0123456789abcdef",
+        "siblings": [
+            {
+                "rfilename": "Qwen-Coder-Q4_K_M-00001-of-00002.gguf",
+                "size": 100,
+            },
+            {
+                "rfilename": "Qwen-Coder-Q4_K_M-00002-of-00002.gguf",
+                "size": 200,
+            },
+            {"rfilename": "Qwen-Coder-Q8_0.gguf", "size": 400},
+            {"rfilename": "README.md", "size": 20},
+        ],
+    },
+    "acme/No-GGUF": {
+        "sha": "fedcba9876543210",
+        "siblings": [{"rfilename": "README.md", "size": 20}],
+    },
+    "acme/Malformed": {"sha": "badbadbad"},
+}
+
+
+class RegistryFixtureHandler(BaseHTTPRequestHandler):
+    server_version = "LemonadeRegistryFixture/1"
+
+    def log_message(self, _format, *_args):
+        return
+
+    def _send_json(self, status, payload):
+        body = json.dumps(payload).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):
+        parsed = urlparse(self.path)
+        if parsed.path == "/api/models":
+            params = parse_qs(parsed.query)
+            query = params.get("search", [""])[0]
+            if query == "rate limit":
+                self._send_json(429, {"error": "mock rate limit"})
+                return
+            limit = int(params.get("limit", ["12"])[0])
+            self.server.last_search_limit = limit
+            self._send_json(200, SEARCH_RESULTS[:limit])
+            return
+
+        prefix = "/api/models/"
+        if parsed.path.startswith(prefix):
+            repo_id = parsed.path[len(prefix) :]
+            payload = REPOSITORIES.get(repo_id)
+            if payload is None:
+                self._send_json(404, {"error": "repository not found"})
+            else:
+                self._send_json(200, payload)
+            return
+
+        self._send_json(404, {"error": "fixture path not found"})
+
+
+def free_port():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def wait_ready(base_url, process, timeout=30):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if process.poll() is not None:
+            raise RuntimeError(f"lemond exited early with code {process.returncode}")
+        try:
+            response = requests.get(f"{base_url}/api/v1/health", timeout=1)
+            if response.status_code == 200:
+                return
+        except requests.RequestException:
+            pass
+        time.sleep(0.1)
+    raise RuntimeError("lemond did not become ready")
+
+
+def tool_call(mcp_url, name, arguments):
+    response = requests.post(
+        mcp_url,
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {"name": name, "arguments": arguments},
+        },
+        timeout=10,
+    )
+    response.raise_for_status()
+    body = response.json()
+    assert "error" not in body, body
+    assert "result" in body, body
+    return body["result"]
+
+
+def assert_tool_error(result, contains=None):
+    assert result.get("isError") is True, result
+    content = result.get("content") or []
+    assert content and content[0].get("type") == "text", result
+    if contains:
+        assert contains.lower() in content[0].get("text", "").lower(), result
+
+
+def run_tests(lemond):
+    registry = ThreadingHTTPServer(("127.0.0.1", 0), RegistryFixtureHandler)
+    registry.last_search_limit = None
+    registry_thread = threading.Thread(target=registry.serve_forever, daemon=True)
+    registry_thread.start()
+
+    try:
+        with tempfile.TemporaryDirectory(prefix="lemonade-mcp-remote-") as temp_dir:
+            port = free_port()
+            base_url = f"http://127.0.0.1:{port}"
+            mcp_url = f"{base_url}/mcp"
+            env = os.environ.copy()
+            env["HF_ENDPOINT"] = f"http://127.0.0.1:{registry.server_port}"
+            env.pop("LEMONADE_API_KEY", None)
+            env.pop("LEMONADE_ADMIN_API_KEY", None)
+            log_path = Path(temp_dir) / "lemond.log"
+            cache_dir = Path(temp_dir) / "cache"
+            cache_dir.mkdir()
+
+            with log_path.open("w", encoding="utf-8") as log_file:
+                process = subprocess.Popen(
+                    [
+                        str(lemond),
+                        str(cache_dir),
+                        "--host",
+                        "127.0.0.1",
+                        "--port",
+                        str(port),
+                    ],
+                    env=env,
+                    stdout=log_file,
+                    stderr=subprocess.STDOUT,
+                    text=True,
+                )
+
+                try:
+                    wait_ready(base_url, process)
+
+                    listed = requests.post(
+                        mcp_url,
+                        json={"jsonrpc": "2.0", "id": 2, "method": "tools/list"},
+                        timeout=10,
+                    ).json()
+                    names = {tool["name"] for tool in listed["result"]["tools"]}
+                    assert "lemonade_search_models" in names
+                    assert "lemonade_get_pull_variants" in names
+
+                    assert_tool_error(
+                        tool_call(mcp_url, "lemonade_search_models", {}), "query"
+                    )
+                    assert_tool_error(
+                        tool_call(mcp_url, "lemonade_search_models", {"query": "  q "}),
+                        "at least 3",
+                    )
+                    assert_tool_error(
+                        tool_call(
+                            mcp_url,
+                            "lemonade_search_models",
+                            {"query": "qwen coder", "source": "other"},
+                        ),
+                        "source",
+                    )
+                    assert_tool_error(
+                        tool_call(
+                            mcp_url,
+                            "lemonade_search_models",
+                            {"query": "qwen coder", "limit": 0},
+                        ),
+                        "limit",
+                    )
+
+                    offline = requests.post(
+                        f"{base_url}/internal/set",
+                        json={"offline": True},
+                        timeout=10,
+                    )
+                    assert offline.status_code == 200, offline.text
+                    offline_search = tool_call(
+                        mcp_url,
+                        "lemonade_search_models",
+                        {"query": "qwen coder"},
+                    )
+                    assert_tool_error(offline_search, "offline")
+                    assert (
+                        offline_search["structuredContent"]["code"] == "lemond_offline"
+                    )
+                    offline_variants = tool_call(
+                        mcp_url,
+                        "lemonade_get_pull_variants",
+                        {"checkpoint": "acme/Qwen-Coder-GGUF"},
+                    )
+                    assert_tool_error(offline_variants, "offline")
+                    assert (
+                        offline_variants["structuredContent"]["code"]
+                        == "lemond_offline"
+                    )
+                    online = requests.post(
+                        f"{base_url}/internal/set",
+                        json={"offline": False},
+                        timeout=10,
+                    )
+                    assert online.status_code == 200, online.text
+
+                    search = tool_call(
+                        mcp_url,
+                        "lemonade_search_models",
+                        {"query": "qwen coder", "source": "huggingface", "limit": 1},
+                    )
+                    assert search.get("isError") is False, search
+                    assert registry.last_search_limit == 1
+                    structured = search.get("structuredContent")
+                    assert isinstance(structured, dict), search
+                    assert structured["query"] == "qwen coder"
+                    assert structured["source"] == "huggingface"
+                    assert len(structured["candidates"]) == 1
+                    candidate = structured["candidates"][0]
+                    assert candidate["checkpoint"] == "acme/Qwen-Coder-GGUF"
+                    assert candidate["downloads"] == 1234
+                    assert candidate["likes"] == 42
+                    assert candidate["tags"] == ["gguf", "text-generation"]
+                    assert len(search["content"]) == 1
+                    assert (
+                        search["content"][0]["text"] == "Found 1 remote repositories."
+                    )
+
+                    assert_tool_error(
+                        tool_call(mcp_url, "lemonade_get_pull_variants", {}),
+                        "checkpoint",
+                    )
+
+                    variants = tool_call(
+                        mcp_url,
+                        "lemonade_get_pull_variants",
+                        {
+                            "checkpoint": "acme/Qwen-Coder-GGUF",
+                            "source": "huggingface",
+                        },
+                    )
+                    assert variants.get("isError") is False, variants
+                    structured = variants.get("structuredContent")
+                    assert structured["checkpoint"] == "acme/Qwen-Coder-GGUF"
+                    assert structured["source"] == "huggingface"
+                    assert structured["repo_kind"] == "gguf"
+                    assert len(structured["variants"]) == 2
+                    by_name = {item["name"]: item for item in structured["variants"]}
+                    q4 = by_name["Q4_K_M"]
+                    assert q4["primary_file"] == "Qwen-Coder-Q4_K_M-00001-of-00002.gguf"
+                    assert q4["files"] == [
+                        "Qwen-Coder-Q4_K_M-00001-of-00002.gguf",
+                        "Qwen-Coder-Q4_K_M-00002-of-00002.gguf",
+                    ]
+                    assert q4["sharded"] is True
+                    assert q4["size_bytes"] == 300
+                    q8 = by_name["Q8_0"]
+                    assert q8["primary_file"] == "Qwen-Coder-Q8_0.gguf"
+                    assert q8["size_bytes"] == 400
+                    assert "selected_variant" not in structured
+                    assert variants["content"][0]["text"] == "Found 2 GGUF variants."
+
+                    rate_limited = tool_call(
+                        mcp_url,
+                        "lemonade_search_models",
+                        {"query": "rate limit", "source": "huggingface"},
+                    )
+                    assert_tool_error(rate_limited, "registry search failed")
+                    assert (
+                        rate_limited["structuredContent"]["upstream_status_code"] == 429
+                    )
+
+                    assert_tool_error(
+                        tool_call(
+                            mcp_url,
+                            "lemonade_get_pull_variants",
+                            {"checkpoint": "acme/Does-Not-Exist"},
+                        ),
+                        "not found",
+                    )
+                    assert_tool_error(
+                        tool_call(
+                            mcp_url,
+                            "lemonade_get_pull_variants",
+                            {"checkpoint": "acme/No-GGUF"},
+                        ),
+                        "no supported model files",
+                    )
+                    assert_tool_error(
+                        tool_call(
+                            mcp_url,
+                            "lemonade_get_pull_variants",
+                            {"checkpoint": "acme/Malformed"},
+                        ),
+                        "siblings",
+                    )
+                except Exception:
+                    log_file.flush()
+                    print("\n--- lemond log ---", file=os.sys.stderr)
+                    print(log_path.read_text(encoding="utf-8"), file=os.sys.stderr)
+                    raise
+                finally:
+                    try:
+                        requests.post(f"{base_url}/internal/shutdown", timeout=2)
+                    except requests.RequestException:
+                        pass
+                    try:
+                        process.wait(timeout=5)
+                    except subprocess.TimeoutExpired:
+                        process.terminate()
+                        try:
+                            process.wait(timeout=3)
+                        except subprocess.TimeoutExpired:
+                            process.kill()
+                            process.wait(timeout=3)
+
+    finally:
+        registry.shutdown()
+        registry.server_close()
+        registry_thread.join(timeout=2)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--lemond", required=True, type=Path)
+    args = parser.parse_args()
+
+    lemond = args.lemond.resolve()
+    if not lemond.is_file():
+        raise SystemExit(f"lemond binary not found: {lemond}")
+
+    run_tests(lemond)
+    print("MCP remote discovery tests passed.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Expose remote model discovery through two new read-only MCP tools:

- `lemonade_search_models` searches supported remote registries for repository candidates.
- `lemonade_get_pull_variants` inspects the pull variants available for a selected remote repository.

Both tools reuse the existing Lemonade server implementations used by `/v1/registry/search` and `/v1/pull/variants`. The MCP layer does not add its own registry HTTP requests, variant parsing, model selection, download, registration, or loading logic.

Results include `structuredContent` for programmatic MCP clients together with a short text summary. Expected tool failures, including invalid arguments, offline mode, upstream rate limits, missing repositories, and unsupported model contents, are returned as MCP tool errors with `isError: true`.

This provides the discovery steps needed before an explicit model pull while keeping the actual mutating pull operation separate.

Related to #3275

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_

Added deterministic MCP integration coverage using a local mock registry, without external model downloads or registry dependencies.

Coverage includes:

- MCP `tools/list` exposes both new tools.
- Remote search returns normalized repository candidates.
- Search result limits are forwarded correctly.
- Pull variant discovery preserves the server-owned variant response, including GGUF shard grouping and sizes.
- Missing or invalid arguments return `isError: true`.
- Unsupported registry sources are rejected.
- Offline mode returns a clean MCP tool error.
- Upstream HTTP 429 responses remain visible as rate-limit failures.
- Missing repositories, malformed responses, and repositories without supported model files return tool errors.
- Variant discovery does not automatically select a quantization or pull a model.

Commands:


```bash
cmake --build --preset default --target lemond
python test/server_mcp_remote_discovery.py --lemond ./build/lemond
python test/server_mcp.py
```

## Documentation

<!-- Select ONE of the following -->

- [ ] Documentation is not affected by this change.
- [x] Documentation is affected and has been updated.
- [ ] Documentation is affected but will be handled in a separate PR or issue.

## Breaking Changes

- [ ] This PR introduces breaking changes.
- [x] This PR does not introduce breaking changes.

<!-- If breaking changes, describe them and migration path -->

## AI-assisted contribution

Please select one:

- [x] I used AI tools for this PR.
- [ ] I did not use AI tools for this PR.

If AI tools were used:

<!-- Only complete this section if you checked "I used AI tools for this PR" above -->

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.
