### PR TITLE
Add checkpoints to bench output

### DIFF
--- a/src/cpp/cli/bench.cpp
+++ b/src/cpp/cli/bench.cpp
@@ -1008,6 +1008,7 @@ int handle_bench_command(lemonade::LemonadeClient& client, const BenchConfig& co
     struct ModelBenchResult {
         std::string model;
         std::string timestamp;
+        json model_info;
         std::vector<BenchBackendResult> results;
     };
     std::vector<ModelBenchResult> by_model;
@@ -1111,7 +1112,7 @@ int handle_bench_command(lemonade::LemonadeClient& client, const BenchConfig& co
             return 1;
         }
 
-        by_model.push_back({model, model_timestamp, std::move(all_results)});
+        by_model.push_back({model, model_timestamp, model_info, std::move(all_results)});
     }
 
     // Output results
@@ -1123,7 +1124,7 @@ int handle_bench_command(lemonade::LemonadeClient& client, const BenchConfig& co
             output["hardware"] = hardware_profile;
             output["models"] = json::array();
             for (const auto& mr : by_model)
-                output["models"].push_back(to_json(mr.results, mr.model, mr.timestamp, config));
+                output["models"].push_back(to_json(mr.results, mr.model, mr.timestamp, config, mr.model_info));
 
             std::string json_str = output.dump(2);
             if (!config.output_file.empty()) {
@@ -1147,7 +1148,7 @@ int handle_bench_command(lemonade::LemonadeClient& client, const BenchConfig& co
                 output["hardware"] = hardware_profile;
                 output["models"] = json::array();
                 for (const auto& mr : by_model)
-                    output["models"].push_back(to_json(mr.results, mr.model, mr.timestamp, config));
+                    output["models"].push_back(to_json(mr.results, mr.model, mr.timestamp, config, mr.model_info));
                 std::ofstream out(config.output_file);
                 if (out.is_open()) {
                     out << output.dump(2);
@@ -1177,6 +1178,7 @@ int handle_bench_command(lemonade::LemonadeClient& client, const BenchConfig& co
         struct ModelComparisonResult {
             std::string model;
             std::string timestamp;
+            json model_info;
             json previous_for_model;
             std::vector<BenchComparisonDelta> deltas;
             const std::vector<BenchBackendResult>* results = nullptr;
@@ -1189,7 +1191,7 @@ int handle_bench_command(lemonade::LemonadeClient& client, const BenchConfig& co
             auto it = previous_by_model.find(mr.model);
             if (it != previous_by_model.end()) prev_for_model = it->second;
             comparison_results.emplace_back(ModelComparisonResult{
-                mr.model, mr.timestamp, prev_for_model,
+                mr.model, mr.timestamp, mr.model_info, prev_for_model,
                 compute_deltas(mr.results, prev_for_model), &mr.results
             });
         }
@@ -1210,7 +1212,7 @@ int handle_bench_command(lemonade::LemonadeClient& client, const BenchConfig& co
             output["models"] = json::array();
             for (const auto& c : comparison_results)
                 output["models"].push_back(build_comparison_json(*c.results, c.model, c.timestamp,
-                                                                  config, c.previous_for_model, c.deltas));
+                                                                  config, c.model_info, c.previous_for_model, c.deltas));
 
             std::string json_str = output.dump(2);
             if (!config.output_file.empty()) {

--- a/src/cpp/cli/bench_comparison.cpp
+++ b/src/cpp/cli/bench_comparison.cpp
@@ -238,9 +238,10 @@ json build_comparison_json(const std::vector<BenchBackendResult>& results,
                            const std::string& model,
                            const std::string& timestamp,
                            const BenchConfig& config,
+                           const json& model_info,
                            const json& previous_results,
                            const std::vector<BenchComparisonDelta>& deltas) {
-    json output = to_json(results, model, timestamp, config);
+    json output = to_json(results, model, timestamp, config, model_info);
 
     output["compare_file"] = config.compare_file;
     if (previous_results.contains("timestamp")) {

--- a/src/cpp/cli/bench_output.cpp
+++ b/src/cpp/cli/bench_output.cpp
@@ -167,10 +167,15 @@ void print_table(const std::vector<BenchBackendResult>& results, const std::stri
 json to_json(const std::vector<BenchBackendResult>& results,
              const std::string& model,
              const std::string& timestamp,
-             const BenchConfig& config) {
+             const BenchConfig& config,
+             const json& model_info) {
     json output;
     output["model"] = model;
     output["timestamp"] = timestamp;
+
+    if (model_info.contains("checkpoints") && model_info["checkpoints"].is_object() &&
+        !model_info["checkpoints"].empty())
+        output["checkpoints"] = model_info["checkpoints"];
 
     json config_json;
     config_json["warmup_runs"] = config.warmup_runs;

--- a/src/cpp/include/lemon_cli/bench_comparison.h
+++ b/src/cpp/include/lemon_cli/bench_comparison.h
@@ -51,6 +51,7 @@ json build_comparison_json(const std::vector<BenchBackendResult>& results,
                            const std::string& model,
                            const std::string& timestamp,
                            const BenchConfig& config,
+                           const json& model_info,
                            const json& previous_results,
                            const std::vector<BenchComparisonDelta>& deltas);
 

--- a/src/cpp/include/lemon_cli/bench_output.h
+++ b/src/cpp/include/lemon_cli/bench_output.h
@@ -39,6 +39,7 @@ void print_table(const std::vector<BenchBackendResult>& results, const std::stri
 json to_json(const std::vector<BenchBackendResult>& results,
              const std::string& model,
              const std::string& timestamp,
-             const BenchConfig& config);
+             const BenchConfig& config,
+             const json& model_info);
 
 } // namespace lemon_cli


### PR DESCRIPTION
## Summary

Adds the model's checkpoints to the JSON output of the bench command, so that which exact quant is being used can be compared.

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

Run `lemonade bench ModelName --json` and check the output contains the checkpoints

## Documentation

<!-- Select ONE of the following -->

- [x] Documentation is not affected by this change.

## Breaking Changes

- [x] This PR does not introduce breaking changes.

## AI-assisted contribution

Please select one:

- [x] I used AI tools for this PR.

If AI tools were used:

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.
