### PR TITLE
fix(gui): mtp draft companion

### DIFF
--- a/src/app/src/api.ts
+++ b/src/app/src/api.ts
@@ -443,6 +443,7 @@ function downloadPayloadCompleted(data: unknown): boolean {
 export interface PullVariant {
   name: string;
   primary_file: string;
+  draft_file?: string;
   files: string[];
   sharded: boolean;
   size_bytes: number;
@@ -458,6 +459,7 @@ export interface PullVariantsResult {
   suggested_name: string;
   suggested_labels: string[];
   mmproj_files: string[];
+  draft_files?: string[];
   variants: PullVariant[];
   capabilities?: string[];
   input_modalities?: string[];

--- a/src/app/src/components/ModelManager.tsx
+++ b/src/app/src/components/ModelManager.tsx
@@ -1876,12 +1876,27 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
 
     const labels = new Set(vdata?.suggested_labels || []);
     if (vdata?.mmproj_files?.length) labels.add('vision');
+
+    // New servers resolve a draft per selected main variant. Older servers only
+    // expose the legacy list, which is safe to auto-use when it has one entry.
+    const variantDraftFile = vdata?.variants.find(v => v.name === variantName)?.draft_file;
+    const legacyDraftFile = vdata?.draft_files?.length === 1 ? vdata.draft_files[0] : undefined;
+    const selectedDraftFile = variantDraftFile || legacyDraftFile;
+    if (selectedDraftFile) {
+      const draftName = selectedDraftFile.split(/[\\/]/).pop()?.toLowerCase() || '';
+      if (draftName.startsWith('mtp-')) labels.add('mtp');
+      if (draftName === 'dflash.gguf' || draftName.startsWith('dflash-')) labels.add('dflash');
+    }
+    const checkpoints = selectedDraftFile
+      ? { main: checkpoint, draft: `${modelId}:${selectedDraftFile}` }
+      : undefined;
     try {
       await api.pullModel(targetModelName, callbacks, {
         checkpoint,
         recipe,
         source: provider,
         mmproj: vdata?.mmproj_files?.[0],
+        checkpoints,
         labels: [...labels],
         vision: labels.has('vision'),
         embedding: labels.has('embeddings'),

--- a/src/app/tests/ui-regression-contracts.runtime.cjs
+++ b/src/app/tests/ui-regression-contracts.runtime.cjs
@@ -118,6 +118,14 @@ assert.match(sources.modelManager, /EXTRA_MODELS_DIR_SOURCE = 'extra_models_dir'
 assert.match(sources.modelManager, /isExtraModelsDirModel\(model\)[\s\S]*?showExternalModelDeleteNotice\(model\)[\s\S]*?return;/);
 assert.match(sources.modelManager, /managed in your external models folder\. Delete it directly from that folder\./);
 assert.doesNotMatch(sources.modelManager, /openExternalModelsFolder|manager__toast-folder-action/);
+assert.match(sources.api, /draft_file\?: string;/);
+assert.match(sources.api, /draft_files\?: string\[\];/);
+assert.match(sources.modelManager, /const variantDraftFile = vdata\?\.variants\.find\(v => v\.name === variantName\)\?\.draft_file;/);
+assert.match(sources.modelManager, /const legacyDraftFile = vdata\?\.draft_files\?\.length === 1/);
+assert.match(sources.modelManager, /labels\.add\('mtp'\)/);
+assert.match(sources.modelManager, /labels\.add\('dflash'\)/);
+assert.match(sources.modelManager, /draft: `\$\{modelId\}:\$\{selectedDraftFile\}`/);
+assert.match(sources.modelManager, /mmproj: vdata\?\.mmproj_files\?\.\[0\],[\s\S]*?checkpoints,[\s\S]*?labels:/);
 
 assert.match(sources.mcpPanel, /transport: 'streamable-http'/);
 assert.match(sources.mcpPanel, />HTTP endpoint</);


### PR DESCRIPTION
## Summary

Teach GUI3 to include an auto-detected draft GGUF companion when pulling a model from a remote registry.

The `/pull/variants` response can expose a `draft_file` for the selected GGUF variant. GUI3 now forwards that file as the `draft` checkpoint alongside the selected main checkpoint, so MTP and other draft-based models download both required files.

For compatibility with older Lemonade servers, GUI3 also falls back to `draft_files` when the response contains exactly one unambiguous draft companion. Multiple draft files are never guessed client-side.

Related to #3290

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [ ] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_

- Run the GUI TypeScript typecheck.
- Run the UI regression contract tests.
- Verify a remote GGUF response with `draft_file` creates `checkpoints.main` and `checkpoints.draft`.
- Verify an older server response with exactly one `draft_files` entry uses the compatibility fallback.
- Verify multiple `draft_files` entries are not selected client-side.
- End-to-end testing can be performed with the companion server-side patch for #3290 temporarily applied.

## Documentation

- [x] Documentation is not affected by this change.
- [ ] Documentation is affected and has been updated.
- [ ] Documentation is affected but will be handled in a separate PR or issue.

## Breaking Changes

- [ ] This PR introduces breaking changes.
- [x] This PR does not introduce breaking changes.

## AI-assisted contribution

Please select one:

- [x] I used AI tools for this PR.
- [ ] I did not use AI tools for this PR.

If AI tools were used:

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.