### PR TITLE
test(gpu-hang): scale request timeouts to the model-operation budget

### DIFF
--- a/test/test_gpu_hang_retry.py
+++ b/test/test_gpu_hang_retry.py
@@ -20,7 +20,11 @@ import concurrent.futures
 
 # Add test/ to path
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
-from utils.test_models import ENDPOINT_TEST_MODEL, get_default_lemond_binary
+from utils.test_models import (
+    ENDPOINT_TEST_MODEL,
+    TIMEOUT_MODEL_OPERATION,
+    get_default_lemond_binary,
+)
 from utils.server_base import parse_args, get_cli_binary, run_server_tests
 
 args = parse_args()
@@ -379,7 +383,7 @@ class TestGpuHangRecovery(unittest.TestCase):
         load_resp = self.session.post(
             f"{self.base_url}/api/v1/load",
             json={"model_name": ENDPOINT_TEST_MODEL},
-            timeout=60,
+            timeout=TIMEOUT_MODEL_OPERATION,
         )
         self.assertEqual(load_resp.status_code, 200)
 
@@ -392,7 +396,9 @@ class TestGpuHangRecovery(unittest.TestCase):
         }
 
         resp = self.session.post(
-            f"{self.base_url}/api/v1/chat/completions", json=payload, timeout=60
+            f"{self.base_url}/api/v1/chat/completions",
+            json=payload,
+            timeout=TIMEOUT_MODEL_OPERATION,
         )
 
         # Verify request succeeded
@@ -425,7 +431,7 @@ class TestGpuHangRecovery(unittest.TestCase):
         load_resp = self.session.post(
             f"{self.base_url}/api/v1/load",
             json={"model_name": ENDPOINT_TEST_MODEL},
-            timeout=60,
+            timeout=TIMEOUT_MODEL_OPERATION,
         )
         self.assertEqual(load_resp.status_code, 200)
 
@@ -441,7 +447,7 @@ class TestGpuHangRecovery(unittest.TestCase):
             f"{self.base_url}/api/v1/chat/completions",
             json=payload,
             stream=True,
-            timeout=60,
+            timeout=TIMEOUT_MODEL_OPERATION,
         )
 
         # Consume the stream
@@ -485,7 +491,7 @@ class TestGpuHangRecovery(unittest.TestCase):
         load_resp = self.session.post(
             f"{self.base_url}/api/v1/load",
             json={"model_name": ENDPOINT_TEST_MODEL},
-            timeout=60,
+            timeout=TIMEOUT_MODEL_OPERATION,
         )
         self.assertEqual(load_resp.status_code, 200)
 
@@ -503,7 +509,9 @@ class TestGpuHangRecovery(unittest.TestCase):
                 s = requests.Session()
                 s.trust_env = False
                 return s.post(
-                    f"{self.base_url}/api/v1/chat/completions", json=payload, timeout=60
+                    f"{self.base_url}/api/v1/chat/completions",
+                    json=payload,
+                    timeout=TIMEOUT_MODEL_OPERATION,
                 )
             except Exception as e:
                 return e


### PR DESCRIPTION
## Summary

`test_gpu_hang_retry.py` exercises a path where lemond resets a hung backend, reloads the model, and replays the request, but it capped every request at a fixed 60 seconds. On a loaded runner the reload does not finish inside that budget, so the test raises `requests.exceptions.ReadTimeout` instead of seeing the recovery it is meant to verify. That failed the `Test streaming-errors` job in the merge queue on 2026-08-26.

The six request timeouts now use `TIMEOUT_MODEL_OPERATION`, which is **500 seconds** (`test/utils/test_models.py:138`). That is the shared constant `server_watchdog_lifecycle.py` and `server_base.py` already use for requests that can span a model load, so this raises the budget from 60s to 500s and stops hard-coding it in a third place.

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [ ] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_

No C++ changes, so nothing to build. Verified locally that the new import resolves to 500 and that `pre-commit run` passes including black.

The test itself needs a built `lemond` plus the mock backend harness, so the run is left to CI on this PR.

## Documentation

- [x] Documentation is not affected by this change.

## Breaking Changes

- [x] This PR does not introduce breaking changes.

## AI-assisted contribution

Please select one:

- [x] I used AI tools for this PR.

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.
