### PR TITLE
ci: shared apt-get retry helper + reuse build-environment containers on arm64

### DIFF
--- a/.github/actions/build-debian-package/action.yml
+++ b/.github/actions/build-debian-package/action.yml
@@ -22,14 +22,10 @@ runs:
   using: composite
   steps:
     - name: Install build dependencies
-      shell: bash
-      run: |
-        set -e
-        if [ "${{ inputs.arch-only }}" = "true" ]; then
-          apt-get update && apt-get build-dep --arch-only . -y
-        else
-          apt-get update && apt-get build-dep . -y
-        fi
+      uses: ./.github/actions/retry-apt-get
+      with:
+        command: >-
+          ${{ inputs.arch-only == 'true' && 'build-dep --arch-only . -y' || 'build-dep . -y' }}
 
     - name: Build Debian package
       id: build

--- a/.github/actions/retry-apt-get/action.yml
+++ b/.github/actions/retry-apt-get/action.yml
@@ -1,0 +1,52 @@
+name: Retry apt-get
+description: >
+  Runs `apt-get update` followed by an apt-get subcommand, retrying with
+  exponential backoff. Mirrors (esp. the arm64 ports.ubuntu.com mirror) can
+  briefly serve a package index that is out of sync with its pool, causing
+  404s on individual .deb files that a plain apt-get won't recover from.
+
+inputs:
+  command:
+    description: >
+      The apt-get subcommand and args to run after `update`, e.g.
+      "install -y cmake ninja-build" or "build-dep . -y".
+    required: true
+  use-sudo:
+    description: >
+      Prefix apt-get invocations with sudo. Needed on GitHub-hosted runners;
+      leave at the default when already running as root inside a container.
+    required: false
+    default: 'false'
+  attempts:
+    description: 'Number of attempts before giving up.'
+    required: false
+    default: '3'
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        set -e
+        SUDO=""
+        if [ "${{ inputs.use-sudo }}" = "true" ]; then
+          SUDO="sudo"
+        fi
+        attempts=${{ inputs.attempts }}
+        delay=5
+        for i in $(seq 1 "$attempts"); do
+          # Discard the cached index before retrying so we don't just get the
+          # same stale, out-of-sync listing served back from local cache.
+          $SUDO rm -rf /var/lib/apt/lists/*
+          if $SUDO apt-get -o Acquire::Retries=3 update && \
+              $SUDO apt-get -o Acquire::Retries=3 ${{ inputs.command }}; then
+            exit 0
+          fi
+          if [ "$i" -lt "$attempts" ]; then
+            echo "apt-get failed (attempt $i/$attempts); retrying in ${delay}s..."
+            sleep "$delay"
+            delay=$((delay * 2))
+          fi
+        done
+        echo "apt-get failed after $attempts attempts"
+        exit 1

--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -817,10 +817,10 @@ jobs:
         uses: ./.github/actions/get-version
 
       - name: Install minimal build dependencies
-        run: |
-          set -e
-          sudo apt-get update
-          sudo apt-get install -y cmake ninja-build g++ pkg-config libssl-dev libdrm-dev
+        uses: ./.github/actions/retry-apt-get
+        with:
+          command: install -y cmake ninja-build g++ pkg-config libssl-dev libdrm-dev
+          use-sudo: 'true'
 
       - name: Build embeddable archive
         shell: bash
@@ -851,21 +851,34 @@ jobs:
     runs-on: ubuntu-24.04-arm
     outputs:
       version: ${{ steps.get_version.outputs.version }}
+    # Reuses the same multi-arch build-environment image as build-lemonade-deb
+    # instead of apt-get-installing a minimal toolchain on the bare runner —
+    # avoids hitting the arm64 ports.ubuntu.com mirror at job runtime at all.
+    container:
+      image: ghcr.io/lemonade-sdk/lemonade/build-environment:ubuntu24.04
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v5
         with:
           clean: true
           fetch-depth: 0
 
+      - name: Configure git safe directory
+        run: git config --global --add safe.directory $(pwd)
+
       - name: Get version from CMakeLists.txt
         id: get_version
         uses: ./.github/actions/get-version
 
       - name: Install build dependencies
-        run: |
-          set -e
-          sudo apt-get update
-          sudo apt-get install -y cmake ninja-build g++ pkg-config libssl-dev libdrm-dev
+        # Mirrors cpp-unit-tests: the image already has these Build-Depends
+        # baked in, so this only catches ones added since the last nightly
+        # image publish.
+        uses: ./.github/actions/retry-apt-get
+        with:
+          command: build-dep ./contrib -y
 
       - name: Build
         run: |

--- a/.github/workflows/launchpad-ppa.yml
+++ b/.github/workflows/launchpad-ppa.yml
@@ -97,8 +97,9 @@ jobs:
         run: echo "sha=$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_OUTPUT
 
       - name: Catch missing build-deps
-        run: |
-          apt-get update && apt-get build-dep . -y
+        uses: ./.github/actions/retry-apt-get
+        with:
+          command: build-dep . -y
 
       - name: Build binary package
         id: build_binary
@@ -136,10 +137,6 @@ jobs:
 
   package-arm64:
     name: Build (ARM64)
-    # Uses official ubuntu:${{ matrix.release }} images from Docker Hub instead of
-    # the custom build-environment images, because the latter do not yet carry
-    # linux/arm64 manifests. build-container.yml will publish multi-arch images
-    # post-merge; once that happens this can revert to the custom build-environment.
     needs: prepare-matrix
     runs-on: ubuntu-24.04-arm
     permissions:
@@ -149,17 +146,11 @@ jobs:
     strategy:
       matrix: ${{ fromJSON(needs.prepare-matrix.outputs.package_matrix) }}
     container:
-      image: ubuntu:${{ matrix.release }}
+      image: ghcr.io/lemonade-sdk/lemonade/build-environment:${{ matrix.distro }}${{ matrix.release }}
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - name: Install checkout prerequisites
-        run: |
-          apt-get update
-          apt-get install -y git ca-certificates software-properties-common
-
-      - name: Add PPA for build dependencies
-        if: matrix.ppa != ''
-        run: add-apt-repository -y ${{ matrix.ppa }}
-
       - name: Checkout code
         uses: actions/checkout@v5
         with:
@@ -170,26 +161,17 @@ jobs:
       - name: Configure git safe directory
         run: git config --global --add safe.directory $(pwd)
 
-      - name: Install build dependencies
-        run: |
-          apt-get update
-          apt-get install -y \
-            build-essential \
-            curl \
-            debhelper \
-            devscripts \
-            dpkg-dev \
-            git \
-            python3-pip \
-            python3-venv \
-            unzip
-
       - name: Prepare Debian build
         id: get_version
         uses: ./.github/actions/prepare-debian-build
         with:
           release: ${{ matrix.release }}
           codename: ${{ matrix.codename }}
+
+      - name: Catch missing build-deps
+        uses: ./.github/actions/retry-apt-get
+        with:
+          command: build-dep --arch-only . -y
 
       - name: Build binary package
         id: build_binary


### PR DESCRIPTION
## Summary

Follow-up to #3353 (temporary fix) per review feedback: replaces the duplicated inline `apt-get` retry loops with a shared `retry-apt-get` composite action (exponential backoff, clears `/var/lib/apt/lists` before retrying, passes `Acquire::Retries=3`), extends retry coverage to `build-debian-package`'s `apt-get build-dep` and launchpad-ppa's `Catch missing build-deps` step, and — per the suggestion to reuse existing container infrastructure — switches `build-lemonade-linux-arm64` and launchpad-ppa's `package-arm64` job to reuse the same multi-arch `ghcr.io/lemonade-sdk/lemonade/build-environment` image the x86_64 jobs already pull (confirmed it now has an arm64 manifest), instead of apt-get-installing a toolchain against the flaky `ports.ubuntu.com` mirror on every run.

Fixes #<!-- issue number -->

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] I described the testing performed below.

_Testing details:_ Validated all changed workflow/action YAML with `python3 -c "import yaml; yaml.safe_load(...)"` and pre-commit's `check-yaml`/`Validate GitHub Actions`/`Validate GitHub Workflows` hooks. Manually simulated the retry loop's success/failure/backoff behavior in bash outside of CI. Confirmed via the ghcr.io registry API that `build-environment:ubuntu24.04` (and other tags) publish an `arm64` manifest, which the launchpad-ppa `package-arm64` job now relies on. Real-world correctness will also be observed once this workflow runs in CI.

## Documentation

- [x] Documentation is not affected by this change.

## Breaking Changes

- [x] This PR does not introduce breaking changes.

## AI-assisted contribution

- [x] I used AI tools for this PR.

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.