### PR TITLE
test(utils): add shared lemond_server test fixture and deduplicate suites

### DIFF
--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -1971,6 +1971,9 @@ jobs:
         run: |
           .venv/bin/python -m test.utils.reset_server_state --best-effort --label "ubuntu endpoints"
           .venv/bin/python test/server_endpoints.py --cli-binary lemonade
+          echo "Running server fixture tests..."
+          .venv/bin/python -m unittest test/test_server_fixture.py
+          echo "Server fixture tests PASSED!"
           echo "Running WebSocket idle test..."
           .venv/bin/python test/test_websocket_idle.py
           echo "WebSocket idle test PASSED!"
@@ -2134,6 +2137,9 @@ jobs:
           elif [ "${{ matrix.test_type }}" = "endpoints" ]; then
             echo "Running endpoint tests..."
             $VENV_PYTHON test/server_endpoints.py --cli-binary "$CLI_BINARY"
+            echo "Running server fixture tests..."
+            $VENV_PYTHON -m unittest test/test_server_fixture.py
+            echo "Server fixture tests PASSED!"
             echo "Running WebSocket idle test..."
             $VENV_PYTHON test/test_websocket_idle.py
             echo "WebSocket idle test PASSED!"
@@ -2222,6 +2228,9 @@ jobs:
         run: |
           $VENV_PYTHON -m test.utils.reset_server_state --best-effort --label "windows-latest endpoints"
           $VENV_PYTHON test/server_endpoints.py --cli-binary "$CLI_BINARY"
+          echo "Running server fixture tests..."
+          $VENV_PYTHON -m unittest test/test_server_fixture.py
+          echo "Server fixture tests PASSED!"
           echo "Running WebSocket idle test..."
           $VENV_PYTHON test/test_websocket_idle.py
           echo "WebSocket idle test PASSED!"
@@ -2407,6 +2416,7 @@ jobs:
         run: |
           $VENV_PYTHON -m test.utils.reset_server_state --best-effort --label "macos-latest endpoints"
           $VENV_PYTHON test/server_endpoints.py --cli-binary "$CLI_BINARY"
+          $VENV_PYTHON -m unittest test/test_server_fixture.py
           $VENV_PYTHON test/test_websocket_idle.py
           $VENV_PYTHON test/server_websocket_auth.py
           $VENV_PYTHON test/test_tray_https.py

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,7 +130,38 @@ python test/server_whisper.py
 python test/server_sd.py
 ```
 
-Test utilities in `test/utils/` with `server_base.py` as the base class should be reused when defining new tests.
+Test utilities in `test/utils/` with `server_base.py` as the base class and `server_fixture.py` for hermetic server lifecycle management (`lemond_server`, `allocate_free_port`, `wait_for_http_health`). Test dependencies include `requests`, `httpx`, `openai`, `huggingface_hub`, `psutil`, `numpy`, `websockets`, and `ollama`.
+
+### C++ unit tests
+
+C++ unit tests live in `test/cpp/` and are wired up in the root `CMakeLists.txt`. The packaging workflow builds the `cpp-ci-tests` aggregate target and runs `ctest -L cpp-ci`, so a test only runs in CI if it is both labeled `cpp-ci` **and** a dependency of that aggregate target.
+
+**Direct `add_test()` is disabled** (the built-in is overridden to fail with a fatal error just before the test section). Every test MUST be declared with the `add_cpp_ci_test()` helper, which forces an explicit `CI <ON|OFF>` decision at the call site so a test is never silently omitted from — or accidentally added to — CI.
+
+**The enclosing `if()` MUST test `BUILD_TESTING`.** Distro packaging (`contrib/debian/rules`, the RPM job) configures with `BUILD_TESTING=OFF` so it does not build ~45 test binaries it then discards; calling `add_cpp_ci_test()` in that configuration is a fatal error rather than a silent return to the slow build.
+
+```cmake
+if(BUILD_TESTING AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_my_feature.cpp")
+    add_executable(test_my_feature test/cpp/test_my_feature.cpp ...)
+    # ...target_include_directories / target_link_libraries...
+
+    include(CTest)
+    add_cpp_ci_test(MyFeatureTest CI ON COMMAND test_my_feature)
+endif()
+```
+
+```cmake
+add_cpp_ci_test(<TestName>
+                CI <ON|OFF>                 # required — run under `ctest -L cpp-ci`?
+                COMMAND <command> [args...] # required — what CTest runs
+                [DEPENDS <target>...])      # CI build deps; defaults to the
+                                            # first COMMAND token (the test target)
+```
+
+- `CI ON` labels the test `cpp-ci` and makes its build target(s) a dependency of `cpp-ci-tests`.
+- `CI OFF` still creates the CTest test (for local/other runs) but keeps it out of packaging CI. Use this only for tests that are intentionally excluded (e.g. tests that need a backend, are platform-gated, or are slow CMake-configuration tests).
+
+Pass `DEPENDS` only when the CI build needs targets beyond the `COMMAND` executable. `add_cpp_ci_test` calls `register_cpp_ci_test()` internally; do not call `add_test()` or `register_cpp_ci_test()` directly.
 
 ## Code Style
 

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -131,6 +131,7 @@ python test/test_schema_lock.py
 - Gate tests on declared server capabilities with `@skip_if_unsupported` from `test/utils/capabilities.py`; it skips based on what the configured `--wrapped-server` / `--backend` reports supporting, not on detected hardware. Use `@requires_backend(...)` to gate on a specific backend. In practice, capability- and backend-gated tests execute on the self-hosted hardware runners and skip elsewhere.
 - Mock external services in-process (for example, the mock cloud provider) so tests run in CI without secrets or network dependencies.
 - Clean up after yourself: restore environment variables with `self.addCleanup(...)`, terminate any subprocess the test starts, and never leave a server running on a hardcoded port.
+- For tests that launch a dedicated `lemond` process or need an ephemeral port, import the shared fixture utilities from `test/utils/server_fixture.py` (`lemond_server`, `allocate_free_port`, `wait_for_http_health`) rather than writing manual socket binds, subprocess loops, or sleep-polling routines.
 
 ---
 

--- a/test/server_cli2.py
+++ b/test/server_cli2.py
@@ -36,6 +36,7 @@ import unittest
 import uuid
 
 from utils.server_base import _auth_headers, set_server_config, wait_for_server
+from utils.server_fixture import allocate_free_port
 from utils.test_models import (
     ENDPOINT_TEST_MODEL,
     ENDPOINT_TEST_MODEL_CTX_SIZE,
@@ -2445,11 +2446,7 @@ class CLIUrlSchemeTests(unittest.TestCase):
                     self.send_response(404)
                     self.end_headers()
 
-        # Find a free port
-        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        s.bind(("127.0.0.1", 0))
-        cls.mock_port = s.getsockname()[1]
-        s.close()
+        cls.mock_port = allocate_free_port()
 
         cls.server = http.server.HTTPServer(
             ("127.0.0.1", cls.mock_port), MockHTTPHandler

--- a/test/server_endpoints.py
+++ b/test/server_endpoints.py
@@ -26,6 +26,7 @@ import os
 import platform
 import socket
 import subprocess
+import sys
 import time
 import unittest
 import shutil
@@ -34,6 +35,9 @@ import uuid
 import requests
 from openai import NotFoundError
 from prometheus_client.parser import text_string_to_metric_families
+
+# Make test utilities importable regardless of test runner invocation mode
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from utils.server_base import (
     ServerTestBase,
@@ -63,101 +67,12 @@ from utils.test_models import (
 )
 
 
-def _resolve_lemond_binary():
-    """Locate the lemond daemon binary for the duplicate-port test.
-
-    Prefers the binary built alongside this checkout; falls back to whatever is
-    on PATH. Returns None if neither exists so the test can skip cleanly rather
-    than fail on a machine without a built daemon.
-    """
-    candidate = get_default_lemond_binary()
-    if candidate and os.path.exists(candidate):
-        return candidate
-    return shutil.which("lemond")
-
-
-def _pick_free_port():
-    """Return an unused TCP port assigned by the OS on the IPv4 loopback.
-
-    Binding to port 0 lets the kernel pick a free port; we read it back and
-    close the socket immediately. Both lemond instances in the duplicate-port
-    test target this port, which is independent of the suite's server on PORT.
-    """
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    try:
-        s.bind(("127.0.0.1", 0))
-        return s.getsockname()[1]
-    finally:
-        s.close()
-
-
-def _lemond_health_ok(port, headers):
-    """True if lemond answers a 200 on /api/v1/health at the given port."""
-    try:
-        response = requests.get(
-            f"http://localhost:{port}/api/v1/health",
-            headers=headers,
-            timeout=2,
-        )
-        return response.status_code == 200
-    except requests.RequestException:
-        return False
-
-
-@contextlib.contextmanager
-def _running_lemond(config=None, cache_prefix="lemond_test_"):
-    """Spawn lemond on a free port with the given config.json body.
-
-    Skips the calling test when no daemon binary is available. Yields
-    (proc, port, headers, log_path) and terminates the daemon plus removes
-    its cache directory on exit.
-    """
-    lemond_binary = _resolve_lemond_binary()
-    if not lemond_binary:
-        raise unittest.SkipTest("lemond binary not found (build it or add it to PATH)")
-
-    headers = {}
-    api_key = os.environ.get("LEMONADE_API_KEY")
-    if api_key:
-        headers["Authorization"] = f"Bearer {api_key}"
-
-    port = _pick_free_port()
-    cache_dir = tempfile.mkdtemp(prefix=cache_prefix)
-    log_path = os.path.join(cache_dir, "lemond.log")
-    with open(os.path.join(cache_dir, "config.json"), "w", encoding="utf-8") as f:
-        json.dump({"config_version": 2, **(config or {})}, f)
-
-    proc = None
-    try:
-        with open(log_path, "w", encoding="utf-8") as log:
-            proc = subprocess.Popen(
-                [lemond_binary, cache_dir, "--port", str(port)],
-                stdout=log,
-                stderr=subprocess.STDOUT,
-                env=os.environ.copy(),
-            )
-        yield proc, port, headers, log_path
-    finally:
-        if proc is not None and proc.poll() is None:
-            proc.terminate()
-            try:
-                proc.wait(timeout=10)
-            except subprocess.TimeoutExpired:
-                proc.kill()
-                proc.wait(timeout=10)
-        shutil.rmtree(cache_dir, ignore_errors=True)
-
-
-def _wait_until_healthy(proc, port, headers, timeout_s=60):
-    """Poll /api/v1/health until lemond answers or the deadline expires."""
-    deadline = time.time() + timeout_s
-    while time.time() < deadline:
-        if proc.poll() is not None:
-            return False
-        if _lemond_health_ok(port, headers):
-            return True
-        time.sleep(1)
-    return False
+from utils.server_fixture import (
+    allocate_free_port,
+    lemond_server,
+    make_clean_env,
+    wait_for_http_health,
+)
 
 
 class EndpointTests(ServerTestBase):
@@ -7344,103 +7259,71 @@ class EndpointTests(ServerTestBase):
         same port, and asserts the second one (a) exits non-zero, (b) reports the
         port is already in use, and (c) leaves the first server healthy.
         """
-        lemond_binary = _resolve_lemond_binary()
-        if not lemond_binary:
-            self.skipTest("lemond binary not found (build it or add it to PATH)")
-
-        headers = {}
-        api_key = os.environ.get("LEMONADE_API_KEY")
-        if api_key:
-            headers["Authorization"] = f"Bearer {api_key}"
-
-        port = _pick_free_port()
+        headers = _auth_headers()
+        port = allocate_free_port()
         cache_dir = tempfile.mkdtemp(prefix="lemond_dupport_")
+        env = make_clean_env(cache_dir)
         first_log_path = os.path.join(cache_dir, "first_lemond.log")
-        cmd = [lemond_binary, cache_dir, "--port", str(port)]
 
-        first = None
-        second = None
         try:
             # --- Start the first lemond and wait until it is healthy ---
             with open(first_log_path, "w", encoding="utf-8") as first_log:
-                first = subprocess.Popen(
-                    cmd,
+                with lemond_server(
+                    port=port,
+                    cache_dir=cache_dir,
+                    env=env,
+                    wait_health=True,
+                    health_headers=headers,
                     stdout=first_log,
                     stderr=subprocess.STDOUT,
-                    env=os.environ.copy(),
-                )
+                    skip_if_unavailable=True,
+                ):
+                    # --- Start the second lemond on the SAME port; it must refuse ---
+                    with lemond_server(
+                        port=port,
+                        cache_dir=cache_dir,
+                        env=env,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.PIPE,
+                        skip_if_unavailable=True,
+                    ) as second:
+                        try:
+                            out, err = second.communicate(timeout=30)
+                        except subprocess.TimeoutExpired:
+                            second.kill()
+                            out, err = second.communicate()
+                            self.fail(
+                                "Second lemond did not exit; it should fail fast on the "
+                                f"in-use port {port}."
+                            )
 
-            deadline = time.time() + 60
-            first_healthy = False
-            while time.time() < deadline:
-                if first.poll() is not None:
-                    break  # exited early; surface the log below
-                if _lemond_health_ok(port, headers):
-                    first_healthy = True
-                    break
-                time.sleep(1)
+                        combined = f"{out or ''}\n{err or ''}"
 
-            if not first_healthy:
-                with open(first_log_path, "r", encoding="utf-8", errors="replace") as f:
-                    log = f.read()
-                self.fail(
-                    f"First lemond never became healthy on port {port}.\n"
-                    f"=== lemond log ===\n{log}"
-                )
+                        self.assertNotEqual(
+                            second.returncode,
+                            0,
+                            "Second lemond on an in-use port must exit non-zero, "
+                            f"got exit code 0.\n=== output ===\n{combined}",
+                        )
+                        self.assertIn(
+                            "already in use",
+                            combined.lower(),
+                            "Second lemond should report the port is already in use.\n"
+                            f"=== output ===\n{combined}",
+                        )
 
-            # --- Start the second lemond on the SAME port; it must refuse ---
-            second = subprocess.Popen(
-                cmd,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                text=True,
-                env=os.environ.copy(),
-            )
-            try:
-                out, err = second.communicate(timeout=30)
-            except subprocess.TimeoutExpired:
-                second.kill()
-                out, err = second.communicate()
-                self.fail(
-                    "Second lemond did not exit; it should fail fast on the "
-                    f"in-use port {port}."
-                )
+                        # --- The original server must still be healthy ---
+                        self.assertTrue(
+                            wait_for_http_health(port, headers=headers),
+                            "First lemond should remain healthy after the duplicate was "
+                            "rejected.",
+                        )
 
-            combined = f"{out or ''}\n{err or ''}"
-
-            self.assertNotEqual(
-                second.returncode,
-                0,
-                "Second lemond on an in-use port must exit non-zero, "
-                f"got exit code 0.\n=== output ===\n{combined}",
-            )
-            self.assertIn(
-                "already in use",
-                combined.lower(),
-                "Second lemond should report the port is already in use.\n"
-                f"=== output ===\n{combined}",
-            )
-
-            # --- The original server must still be healthy ---
-            self.assertTrue(
-                _lemond_health_ok(port, headers),
-                "First lemond should remain healthy after the duplicate was "
-                "rejected.",
-            )
-
-            print(
-                f"[OK] Second lemond on in-use port {port} exited "
-                f"{second.returncode} and first server stayed healthy"
-            )
+                        print(
+                            f"[OK] Second lemond on in-use port {port} exited "
+                            f"{second.returncode} and first server stayed healthy"
+                        )
         finally:
-            for proc in (second, first):
-                if proc is not None and proc.poll() is None:
-                    proc.terminate()
-                    try:
-                        proc.wait(timeout=10)
-                    except subprocess.TimeoutExpired:
-                        proc.kill()
-                        proc.wait(timeout=10)
             shutil.rmtree(cache_dir, ignore_errors=True)
 
     def test_034_shared_repo_variant_resolves_after_refs_main_advances(self):
@@ -7601,94 +7484,51 @@ class EndpointTests(ServerTestBase):
         client socket is kept open (which creates a lingering server-side connection
         in the TCP stack). The second lemond should start successfully.
         """
-        lemond_binary = _resolve_lemond_binary()
-        if not lemond_binary:
-            self.skipTest("lemond binary not found")
-
-        headers = {}
-        api_key = os.environ.get("LEMONADE_API_KEY")
-        if api_key:
-            headers["Authorization"] = f"Bearer {api_key}"
-
-        port = _pick_free_port()
+        headers = _auth_headers()
+        port = allocate_free_port()
         cache_dir = tempfile.mkdtemp(prefix="lemond_lingering_")
+        env = make_clean_env(cache_dir)
         first_log_path = os.path.join(cache_dir, "first_lemond.log")
         second_log_path = os.path.join(cache_dir, "second_lemond.log")
-        cmd = [lemond_binary, cache_dir, "--port", str(port)]
 
-        first = None
-        second = None
         client_sock = None
         try:
             # 1. Start the first lemond
             with open(first_log_path, "w", encoding="utf-8") as first_log:
-                first = subprocess.Popen(
-                    cmd,
+                with lemond_server(
+                    port=port,
+                    cache_dir=cache_dir,
+                    env=env,
+                    wait_health=True,
+                    health_headers=headers,
                     stdout=first_log,
                     stderr=subprocess.STDOUT,
-                    env=os.environ.copy(),
-                )
+                    skip_if_unavailable=True,
+                ):
+                    # 2. Establish a TCP connection from a client socket and keep it open
+                    client_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                    client_sock.connect(("127.0.0.1", port))
+                    client_sock.sendall(
+                        b"GET /health HTTP/1.1\r\nHost: localhost\r\n\r\n"
+                    )
 
-            # Wait for it to be healthy
-            deadline = time.time() + 30
-            first_healthy = False
-            while time.time() < deadline:
-                if first.poll() is not None:
-                    break
-                if _lemond_health_ok(port, headers):
-                    first_healthy = True
-                    break
-                time.sleep(1)
-
-            self.assertTrue(first_healthy, "First lemond failed to start")
-
-            # 2. Establish a TCP connection from a client socket and keep it open
-            client_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            client_sock.connect(("127.0.0.1", port))
-            client_sock.sendall(b"GET /health HTTP/1.1\r\nHost: localhost\r\n\r\n")
-
-            # 3. Shutdown the first lemond
-            first.terminate()
-            try:
-                first.wait(timeout=10)
-            except subprocess.TimeoutExpired:
-                first.kill()
-                first.wait(timeout=10)
-
-            # 4. Attempt to start a second lemond on the SAME port while client_sock is still active.
+            # First lemond is terminated on context exit.
+            # 3. Attempt to start a second lemond on the SAME port while client_sock is still active.
             # Without the fix, the second lemond would fail to start with EADDRINUSE (port already in use).
             with open(second_log_path, "w", encoding="utf-8") as second_log:
-                second = subprocess.Popen(
-                    cmd,
+                with lemond_server(
+                    port=port,
+                    cache_dir=cache_dir,
+                    env=env,
+                    wait_health=True,
+                    health_headers=headers,
                     stdout=second_log,
                     stderr=subprocess.STDOUT,
-                    env=os.environ.copy(),
-                )
-
-            # Assert that the second lemond starts and becomes healthy
-            deadline = time.time() + 30
-            second_healthy = False
-            while time.time() < deadline:
-                if second.poll() is not None:
-                    break
-                if _lemond_health_ok(port, headers):
-                    second_healthy = True
-                    break
-                time.sleep(1)
-
-            if not second_healthy:
-                with open(
-                    second_log_path, "r", encoding="utf-8", errors="replace"
-                ) as f:
-                    log = f.read()
-                self.fail(
-                    f"Second lemond failed to start on port {port} with lingering connection.\n"
-                    f"=== second lemond log ===\n{log}"
-                )
-
-            print(
-                f"[OK] Second lemond started successfully on port {port} with lingering connections"
-            )
+                    skip_if_unavailable=True,
+                ):
+                    print(
+                        f"[OK] Second lemond started successfully on port {port} with lingering connections"
+                    )
 
         finally:
             if client_sock:
@@ -7696,14 +7536,6 @@ class EndpointTests(ServerTestBase):
                     client_sock.close()
                 except Exception:
                     pass
-            for proc in (second, first):
-                if proc is not None and proc.poll() is None:
-                    proc.terminate()
-                    try:
-                        proc.wait(timeout=10)
-                    except subprocess.TimeoutExpired:
-                        proc.kill()
-                        proc.wait(timeout=10)
             shutil.rmtree(cache_dir, ignore_errors=True)
 
     def test_050_telemetry_trust_incoming_trace_context_config(self):
@@ -8239,189 +8071,221 @@ class EndpointTests(ServerTestBase):
         via /internal/set. Spawns its own lemond so it does not depend on an
         externally-managed server (unlike the shared-server assumption of
         ServerTestBase)."""
-        with _running_lemond(cache_prefix="lemond_ratecfg_") as (
-            proc,
-            port,
-            headers,
-            log_path,
-        ):
-            self.assertTrue(
-                _wait_until_healthy(proc, port, headers),
-                f"lemond never became healthy on port {port} (see {log_path})",
-            )
+        temp_cache = tempfile.mkdtemp(prefix="lemond_ratecfg_")
+        env = make_clean_env(temp_cache)
+        port = allocate_free_port()
+        log_path = os.path.join(temp_cache, "lemond.log")
+        headers = _auth_headers()
+        try:
+            with open(log_path, "w", encoding="utf-8") as log:
+                with lemond_server(
+                    port=port,
+                    cache_dir=temp_cache,
+                    env=env,
+                    wait_health=True,
+                    health_headers=headers,
+                    stdout=log,
+                    stderr=subprocess.STDOUT,
+                    skip_if_unavailable=True,
+                ):
+                    config_url = f"http://localhost:{port}/internal/config"
+                    set_url = f"http://localhost:{port}/internal/set"
 
-            config_url = f"http://localhost:{port}/internal/config"
-            set_url = f"http://localhost:{port}/internal/set"
+                    # Invalid values are rejected by config validation.
+                    bad_changes = [
+                        {"download_rate_limit": "10M5"},  # malformed rate string
+                        {"download_rate_limit": -5},  # non-string / negative
+                        {"download_rate_limit": "abc"},  # invalid rate string
+                    ]
+                    for body in bad_changes:
+                        resp = requests.post(
+                            set_url,
+                            headers=headers,
+                            json=body,
+                            timeout=TIMEOUT_DEFAULT,
+                        )
+                        self.assertEqual(
+                            resp.status_code,
+                            400,
+                            f"expected 400 for {body!r}, got {resp.status_code}: {resp.text}",
+                        )
 
-            # Invalid values are rejected by config validation.
-            bad_changes = [
-                {"download_rate_limit": "10M5"},  # malformed rate string
-                {"download_rate_limit": -5},  # non-string / negative
-                {"download_rate_limit": "abc"},  # invalid rate string
-            ]
-            for body in bad_changes:
-                resp = requests.post(
-                    set_url,
-                    headers=headers,
-                    json=body,
-                    timeout=TIMEOUT_DEFAULT,
-                )
-                self.assertEqual(
-                    resp.status_code,
-                    400,
-                    f"expected 400 for {body!r}, got {resp.status_code}: {resp.text}",
-                )
+                    # A full round-trip persists in the config snapshot.
+                    resp = requests.post(
+                        set_url,
+                        headers=headers,
+                        json={"download_rate_limit": "10M"},
+                        timeout=TIMEOUT_DEFAULT,
+                    )
+                    self.assertEqual(
+                        resp.status_code, 200, f"/internal/set failed: {resp.text}"
+                    )
+                    cfg = requests.get(
+                        config_url, headers=headers, timeout=TIMEOUT_DEFAULT
+                    ).json()
+                    self.assertEqual(cfg["download_rate_limit"], "10M")
 
-            # A full round-trip persists in the config snapshot.
-            resp = requests.post(
-                set_url,
-                headers=headers,
-                json={"download_rate_limit": "10M"},
-                timeout=TIMEOUT_DEFAULT,
-            )
-            self.assertEqual(
-                resp.status_code, 200, f"/internal/set failed: {resp.text}"
-            )
-            cfg = requests.get(
-                config_url, headers=headers, timeout=TIMEOUT_DEFAULT
-            ).json()
-            self.assertEqual(cfg["download_rate_limit"], "10M")
+                    # A partial update preserves unrelated keys.
+                    resp = requests.post(
+                        set_url,
+                        headers=headers,
+                        json={"download_rate_limit": "20M"},
+                        timeout=TIMEOUT_DEFAULT,
+                    )
+                    self.assertEqual(
+                        resp.status_code, 200, f"/internal/set failed: {resp.text}"
+                    )
+                    cfg = requests.get(
+                        config_url, headers=headers, timeout=TIMEOUT_DEFAULT
+                    ).json()
+                    self.assertEqual(cfg["download_rate_limit"], "20M")
 
-            # A partial update preserves unrelated keys.
-            resp = requests.post(
-                set_url,
-                headers=headers,
-                json={"download_rate_limit": "20M"},
-                timeout=TIMEOUT_DEFAULT,
-            )
-            self.assertEqual(
-                resp.status_code, 200, f"/internal/set failed: {resp.text}"
-            )
-            cfg = requests.get(
-                config_url, headers=headers, timeout=TIMEOUT_DEFAULT
-            ).json()
-            self.assertEqual(cfg["download_rate_limit"], "20M")
+                    # Clearing the cap means runtime unlimited.
+                    resp = requests.post(
+                        set_url,
+                        headers=headers,
+                        json={"download_rate_limit": ""},
+                        timeout=TIMEOUT_DEFAULT,
+                    )
+                    self.assertEqual(
+                        resp.status_code, 200, f"/internal/set failed: {resp.text}"
+                    )
+                    cfg = requests.get(
+                        config_url, headers=headers, timeout=TIMEOUT_DEFAULT
+                    ).json()
+                    self.assertEqual(cfg["download_rate_limit"], "")
 
-            # Clearing the cap means runtime unlimited.
-            resp = requests.post(
-                set_url,
-                headers=headers,
-                json={"download_rate_limit": ""},
-                timeout=TIMEOUT_DEFAULT,
-            )
-            self.assertEqual(
-                resp.status_code, 200, f"/internal/set failed: {resp.text}"
-            )
-            cfg = requests.get(
-                config_url, headers=headers, timeout=TIMEOUT_DEFAULT
-            ).json()
-            self.assertEqual(cfg["download_rate_limit"], "")
-
-            print(
-                "[OK] download_rate_limit validates and round-trips via /internal/set"
-            )
+                    print(
+                        "[OK] download_rate_limit validates and round-trips via /internal/set"
+                    )
+        finally:
+            shutil.rmtree(temp_cache, ignore_errors=True)
 
     def test_058_download_rate_limit_invalid_config_startup(self):
         """An invalid download_rate_limit in config.json must not crash
         lemond: the raw value is preserved in the snapshot and the server stays
         healthy (invalid caps are treated as unlimited)."""
-        with _running_lemond(
-            config={"download_rate_limit": "-1"},
-            cache_prefix="lemond_badcfg_",
-        ) as (proc, port, headers, log_path):
-            if not _wait_until_healthy(proc, port, headers):
-                with open(log_path, "r", encoding="utf-8", errors="replace") as f:
-                    log = f.read()
-                self.fail(
-                    f"lemond with invalid download_rate_limit crashed or never "
-                    f"became healthy on port {port}.\n=== lemond log ===\n{log}"
-                )
+        temp_cache = tempfile.mkdtemp(prefix="lemond_badcfg_")
+        env = make_clean_env(temp_cache)
+        port = allocate_free_port()
+        log_path = os.path.join(temp_cache, "lemond.log")
+        headers = _auth_headers()
+        try:
+            with open(log_path, "w", encoding="utf-8") as log:
+                with lemond_server(
+                    port=port,
+                    cache_dir=temp_cache,
+                    config={"download_rate_limit": "-1"},
+                    env=env,
+                    wait_health=True,
+                    health_headers=headers,
+                    stdout=log,
+                    stderr=subprocess.STDOUT,
+                    skip_if_unavailable=True,
+                ):
+                    cfg = requests.get(
+                        f"http://localhost:{port}/internal/config",
+                        headers=headers,
+                        timeout=TIMEOUT_DEFAULT,
+                    ).json()
+                    # The raw value is preserved verbatim in the config snapshot.
+                    self.assertEqual(cfg.get("download_rate_limit"), "-1")
 
-            cfg = requests.get(
-                f"http://localhost:{port}/internal/config",
-                headers=headers,
-                timeout=TIMEOUT_DEFAULT,
-            ).json()
-            # The raw value is preserved verbatim in the config snapshot.
-            self.assertEqual(cfg.get("download_rate_limit"), "-1")
-
-            print(
-                "[OK] lemond stays healthy with an invalid download_rate_limit "
-                "in config.json"
-            )
+                    print(
+                        "[OK] lemond stays healthy with an invalid download_rate_limit "
+                        "in config.json"
+                    )
+        finally:
+            shutil.rmtree(temp_cache, ignore_errors=True)
 
     def test_059_download_rate_limit_runtime_effect(self):
         """Changing download_rate_limit via /internal/set must actually apply
         the cap to HttpClient at runtime: the side-effect log line records the
         newly active byte rate, clearing it disables capping, and the last
         value is persisted to config.json."""
-        with _running_lemond(
-            config={"download_rate_limit": "10M"},
-            cache_prefix="lemond_ratecfg_",
-        ) as (proc, port, headers, log_path):
-            config_path = os.path.join(os.path.dirname(log_path), "config.json")
-            self.assertTrue(
-                _wait_until_healthy(proc, port, headers),
-                f"lemond never became healthy on port {port} (see {log_path})",
-            )
+        temp_cache = tempfile.mkdtemp(prefix="lemond_ratecfg_")
+        env = make_clean_env(temp_cache)
+        config_path = os.path.join(env["LEMONADE_CONFIG_DIR"], "config.json")
+        port = allocate_free_port()
+        log_path = os.path.join(temp_cache, "lemond.log")
+        headers = _auth_headers()
+        try:
+            with open(log_path, "w", encoding="utf-8") as log:
+                with lemond_server(
+                    port=port,
+                    cache_dir=temp_cache,
+                    config={"download_rate_limit": "10M"},
+                    env=env,
+                    wait_health=True,
+                    health_headers=headers,
+                    stdout=log,
+                    stderr=subprocess.STDOUT,
+                    skip_if_unavailable=True,
+                ):
+                    config_url = f"http://localhost:{port}/internal/config"
+                    set_url = f"http://localhost:{port}/internal/set"
 
-            config_url = f"http://localhost:{port}/internal/config"
-            set_url = f"http://localhost:{port}/internal/set"
+                    def _wait_for_log(needle, timeout_s=10.0):
+                        deadline = time.time() + timeout_s
+                        while time.time() < deadline:
+                            with open(
+                                log_path, "r", encoding="utf-8", errors="replace"
+                            ) as f:
+                                if needle in f.read():
+                                    return True
+                            time.sleep(0.2)
+                        return False
 
-            def _wait_for_log(needle, timeout_s=10.0):
-                deadline = time.time() + timeout_s
-                while time.time() < deadline:
-                    with open(log_path, "r", encoding="utf-8", errors="replace") as f:
-                        if needle in f.read():
-                            return True
-                    time.sleep(0.2)
-                return False
+                    cfg = requests.get(
+                        config_url, headers=headers, timeout=TIMEOUT_DEFAULT
+                    ).json()
+                    self.assertEqual(cfg.get("download_rate_limit"), "10M")
 
-            cfg = requests.get(
-                config_url, headers=headers, timeout=TIMEOUT_DEFAULT
-            ).json()
-            self.assertEqual(cfg.get("download_rate_limit"), "10M")
+                    # Raising the cap takes effect immediately and is logged.
+                    resp = requests.post(
+                        set_url,
+                        headers=headers,
+                        json={"download_rate_limit": "50M"},
+                        timeout=TIMEOUT_DEFAULT,
+                    )
+                    self.assertEqual(resp.status_code, 200, resp.text)
+                    self.assertTrue(
+                        _wait_for_log("Download rate limit enabled at 52428800 B/s"),
+                        "runtime cap change was not applied to HttpClient",
+                    )
 
-            # Raising the cap takes effect immediately and is logged.
-            resp = requests.post(
-                set_url,
-                headers=headers,
-                json={"download_rate_limit": "50M"},
-                timeout=TIMEOUT_DEFAULT,
-            )
-            self.assertEqual(resp.status_code, 200, resp.text)
-            self.assertTrue(
-                _wait_for_log("Download rate limit enabled at 52428800 B/s"),
-                "runtime cap change was not applied to HttpClient",
-            )
+                    # Clearing the cap disables limiting at runtime too.
+                    resp = requests.post(
+                        set_url,
+                        headers=headers,
+                        json={"download_rate_limit": ""},
+                        timeout=TIMEOUT_DEFAULT,
+                    )
+                    self.assertEqual(resp.status_code, 200, resp.text)
+                    self.assertTrue(
+                        _wait_for_log("Download rate limit disabled"),
+                        "clearing the cap did not disable runtime limiting",
+                    )
 
-            # Clearing the cap disables limiting at runtime too.
-            resp = requests.post(
-                set_url,
-                headers=headers,
-                json={"download_rate_limit": ""},
-                timeout=TIMEOUT_DEFAULT,
-            )
-            self.assertEqual(resp.status_code, 200, resp.text)
-            self.assertTrue(
-                _wait_for_log("Download rate limit disabled"),
-                "clearing the cap did not disable runtime limiting",
-            )
+                    # The persistent channel wrote the final value; "" equals the
+                    # default, so the key may be pruned from disk.
+                    if os.path.exists(config_path):
+                        with open(config_path, "r", encoding="utf-8") as f:
+                            self.assertEqual(
+                                json.load(f).get("download_rate_limit", ""), ""
+                            )
 
-            # The persistent channel wrote the final value; "" equals the
-            # default, so the key may be pruned from disk.
-            with open(config_path, "r", encoding="utf-8") as f:
-                self.assertEqual(json.load(f).get("download_rate_limit", ""), "")
+                    cfg = requests.get(
+                        config_url, headers=headers, timeout=TIMEOUT_DEFAULT
+                    ).json()
+                    self.assertEqual(cfg.get("download_rate_limit"), "")
 
-            cfg = requests.get(
-                config_url, headers=headers, timeout=TIMEOUT_DEFAULT
-            ).json()
-            self.assertEqual(cfg.get("download_rate_limit"), "")
-
-            print(
-                "[OK] /internal/set applies download_rate_limit at runtime "
-                "and persists it"
-            )
+                    print(
+                        "[OK] /internal/set applies download_rate_limit at runtime "
+                        "and persists it"
+                    )
+        finally:
+            shutil.rmtree(temp_cache, ignore_errors=True)
 
     def test_060_docs_index(self):
         """GET /docs returns an index of the bundled documentation (#1700)."""

--- a/test/server_jobs.py
+++ b/test/server_jobs.py
@@ -12,6 +12,9 @@ import unittest
 
 import requests
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from utils.server_fixture import wait_for_http_health
+
 PORT = 13401
 HOST = "127.0.0.1"
 BASE = f"http://{HOST}:{PORT}/api/v1"
@@ -47,6 +50,14 @@ def find_lemond_binary():
     env = os.environ.get("LEMOND_BINARY")
     if env:
         return env
+    try:
+        from utils.test_models import get_default_lemond_binary
+
+        candidate = get_default_lemond_binary()
+        if candidate and os.path.isfile(candidate):
+            return candidate
+    except ImportError:
+        pass
     for candidate in ("build/lemond", "build-debug/lemond", "build-release/lemond"):
         path = os.path.join(REPO_ROOT, candidate)
         if os.path.isfile(path):
@@ -159,18 +170,10 @@ class JobEngineTests(unittest.TestCase):
             stderr=subprocess.DEVNULL,
         )
         type(self)._shared_proc = self.proc
-        deadline = time.time() + 40
-        while time.time() < deadline:
+        if not wait_for_http_health(PORT, host=HOST, timeout=40.0):
             if self.proc.poll() is not None:
                 raise RuntimeError("lemond exited during startup")
-            try:
-                r = requests.get(f"{BASE}/health", timeout=2)
-                if r.status_code == 200:
-                    return
-            except requests.RequestException:
-                pass
-            time.sleep(POLL_INTERVAL)
-        raise RuntimeError("lemond did not become healthy in time")
+            raise RuntimeError("lemond did not become healthy in time")
 
     def stop_server(self, hard=False):
         if not self.proc:

--- a/test/server_log_rotation.py
+++ b/test/server_log_rotation.py
@@ -13,7 +13,6 @@ Verifies:
 import json
 import os
 import shutil
-import socket
 import subprocess
 import sys
 import tempfile
@@ -21,28 +20,10 @@ import time
 import unittest
 import requests
 
-from utils.test_models import get_default_cli_binary
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-
-def get_free_port():
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(("127.0.0.1", 0))
-        return s.getsockname()[1]
-
-
-def find_lemond_binary():
-    cli_bin = get_default_cli_binary()
-    if cli_bin:
-        build_dir = os.path.dirname(cli_bin)
-        exe = "lemond.exe" if sys.platform == "win32" else "lemond"
-        lemond_bin = os.path.join(build_dir, exe)
-        if os.path.exists(lemond_bin):
-            return lemond_bin
-    exe = "lemond.exe" if sys.platform == "win32" else "lemond"
-    for path in [f"build/{exe}", f"build/src/cpp/server/{exe}"]:
-        if os.path.exists(path):
-            return os.path.abspath(path)
-    return exe
+from utils.server_fixture import allocate_free_port, lemond_server, make_clean_env
+from utils.test_models import get_default_lemond_binary
 
 
 class TestLogRotation(unittest.TestCase):
@@ -50,20 +31,12 @@ class TestLogRotation(unittest.TestCase):
         self.test_dir = tempfile.mkdtemp(prefix="lemonade_log_test_")
         self.runtime_dir = os.path.join(self.test_dir, "runtime")
         os.makedirs(self.runtime_dir, exist_ok=True)
-        self.lemond_bin = find_lemond_binary()
-        self.server_proc = None
+        self.lemond_bin = get_default_lemond_binary()
+        if not self.lemond_bin or not os.path.exists(self.lemond_bin):
+            if not shutil.which("lemond"):
+                raise unittest.SkipTest("lemond binary not found")
 
     def tearDown(self):
-        if self.server_proc:
-            if self.server_proc.stdout:
-                self.server_proc.stdout.close()
-            if self.server_proc.stderr:
-                self.server_proc.stderr.close()
-            try:
-                self.server_proc.terminate()
-                self.server_proc.wait(timeout=5)
-            except Exception:
-                self.server_proc.kill()
         if os.path.exists(self.test_dir):
             shutil.rmtree(self.test_dir, ignore_errors=True)
 
@@ -82,14 +55,11 @@ class TestLogRotation(unittest.TestCase):
         with open(active_log, "wb") as f:
             f.write(b"FIRST_LOG_BLOCK\n" + b"A" * (1024 * 1024 + 200))
 
-        env = os.environ.copy()
+        env = make_clean_env(self.test_dir)
         env["XDG_RUNTIME_DIR"] = self.runtime_dir
-        env["LEMONADE_CACHE_DIR"] = self.test_dir
         env["LEMONADE_DISABLE_SYSTEMD_JOURNAL"] = "1"
 
-        base_cmd = [
-            self.lemond_bin,
-            self.test_dir,
+        cli_args = [
             "--log-file",
             "enabled",
             "--log-max-size-mb",
@@ -99,7 +69,7 @@ class TestLogRotation(unittest.TestCase):
         ]
 
         self.assertTrue(
-            self.run_server_instance(base_cmd, env), "Instance 1 failed to start"
+            self.run_server_instance(cli_args, env), "Instance 1 failed to start"
         )
         backup_1 = os.path.join(log_dir, "lemonade-server.log.1")
         self.assertTrue(os.path.exists(backup_1), "Rotation 1 failed to create .1")
@@ -114,7 +84,7 @@ class TestLogRotation(unittest.TestCase):
         with open(active_log, "wb") as f:
             f.write(b"SECOND_LOG_BLOCK\n" + b"B" * (1024 * 1024 + 200))
         self.assertTrue(
-            self.run_server_instance(base_cmd, env), "Instance 2 failed to start"
+            self.run_server_instance(cli_args, env), "Instance 2 failed to start"
         )
         backup_2 = os.path.join(log_dir, "lemonade-server.log.2")
         self.assertTrue(os.path.exists(backup_2), "Rotation 2 failed to create .2")
@@ -123,7 +93,7 @@ class TestLogRotation(unittest.TestCase):
         with open(active_log, "wb") as f:
             f.write(b"THIRD_LOG_BLOCK\n" + b"C" * (1024 * 1024 + 200))
         self.assertTrue(
-            self.run_server_instance(base_cmd, env), "Instance 3 failed to start"
+            self.run_server_instance(cli_args, env), "Instance 3 failed to start"
         )
 
         backup_3 = os.path.join(log_dir, "lemonade-server.log.3")
@@ -132,31 +102,21 @@ class TestLogRotation(unittest.TestCase):
             f"Backup {backup_3} exists but should have been pruned (max_files=2)",
         )
 
-    def run_server_instance(self, base_cmd, env):
-        port = get_free_port()
-        cmd = base_cmd + ["--port", str(port)]
-        with subprocess.Popen(
-            cmd,
-            env=env,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-        ) as proc:
-            ready = False
-            for _ in range(30):
-                try:
-                    conn = socket.create_connection(("127.0.0.1", port))
-                    conn.close()
-                    ready = True
-                    break
-                except Exception:
-                    time.sleep(0.2)
-            try:
-                proc.terminate()
-                proc.wait(timeout=3)
-            except Exception:
-                proc.kill()
-                proc.wait(timeout=3)
-            return ready
+    def run_server_instance(self, cli_args, env):
+        port = allocate_free_port()
+        try:
+            with lemond_server(
+                port=port,
+                cache_dir=self.test_dir,
+                args=cli_args,
+                env=env,
+                binary_path=self.lemond_bin,
+                wait_health=True,
+                health_timeout=10.0,
+            ):
+                return True
+        except Exception:
+            return False
 
     def test_max_files_zero(self):
         """Verify max_files=0 truncates active file upon rotation without creating backup files."""
@@ -167,14 +127,11 @@ class TestLogRotation(unittest.TestCase):
         with open(active_log, "wb") as f:
             f.write(b"INITIAL_OVERSIZE\n" + b"Z" * (1024 * 1024 + 500))
 
-        env = os.environ.copy()
+        env = make_clean_env(self.test_dir)
         env["XDG_RUNTIME_DIR"] = self.runtime_dir
-        env["LEMONADE_CACHE_DIR"] = self.test_dir
         env["LEMONADE_DISABLE_SYSTEMD_JOURNAL"] = "1"
 
-        base_cmd = [
-            self.lemond_bin,
-            self.test_dir,
+        cli_args = [
             "--log-file",
             "enabled",
             "--log-max-size-mb",
@@ -184,7 +141,7 @@ class TestLogRotation(unittest.TestCase):
         ]
 
         self.assertTrue(
-            self.run_server_instance(base_cmd, env),
+            self.run_server_instance(cli_args, env),
             "Server failed to start in max_files=0 mode",
         )
         backup_1 = os.path.join(log_dir, "lemonade-server.log.1")
@@ -201,17 +158,12 @@ class TestLogRotation(unittest.TestCase):
         with open(active_log, "wb") as f:
             f.write(b"PRE_SEED_LOG_LINE\n" + b"X" * (1020 * 1024))
 
-        env = os.environ.copy()
+        env = make_clean_env(self.test_dir)
         env["XDG_RUNTIME_DIR"] = self.runtime_dir
-        env["LEMONADE_CACHE_DIR"] = self.test_dir
         env["LEMONADE_DISABLE_SYSTEMD_JOURNAL"] = "1"
 
-        port = get_free_port()
-        cmd = [
-            self.lemond_bin,
-            self.test_dir,
-            "--port",
-            str(port),
+        port = allocate_free_port()
+        cli_args = [
             "--log-file",
             "enabled",
             "--log-max-size-mb",
@@ -220,25 +172,15 @@ class TestLogRotation(unittest.TestCase):
             "2",
         ]
 
-        proc = subprocess.Popen(
-            cmd,
+        with lemond_server(
+            port=port,
+            cache_dir=self.test_dir,
+            args=cli_args,
             env=env,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-        )
-
-        ready = False
-        try:
-            for _ in range(30):
-                try:
-                    conn = socket.create_connection(("127.0.0.1", port))
-                    conn.close()
-                    ready = True
-                    break
-                except Exception:
-                    time.sleep(0.2)
-
-            self.assertTrue(ready, "Server failed to start for runtime rotation test")
+            binary_path=self.lemond_bin,
+            wait_health=True,
+            health_timeout=10.0,
+        ):
             self.assertFalse(
                 os.path.exists(backup_1),
                 "Backup .1 must NOT exist immediately after startup (proves startup did not rotate)",
@@ -258,14 +200,6 @@ class TestLogRotation(unittest.TestCase):
                     )
                 except Exception:
                     pass
-
-        finally:
-            try:
-                proc.terminate()
-                proc.wait(timeout=3)
-            except Exception:
-                proc.kill()
-                proc.wait(timeout=3)
 
         self.assertTrue(os.path.exists(active_log), "Active log file should exist")
         self.assertTrue(

--- a/test/server_telemetry.py
+++ b/test/server_telemetry.py
@@ -15,7 +15,9 @@ Usage:
 
 import json
 import os
+import shutil
 import sys
+import tempfile
 import time
 import http.server
 import threading
@@ -258,12 +260,9 @@ class MockOTLPServer(http.server.HTTPServer):
         self.request_queue = Queue()
 
 
-def find_free_port():
-    s = socket.socket()
-    s.bind(("", 0))
-    port = s.getsockname()[1]
-    s.close()
-    return port
+from utils.server_fixture import allocate_free_port, lemond_server, make_clean_env
+
+find_free_port = allocate_free_port
 
 
 def _get_header_value(headers, target_key):
@@ -1279,80 +1278,61 @@ class ReliabilityTests(TelemetryTestBase):
         original_env_val = os.environ.get(env_key)
         os.environ[env_key] = "X-Env-Header=EnvValue, Authorization=Bearer env_token"
 
-        lemond_bin = get_default_lemond_binary()
-        temp_port = find_free_port()
-
-        # Start a temporary server process with the updated env
-        env = os.environ.copy()
-        proc = subprocess.Popen(
-            [lemond_bin, "./build/temp_cache", "--port", str(temp_port)],
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            env=env,
-        )
-
+        temp_port = allocate_free_port()
+        temp_cache = tempfile.mkdtemp(prefix="temp_cache_")
+        env = make_clean_env(temp_cache)
+        env[env_key] = "X-Env-Header=EnvValue, Authorization=Bearer env_token"
         try:
-            # Wait for temporary server to start
-            for i in range(30):
-                try:
-                    requests.get(
-                        f"http://localhost:{temp_port}/api/v1/models", timeout=1
-                    )
-                    break
-                except:
-                    time.sleep(1)
-            else:
-                self.fail("Temporary lemond server failed to start")
-
-            # Enable telemetry pointing to mock collector on the temporary server
-            config_payload = {
-                "telemetry": {
-                    "enabled": True,
-                    "otlp": {
-                        "endpoint": f"http://127.0.0.1:{self.mock_port}/v1/traces",
-                        "headers": {},
-                    },
+            with lemond_server(
+                port=temp_port,
+                cache_dir=temp_cache,
+                env=env,
+                wait_health=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            ):
+                # Enable telemetry pointing to mock collector on the temporary server
+                config_payload = {
+                    "telemetry": {
+                        "enabled": True,
+                        "otlp": {
+                            "endpoint": f"http://127.0.0.1:{self.mock_port}/v1/traces",
+                            "headers": {},
+                        },
+                    }
                 }
-            }
-            res = self._auth_post(
-                f"http://localhost:{temp_port}/internal/set", config_payload
-            )
-            self.assertEqual(res.status_code, 200, res.text)
+                res = self._auth_post(
+                    f"http://localhost:{temp_port}/internal/set", config_payload
+                )
+                self.assertEqual(res.status_code, 200, res.text)
 
-            # Send completions request to the temporary server
-            self._chat_completion("Hi.", port=temp_port)
+                # Send completions request to the temporary server
+                self._chat_completion("Hi.", port=temp_port)
 
-            # Wait for mock collector to receive telemetry span
-            span_received = self._wait_for_span()
+                # Wait for mock collector to receive telemetry span
+                span_received = self._wait_for_span()
 
-            self.assertIsNotNone(
-                span_received,
-                "Telemetry span was not received by the OTLP mock receiver.",
-            )
+                self.assertIsNotNone(
+                    span_received,
+                    "Telemetry span was not received by the OTLP mock receiver.",
+                )
 
-            # Assert headers case-insensitively
-            headers = span_received["headers"]
-            val_env = _get_header_value(headers, "x-env-header")
-            val_auth = _get_header_value(headers, "authorization")
+                # Assert headers case-insensitively
+                headers = span_received["headers"]
+                val_env = _get_header_value(headers, "x-env-header")
+                val_auth = _get_header_value(headers, "authorization")
 
-            self.assertIsNotNone(
-                val_env, "x-env-header was not found in received headers"
-            )
-            self.assertIsNotNone(
-                val_auth, "authorization header was not found in received headers"
-            )
-            self.assertEqual(val_env.lower(), "EnvValue".lower())
-            self.assertEqual(val_auth.lower(), "Bearer env_token".lower())
+                self.assertIsNotNone(
+                    val_env, "x-env-header was not found in received headers"
+                )
+                self.assertIsNotNone(
+                    val_auth, "authorization header was not found in received headers"
+                )
+                self.assertEqual(val_env.lower(), "EnvValue".lower())
+                self.assertEqual(val_auth.lower(), "Bearer env_token".lower())
 
         finally:
-            # Terminate temporary server
-            proc.terminate()
-            try:
-                proc.wait(timeout=5)
-            except subprocess.TimeoutExpired:
-                proc.kill()
-                proc.wait()
-
+            shutil.rmtree(temp_cache, ignore_errors=True)
             # Clean up os.environ
             if original_env_val is not None:
                 os.environ[env_key] = original_env_val

--- a/test/server_websocket_auth.py
+++ b/test/server_websocket_auth.py
@@ -12,6 +12,7 @@ and the main HTTP port, plus the backward-compatible api_key query parameter.
 
 import asyncio
 import base64
+import contextlib
 import json
 import os
 import sys
@@ -27,18 +28,15 @@ import websockets
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from utils.test_models import get_default_lemond_binary
+from utils.server_fixture import (
+    allocate_free_port,
+    lemond_server,
+    make_clean_env,
+    wait_for_http_health,
+)
 
 API_KEY = "secret_key"
 APP_PROTOCOL = "lemonade-realtime"
-
-
-def find_free_port():
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    try:
-        s.bind(("127.0.0.1", 0))
-        return s.getsockname()[1]
-    finally:
-        s.close()
 
 
 def credential_protocol(api_key):
@@ -60,54 +58,49 @@ class WebSocketAuthTests(unittest.TestCase):
                 "skipping (source-build only)"
             )
         cls.temp_dir = tempfile.mkdtemp(prefix="lemond_ws_auth_")
-        cls.port = find_free_port()
+        cls.port = allocate_free_port()
 
-        env = os.environ.copy()
-        env.pop("LEMONADE_ADMIN_API_KEY", None)
+        env = make_clean_env(cls.temp_dir)
         env["LEMONADE_API_KEY"] = API_KEY
 
-        cls.log_path = os.path.join(cls.temp_dir, "lemond.log")
-        cls.log_file = open(cls.log_path, "w")
-        cls.proc = subprocess.Popen(
-            [cls.lemond_bin, cls.temp_dir, "--port", str(cls.port)],
-            stdout=cls.log_file,
-            stderr=cls.log_file,
-            env=env,
-        )
+        cls._exit_stack = contextlib.ExitStack()
+        try:
+            cls.log_path = os.path.join(cls.temp_dir, "lemond.log")
+            cls.log_file = cls._exit_stack.enter_context(
+                open(cls.log_path, "w", encoding="utf-8")
+            )
+            cls.proc = cls._exit_stack.enter_context(
+                lemond_server(
+                    port=cls.port,
+                    cache_dir=cls.temp_dir,
+                    binary_path=cls.lemond_bin,
+                    env=env,
+                    wait_health=True,
+                    health_headers={"Authorization": f"Bearer {API_KEY}"},
+                    stdout=cls.log_file,
+                    stderr=subprocess.STDOUT,
+                )
+            )
 
-        cls.ws_port = None
-        for _ in range(60):
-            try:
-                res = requests.get(f"http://localhost:{cls.port}/live", timeout=0.2)
-                if res.status_code == 200:
-                    health = requests.get(
-                        f"http://localhost:{cls.port}/api/v1/health",
-                        headers={"Authorization": f"Bearer {API_KEY}"},
-                        timeout=0.5,
-                    )
-                    cls.ws_port = health.json().get("websocket_port")
-                    break
-            except Exception:
-                pass
-            time.sleep(0.05)
+            health = requests.get(
+                f"http://localhost:{cls.port}/api/v1/health",
+                headers={"Authorization": f"Bearer {API_KEY}"},
+                timeout=2,
+            )
+            cls.ws_port = health.json().get("websocket_port")
+            if cls.ws_port is None:
+                raise RuntimeError("Failed to get websocket_port from health response")
+        except Exception:
+            cls._exit_stack.close()
+            import shutil
 
-        if cls.ws_port is None:
-            cls.tearDownClass()
-            raise RuntimeError("Failed to start lemond server for WebSocket auth tests")
+            shutil.rmtree(cls.temp_dir, ignore_errors=True)
+            raise
 
     @classmethod
     def tearDownClass(cls):
-        proc = getattr(cls, "proc", None)
-        if proc and proc.poll() is None:
-            proc.terminate()
-            try:
-                proc.wait(timeout=3)
-            except Exception:
-                proc.kill()
-                proc.wait()
-        log_file = getattr(cls, "log_file", None)
-        if log_file:
-            log_file.close()
+        if hasattr(cls, "_exit_stack"):
+            cls._exit_stack.close()
         temp_dir = getattr(cls, "temp_dir", None)
         if temp_dir:
             import shutil
@@ -340,72 +333,59 @@ class WebSocketAuthTests(unittest.TestCase):
         """Under admin-only auth configuration (LEMONADE_API_KEY empty, LEMONADE_ADMIN_API_KEY set),
         verify that WebSocket connection retains admin token and can authenticate."""
         temp_dir = tempfile.mkdtemp(prefix="lemond_admin_only_")
-        port = find_free_port()
-        env = os.environ.copy()
-        env.pop("LEMONADE_API_KEY", None)
+        port = allocate_free_port()
+        env = make_clean_env(temp_dir)
         env["LEMONADE_ADMIN_API_KEY"] = "admin_secret"
 
-        proc = subprocess.Popen(
-            [self.lemond_bin, temp_dir, "--port", str(port)],
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            env=env,
-        )
-
         try:
-            # Wait for startup
-            ws_port = None
-            for _ in range(60):
-                try:
-                    res = requests.get(f"http://localhost:{port}/live", timeout=0.2)
-                    if res.status_code == 200:
-                        # Since api_key is empty, health is public
-                        health = requests.get(
-                            f"http://localhost:{port}/api/v1/health", timeout=0.5
-                        )
-                        ws_port = health.json().get("websocket_port")
-                        break
-                except Exception:
-                    pass
-                time.sleep(0.05)
+            with lemond_server(
+                port=port,
+                cache_dir=temp_dir,
+                env=env,
+                wait_health=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            ):
+                health = requests.get(
+                    f"http://localhost:{port}/api/v1/health", timeout=0.5
+                )
+                ws_port = health.json().get("websocket_port")
+                self.assertIsNotNone(
+                    ws_port, "Failed to get websocket_port for admin-only test"
+                )
 
-            self.assertIsNotNone(ws_port, "Failed to start server for admin-only test")
+                # Now let's connect to /spans/stream with the admin subprotocol
+                async def run():
+                    uri = f"ws://localhost:{port}/v1/spans/stream"
+                    async with websockets.connect(
+                        uri,
+                        subprotocols=auth_subprotocols("admin_secret"),
+                    ) as ws:
+                        # Connection should upgrade successfully
+                        self.assertEqual(ws.subprotocol, APP_PROTOCOL)
 
-            # Now let's connect to /spans/stream with the admin subprotocol
-            async def run():
-                uri = f"ws://localhost:{port}/v1/spans/stream"
-                async with websockets.connect(
-                    uri,
-                    subprotocols=auth_subprotocols("admin_secret"),
-                ) as ws:
-                    # Connection should upgrade successfully
-                    self.assertEqual(ws.subprotocol, APP_PROTOCOL)
+                        # Now trigger a span from a public request without an Authorization token
+                        def trigger():
+                            payload = {
+                                "model": "nonexistent-model",
+                                "messages": [{"role": "user", "content": "hello"}],
+                            }
+                            requests.post(
+                                f"http://localhost:{port}/api/v1/chat/completions",
+                                json=payload,
+                                timeout=5,
+                            )
 
-                    # Now trigger a span from a public request without an Authorization token
-                    def trigger():
-                        payload = {
-                            "model": "nonexistent-model",
-                            "messages": [{"role": "user", "content": "hello"}],
-                        }
-                        requests.post(
-                            f"http://localhost:{port}/api/v1/chat/completions",
-                            json=payload,
-                            timeout=5,
-                        )
+                        loop = asyncio.get_running_loop()
+                        await loop.run_in_executor(None, trigger)
 
-                    loop = asyncio.get_running_loop()
-                    await loop.run_in_executor(None, trigger)
+                        # Assert that the admin WebSocket receives the span
+                        msg = json.loads(await asyncio.wait_for(ws.recv(), timeout=3.0))
+                        self.assertIn("name", msg)
+                        self.assertEqual(msg.get("name"), "chat.completions")
 
-                    # Assert that the admin WebSocket receives the span
-                    msg = json.loads(await asyncio.wait_for(ws.recv(), timeout=3.0))
-                    self.assertIn("name", msg)
-                    self.assertEqual(msg.get("name"), "chat.completions")
-
-            asyncio.run(run())
-
+                asyncio.run(run())
         finally:
-            proc.terminate()
-            proc.wait()
             import shutil
 
             shutil.rmtree(temp_dir, ignore_errors=True)
@@ -413,56 +393,45 @@ class WebSocketAuthTests(unittest.TestCase):
     def test_014_null_origin_explicit_allowlist(self):
         """Verify that Origin: null is accepted when allowed origins config contains 'null'."""
         temp_dir = tempfile.mkdtemp(prefix="lemond_null_origin_")
-        port = find_free_port()
-        env = os.environ.copy()
-        env.pop("LEMONADE_ADMIN_API_KEY", None)
+        port = allocate_free_port()
+        env = make_clean_env(temp_dir)
         env["LEMONADE_API_KEY"] = API_KEY
         env["LEMONADE_ALLOWED_ORIGINS"] = "null"
 
-        proc = subprocess.Popen(
-            [self.lemond_bin, temp_dir, "--port", str(port)],
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            env=env,
-        )
-
         try:
-            # Wait for startup
-            ws_port = None
-            for _ in range(60):
-                try:
-                    res = requests.get(f"http://localhost:{port}/live", timeout=0.2)
-                    if res.status_code == 200:
-                        health = requests.get(
-                            f"http://localhost:{port}/api/v1/health",
-                            headers={"Authorization": f"Bearer {API_KEY}"},
-                            timeout=0.5,
-                        )
-                        ws_port = health.json().get("websocket_port")
-                        break
-                except Exception:
-                    pass
-                time.sleep(0.05)
+            with lemond_server(
+                port=port,
+                cache_dir=temp_dir,
+                env=env,
+                wait_health=True,
+                health_headers={"Authorization": f"Bearer {API_KEY}"},
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            ):
+                health = requests.get(
+                    f"http://localhost:{port}/api/v1/health",
+                    headers={"Authorization": f"Bearer {API_KEY}"},
+                    timeout=0.5,
+                )
+                ws_port = health.json().get("websocket_port")
+                self.assertIsNotNone(
+                    ws_port, "Failed to get websocket_port for null origin test"
+                )
 
-            self.assertIsNotNone(ws_port, "Failed to start server for null origin test")
+                # Connect with Origin: null
+                async def run():
+                    uri = f"ws://localhost:{ws_port}/logs/stream"
+                    async with websockets.connect(
+                        uri,
+                        subprotocols=auth_subprotocols(API_KEY),
+                        origin="null",
+                    ) as ws:
+                        await ws.send(json.dumps({"type": "logs.subscribe"}))
+                        msg = json.loads(await asyncio.wait_for(ws.recv(), timeout=3.0))
+                        self.assertEqual(msg.get("type"), "logs.snapshot")
 
-            # Connect with Origin: null
-            async def run():
-                uri = f"ws://localhost:{ws_port}/logs/stream"
-                async with websockets.connect(
-                    uri,
-                    subprotocols=auth_subprotocols(API_KEY),
-                    origin="null",
-                ) as ws:
-                    await ws.send(json.dumps({"type": "logs.subscribe"}))
-                    msg = json.loads(await asyncio.wait_for(ws.recv(), timeout=3.0))
-                    self.assertEqual(msg.get("type"), "logs.snapshot")
-
-            asyncio.run(run())
-
+                asyncio.run(run())
         finally:
-            proc.terminate()
-            proc.wait()
             import shutil
 
             shutil.rmtree(temp_dir, ignore_errors=True)

--- a/test/server_websocket_telemetry.py
+++ b/test/server_websocket_telemetry.py
@@ -6,6 +6,7 @@ WebSocket Origin Verification, Ephemeral Session Tokens, and Admin Fallback.
 """
 
 import asyncio
+import contextlib
 import json
 import os
 import sys
@@ -21,14 +22,14 @@ import websockets
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from utils.test_models import get_default_lemond_binary
+from utils.server_fixture import (
+    allocate_free_port,
+    lemond_server,
+    make_clean_env,
+    wait_for_http_health,
+)
 
-
-def find_free_port():
-    s = socket.socket()
-    s.bind(("", 0))
-    port = s.getsockname()[1]
-    s.close()
-    return port
+find_free_port = allocate_free_port
 
 
 def get_span_attributes(span_data):
@@ -75,32 +76,19 @@ class TelemetrySecurityTestBase(unittest.TestCase):
             raise RuntimeError(
                 f"lemond binary not found at {cls.lemond_bin}. Build it first."
             )
-        cls.procs = []
+        cls._exit_stack = contextlib.ExitStack()
         cls.temp_dirs = []
+        cls.procs = []
 
     @classmethod
     def tearDownClass(cls):
-        for proc, log_file, log_file_path in cls.procs:
-            if proc.poll() is None:
-                proc.terminate()
-                try:
-                    proc.wait(timeout=3)
-                except Exception:
-                    try:
-                        proc.kill()
-                        proc.wait()
-                    except Exception:
-                        pass
-            try:
-                log_file.close()
-            except Exception:
-                pass
-            pass
-        for temp_dir in cls.temp_dirs:
+        if hasattr(cls, "_exit_stack"):
+            cls._exit_stack.close()
+        for temp_dir in getattr(cls, "temp_dirs", []):
             try:
                 import shutil
 
-                shutil.rmtree(temp_dir)
+                shutil.rmtree(temp_dir, ignore_errors=True)
             except Exception:
                 pass
 
@@ -109,16 +97,8 @@ class TelemetrySecurityTestBase(unittest.TestCase):
         temp_dir = tempfile.mkdtemp(prefix="lemond_ws_sec_")
         cls.temp_dirs.append(temp_dir)
 
-        port = find_free_port()
-        env = os.environ.copy()
-
-        # Clean all relevant env vars by default so tests are isolated
-        for k in [
-            "LEMONADE_API_KEY",
-            "LEMONADE_ADMIN_API_KEY",
-            "LEMONADE_ALLOWED_ORIGINS",
-        ]:
-            env.pop(k, None)
+        port = allocate_free_port()
+        env = make_clean_env(temp_dir)
 
         if env_overrides:
             for k, v in env_overrides.items():
@@ -127,49 +107,47 @@ class TelemetrySecurityTestBase(unittest.TestCase):
                 else:
                     env[k] = v
 
-        log_file_path = os.path.join(temp_dir, "lemond.log")
-        log_file = open(log_file_path, "w")
-        proc = subprocess.Popen(
-            [cls.lemond_bin, temp_dir, "--port", str(port)],
-            stdout=log_file,
-            stderr=log_file,
-            env=env,
-        )
-        cls.procs.append((proc, log_file, log_file_path))
+        headers = {}
+        api_key = env_overrides.get("LEMONADE_API_KEY") if env_overrides else None
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
 
-        # Wait for server to start
-        for _ in range(60):
-            try:
-                res = requests.get(f"http://localhost:{port}/live", timeout=0.2)
-                if res.status_code == 200:
-                    # Get ws port from /health
-                    headers = {}
-                    api_key = (
-                        env_overrides.get("LEMONADE_API_KEY") if env_overrides else None
-                    )
-                    if api_key:
-                        headers["Authorization"] = f"Bearer {api_key}"
-
-                    health_res = requests.get(
-                        f"http://localhost:{port}/api/v1/health",
-                        headers=headers,
-                        timeout=0.5,
-                    )
-                    ws_port = health_res.json().get("websocket_port")
-                    return port, ws_port
-            except Exception:
-                pass
-            time.sleep(0.05)
-
-        proc.terminate()
+        call_stack = contextlib.ExitStack()
         try:
-            with open(log_file_path, "r") as f:
-                log_content = f.read()
+            log_file_path = os.path.join(temp_dir, "lemond.log")
+            log_file = call_stack.enter_context(
+                open(log_file_path, "w", encoding="utf-8")
+            )
+            proc = call_stack.enter_context(
+                lemond_server(
+                    port=port,
+                    cache_dir=temp_dir,
+                    binary_path=cls.lemond_bin,
+                    env=env,
+                    wait_health=True,
+                    health_headers=headers,
+                    stdout=log_file,
+                    stderr=subprocess.STDOUT,
+                )
+            )
+
+            health_res = requests.get(
+                f"http://localhost:{port}/api/v1/health",
+                headers=headers,
+                timeout=2.0,
+            )
+            ws_port = health_res.json().get("websocket_port")
+            if ws_port is None:
+                raise RuntimeError("Failed to get websocket_port from health response")
+            cls._exit_stack.enter_context(call_stack.pop_all())
+            cls.procs.append((proc, log_file, log_file_path))
+            return port, ws_port
         except Exception:
-            log_content = "Could not read log file"
-        raise RuntimeError(
-            f"Failed to start temporary lemond server on port {port}. Log:\n{log_content}"
-        )
+            call_stack.close()
+            import shutil
+
+            shutil.rmtree(temp_dir, ignore_errors=True)
+            raise
 
 
 class TelemetryAuthSecurityTests(TelemetrySecurityTestBase):

--- a/test/test_flm_status.py
+++ b/test/test_flm_status.py
@@ -36,7 +36,12 @@ try:
 except ImportError as e:
     raise ImportError("You must `pip install requests` to run this test", e)
 
-from utils.test_models import PORT, TIMEOUT_DEFAULT, get_default_cli_binary
+from utils.test_models import (
+    PORT,
+    TIMEOUT_DEFAULT,
+    get_default_cli_binary,
+    get_default_lemond_binary,
+)
 from utils.server_base import _auth_headers, wait_for_server
 
 
@@ -259,14 +264,16 @@ class FlmStatusTests(unittest.TestCase):
         cls.server_version = get_server_version(cls.cli_binary)
         print(f"[SETUP] Using server version: {cls.server_version}")
 
-        # Derive lemond path from the CLI binary (they live in the same build dir)
+        # Derive lemond path from the CLI binary / build dir
         build_dir = os.path.dirname(cls.cli_binary)
-        if IS_WINDOWS:
-            cls.router_binary = os.path.join(build_dir, "lemond.exe")
-        else:
-            cls.router_binary = os.path.join(build_dir, "lemond")
-        if not os.path.exists(cls.router_binary):
-            cls.router_binary = shutil.which("lemond") or cls.router_binary
+        cls.router_binary = get_default_lemond_binary()
+        if not cls.router_binary or not os.path.exists(cls.router_binary):
+            candidates = ["LemonadeServer", "lemond"] if IS_WINDOWS else ["lemond"]
+            for c in candidates:
+                which_path = shutil.which(c)
+                if which_path:
+                    cls.router_binary = which_path
+                    break
         print(f"[SETUP] Using router binary: {cls.router_binary}")
 
         # Read required FLM version from backend_versions.json

--- a/test/test_gpu_hang_retry.py
+++ b/test/test_gpu_hang_retry.py
@@ -17,14 +17,21 @@ import subprocess
 import requests
 import unittest
 import concurrent.futures
+import contextlib
 
 # Add test/ to path
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+
 from utils.server_base import (
     get_cli_binary,
     parse_args,
     pull_model_with_retry,
     run_server_tests,
+)
+from utils.server_fixture import (
+    allocate_free_port,
+    lemond_server,
+    wait_for_http_health,
 )
 from utils.test_models import (
     ENDPOINT_TEST_MODEL,
@@ -34,14 +41,7 @@ from utils.test_models import (
 
 args = parse_args()
 
-
-def find_free_port():
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    try:
-        s.bind(("127.0.0.1", 0))
-        return s.getsockname()[1]
-    finally:
-        s.close()
+find_free_port = allocate_free_port
 
 
 MOCK_BIN_DIR = os.path.join(
@@ -212,28 +212,15 @@ class TestGpuHangRecovery(unittest.TestCase):
         self.session = requests.Session()
         self.session.trust_env = False
 
-        # Resolve build directory and lemond binary
-        name = "lemond.exe" if os.name == "nt" else "lemond"
-        cli_binary = get_cli_binary()
-        lemond_bin = None
-        if cli_binary:
-            if os.path.isabs(cli_binary):
-                build_dir = os.path.dirname(cli_binary)
-            else:
-                resolved_cli = shutil.which(cli_binary)
-                if resolved_cli:
-                    build_dir = os.path.dirname(resolved_cli)
-                else:
-                    build_dir = os.path.dirname(os.path.abspath(cli_binary))
-            candidate = os.path.join(build_dir, name)
-            if os.path.exists(candidate):
-                lemond_bin = candidate
-
+        lemond_bin = get_default_lemond_binary()
         if not lemond_bin or not os.path.exists(lemond_bin):
-            lemond_bin = shutil.which(name) or get_default_lemond_binary()
-            build_dir = (
-                os.path.dirname(os.path.abspath(lemond_bin)) if lemond_bin else "."
-            )
+            candidates = ["LemonadeServer", "lemond"] if os.name == "nt" else ["lemond"]
+            for c in candidates:
+                which_path = shutil.which(c)
+                if which_path:
+                    lemond_bin = which_path
+                    break
+        build_dir = os.path.dirname(os.path.abspath(lemond_bin)) if lemond_bin else "."
 
         cache_dir = os.path.join(build_dir, "test_cache")
         os.makedirs(cache_dir, exist_ok=True)
@@ -279,74 +266,34 @@ class TestGpuHangRecovery(unittest.TestCase):
         env["NO_PROXY"] = "127.0.0.1,localhost"
         env["no_proxy"] = "127.0.0.1,localhost"
 
+        self.exit_stack = contextlib.ExitStack()
         self.log_file_path = os.path.join(cache_dir, f"lemond_{self.port}.log")
-        self.log_file = open(self.log_file_path, "w")
-
-        print(f"Starting lemond on port {self.port}...")
-        self.lemond_proc = subprocess.Popen(
-            [
-                lemond_bin,
-                cache_dir,
-                "--port",
-                str(self.port),
-                "--host",
-                "127.0.0.1",
-                "--no-broadcast",
-            ],
-            env=env,
-            stdout=self.log_file,
-            stderr=subprocess.STDOUT,
-            text=True,
+        self.log_file = self.exit_stack.enter_context(
+            open(self.log_file_path, "w", encoding="utf-8")
         )
 
-        # Wait for lemond to be healthy (up to 60s for slow CI runners)
-        healthy = False
-        for _ in range(120):
-            try:
-                resp = self.session.get(f"{self.base_url}/api/v1/health", timeout=1)
-                if resp.status_code == 200:
-                    healthy = True
-                    break
-            except requests.RequestException:
-                pass
-            time.sleep(0.5)
-
-        if not healthy:
-            self.lemond_proc.terminate()
-            try:
-                self.lemond_proc.wait(timeout=2)
-            except subprocess.TimeoutExpired:
-                self.lemond_proc.kill()
-            if getattr(self, "log_file", None):
-                try:
-                    self.log_file.flush()
-                    self.log_file.close()
-                    self.log_file = None
-                except Exception:
-                    pass
-            with open(self.log_file_path, "r") as f:
-                print("Lemond output:", f.read())
-            self.fail("lemond failed to start / respond to health check")
+        print(f"Starting lemond on port {self.port}...")
+        self.lemond_proc = self.exit_stack.enter_context(
+            lemond_server(
+                port=self.port,
+                cache_dir=cache_dir,
+                args=["--host", "127.0.0.1", "--no-broadcast"],
+                env=env,
+                binary_path=lemond_bin,
+                wait_health=True,
+                health_timeout=60.0,
+                stdout=self.log_file,
+                stderr=subprocess.STDOUT,
+            )
+        )
 
         # These tests time /load tightly to observe the reload, so the model has
         # to be in this server's cache before that clock starts.
         pull_model_with_retry(ENDPOINT_TEST_MODEL, port=self.port)
 
     def tearDown(self):
-        # Terminate lemond
-        if getattr(self, "lemond_proc", None):
-            self.lemond_proc.terminate()
-            try:
-                self.lemond_proc.wait(timeout=5)
-            except subprocess.TimeoutExpired:
-                self.lemond_proc.kill()
-                self.lemond_proc.wait()
-
-        if getattr(self, "log_file", None):
-            try:
-                self.log_file.close()
-            except Exception:
-                pass
+        if hasattr(self, "exit_stack"):
+            self.exit_stack.close()
 
         # Restore config.json backup
         if hasattr(self, "config_path"):

--- a/test/test_llamacpp_system_backend.py
+++ b/test/test_llamacpp_system_backend.py
@@ -22,6 +22,8 @@ import time
 import stat
 import unittest
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
 import requests
 from utils.server_base import (
     _auth_headers,
@@ -35,6 +37,7 @@ from utils.test_models import (
     ENDPOINT_TEST_MODEL,
     TIMEOUT_DEFAULT,
     TIMEOUT_MODEL_OPERATION,
+    get_default_lemond_binary,
 )
 
 args = parse_args()  # Initialize global _config
@@ -191,54 +194,36 @@ def _wait_for_server_stop(port=PORT, timeout=30):
 
 def _get_lemond_binary():
     """Find the lemond binary in the same directory as the lemonade CLI."""
-    cli_binary = get_cli_binary()
-    if cli_binary:
-        build_dir = os.path.dirname(cli_binary)
-        name = "lemond.exe" if os.name == "nt" else "lemond"
-        candidate = os.path.join(build_dir, name)
-        if os.path.exists(candidate):
-            return candidate
-    return shutil.which("lemond") or "lemond"
+    bin_path = get_default_lemond_binary()
+    if bin_path and os.path.exists(bin_path):
+        return bin_path
+    candidates = ["LemonadeServer", "lemond"] if os.name == "nt" else ["lemond"]
+    for c in candidates:
+        which_path = shutil.which(c)
+        if which_path:
+            return which_path
+    return "lemond"
 
 
-def _pick_free_port():
-    """Return an unused TCP port assigned by the OS on the IPv4 loopback.
-
-    This suite owns one lemond instance. An OS-assigned port avoids colliding
-    with another test/server while retaining retry-on-startup-failure behavior.
-    """
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    try:
-        s.bind(("127.0.0.1", 0))
-        return s.getsockname()[1]
-    finally:
-        s.close()
+import contextlib
+from utils.server_fixture import (
+    allocate_free_port,
+    lemond_server,
+    make_clean_env,
+    wait_for_http_health,
+)
 
 
 def _stop_server():
-    """Stop the currently-running server via /internal/shutdown."""
-    try:
-        requests.post(
-            f"http://localhost:{PORT}/internal/shutdown",
-            headers=_auth_headers(),
-            timeout=5,
-        )
-        _wait_for_server_stop(PORT)
-    except Exception as e:
-        print(f"Warning: Failed to stop server: {e}")
+    """Stop the currently-running server via exit stack."""
+    stack = getattr(LlamaCppSystemBackendTests, "_server_exit_stack", None)
+    if stack:
+        stack.close()
+        LlamaCppSystemBackendTests._server_exit_stack = None
 
 
 def _server_healthy(port=PORT):
-    """True if lemond answers a health check on the port."""
-    try:
-        response = requests.get(
-            f"http://localhost:{port}/api/v1/health",
-            headers=_auth_headers(),
-            timeout=2,
-        )
-        return response.status_code == 200
-    except Exception:
-        return False
+    return wait_for_http_health(port, headers=_auth_headers(), timeout=2)
 
 
 def _start_server(wrapped_server=None, backend=None, config_updates=None):
@@ -247,60 +232,32 @@ def _start_server(wrapped_server=None, backend=None, config_updates=None):
 
     lemond_binary = _get_lemond_binary()
     cache_dir = LlamaCppSystemBackendTests.cache_dir
+    port = allocate_free_port()
+    PORT = port
 
-    # Redirect output to a log file rather than a PIPE: lemond runs with
-    # debug logging here, and an undrained PIPE can fill its buffer and block
-    # the process before it opens the port. The log is printed on failure.
-    log_path = os.path.join(tempfile.gettempdir(), "lemond_test.log")
-    last_log = ""
+    env = make_clean_env(cache_dir)
+    env["PATH"] = os.environ.get("PATH", "")
+    env["MOCK_LLAMA_REQUEST_PATH"] = os.environ.get("MOCK_LLAMA_REQUEST_PATH", "")
+    env["MOCK_LLAMA_CONTROL_PATH"] = os.environ.get("MOCK_LLAMA_CONTROL_PATH", "")
 
-    proc = None
-    started = False
-    max_attempts = 5
-    for _attempt in range(1, max_attempts + 1):
-        port = _pick_free_port()
-        PORT = port
-        cmd = [lemond_binary, cache_dir, "--port", str(port)]
-
-        with open(log_path, "w", encoding="utf-8") as log_file:
-            proc = subprocess.Popen(
-                cmd,
-                stdout=log_file,
-                stderr=subprocess.STDOUT,
-                env=os.environ.copy(),
+    stack = contextlib.ExitStack()
+    try:
+        stack.enter_context(
+            lemond_server(
+                port=port,
+                cache_dir=cache_dir,
+                env=env,
+                binary_path=lemond_binary,
+                wait_health=True,
+                health_headers=_auth_headers(),
+                health_timeout=30.0,
             )
+        )
+    except Exception:
+        stack.close()
+        raise
 
-        # Wait for this instance to become healthy, bailing early if it exits
-        # so we can retry on a fresh port.
-        deadline = time.time() + 30
-        while time.time() < deadline:
-            if proc.poll() is not None:
-                break  # lemond exited early -> retry on a new port
-            if _server_healthy(port):
-                started = True
-                break
-            time.sleep(1)
-
-        if started:
-            break
-
-        # This attempt failed: clean up before retrying on a new port.
-        try:
-            if proc.poll() is None:
-                proc.kill()
-                proc.wait(timeout=10)
-        except Exception:
-            pass
-        try:
-            with open(log_path, "r", encoding="utf-8", errors="replace") as f:
-                last_log = f.read()
-        except OSError:
-            last_log = ""
-
-    if not started:
-        print("=== lemond startup log (last attempt) ===")
-        print(last_log)
-        raise RuntimeError(f"lemond failed to start after {max_attempts} attempts")
+    LlamaCppSystemBackendTests._server_exit_stack = stack
 
     try:
         runtime_config = {}

--- a/test/test_multi_checkpoint_completeness.py
+++ b/test/test_multi_checkpoint_completeness.py
@@ -2,12 +2,14 @@ import json
 import os
 import shutil
 import subprocess
+import sys
 import tempfile
-import time
 import unittest
-import requests
 
-from utils.test_models import get_default_lemond_binary, get_default_cli_binary
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from utils.server_fixture import allocate_free_port, lemond_server, make_clean_env
+from utils.test_models import get_default_cli_binary
 
 
 class TestMultiCheckpointCompleteness(unittest.TestCase):
@@ -21,56 +23,11 @@ class TestMultiCheckpointCompleteness(unittest.TestCase):
 
     def setUp(self):
         self.tmp_dir = tempfile.mkdtemp()
-        self.lemond_bin = get_default_lemond_binary()
         self.cli_bin = get_default_cli_binary()
-        self.port = 13306
-        self.server_proc = None
-        self.server_stdout = ""
-        self.server_stderr = ""
+        self.port = allocate_free_port()
 
     def tearDown(self):
-        self.stop_server()
-        shutil.rmtree(self.tmp_dir)
-
-    def start_server(self, capture_output=False):
-        self.stop_server()
-        env = os.environ.copy()
-        # Ensure it doesn't use the real HF cache
-        env["HF_HUB_CACHE"] = os.path.join(self.tmp_dir, "hf")
-        os.makedirs(env["HF_HUB_CACHE"], exist_ok=True)
-
-        stdout = subprocess.PIPE if capture_output else subprocess.DEVNULL
-        stderr = subprocess.PIPE if capture_output else subprocess.DEVNULL
-
-        self.server_proc = subprocess.Popen(
-            [self.lemond_bin, self.tmp_dir, "--port", str(self.port)],
-            stdout=stdout,
-            stderr=stderr,
-            text=True,
-            env=env,
-        )
-        for i in range(30):
-            try:
-                requests.get(f"http://localhost:{self.port}/api/v1/models", timeout=1)
-                break
-            except:
-                time.sleep(1)
-        else:
-            self.fail("Server timed out")
-
-    def stop_server(self):
-        if self.server_proc:
-            self.server_proc.terminate()
-            try:
-                stdout, stderr = self.server_proc.communicate(timeout=5)
-                self.server_stdout = stdout if stdout else ""
-                self.server_stderr = stderr if stderr else ""
-            except:
-                self.server_proc.kill()
-                stdout, stderr = self.server_proc.communicate()
-                self.server_stdout = stdout if stdout else ""
-                self.server_stderr = stderr if stderr else ""
-            self.server_proc = None
+        shutil.rmtree(self.tmp_dir, ignore_errors=True)
 
     def test_incomplete_component_reaches_cli_and_collection_pull(self):
         comp_id = "comp-multi"
@@ -87,35 +44,63 @@ class TestMultiCheckpointCompleteness(unittest.TestCase):
             coll_id: {"components": [comp_id], "recipe": "collection.omni"},
         }
 
-        with open(os.path.join(self.tmp_dir, "user_models.json"), "w") as f:
+        env = make_clean_env(self.tmp_dir)
+        os.makedirs(env["LEMONADE_CONFIG_DIR"], exist_ok=True)
+        with open(
+            os.path.join(env["LEMONADE_CONFIG_DIR"], "user_models.json"), "w"
+        ) as f:
             json.dump(user_models, f)
 
         with open(path1, "wb") as f:
             f.write(b"GGUF")
 
-        self.start_server(capture_output=True)
+        log_path = os.path.join(self.tmp_dir, "lemond.log")
+        with open(log_path, "w", encoding="utf-8") as log_file:
+            with lemond_server(
+                port=self.port,
+                cache_dir=self.tmp_dir,
+                env=env,
+                wait_health=True,
+                stdout=log_file,
+                stderr=subprocess.STDOUT,
+            ):
+                list_result = subprocess.run(
+                    [
+                        self.cli_bin,
+                        "--host",
+                        "127.0.0.1",
+                        "--port",
+                        str(self.port),
+                        "list",
+                    ],
+                    capture_output=True,
+                    text=True,
+                    env=env,
+                )
+                self.assertEqual(list_result.returncode, 0, list_result.stderr)
+                component_rows = [
+                    line for line in list_result.stdout.splitlines() if comp_id in line
+                ]
+                self.assertTrue(component_rows, list_result.stdout)
+                self.assertIn("No", component_rows[0])
 
-        list_result = subprocess.run(
-            [self.cli_bin, "--port", str(self.port), "list"],
-            capture_output=True,
-            text=True,
-        )
-        self.assertEqual(list_result.returncode, 0, list_result.stderr)
-        component_rows = [
-            line for line in list_result.stdout.splitlines() if comp_id in line
-        ]
-        self.assertTrue(component_rows, list_result.stdout)
-        self.assertIn("No", component_rows[0])
+                subprocess.run(
+                    [
+                        self.cli_bin,
+                        "--host",
+                        "127.0.0.1",
+                        "--port",
+                        str(self.port),
+                        "pull",
+                        coll_id,
+                    ],
+                    capture_output=True,
+                    text=True,
+                    env=env,
+                )
 
-        subprocess.run(
-            [self.cli_bin, "--port", str(self.port), "pull", coll_id],
-            capture_output=True,
-            text=True,
-        )
-
-        self.stop_server()
-
-        log_output = self.server_stdout + self.server_stderr
+        with open(log_path, "r", encoding="utf-8", errors="replace") as f:
+            log_output = f.read()
         self.assertIn(f"Downloading component: {comp_id}", log_output)
 
 

--- a/test/test_server_fixture.py
+++ b/test/test_server_fixture.py
@@ -1,0 +1,166 @@
+import json
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+# Ensure test/ directory is in sys.path when run directly or via unittest
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+try:
+    from utils.server_fixture import (
+        allocate_free_port,
+        lemond_server,
+        make_clean_env,
+        wait_for_http_health,
+    )
+    from utils.test_models import get_default_lemond_binary
+except ImportError:
+    from test.utils.server_fixture import (
+        allocate_free_port,
+        lemond_server,
+        make_clean_env,
+        wait_for_http_health,
+    )
+    from test.utils.test_models import get_default_lemond_binary
+
+
+class ServerFixtureTests(unittest.TestCase):
+    def _require_lemond_binary(self):
+        bin_path = get_default_lemond_binary()
+        if not bin_path or not os.path.exists(bin_path):
+            if not shutil.which("lemond"):
+                raise unittest.SkipTest("lemond binary not found")
+
+    def test_allocate_free_port(self):
+        port = allocate_free_port()
+        self.assertIsInstance(port, int)
+        self.assertGreater(port, 0)
+
+    @patch.dict(
+        os.environ,
+        {
+            "LEMONADE_API_KEY": "secret_test_key",
+            "LEMONADE_ADMIN_API_KEY": "admin_test_key",
+            "LEMONADE_ALLOWED_ORIGINS": "http://example.com",
+        },
+        clear=False,
+    )
+    def test_make_clean_env(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            env = make_clean_env(tmpdir)
+            self.assertIn("LEMONADE_CACHE_DIR", env)
+            self.assertTrue(env["LEMONADE_CACHE_DIR"].startswith(tmpdir))
+            self.assertIn("LEMONADE_CONFIG_DIR", env)
+            self.assertTrue(env["LEMONADE_CONFIG_DIR"].startswith(tmpdir))
+            self.assertIn("LEMONADE_MODELS_DIR", env)
+            self.assertTrue(env["LEMONADE_MODELS_DIR"].startswith(tmpdir))
+            self.assertIn("HF_HUB_CACHE", env)
+            self.assertTrue(env["HF_HUB_CACHE"].startswith(tmpdir))
+
+            self.assertNotIn("LEMONADE_API_KEY", env)
+            self.assertNotIn("LEMONADE_ADMIN_API_KEY", env)
+            self.assertNotIn("LEMONADE_ALLOWED_ORIGINS", env)
+
+    def test_lemond_server_starts_and_stops(self):
+        self._require_lemond_binary()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            env = make_clean_env(tmpdir)
+            port = allocate_free_port()
+
+            with lemond_server(port=port, env=env, cache_dir=tmpdir) as proc:
+                self.assertIsNone(proc.poll())
+                self.assertTrue(wait_for_http_health(port))
+
+            # Context manager exit should have terminated the process
+            self.assertIsNotNone(proc.poll())
+
+    def test_lemond_server_wait_health(self):
+        self._require_lemond_binary()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            env = make_clean_env(tmpdir)
+            port = allocate_free_port()
+
+            with lemond_server(
+                port=port, env=env, cache_dir=tmpdir, wait_health=True
+            ) as proc:
+                self.assertIsNone(proc.poll())
+                self.assertTrue(wait_for_http_health(port))
+
+            self.assertIsNotNone(proc.poll())
+
+    def test_lemond_server_wait_health_early_exit_diagnostic(self):
+        self._require_lemond_binary()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            env = make_clean_env(tmpdir)
+            port = allocate_free_port()
+
+            with self.assertRaises(RuntimeError) as ctx:
+                with lemond_server(
+                    port=port,
+                    env=env,
+                    cache_dir=tmpdir,
+                    args=["--completely-invalid-flag-xyz"],
+                    wait_health=True,
+                    health_timeout=2.0,
+                ):
+                    pass
+            self.assertIn("process exited early with code", str(ctx.exception))
+
+    def test_lemond_server_inherits_cache_and_config_from_env(self):
+        self._require_lemond_binary()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            env = make_clean_env(tmpdir)
+            port = allocate_free_port()
+
+            with lemond_server(port=port, env=env, wait_health=True) as proc:
+                self.assertIsNone(proc.poll())
+                self.assertTrue(wait_for_http_health(port))
+
+            self.assertIsNotNone(proc.poll())
+
+    def test_lemond_server_config_dir_requires_cache_dir(self):
+        with self.assertRaises(ValueError):
+            with lemond_server(config_dir="/tmp/some_config"):
+                pass
+
+    def test_lemond_server_explicit_binary_path_missing_raises(self):
+        with self.assertRaises(RuntimeError) as ctx:
+            with lemond_server(binary_path="/nonexistent/lemond_bin_12345"):
+                pass
+        self.assertIn("explicit binary_path", str(ctx.exception))
+
+    def test_lemond_server_seeds_config(self):
+        self._require_lemond_binary()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            env = make_clean_env(tmpdir)
+            port = allocate_free_port()
+
+            with lemond_server(
+                port=port,
+                env=env,
+                config={"download_rate_limit": "25M"},
+                wait_health=True,
+            ) as proc:
+                self.assertIsNone(proc.poll())
+                config_file = os.path.join(env["LEMONADE_CONFIG_DIR"], "config.json")
+                self.assertTrue(os.path.exists(config_file))
+                with open(config_file, "r", encoding="utf-8") as f:
+                    data = json.load(f)
+                self.assertEqual(data.get("config_version"), 2)
+                self.assertEqual(data.get("download_rate_limit"), "25M")
+
+            self.assertIsNotNone(proc.poll())
+
+    def test_lemond_server_config_without_target_dir_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            with lemond_server(config={"download_rate_limit": "10M"}):
+                pass
+        self.assertIn("config requires cache_dir", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/utils/__init__.py
+++ b/test/utils/__init__.py
@@ -1,1 +1,14 @@
 # Utils package for lemonade server tests
+from .server_fixture import (
+    allocate_free_port,
+    lemond_server,
+    make_clean_env,
+    wait_for_http_health,
+)
+
+__all__ = [
+    "allocate_free_port",
+    "lemond_server",
+    "make_clean_env",
+    "wait_for_http_health",
+]

--- a/test/utils/server_fixture.py
+++ b/test/utils/server_fixture.py
@@ -1,0 +1,251 @@
+import contextlib
+import json
+import os
+import shutil
+import socket
+import subprocess
+import time
+import unittest
+import urllib.error
+import urllib.request
+from typing import Iterator
+
+try:
+    import httpx
+except ImportError:
+    httpx = None
+
+try:
+    import requests
+except ImportError:
+    requests = None
+
+from .test_models import get_default_lemond_binary
+
+
+def allocate_free_port() -> int:
+    """Finds and returns a free ephemeral port on IPv4 loopback.
+
+    Note: Has an inherent bind-close-rebind TOCTOU window acceptable for isolated tests.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def make_clean_env(tmpdir: str) -> dict[str, str]:
+    """Create a minimal, isolated environment dict backed by a temporary directory.
+
+    Isolates Lemonade caches/models and Hugging Face home directories to prevent
+    host environment leakage.
+    """
+    env = os.environ.copy()
+    for key in (
+        "LEMONADE_API_KEY",
+        "LEMONADE_ADMIN_API_KEY",
+        "LEMONADE_ALLOWED_ORIGINS",
+    ):
+        env.pop(key, None)
+    for k in list(env.keys()):
+        if k.startswith("LEMONADE_") and k.endswith("_API_KEY"):
+            env.pop(k, None)
+
+    env["LEMONADE_CACHE_DIR"] = os.path.join(tmpdir, "cache")
+    env["LEMONADE_CONFIG_DIR"] = os.path.join(tmpdir, "config")
+    env["LEMONADE_MODELS_DIR"] = os.path.join(tmpdir, "models")
+    env["HF_HOME"] = os.path.join(tmpdir, "hf_home")
+    env["HF_HUB_CACHE"] = os.path.join(tmpdir, "hf_cache")
+    return env
+
+
+def wait_for_http_health(
+    port: int,
+    timeout: float = 10.0,
+    headers: dict[str, str] | None = None,
+    proc: subprocess.Popen | None = None,
+    host: str = "127.0.0.1",
+) -> bool:
+    """Poll the /api/v1/health endpoint until HTTP 200 is returned or timeout expires.
+
+    Returns True if healthy within timeout, False otherwise.
+    If `proc` is provided, short-circuits immediately if the process terminates early.
+    """
+    url = f"http://{host}:{port}/api/v1/health"
+    deadline = time.monotonic() + timeout
+
+    with contextlib.ExitStack() as stack:
+        if httpx is not None:
+            client = stack.enter_context(
+                httpx.Client(
+                    headers=headers,
+                    timeout=1.0,
+                    limits=httpx.Limits(max_keepalive_connections=0),
+                )
+            )
+
+            def _probe():
+                return client.get(url).status_code == 200
+
+            err_types = (httpx.TransportError, httpx.TimeoutException)
+        elif requests is not None:
+            session = stack.enter_context(requests.Session())
+            if headers:
+                session.headers.update(headers)
+
+            def _probe():
+                return session.get(url, timeout=1.0).status_code == 200
+
+            err_types = (
+                requests.exceptions.RequestException,
+                requests.exceptions.Timeout,
+            )
+        else:
+
+            def _probe():
+                req = urllib.request.Request(url, headers=headers or {})
+                with urllib.request.urlopen(req, timeout=1.0) as resp:
+                    return resp.getcode() == 200
+
+            err_types = (urllib.error.URLError, TimeoutError, OSError)
+
+        while time.monotonic() < deadline:
+            if proc is not None and proc.poll() is not None:
+                return False
+            try:
+                if _probe():
+                    return True
+            except err_types:
+                pass
+            time.sleep(0.05)
+
+    return False
+
+
+def _terminate_proc(p: subprocess.Popen, timeout: float = 10.0):
+    if p.poll() is None:
+        p.terminate()
+        try:
+            p.wait(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            p.kill()
+            p.wait(timeout=timeout)
+    for pipe in (p.stdout, p.stderr, p.stdin):
+        if pipe is not None and not getattr(pipe, "closed", True):
+            try:
+                pipe.close()
+            except Exception:
+                pass
+
+
+@contextlib.contextmanager
+def lemond_server(
+    port: int | None = None,
+    cache_dir: str | None = None,
+    config_dir: str | None = None,
+    config: dict | None = None,
+    args: list[str] | None = None,
+    env: dict[str, str] | None = None,
+    timeout: float = 10.0,
+    stdout=subprocess.DEVNULL,
+    stderr=subprocess.DEVNULL,
+    text: bool = True,
+    binary_path: str | None = None,
+    wait_health: bool = False,
+    health_timeout: float = 10.0,
+    health_headers: dict[str, str] | None = None,
+    skip_if_unavailable: bool = False,
+) -> Iterator[subprocess.Popen]:
+    """Context manager for running a hermetic lemond subprocess.
+
+    Ensures deterministic process teardown upon exit (SIGTERM -> SIGKILL on POSIX,
+    TerminateProcess on Windows).
+    """
+    effective_cache_dir = cache_dir
+    if effective_cache_dir is None and env is not None:
+        effective_cache_dir = env.get("LEMONADE_CACHE_DIR")
+
+    effective_config_dir = config_dir
+    if effective_config_dir is None and env is not None:
+        effective_config_dir = env.get("LEMONADE_CONFIG_DIR")
+
+    if (config_dir is not None or effective_config_dir is not None) and (
+        cache_dir is None and effective_cache_dir is None
+    ):
+        raise ValueError("config_dir requires cache_dir to be specified as well")
+
+    if config is not None:
+        target_dir = effective_config_dir or effective_cache_dir
+        if target_dir is None:
+            raise ValueError(
+                "config requires cache_dir, config_dir, or environment variables to be set"
+            )
+        os.makedirs(target_dir, exist_ok=True)
+        payload = (
+            {"config_version": 2, **config}
+            if "config_version" not in config
+            else dict(config)
+        )
+        with open(os.path.join(target_dir, "config.json"), "w", encoding="utf-8") as f:
+            json.dump(payload, f)
+
+    if binary_path is not None:
+        if not os.path.exists(binary_path):
+            if skip_if_unavailable:
+                raise unittest.SkipTest(
+                    f"lemond binary not found at explicit binary_path: {binary_path}"
+                )
+            raise RuntimeError(
+                f"lemond binary not found at explicit binary_path: {binary_path}"
+            )
+        lemond_bin = binary_path
+    else:
+        lemond_bin = get_default_lemond_binary()
+        if not lemond_bin or not os.path.exists(lemond_bin):
+            lemond_bin = shutil.which("lemond")
+            if not lemond_bin:
+                if skip_if_unavailable:
+                    raise unittest.SkipTest(
+                        f"lemond binary not found in build dir ({get_default_lemond_binary()}) or PATH"
+                    )
+                raise RuntimeError(
+                    f"lemond binary not found in build dir ({get_default_lemond_binary()}) or PATH"
+                )
+
+    server_port = port if port is not None else allocate_free_port()
+    cmd = [lemond_bin]
+    if effective_cache_dir is not None:
+        cmd.append(effective_cache_dir)
+    if effective_config_dir is not None:
+        cmd.append(effective_config_dir)
+    cmd.extend(["--port", str(server_port)])
+    if args:
+        cmd.extend(args)
+
+    proc = subprocess.Popen(
+        cmd,
+        stdout=stdout,
+        stderr=stderr,
+        env=env,
+        text=text,
+    )
+    setattr(proc, "port", server_port)
+    try:
+        if wait_health:
+            if not wait_for_http_health(
+                server_port,
+                timeout=health_timeout,
+                headers=health_headers,
+                proc=proc,
+            ):
+                exited = proc.poll()
+                detail = (
+                    f"process exited early with code {exited}"
+                    if exited is not None
+                    else f"process still running but no 200 within {health_timeout}s"
+                )
+                raise RuntimeError(
+                    f"lemond server failed to become healthy on port {server_port} ({detail})"
+                )
+        yield proc
+    finally:
+        _terminate_proc(proc, timeout=timeout)

--- a/test/utils/test_models.py
+++ b/test/utils/test_models.py
@@ -8,6 +8,7 @@ based on the current wrapped server and backend.
 
 import os
 import platform
+import shutil
 
 
 def _workspace_root():
@@ -19,16 +20,57 @@ def _workspace_root():
 
 
 def _default_build_binary(name):
-    """Return the default path for a build binary, handling multi-config generators."""
+    """Return the default path for a build binary, handling multi-config generators and installs."""
+    bin_name = f"{name}.exe" if platform.system() == "Windows" else name
+
+    # Check explicit environment variable overrides
+    if name == "lemond":
+        env_daemon = os.environ.get("LEMONADE_DAEMON_BINARY") or os.environ.get(
+            "LEMONADE_BINARY"
+        )
+        if env_daemon and os.path.exists(env_daemon):
+            return env_daemon
+    elif name == "lemonade":
+        env_cli = os.environ.get("CLI_BINARY")
+        if env_cli and os.path.exists(env_cli):
+            return env_cli
+
+    # Check sibling directory of CLI_BINARY if available (e.g. MSI/package install dir)
+    cli_bin = os.environ.get("CLI_BINARY")
+    if cli_bin:
+        sibling = os.path.join(os.path.dirname(cli_bin), bin_name)
+        if os.path.exists(sibling):
+            return sibling
+
+    # Check LEMONADE_INSTALL_PATH/bin if set
+    install_path = os.environ.get("LEMONADE_INSTALL_PATH")
+    if install_path:
+        installed_bin = os.path.join(install_path, "bin", bin_name)
+        if os.path.exists(installed_bin):
+            return installed_bin
+
     root = _workspace_root()
     if platform.system() == "Windows":
-        release_path = os.path.join(root, "build", "Release", f"{name}.exe")
-        debug_path = os.path.join(root, "build", "Debug", f"{name}.exe")
-        if os.path.exists(release_path):
-            return release_path
-        return debug_path
+        for sub in ("Release", "Debug", ""):
+            build_path = (
+                os.path.join(root, "build", sub, bin_name)
+                if sub
+                else os.path.join(root, "build", bin_name)
+            )
+            if os.path.exists(build_path):
+                return build_path
+        which_path = shutil.which(bin_name)
+        if which_path:
+            return which_path
+        return os.path.join(root, "build", "Release", bin_name)
     else:
-        return os.path.join(root, "build", name)
+        build_path = os.path.join(root, "build", bin_name)
+        if os.path.exists(build_path):
+            return build_path
+        which_path = shutil.which(name)
+        if which_path:
+            return which_path
+        return build_path
 
 
 def get_default_cli_binary():


### PR DESCRIPTION
## Summary

Implement a shared, hermetic `lemond_server` test fixture and utilities in `test/utils/server_fixture.py` (`allocate_free_port`, `make_clean_env`, `wait_for_http_health`, `lemond_server`) and comprehensive unit test coverage in `test/test_server_fixture.py`. Systematically deduplicate server lifecycle management, ephemeral port allocation, config seeding, and health check polling loops across Python test suites (`server_endpoints`, `server_websocket_auth`, `server_websocket_telemetry`, `server_telemetry`, `test_gpu_hang_retry`, `test_llamacpp_system_backend`, `test_multi_checkpoint_completeness`, `server_jobs`, `server_cli2`, and `server_log_rotation`).

**Key Highlights**:
* **Deterministic Process Lifecycle**: RAII context manager with graceful SIGTERM -> wait -> SIGKILL teardown and short-circuit early exit diagnostics.
* **First-Class Config Seeding**: Direct `config: dict | None = None` support on `lemond_server()` to seed `config.json` automatically without manual filesystem boilerplate.
* **Packaging & Runner Compatibility**: Added `skip_if_unavailable: bool = False` so tests requiring isolated `lemond` daemons skip cleanly in package verification environments (e.g. Windows MSI test runners where only `LemonadeServer.exe` is installed).
* **Isolated Environment Scrubbing**: `make_clean_env()` strips ambient API keys and isolates Hugging Face and server cache directories to prevent host environment bleed.

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_
- Ran fixture unit tests: `python -m unittest test/test_server_fixture.py` (10/10 passed in 24.2s)
- Ran refactored test suites:
  - `python -m unittest test/test_gpu_hang_retry.py` (3/3 passed in 36.1s)
  - `python -m unittest test/server_websocket_auth.py` (14/14 passed in 16.0s)
  - `python -m unittest test/server_websocket_telemetry.py` (12/12 passed in 48.1s)
  - `python -m unittest test/server_log_rotation.py` (6/6 passed in 30.2s)
  - `python -m unittest test/test_multi_checkpoint_completeness.py` (1/1 passed in 6.0s)
  - `python test/test_llamacpp_system_backend.py` (4/4 passed in 20.0s)
- Ran full C++ CI unit tests: `ctest --test-dir build -L cpp-ci` (68/68 passed)
- Verified Python formatting with Black: `black --check test/` (53/53 files clean)

## Documentation

- [ ] Documentation is not affected by this change.
- [x] Documentation is affected and has been updated.
- [ ] Documentation is affected but will be handled in a separate PR or issue.

## Breaking Changes

- [ ] This PR introduces breaking changes.
- [x] This PR does not introduce breaking changes.

## AI-assisted contribution

- [x] I used AI tools for this PR.
- [ ] I did not use AI tools for this PR.

If AI tools were used:

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.