### PR TITLE
Fail early on inverted chars band

### DIFF
--- a/src/cpp/server/routing_policy_parser.cpp
+++ b/src/cpp/server/routing_policy_parser.cpp
@@ -309,6 +309,15 @@ void validate_leaf(const json& leaf,
             }
         }
     }
+    for (const auto& band : {std::pair<const char*, const char*>{"min_chars", "max_chars"},
+                             std::pair<const char*, const char*>{"min_total_chars",
+                                                                 "max_total_chars"}}) {
+        if (leaf.contains(band.first) && leaf.contains(band.second) &&
+            leaf.at(band.first).get<long long>() > leaf.at(band.second).get<long long>()) {
+            throw std::invalid_argument(std::string(path) + " has " + band.first +
+                                        " greater than " + band.second);
+        }
+    }
     for (const char* op : {"has_tools", "has_images"}) {
         if (leaf.contains(op)) {
             ++condition_count;


### PR DESCRIPTION
## Summary

Fail-fast on inverted char bands at policy registration. `validate_leaf` now
rejects `min_chars > max_chars` and `min_total_chars > max_total_chars`,
mirroring the existing `min_score`/`max_score` cross-check. Previously such a
band parsed cleanly and then silently never matched at request time.

## Scope

`src/cpp/server/routing_policy_parser.cpp` — one cross-check block in `validate_leaf`.

## Testing

C++ build + routing CTest suites.

## Documentation

No docs change needed.

## Breaking Changes

None — only rejects policies that could never match.

## AI-assisted contribution

Yes.