### PR TITLE
fix(gui3): remove idle app-controls background

### DIFF
--- a/src/app/src/styles/critical.generated.css
+++ b/src/app/src/styles/critical.generated.css
@@ -648,11 +648,17 @@
   border-radius: var(--radius-pill);
   background: var(--surface-1);
   color: var(--text-secondary);
+}.titlebar--desktop .titlebar__utilities-toggle {
+  background: transparent;
 }.titlebar__utilities-toggle:hover,
 .titlebar__utilities-toggle[aria-expanded="true"] {
   border-color: var(--border-strong);
   background: var(--surface-2);
   color: var(--text-primary);
+}.titlebar--desktop .titlebar__utilities-toggle,
+.titlebar--desktop .titlebar__utilities-toggle:hover,
+.titlebar--desktop .titlebar__utilities-toggle[aria-expanded="true"] {
+  border-color: transparent;
 }.titlebar__utility-label { display: none; }.titlebar__utility-status,
 .titlebar__utility-value { display: none; }.titlebar__theme-toggle {
   display: flex;

--- a/src/app/src/styles/styles.css
+++ b/src/app/src/styles/styles.css
@@ -465,6 +465,10 @@ input[type="checkbox"]:disabled {
   color: var(--text-secondary);
 }
 
+.titlebar--desktop .titlebar__utilities-toggle {
+  background: transparent;
+}
+
 .titlebar__utilities-toggle:hover,
 .titlebar__utilities-toggle[aria-expanded="true"] {
   border-color: var(--border-strong);


### PR DESCRIPTION
## Summary

Sorry for missing this detail in the earlier titlebar pass. This removes the persistent circular background from the desktop App controls button at rest while preserving its hover/open highlight, hit area, and behavior. The critical startup stylesheet is kept in sync so the old container does not flash during startup.

Fixes #3320

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_

- `npm.cmd run typecheck`
- `npm.cmd run test:ui-regressions` — UI regression contracts and backend-manager lifecycle checks passed.
- `npm.cmd run build:renderer:prod`
- Applied the same CSS change to the regular and AMD Dev Windows clients, rebuilt and reinstalled both, and verified that both installed native windows launched and remained responsive.

## Screenshots

**Before — base `96a8bd5c`**

The idle App controls button has the persistent circular background.

<img width="900" height="90" alt="Before: idle App controls button with circular background" src="https://github.com/user-attachments/assets/e8895109-6a6e-4f84-b6c4-851a315452fd" />

**After — `3e49eb35`**

The idle background is transparent while the icon, position, and hit area remain unchanged.

<img width="900" height="90" alt="After: idle App controls button with transparent background" src="https://github.com/user-attachments/assets/b6ad0ea8-30c1-4af0-9386-b35385071b35" />

## Documentation

- [x] Documentation is not affected by this change.
- [ ] Documentation is affected and has been updated.
- [ ] Documentation is affected but will be handled in a separate PR or issue.

## Breaking Changes

- [ ] This PR introduces breaking changes.
- [x] This PR does not introduce breaking changes.

## AI-assisted contribution

Please select one:

- [x] I used AI tools for this PR.
- [ ] I did not use AI tools for this PR.

If AI tools were used:

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.
