### PR TITLE
test: give the streaming heartbeat test real timing margin

### DIFF
--- a/test/cpp/test_streaming_heartbeat.cpp
+++ b/test/cpp/test_streaming_heartbeat.cpp
@@ -10,6 +10,11 @@
 
 using namespace std::chrono_literals;
 
+// Heartbeats are emitted from libcurl's CURLOPT_XFERINFOFUNCTION progress
+// callback, which libcurl invokes only about once per second.
+static constexpr auto kIdleWindow = 4000ms;
+static constexpr long kHeartbeatIntervalMs = 250;
+
 static int g_failures = 0;
 
 static void check(bool condition, const char* name) {
@@ -33,7 +38,7 @@ static void test_heartbeat_emission_during_prefill() {
             res.set_chunked_content_provider(
                 "text/event-stream",
                 [&](size_t, httplib::DataSink& sink) {
-                    const auto deadline = std::chrono::steady_clock::now() + 2200ms;
+                    const auto deadline = std::chrono::steady_clock::now() + kIdleWindow;
                     while (std::chrono::steady_clock::now() < deadline) {
                         if (release_backend.load(std::memory_order_acquire)) {
                             return false;
@@ -98,7 +103,7 @@ static void test_heartbeat_emission_during_prefill() {
         },
         10,
         nullptr,
-        1000
+        kHeartbeatIntervalMs
     );
 
     const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -112,7 +117,8 @@ static void test_heartbeat_emission_during_prefill() {
     check(data_chunk_count == 1, "data chunk received intact after prefill");
     check(done_count == 1, "done marker received");
     check(telemetry_result.error_message.empty(), "stream completed without error");
-    check(telemetry_result.time_to_first_token >= 2.0, "telemetry TTFT measured accurately");
+    const double min_ttft = std::chrono::duration<double>(kIdleWindow).count() * 0.8;
+    check(telemetry_result.time_to_first_token >= min_ttft, "telemetry TTFT measured accurately");
 
     std::printf(
         "Prefill test completed in %lld ms with %d heartbeats\n",
@@ -131,7 +137,7 @@ static void test_heartbeat_emission_during_pause_between_tokens() {
                     const std::string chunk1 = "data: {\"choices\":[{\"delta\":{\"content\":\"Chunk1\"}}]}\n\n";
                     sink.write(chunk1.data(), chunk1.size());
 
-                    const auto deadline = std::chrono::steady_clock::now() + 2200ms;
+                    const auto deadline = std::chrono::steady_clock::now() + kIdleWindow;
                     while (std::chrono::steady_clock::now() < deadline) {
                         if (release_backend.load(std::memory_order_acquire)) {
                             return false;
@@ -191,7 +197,7 @@ static void test_heartbeat_emission_during_pause_between_tokens() {
         },
         10,
         nullptr,
-        1000
+        kHeartbeatIntervalMs
     );
 
     release_backend.store(true, std::memory_order_release);
@@ -262,7 +268,7 @@ static void test_heartbeat_client_disconnect_aborts_upstream() {
         },
         10,
         nullptr,
-        1000
+        kHeartbeatIntervalMs
     );
 
     const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(


### PR DESCRIPTION
## Summary

`StreamingHeartbeatTest` is flaky on the macOS `.dmg` job. Heartbeats are emitted from libcurl's `CURLOPT_XFERINFOFUNCTION` callback, which ticks about once per second while a transfer is idle, so the `>= 2` assertion over a 2200 ms window with a 1000 ms interval had 200 ms of slack. Interval drops to 250 ms and the idle window widens to 4000 ms; test-only.

Observed in [run 32879466160](https://github.com/lemonade-sdk/lemonade/actions/runs/32879466160/job/97905204755).

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_

- macOS arm64; `ctest --test-dir build -R "^StreamingHeartbeatTest$"` passes.
- 5 direct runs, plus 3 under 2x CPU oversubscription: 12/12 checks each.
- Prefill observes 3 heartbeats, versus exactly 2 in the passing CI run.
- Runtime 5.9 s to 9.1 s.

## Documentation

- [x] Documentation is not affected by this change.

## Breaking Changes

- [x] This PR does not introduce breaking changes.

## AI-assisted contribution

- [x] I used AI tools for this PR.

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.
