### PR TITLE
docs: add smart router subject area and two router maintainers

### DIFF
--- a/docs/dev/contribute.md
+++ b/docs/dev/contribute.md
@@ -78,19 +78,21 @@ While each maintainer is welcome to work on any part of the Lemonade codebase, e
 
 "Admin maintainer" means that individual is a repository admin who can tag releases and take other administrative actions.
 
-| Maintainer      | Admin | Subject Areas                                                                                                                                    |
-|-----------------|-------|--------------------------------------------------------------------------------------------------------------------------------------------------|
-| @jeremyfowers   | Yes   | new endpoints, new backends, large new features, GUI design language, new CLI commands, website, governance, Lemonade Mix (LMX) omni models, ci  |
-| @kenvandine     | Yes   | snaps, linux, new backends, hardware vendor support, Nvidia CUDA, ARM                                                                            |
-| @ramkrishna2910 | Yes   | new backends, new modalities, vLLM, whisper, stable diffusion, smart router and orchestration, cloud API integration, external partnerships, NPU |
-| @superm1        | Yes   | ROCm, linux packaging, system info, security, Docker, containers, llamacpp, NPU , FastFlowLM                                                     |
-| @abn            |       | telemetry, sandboxing, http                                                                                                                      |
-| @bitgamma       |       | thenoise, cli, recipes, new backends, benchmarking, new models                                                                                   |
-| @fl0rianr       |       | Lemonade Mix (LMX) omni models, GUI, ci                                                                                                          |
-| @Geramy         |       | sockets, tcp/ip, udp, named pipes, mac, security, Nexus mesh compute                                                                             |
-| @kpoineal       |       | GUI, app, a11y, Windows, LemonAIde                                                                                                               |
-| @pwilkin        |       | Trellis, OpenMOSS, ACE-Step, ThinkSound, llamacpp                                                                                                |
-| @sawansri       |       | agents, tui, cli, new backends, launch, vLLM, new models                                                                                                                 |
-| @siavashhub     |       | MCP, chat repl, Docker, containers                                                                                                               |
-| @sofiageo       |       | linux packaging, flatpak, GUI design language, benchmarking                                                                                      |
-| @valiabhay      |       | Fedora                                                                                                                                           |
+| Maintainer        | Admin | Subject Areas                                                                                                                                    |
+|-------------------|-------|--------------------------------------------------------------------------------------------------------------------------------------------------|
+| @jeremyfowers     | Yes   | new endpoints, new backends, large new features, GUI design language, new CLI commands, website, governance, Lemonade Mix (LMX) omni models, ci  |
+| @kenvandine       | Yes   | snaps, linux, new backends, hardware vendor support, Nvidia CUDA, ARM                                                                            |
+| @ramkrishna2910   | Yes   | new backends, new modalities, vLLM, whisper, stable diffusion, smart router and orchestration, cloud API integration, external partnerships, NPU |
+| @superm1          | Yes   | ROCm, linux packaging, system info, security, Docker, containers, llamacpp, NPU , FastFlowLM                                                     |
+| @abn              |       | telemetry, sandboxing, http                                                                                                                      |
+| @bitgamma         |       | thenoise, cli, recipes, new backends, benchmarking, new models                                                                                   |
+| @eddierichter-amd |       | smart router                                                                                                                                     |
+| @fl0rianr         |       | Lemonade Mix (LMX) omni models, GUI, ci, smart router                                                                                            |
+| @Geramy           |       | sockets, tcp/ip, udp, named pipes, mac, security, Nexus mesh compute                                                                             |
+| @kpoineal         |       | GUI, app, a11y, Windows, LemonAIde                                                                                                               |
+| @pwilkin          |       | Trellis, OpenMOSS, ACE-Step, ThinkSound, llamacpp                                                                                                |
+| @sawansri         |       | agents, tui, cli, new backends, launch, vLLM, new models                                                                                         |
+| @siavashhub       |       | MCP, chat repl, Docker, containers                                                                                                               |
+| @SlawomirNowaczyk |       | smart router                                                                                                                                     |
+| @sofiageo         |       | linux packaging, flatpak, GUI design language, benchmarking                                                                                      |
+| @valiabhay        |       | Fedora                                                                                                                                           |


### PR DESCRIPTION
## Summary

Updates the Maintainers table in `docs/dev/contribute.md` so the smart router has listed subject-area experts.
## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

One note on the diff size: both new usernames are 17 characters, which is wider than the previous 15-character name column, so every row is re-padded to keep the table aligned. That is why a 3-line content change shows as 18 insertions / 16 deletions. The only content changes are the three listed above; everything else is whitespace. A side effect of the re-pad is that `@sawansri`'s row, which had extra trailing padding and was 24 characters wider than every other row, is now normalized with the rest.

## Testing

- [ ] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_

No build — this PR changes one Markdown file and touches no code.

Verified locally:
- Every row of the table is exactly 176 characters and parses as 3 cells, so the Markdown table is well formed and visually aligned.
- New rows are inserted in the existing case-insensitive alphabetical order within the non-admin block: `@eddierichter-amd` between `@bitgamma` and `@fl0rianr`, `@SlawomirNowaczyk` between `@siavashhub` and `@sofiageo`.
- Neither username was already present in the table.
- Checked the pre-commit hooks that apply to a Markdown file by hand, since `pre-commit` is not installed in my environment: no trailing whitespace, file ends with a newline, LF line endings only.

## Documentation

- [x] Documentation is affected and has been updated.

This PR is the documentation change.

## Breaking Changes

- [x] This PR does not introduce breaking changes.

## AI-assisted contribution

Please select one:

- [x] I used AI tools for this PR.

If AI tools were used:

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.

@fl0rianr @eddierichter-amd @SlawomirNowaczyk — flagging you since this lists you as reviewers for router work. Say so if you would rather not be on the hook for it, or if you want the subject area worded differently; `@ramkrishna2910`'s row uses "smart router and orchestration" and I kept the shorter "smart router" for these three.
