### PR TITLE
server: fix MTP draft companion handling

### DIFF
--- a/src/cpp/cli/hf_pull.cpp
+++ b/src/cpp/cli/hf_pull.cpp
@@ -427,17 +427,30 @@ int registry_pull_flow(lemonade::LemonadeClient& client,
         pull_body["mmproj"] = variants_response["mmproj_files"][0];
     }
 
-    if (variants_response.contains("draft_files") &&
-        variants_response["draft_files"].is_array()) {
-        if (variants_response["draft_files"].size() == 1) {
-            pull_body["checkpoints"] = json::object();
-            pull_body["checkpoints"]["main"] = pull_body["checkpoint"];
-            pull_body["checkpoints"]["draft"] =
-                checkpoint + ":" + variants_response["draft_files"][0].get<std::string>();
-        } else if (variants_response["draft_files"].size() > 1) {
-            std::cerr << "warning: multiple draft GGUF companions found; "
-                      << "not selecting one automatically" << std::endl;
+    std::string draft_file;
+    for (const auto& candidate : variants) {
+        if (to_lower(candidate.value("name", "")) == to_lower(variant_name)) {
+            draft_file = candidate.value("draft_file", std::string());
+            break;
         }
+    }
+
+    // Backward compatibility with a server that only exposes the legacy list.
+    if (draft_file.empty() && variants_response.contains("draft_files") &&
+        variants_response["draft_files"].is_array() &&
+        variants_response["draft_files"].size() == 1) {
+        draft_file = variants_response["draft_files"][0].get<std::string>();
+    }
+
+    if (!draft_file.empty()) {
+        pull_body["checkpoints"] = json::object();
+        pull_body["checkpoints"]["main"] = pull_body["checkpoint"];
+        pull_body["checkpoints"]["draft"] = checkpoint + ":" + draft_file;
+    } else if (variants_response.contains("draft_files") &&
+               variants_response["draft_files"].is_array() &&
+               variants_response["draft_files"].size() > 1) {
+        std::cerr << "warning: multiple draft GGUF companions found; "
+                  << "not selecting one automatically" << std::endl;
     }
 
     std::cout << "Pulling " << pull_body["checkpoint"].get<std::string>()

--- a/src/cpp/cli/hf_pull.cpp
+++ b/src/cpp/cli/hf_pull.cpp
@@ -428,8 +428,22 @@ int registry_pull_flow(lemonade::LemonadeClient& client,
     }
 
     std::string draft_file;
+    const std::string selected_variant = to_lower(variant_name);
     for (const auto& candidate : variants) {
-        if (to_lower(candidate.value("name", "")) == to_lower(variant_name)) {
+        bool matches = to_lower(candidate.value("name", "")) == selected_variant;
+        if (!matches) {
+            matches = to_lower(candidate.value("primary_file", "")) == selected_variant;
+        }
+        if (!matches && candidate.contains("files") && candidate["files"].is_array()) {
+            for (const auto& file : candidate["files"]) {
+                if (file.is_string() &&
+                    to_lower(file.get<std::string>()) == selected_variant) {
+                    matches = true;
+                    break;
+                }
+            }
+        }
+        if (matches) {
             draft_file = candidate.value("draft_file", std::string());
             break;
         }

--- a/src/cpp/include/lemon/hf_variants.h
+++ b/src/cpp/include/lemon/hf_variants.h
@@ -18,6 +18,9 @@ struct GgufVariant {
     // how `name` was disambiguated. Empty when no quant could be recognized.
     std::string quant;
     std::string primary_file;  // First file (lexicographic) representing this variant.
+    // Repository-relative speculative draft companion selected for this main variant.
+    // Empty when no single draft mechanism can be selected safely.
+    std::string draft_file;
     std::vector<std::string> files;  // All files belonging to this variant.
     bool sharded = false;
     uint64_t size_bytes = 0;   // Sum of file sizes (0 if unknown).

--- a/src/cpp/server/hf_variants.cpp
+++ b/src/cpp/server/hf_variants.cpp
@@ -36,12 +36,21 @@ bool contains_ci(const std::string& s, const std::string& needle) {
     return to_lower(s).find(to_lower(needle)) != std::string::npos;
 }
 
-bool is_draft_companion(const std::string& path) {
+enum class DraftKind { None, Mtp, Dflash };
+
+DraftKind draft_kind(const std::string& path) {
     std::string filename = to_lower(path);
     size_t slash = filename.find_last_of('/');
     if (slash != std::string::npos) filename = filename.substr(slash + 1);
-    return filename.rfind("dflash-", 0) == 0 || filename == "dflash.gguf" ||
-           filename.rfind("mtp-", 0) == 0;
+    if (filename.rfind("mtp-", 0) == 0) return DraftKind::Mtp;
+    if (filename.rfind("dflash-", 0) == 0 || filename == "dflash.gguf") {
+        return DraftKind::Dflash;
+    }
+    return DraftKind::None;
+}
+
+bool is_draft_companion(const std::string& path) {
+    return draft_kind(path) != DraftKind::None;
 }
 
 // Quant token extractor. Recognizes the variants we actually see in
@@ -88,6 +97,87 @@ int quant_priority(const std::string& q) {
     return it == priority.end() ? 100 : it->second;
 }
 
+int quant_bits(const std::string& value) {
+    std::string quant;
+    if (!extract_quant(value, quant)) return 0;
+    size_t pos = quant.find_first_of("0123456789");
+    return pos == std::string::npos ? 0 : std::stoi(quant.substr(pos));
+}
+
+std::vector<std::string> directory_parts(const std::string& path) {
+    size_t slash = path.find_last_of('/');
+    if (slash == std::string::npos) return {};
+
+    std::vector<std::string> parts;
+    size_t start = 0;
+    while (start < slash) {
+        size_t next = path.find('/', start);
+        if (next == std::string::npos || next > slash) next = slash;
+        parts.push_back(path.substr(start, next - start));
+        start = next + 1;
+    }
+    return parts;
+}
+
+size_t shared_directory_depth(const std::string& model, const std::string& companion) {
+    const auto model_parts = directory_parts(model);
+    const auto companion_parts = directory_parts(companion);
+    const size_t count = std::min(model_parts.size(), companion_parts.size());
+    size_t depth = 0;
+    while (depth < count && model_parts[depth] == companion_parts[depth]) ++depth;
+    return depth;
+}
+
+// Mirrors llama.cpp's generic HF sidecar ranking rather than tuning individual
+// models: prefer a deeper shared directory, then an exact quant tag, then the
+// closest quant bit width. A repo exposing both MTP and DFlash remains
+// intentionally ambiguous because choosing a speculative mechanism is policy.
+std::string preferred_draft_companion(
+    const GgufVariant& variant,
+    const std::vector<std::string>& draft_paths) {
+    DraftKind kind = DraftKind::None;
+    for (const auto& path : draft_paths) {
+        const DraftKind current = draft_kind(path);
+        if (current == DraftKind::None) continue;
+        if (kind == DraftKind::None) {
+            kind = current;
+        } else if (kind != current) {
+            return {};
+        }
+    }
+    if (kind == DraftKind::None) return {};
+
+    std::string target_quant = variant.quant;
+    if (target_quant.empty()) extract_quant(variant.primary_file, target_quant);
+    const int target_bits = quant_bits(target_quant);
+
+    std::string best;
+    size_t best_depth = 0;
+    bool best_exact = false;
+    int best_diff = 0;
+    for (const auto& path : draft_paths) {
+        if (draft_kind(path) != kind) continue;
+
+        std::string draft_quant;
+        const bool has_quant = extract_quant(path, draft_quant);
+        const bool exact = !target_quant.empty() && has_quant && draft_quant == target_quant;
+        const int draft_bits = has_quant ? quant_bits(draft_quant) : 0;
+        const int diff = std::abs(draft_bits - target_bits);
+        const size_t depth = shared_directory_depth(variant.primary_file, path);
+
+        if (best.empty() || depth > best_depth ||
+            (depth == best_depth && exact && !best_exact) ||
+            (depth == best_depth && exact == best_exact && diff < best_diff) ||
+            (depth == best_depth && exact == best_exact && diff == best_diff && path < best)) {
+            best = path;
+            best_depth = depth;
+            best_exact = exact;
+            best_diff = diff;
+        }
+    }
+    return best;
+}
+
 }  // namespace
 
 GgufVariantSet enumerate_gguf_variants(
@@ -105,7 +195,10 @@ GgufVariantSet enumerate_gguf_variants(
     };
 
     // Companion GGUFs must not become selectable main-model variants.
+    // Keep repository-relative draft paths internally for variant association;
+    // draft_files remains the legacy bare-filename list for API compatibility.
     std::vector<std::string> gguf_files;
+    std::vector<std::string> draft_paths;
     for (const auto& f : repo_files) {
         std::string f_lower = to_lower(f);
         if (!ends_with(f_lower, ".gguf")) continue;
@@ -115,12 +208,14 @@ GgufVariantSet enumerate_gguf_variants(
             result.mmproj_files.push_back(bare);
         } else if (is_draft_companion(f)) {
             result.draft_files.push_back(bare);
+            draft_paths.push_back(f);
         } else {
             gguf_files.push_back(f);
         }
     }
     std::sort(result.mmproj_files.begin(), result.mmproj_files.end());
     std::sort(result.draft_files.begin(), result.draft_files.end());
+    std::sort(draft_paths.begin(), draft_paths.end());
 
     // Group by top-level folder vs root files.
     std::map<std::string, std::vector<std::string>> folder_groups;
@@ -221,6 +316,10 @@ GgufVariantSet enumerate_gguf_variants(
                   if (pa != pb) return pa < pb;
                   return a.name < b.name;
               });
+
+    for (auto& variant : result.variants) {
+        variant.draft_file = preferred_draft_companion(variant, draft_paths);
+    }
 
     return result;
 }
@@ -391,6 +490,13 @@ nlohmann::json fetch_pull_variants(const std::string& checkpoint,
     // registration; otherwise the preview and the registered model disagree.
     std::vector<std::string> labels;
     if (!vset.mmproj_files.empty()) add_label_once(labels, "vision");
+    if (!vset.variants.empty() && !vset.variants.front().draft_file.empty()) {
+        switch (draft_kind(vset.variants.front().draft_file)) {
+            case DraftKind::Mtp: add_label_once(labels, "mtp"); break;
+            case DraftKind::Dflash: add_label_once(labels, "dflash"); break;
+            case DraftKind::None: break;
+        }
+    }
     {
         std::string id_lower = to_lower(checkpoint);
         if (id_lower.find("embed") != std::string::npos) add_label_once(labels, "embeddings");
@@ -413,6 +519,7 @@ nlohmann::json fetch_pull_variants(const std::string& checkpoint,
         nlohmann::json vj;
         vj["name"] = v.name;
         vj["primary_file"] = v.primary_file;
+        if (!v.draft_file.empty()) vj["draft_file"] = v.draft_file;
         vj["files"] = v.files;
         vj["sharded"] = v.sharded;
         vj["size_bytes"] = v.size_bytes;

--- a/src/cpp/server/hf_variants.cpp
+++ b/src/cpp/server/hf_variants.cpp
@@ -36,12 +36,15 @@ bool contains_ci(const std::string& s, const std::string& needle) {
     return to_lower(s).find(to_lower(needle)) != std::string::npos;
 }
 
+std::string filename_only(const std::string& path) {
+    size_t slash = path.find_last_of('/');
+    return slash == std::string::npos ? path : path.substr(slash + 1);
+}
+
 enum class DraftKind { None, Mtp, Dflash };
 
 DraftKind draft_kind(const std::string& path) {
-    std::string filename = to_lower(path);
-    size_t slash = filename.find_last_of('/');
-    if (slash != std::string::npos) filename = filename.substr(slash + 1);
+    const std::string filename = to_lower(filename_only(path));
     if (filename.rfind("mtp-", 0) == 0) return DraftKind::Mtp;
     if (filename.rfind("dflash-", 0) == 0 || filename == "dflash.gguf") {
         return DraftKind::Dflash;
@@ -99,7 +102,7 @@ int quant_priority(const std::string& q) {
 
 int quant_bits(const std::string& value) {
     std::string quant;
-    if (!extract_quant(value, quant)) return 0;
+    if (!extract_quant(filename_only(value), quant)) return 0;
     size_t pos = quant.find_first_of("0123456789");
     return pos == std::string::npos ? 0 : std::stoi(quant.substr(pos));
 }
@@ -148,7 +151,9 @@ std::string preferred_draft_companion(
     if (kind == DraftKind::None) return {};
 
     std::string target_quant = variant.quant;
-    if (target_quant.empty()) extract_quant(variant.primary_file, target_quant);
+    if (target_quant.empty()) {
+        extract_quant(filename_only(variant.primary_file), target_quant);
+    }
     const int target_bits = quant_bits(target_quant);
 
     std::string best;
@@ -158,11 +163,14 @@ std::string preferred_draft_companion(
     for (const auto& path : draft_paths) {
         if (draft_kind(path) != kind) continue;
 
+        const std::string draft_filename = filename_only(path);
         std::string draft_quant;
-        const bool has_quant = extract_quant(path, draft_quant);
+        const bool has_quant = extract_quant(draft_filename, draft_quant);
         const bool exact = !target_quant.empty() && has_quant && draft_quant == target_quant;
-        const int draft_bits = has_quant ? quant_bits(draft_quant) : 0;
-        const int diff = std::abs(draft_bits - target_bits);
+        const int draft_bits = has_quant ? quant_bits(draft_filename) : 0;
+        // With an unquantized main there is no meaningful bit-distance target.
+        // Keep selection deterministic through the existing depth/path ordering
+        const int diff = target_bits > 0 ? std::abs(draft_bits - target_bits) : 0;
         const size_t depth = shared_directory_depth(variant.primary_file, path);
 
         if (best.empty() || depth > best_depth ||
@@ -490,8 +498,11 @@ nlohmann::json fetch_pull_variants(const std::string& checkpoint,
     // registration; otherwise the preview and the registered model disagree.
     std::vector<std::string> labels;
     if (!vset.mmproj_files.empty()) add_label_once(labels, "vision");
-    if (!vset.variants.empty() && !vset.variants.front().draft_file.empty()) {
-        switch (draft_kind(vset.variants.front().draft_file)) {
+    const auto draft_variant = std::find_if(
+        vset.variants.begin(), vset.variants.end(),
+        [](const GgufVariant& variant) { return !variant.draft_file.empty(); });
+    if (draft_variant != vset.variants.end()) {
+        switch (draft_kind(draft_variant->draft_file)) {
             case DraftKind::Mtp: add_label_once(labels, "mtp"); break;
             case DraftKind::Dflash: add_label_once(labels, "dflash"); break;
             case DraftKind::None: break;

--- a/test/cpp/test_hf_variants.cpp
+++ b/test/cpp/test_hf_variants.cpp
@@ -161,13 +161,53 @@ int main() {
 
     {
         auto set = lemon::enumerate_gguf_variants({
-            "Gemma-Q4_K_M.gguf",
-            "mtp-Gemma.gguf",
+            "Model-Q4_K_M.gguf",
+            "mtp-Model.gguf",
         });
         result.expect("MTP companion is reported as a draft",
                       set.variants.size() == 1 && set.variants[0].name == "Q4_K_M" &&
-                          set.draft_files.size() == 1 && set.draft_files[0] == "mtp-Gemma.gguf",
+                          set.draft_files.size() == 1 && set.draft_files[0] == "mtp-Model.gguf",
                       "got " + join_names(set));
+        result.expect("single draft is associated with the main variant",
+                      set.variants.size() == 1 && set.variants[0].draft_file == "mtp-Model.gguf",
+                      set.variants.empty() ? "no main variant" :
+                          "draft=" + set.variants[0].draft_file);
+    }
+
+    // Multiple MTP precisions are resolved generically. The main Q4_K_M has no
+    // exact sidecar tag, so nearest bit width selects Q4_0; Q8_0 matches exactly.
+    {
+        auto set = lemon::enumerate_gguf_variants({
+            "Model-Q4_K_M.gguf",
+            "Model-Q8_0.gguf",
+            "mtp-Model-Q4_0.gguf",
+            "mtp-Model-Q8_0.gguf",
+        });
+        result.expect("Q4 target selects nearest-bit MTP companion",
+                      set.variants.size() == 2 && set.variants[0].quant == "Q4_K_M" &&
+                          set.variants[0].draft_file == "mtp-Model-Q4_0.gguf",
+                      set.variants.empty() ? "no variants" :
+                          "draft=" + set.variants[0].draft_file);
+        result.expect("Q8 target selects exact MTP companion",
+                      set.variants.size() == 2 && set.variants[1].quant == "Q8_0" &&
+                          set.variants[1].draft_file == "mtp-Model-Q8_0.gguf",
+                      set.variants.size() < 2 ? "missing Q8 variant" :
+                          "draft=" + set.variants[1].draft_file);
+    }
+
+    // Repository-relative paths matter for auxiliary checkpoint downloads.
+    {
+        auto set = lemon::enumerate_gguf_variants({
+            "Q4_K_M/Model-Q4_K_M-00001-of-00002.gguf",
+            "Q4_K_M/Model-Q4_K_M-00002-of-00002.gguf",
+            "Q4_K_M/mtp-Model-Q4_0.gguf",
+            "mtp-Model-Q8_0.gguf",
+        });
+        result.expect("draft association preserves repository-relative path",
+                      set.variants.size() == 1 &&
+                          set.variants[0].draft_file == "Q4_K_M/mtp-Model-Q4_0.gguf",
+                      set.variants.empty() ? "no variant" :
+                          "draft=" + set.variants[0].draft_file);
     }
 
     {
@@ -179,6 +219,10 @@ int main() {
         result.expect("Multiple draft companions are all reported",
                       set.draft_files.size() == 2,
                       "draft count = " + std::to_string(set.draft_files.size()));
+        result.expect("different speculative mechanisms stay ambiguous",
+                      set.variants.size() == 1 && set.variants[0].draft_file.empty(),
+                      set.variants.empty() ? "no variant" :
+                          "draft=" + set.variants[0].draft_file);
     }
 
     {

--- a/test/cpp/test_hf_variants.cpp
+++ b/test/cpp/test_hf_variants.cpp
@@ -195,17 +195,41 @@ int main() {
                           "draft=" + set.variants[1].draft_file);
     }
 
-    // Repository-relative paths matter for auxiliary checkpoint downloads.
+    // A quant-named directory must not mask the draft file's own quant tag.
+    // Both drafts have the same directory depth; the deliberately earlier
+    // Q8 filename would win lexicographically if extraction read Q4_K_M from
+    // the parent directory instead of Q8_0 from the filename.
     {
         auto set = lemon::enumerate_gguf_variants({
             "Q4_K_M/Model-Q4_K_M-00001-of-00002.gguf",
             "Q4_K_M/Model-Q4_K_M-00002-of-00002.gguf",
-            "Q4_K_M/mtp-Model-Q4_0.gguf",
-            "mtp-Model-Q8_0.gguf",
+            "Q4_K_M/mtp-A-Model-Q8_0.gguf",
+            "Q4_K_M/mtp-Z-Model-Q4_0.gguf",
         });
+        result.expect("draft quant comes from filename, not parent directory",
+                      set.variants.size() == 1 &&
+                          set.variants[0].draft_file == "Q4_K_M/mtp-Z-Model-Q4_0.gguf",
+                      set.variants.empty() ? "no variant" :
+                          "draft=" + set.variants[0].draft_file);
         result.expect("draft association preserves repository-relative path",
                       set.variants.size() == 1 &&
-                          set.variants[0].draft_file == "Q4_K_M/mtp-Model-Q4_0.gguf",
+                          set.variants[0].draft_file.find("Q4_K_M/") == 0,
+                      set.variants.empty() ? "no variant" :
+                          "draft=" + set.variants[0].draft_file);
+    }
+
+    // Without a quantized main there is no meaningful bit-distance comparison.
+    // Stable path ordering wins instead of silently choosing the smallest-bit
+    // draft (the old target_bits == 0 behavior).
+    {
+        auto set = lemon::enumerate_gguf_variants({
+            "model.gguf",
+            "mtp-A-Model-Q8_0.gguf",
+            "mtp-Z-Model-Q2_0.gguf",
+        });
+        result.expect("unquantized main does not prefer smallest-bit draft",
+                      set.variants.size() == 1 &&
+                          set.variants[0].draft_file == "mtp-A-Model-Q8_0.gguf",
                       set.variants.empty() ? "no variant" :
                           "draft=" + set.variants[0].draft_file);
     }


### PR DESCRIPTION
## Summary

Fix automatic GGUF draft companion selection for remote registry pulls.

Lemonade already detects MTP and DFlash GGUF companions, but currently returns them only as a flat `draft_files` list. When a repository contains multiple draft variants, the CLI refuses to select one and GUI clients have no deterministic way to know which draft belongs to the selected main model.

This change resolves the best draft companion per GGUF variant and exposes it as `draft_file`.

The selection is generic and follows llama.cpp's model-sidecar resolution behavior rather than containing model- or repository-specific rules:

- prefer the closest shared directory with the selected main model
- prefer an exact quantization match
- otherwise prefer the closest quantization bit width

The existing `draft_files` field remains available for compatibility.

The CLI now consumes the per-variant `draft_file` when available and retains the existing single-entry `draft_files` fallback for compatibility.

Regression coverage includes multiple draft companions and quantizations without hard-coding behavior for a specific model repository.

Related to #3290

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [ ] Code builds without errors locally.
- [ ] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_

```bash
cmake --build --preset default --target test_hf_variants
ctest --test-dir build -R '^HfVariantsTest$' --output-on-failure
```

Regression cases cover:

- a single draft companion
- multiple MTP quantizations
- selection of the matching draft for a selected main-model quantization
- fallback to the closest available quantization when an exact draft quantization does not exist
- preservation of existing DFlash detection
- preservation of the full draft_files compatibility list

The server patch can also be applied temporarily on GUI3_merging together with the GUI-only #3367 patch for an end-to-end download test.

## Documentation

- [x] Documentation is not affected by this change.
- [ ] Documentation is affected and has been updated.
- [ ] Documentation is affected but will be handled in a separate PR or issue.

## Breaking Changes

- [ ] This PR introduces breaking changes.
- [x] This PR does not introduce breaking changes.

## AI-assisted contribution

Please select one:

- [x] I used AI tools for this PR.
- [ ] I did not use AI tools for this PR.

If AI tools were used:

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.