### PR TITLE
MCP: add prompt-to-3D orchestration

### DIFF
--- a/.github/workflows/mcp-smoke-test.yml
+++ b/.github/workflows/mcp-smoke-test.yml
@@ -1,7 +1,8 @@
 name: MCP Smoke Test
 
-# Smoke-tests all 5 MCP tools (lemonade_list_models, lemonade_chat,
-# lemonade_transcribe_audio, lemonade_generate_image, lemonade_omni) via two
+# Smoke-tests all 6 MCP tools (lemonade_list_models, lemonade_chat,
+# lemonade_transcribe_audio, lemonade_generate_image, lemonade_generate_3d,
+# lemonade_omni) via two
 # independent build paths: a native CMake build and a Docker image build.
 # Either job failing fails the workflow.
 
@@ -10,6 +11,8 @@ on:
     paths:
       - "src/cpp/server/mcp_server.cpp"
       - "src/cpp/include/lemon/mcp_server.h"
+      - "src/cpp/server/mcp_3d_orchestrator.cpp"
+      - "src/cpp/include/lemon/mcp_3d_orchestrator.h"
       - "src/cpp/server/server.cpp"
       - "src/cpp/server/router.cpp"
       - "src/cpp/server/model_manager.cpp"
@@ -22,6 +25,7 @@ on:
       - "setup.sh"
       - "test/server_mcp_smoke.py"
       - "test/server_mcp.py"
+      - "test/cpp/test_mcp_3d_orchestrator.cpp"
       - ".github/workflows/mcp-smoke-test.yml"
   push:
     branches: ["main"]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -992,6 +992,7 @@ set(SOURCES_CORE
     src/cpp/server/anthropic_api.cpp
     src/cpp/server/mcp_client.cpp
     src/cpp/server/mcp_server.cpp
+    src/cpp/server/mcp_3d_orchestrator.cpp
     src/cpp/server/streaming_audio_buffer.cpp
     src/cpp/server/vad.cpp
     src/cpp/server/realtime_session.cpp
@@ -2508,6 +2509,25 @@ if(BUILD_TESTING AND EXISTS "${_BACKEND_MODE_CONTRACT_TEST_SRC}")
 
     include(CTest)
     add_cpp_ci_test(BackendModeContractTest CI ON COMMAND test_backend_mode_contract)
+endif()
+
+# Prompt-to-3D orchestration is transport/model independent and uses injected
+# callbacks, so this regression suite needs no server process, GPU, or model.
+set(_MCP_3D_ORCHESTRATOR_TEST_SRC
+    "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_mcp_3d_orchestrator.cpp"
+)
+if(BUILD_TESTING AND EXISTS "${_MCP_3D_ORCHESTRATOR_TEST_SRC}")
+    add_executable(test_mcp_3d_orchestrator
+        test/cpp/test_mcp_3d_orchestrator.cpp
+        src/cpp/server/mcp_3d_orchestrator.cpp
+    )
+    target_include_directories(test_mcp_3d_orchestrator PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/include
+    )
+    target_link_libraries(test_mcp_3d_orchestrator PRIVATE
+        nlohmann_json::nlohmann_json
+    )
+    add_cpp_ci_test(Mcp3dOrchestratorTest CI ON COMMAND test_mcp_3d_orchestrator)
 endif()
 
 # Job engine pure core: the `when`/`branch` expression evaluator + reference

--- a/docs/api/mcp.md
+++ b/docs/api/mcp.md
@@ -34,7 +34,7 @@ curl -s http://localhost:13305/mcp \
 
 ## Tools
 
-All tools auto-load (and download, if missing) the requested model on first call, exactly like `POST /v1/chat/completions`. Errors are returned as MCP results with `"isError": true` rather than JSON-RPC errors, matching the spec's guidance for tool failures.
+Model-backed tools reuse Lemonade's existing server loading paths, with each tool documenting whether a download is permitted. In particular, prompt-to-3D never searches for or downloads an image-generation model automatically: it uses an explicitly named local model, then a loaded image model, then a downloaded image model, or returns a clear error. Errors are returned as MCP results with `"isError": true` rather than JSON-RPC errors, matching the spec's guidance for tool failures.
 
 ### `lemonade_list_models`
 
@@ -118,6 +118,28 @@ When disk paths are provided, returns text block(s) with the absolute path(s). O
 - Override with the `LEMONADE_MCP_IMAGE_DIR` environment variable (absolute path).
 - Relative paths resolve against the sandbox root; absolute paths must stay within it. Paths that escape the sandbox (via `..` or symlinks) are rejected.
 - `output_dir` writes use auto-generated, unique filenames (`image_<token>_<i>.png`), so concurrent callers never clobber one another's images — the returned `paths` tell you the exact names. Use `output_path` when you need an exact, caller-chosen filename (it is written as named, replacing any existing file at that path).
+
+### `lemonade_generate_3d`
+
+Create a GLB from **exactly one** of an explicit image or a text prompt. The image-only path remains a thin adapter over the existing `/api/v1/3d/generations` implementation and does not invoke image generation.
+
+With `prompt`, Lemonade resolves `image_model` without network side effects: an explicitly named image model must already be loaded or downloaded; otherwise the server prefers a loaded image-generation model and then a downloaded one. If neither exists, the tool returns an error and asks the caller to pull one first. Lemonade appends reconstruction-oriented guidance (single centered subject, full object in frame, three-quarter/slightly elevated view, plain background, even studio lighting, clear geometry) and generates exactly one `1024x1024` reference image. The 3D `resolution` remains independent and is forwarded only to reconstruction.
+
+```json
+{
+  "name": "lemonade_generate_3d",
+  "arguments": {
+    "prompt": "a small industrial centrifugal pump",
+    "resolution": 1024,
+    "bg_removal": "threshold",
+    "uv": "xatlas"
+  }
+}
+```
+
+The prompt path returns a short text content block plus the generated reference image as a native MCP image block. `structuredContent` contains `reference_generated`, `image_model`, `model`, `mime_type`, and the GLB in `data_base64`. The GLB base64 is **not** duplicated into a normal text block. Image-only calls retain the same compact GLB structured result without reference-generation metadata.
+
+Pipeline failures identify the failing stage (`Reference image generation failed: ...` versus `3D reconstruction failed: ...`). No MCP resource/file-hosting protocol is introduced by this tool.
 
 ### `lemonade_omni`
 

--- a/src/cpp/include/lemon/mcp_3d_orchestrator.h
+++ b/src/cpp/include/lemon/mcp_3d_orchestrator.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <functional>
+#include <optional>
+#include <string>
+
+#include <nlohmann/json.hpp>
+
+namespace lemon::mcp_3d {
+
+using json = nlohmann::json;
+
+// Small transport-neutral adapter result used to compose MCP orchestration with
+// the existing Lemonade server generation handlers. The body may contain JSON
+// (image generation) or arbitrary binary bytes (GLB generation).
+struct GenerationResponse {
+    int status = 200;
+    std::string content_type;
+    std::string body;
+};
+
+using GenerationFn = std::function<GenerationResponse(const json&)>;
+
+struct PipelineResult {
+    bool reference_generated = false;
+    std::string reference_image_base64;
+    std::string glb_bytes;
+    std::string glb_mime_type = "model/gltf-binary";
+};
+
+inline constexpr const char* kReferenceImageSize = "1024x1024";
+inline constexpr const char* kReconstructionReferenceGuidance =
+    "single centered subject; whole object visible; three-quarter view; "
+    "slightly elevated camera; plain background; even studio lighting; "
+    "clear geometry and surface detail";
+
+std::string build_reconstruction_reference_prompt(const std::string& user_prompt);
+
+// Validate reconstruction options before any reference-image backend is called,
+// so a bad 3D option cannot waste an expensive image generation.
+std::optional<std::string> validate_3d_options(const json& arguments);
+
+// Pull a concise human-readable message out of a server-handler response.
+std::string response_error_message(const GenerationResponse& response);
+
+// Pure orchestration core. Model selection is deliberately outside this helper
+// so tests can inject fakes without constructing Router/ModelManager instances.
+PipelineResult run_pipeline(const json& arguments,
+                            const std::string& model_3d,
+                            const std::string& image_model,
+                            const GenerationFn& generate_image,
+                            const GenerationFn& generate_3d);
+
+}  // namespace lemon::mcp_3d

--- a/src/cpp/include/lemon/mcp_server.h
+++ b/src/cpp/include/lemon/mcp_server.h
@@ -8,6 +8,7 @@
 #include <httplib.h>
 #include <nlohmann/json.hpp>
 
+#include "lemon/mcp_3d_orchestrator.h"
 #include "model_manager.h"
 #include "router.h"
 
@@ -23,7 +24,11 @@ class McpServer : public std::enable_shared_from_this<McpServer> {
 public:
     using EnsureLoadedFn = std::function<void(const std::string&)>;
 
-    McpServer(Router* router, ModelManager* model_manager, EnsureLoadedFn ensure_loaded);
+    McpServer(Router* router,
+              ModelManager* model_manager,
+              EnsureLoadedFn ensure_loaded,
+              mcp_3d::GenerationFn image_generation,
+              mcp_3d::GenerationFn generation_3d);
     ~McpServer();
 
     // Must be called on a shared_ptr instance — handlers capture shared_from_this().
@@ -42,6 +47,7 @@ private:
     json tool_chat(const json& arguments);
     json tool_transcribe_audio(const json& arguments);
     json tool_generate_image(const json& arguments);
+    json tool_generate_3d(const json& arguments);
     json tool_omni(const json& arguments);
     json tool_list_models(const json& arguments);
 
@@ -76,6 +82,8 @@ private:
     Router* router_;
     ModelManager* model_manager_;
     EnsureLoadedFn ensure_loaded_;
+    mcp_3d::GenerationFn image_generation_;
+    mcp_3d::GenerationFn generation_3d_;
 };
 
 }  // namespace lemon

--- a/src/cpp/server/mcp_3d_orchestrator.cpp
+++ b/src/cpp/server/mcp_3d_orchestrator.cpp
@@ -1,0 +1,206 @@
+#include "lemon/mcp_3d_orchestrator.h"
+
+#include <stdexcept>
+#include <utility>
+
+namespace lemon::mcp_3d {
+
+namespace {
+
+bool has_nonempty_string(const json& object, const char* key) {
+    auto it = object.find(key);
+    return it != object.end() && it->is_string() && !it->get<std::string>().empty();
+}
+
+std::string error_from_json(const json& payload) {
+    if (!payload.is_object()) return {};
+
+    auto error = payload.find("error");
+    if (error != payload.end()) {
+        if (error->is_string()) return error->get<std::string>();
+        if (error->is_object()) {
+            auto message = error->find("message");
+            if (message != error->end() && message->is_string()) {
+                return message->get<std::string>();
+            }
+        }
+    }
+
+    auto message = payload.find("message");
+    if (message != payload.end() && message->is_string()) {
+        return message->get<std::string>();
+    }
+    return {};
+}
+
+GenerationResponse invoke_stage(const char* label,
+                                const GenerationFn& fn,
+                                const json& request) {
+    if (!fn) {
+        throw std::runtime_error(std::string(label) + ": server generation callback is not configured");
+    }
+    try {
+        return fn(request);
+    } catch (const std::exception& e) {
+        throw std::runtime_error(std::string(label) + ": " + e.what());
+    }
+}
+
+}  // namespace
+
+std::string build_reconstruction_reference_prompt(const std::string& user_prompt) {
+    return user_prompt +
+        "\n\n3D reconstruction reference requirements: " +
+        kReconstructionReferenceGuidance + ".";
+}
+
+std::optional<std::string> validate_3d_options(const json& arguments) {
+    if (arguments.contains("resolution")) {
+        if (!arguments["resolution"].is_number_integer()) {
+            return "'resolution' must be an integer: 512, 1024, or 1536";
+        }
+        const int resolution = arguments["resolution"].get<int>();
+        if (resolution != 512 && resolution != 1024 && resolution != 1536) {
+            return "'resolution' must be 512, 1024, or 1536";
+        }
+    }
+    if (arguments.contains("bg_removal")) {
+        const auto& value = arguments["bg_removal"];
+        if (!value.is_string() || (value != "threshold" && value != "birefnet")) {
+            return "'bg_removal' must be 'threshold' or 'birefnet'";
+        }
+    }
+    if (arguments.contains("seed") && !arguments["seed"].is_number_integer()) {
+        return "'seed' must be an integer";
+    }
+    if (arguments.contains("uv")) {
+        const auto& value = arguments["uv"];
+        if (!value.is_string() || (value != "box" && value != "xatlas")) {
+            return "'uv' must be 'box' or 'xatlas'";
+        }
+    }
+    return std::nullopt;
+}
+
+std::string response_error_message(const GenerationResponse& response) {
+    if (!response.body.empty()) {
+        try {
+            const json payload = json::parse(response.body);
+            const std::string parsed = error_from_json(payload);
+            if (!parsed.empty()) return parsed;
+        } catch (const std::exception&) {
+            // Fall through to the raw body for non-JSON backend errors.
+        }
+        return response.body;
+    }
+    if (response.status >= 400) {
+        return "server returned HTTP " + std::to_string(response.status) + " with an empty body";
+    }
+    return "server returned an empty response";
+}
+
+PipelineResult run_pipeline(const json& arguments,
+                            const std::string& model_3d,
+                            const std::string& image_model,
+                            const GenerationFn& generate_image,
+                            const GenerationFn& generate_3d) {
+    if (!arguments.is_object()) {
+        throw std::invalid_argument("3D tool arguments must be an object");
+    }
+
+    const bool has_image = arguments.contains("image");
+    const bool has_prompt = arguments.contains("prompt");
+    if (has_image == has_prompt) {
+        throw std::invalid_argument("Provide exactly one of 'image' or 'prompt'");
+    }
+    if (model_3d.empty()) {
+        throw std::invalid_argument("3D model must not be empty");
+    }
+    if (auto validation_error = validate_3d_options(arguments)) {
+        throw std::invalid_argument(*validation_error);
+    }
+
+    PipelineResult result;
+    std::string reconstruction_image;
+
+    if (has_prompt) {
+        if (!has_nonempty_string(arguments, "prompt")) {
+            throw std::invalid_argument("'prompt' must be a non-empty string");
+        }
+        if (image_model.empty()) {
+            throw std::invalid_argument("image model must not be empty for prompt-to-3D");
+        }
+
+        const json image_request = {
+            {"model", image_model},
+            {"prompt", build_reconstruction_reference_prompt(
+                arguments["prompt"].get<std::string>())},
+            {"n", 1},
+            {"size", kReferenceImageSize},
+            {"response_format", "b64_json"},
+        };
+
+        const GenerationResponse image_response = invoke_stage(
+            "Reference image generation failed", generate_image, image_request);
+        if (image_response.status >= 400) {
+            throw std::runtime_error(
+                "Reference image generation failed: " + response_error_message(image_response));
+        }
+
+        json image_payload;
+        try {
+            image_payload = json::parse(image_response.body);
+        } catch (const std::exception& e) {
+            throw std::runtime_error(
+                std::string("Reference image generation failed: invalid JSON response: ") + e.what());
+        }
+        const std::string payload_error = error_from_json(image_payload);
+        if (!payload_error.empty()) {
+            throw std::runtime_error("Reference image generation failed: " + payload_error);
+        }
+        if (!image_payload.contains("data") || !image_payload["data"].is_array() ||
+            image_payload["data"].empty() ||
+            !image_payload["data"][0].contains("b64_json") ||
+            !image_payload["data"][0]["b64_json"].is_string() ||
+            image_payload["data"][0]["b64_json"].get<std::string>().empty()) {
+            throw std::runtime_error(
+                "Reference image generation failed: backend returned no image");
+        }
+
+        reconstruction_image = image_payload["data"][0]["b64_json"].get<std::string>();
+        result.reference_generated = true;
+        result.reference_image_base64 = reconstruction_image;
+    } else {
+        if (!has_nonempty_string(arguments, "image")) {
+            throw std::invalid_argument("'image' must be a non-empty string");
+        }
+        reconstruction_image = arguments["image"].get<std::string>();
+    }
+
+    json reconstruction_request = {
+        {"model", model_3d},
+        {"image", std::move(reconstruction_image)},
+        {"response_format", "glb"},
+    };
+    for (const char* key : {"resolution", "bg_removal", "seed", "uv"}) {
+        if (arguments.contains(key)) reconstruction_request[key] = arguments[key];
+    }
+
+    const GenerationResponse reconstruction_response = invoke_stage(
+        "3D reconstruction failed", generate_3d, reconstruction_request);
+    if (reconstruction_response.status >= 400) {
+        throw std::runtime_error(
+            "3D reconstruction failed: " + response_error_message(reconstruction_response));
+    }
+    if (reconstruction_response.body.empty()) {
+        throw std::runtime_error("3D reconstruction failed: backend returned an empty GLB");
+    }
+
+    result.glb_bytes = reconstruction_response.body;
+    if (!reconstruction_response.content_type.empty()) {
+        result.glb_mime_type = reconstruction_response.content_type;
+    }
+    return result;
+}
+
+}  // namespace lemon::mcp_3d

--- a/src/cpp/server/mcp_server.cpp
+++ b/src/cpp/server/mcp_server.cpp
@@ -215,10 +215,16 @@ std::string unique_token() {
 
 }  // namespace
 
-McpServer::McpServer(Router* router, ModelManager* model_manager, EnsureLoadedFn ensure_loaded)
+McpServer::McpServer(Router* router,
+                     ModelManager* model_manager,
+                     EnsureLoadedFn ensure_loaded,
+                     mcp_3d::GenerationFn image_generation,
+                     mcp_3d::GenerationFn generation_3d)
     : router_(router),
       model_manager_(model_manager),
-      ensure_loaded_(std::move(ensure_loaded)) {}
+      ensure_loaded_(std::move(ensure_loaded)),
+      image_generation_(std::move(image_generation)),
+      generation_3d_(std::move(generation_3d)) {}
 
 McpServer::~McpServer() = default;
 
@@ -386,6 +392,8 @@ json McpServer::handle_tools_call(const json& params, const json& id) {
             result = tool_transcribe_audio(arguments);
         } else if (tool_name == "lemonade_generate_image") {
             result = tool_generate_image(arguments);
+        } else if (tool_name == "lemonade_generate_3d") {
+            result = tool_generate_3d(arguments);
         } else if (tool_name == "lemonade_omni") {
             result = tool_omni(arguments);
         } else if (tool_name == "lemonade_list_models") {
@@ -683,8 +691,9 @@ json McpServer::tool_generate_image(const json& arguments) {
     if (auto err = unsupported_model_error(model_manager_, model, "image generation", {"sd-cpp"})) {
         return *err;
     }
-
-    ensure_loaded_(model);
+    if (!image_generation_) {
+        throw std::runtime_error("Image generation server callback is not configured");
+    }
 
     json router_request = {
         {"model", model},
@@ -698,9 +707,27 @@ json McpServer::tool_generate_image(const json& arguments) {
     }
     router_request["response_format"] = "b64_json";
 
-    json response = router_->image_generations(router_request);
+    mcp_3d::GenerationResponse generated;
+    try {
+        generated = image_generation_(router_request);
+    } catch (const std::exception& e) {
+        throw std::runtime_error(std::string("Image generation failed: ") + e.what());
+    }
+    if (generated.status >= 400) {
+        throw std::runtime_error(
+            "Image generation failed: " + mcp_3d::response_error_message(generated));
+    }
+
+    json response;
+    try {
+        response = json::parse(generated.body);
+    } catch (const std::exception& e) {
+        throw std::runtime_error(
+            std::string("Image generation failed: invalid JSON response: ") + e.what());
+    }
     if (response.contains("error")) {
-        throw std::runtime_error(response["error"].value("message", "image generation failed"));
+        throw std::runtime_error(
+            "Image generation failed: " + mcp_3d::response_error_message(generated));
     }
 
     std::vector<std::string> b64_images;
@@ -794,6 +821,122 @@ json McpServer::tool_generate_image(const json& arguments) {
 
     return json{
         {"content", std::move(content)},
+        {"isError", false},
+    };
+}
+
+json McpServer::tool_generate_3d(const json& arguments) {
+    if (!arguments.is_object()) {
+        throw std::runtime_error("3D tool arguments must be an object");
+    }
+
+    const bool has_image = arguments.contains("image");
+    const bool has_prompt = arguments.contains("prompt");
+    if (has_image == has_prompt) {
+        throw std::runtime_error("Provide exactly one of 'image' or 'prompt'");
+    }
+    if (has_image && arguments.contains("image_model")) {
+        throw std::runtime_error("'image_model' is only valid when 'prompt' is used");
+    }
+    if (auto validation_error = mcp_3d::validate_3d_options(arguments)) {
+        throw std::runtime_error(*validation_error);
+    }
+
+    auto resolve_local_model = [this](ModelType type, const char* label) -> std::string {
+        const std::string wanted_type = model_type_to_string(type);
+        for (const auto& loaded : router_->get_all_loaded_models()) {
+            if (loaded.value("type", std::string()) != wanted_type) continue;
+            const std::string name = loaded.value("model_name", std::string());
+            if (!name.empty()) return name;
+        }
+        for (const auto& [name, info] : model_manager_->get_downloaded_models()) {
+            if (info.type == type) return name;
+        }
+        throw std::runtime_error(
+            std::string("No ") + label +
+            " model is loaded or downloaded; pull one first or pass an explicit model");
+    };
+
+    std::string model_3d;
+    if (arguments.contains("model")) {
+        if (!arguments["model"].is_string() || arguments["model"].get<std::string>().empty()) {
+            throw std::runtime_error("'model' must be a non-empty string");
+        }
+        model_3d = arguments["model"].get<std::string>();
+        if (auto err = unsupported_model_error(model_manager_, model_3d, "3D generation", {"trellis"})) {
+            return *err;
+        }
+        if (!model_manager_->model_exists(model_3d)) {
+            throw std::runtime_error("Unknown 3D model: " + model_3d);
+        }
+        if (model_manager_->get_model_info(model_3d).type != ModelType::MESH) {
+            throw std::runtime_error("Model '" + model_3d + "' is not a 3D-generation model");
+        }
+    } else {
+        model_3d = resolve_local_model(ModelType::MESH, "3D-generation");
+    }
+
+    std::string image_model;
+    if (has_prompt) {
+        if (!arguments["prompt"].is_string() || arguments["prompt"].get<std::string>().empty()) {
+            throw std::runtime_error("'prompt' must be a non-empty string");
+        }
+        if (arguments.contains("image_model")) {
+            if (!arguments["image_model"].is_string() ||
+                arguments["image_model"].get<std::string>().empty()) {
+                throw std::runtime_error("'image_model' must be a non-empty string");
+            }
+            image_model = arguments["image_model"].get<std::string>();
+            if (auto err = unsupported_model_error(
+                    model_manager_, image_model, "image generation", {"sd-cpp"})) {
+                return *err;
+            }
+            if (!model_manager_->model_exists(image_model)) {
+                throw std::runtime_error("Unknown image_model: " + image_model);
+            }
+            if (model_manager_->get_model_info(image_model).type != ModelType::IMAGE) {
+                throw std::runtime_error(
+                    "Model '" + image_model + "' is not an image-generation model");
+            }
+            if (!router_->is_model_loaded(image_model) &&
+                !model_manager_->is_model_downloaded(image_model)) {
+                throw std::runtime_error(
+                    "image_model '" + image_model +
+                    "' is neither loaded nor downloaded; prompt-to-3D never auto-downloads "
+                    "image models, pull it first");
+            }
+        } else {
+            image_model = resolve_local_model(ModelType::IMAGE, "image-generation");
+        }
+    } else if (!arguments["image"].is_string() ||
+               arguments["image"].get<std::string>().empty()) {
+        throw std::runtime_error("'image' must be a non-empty string");
+    }
+
+    const mcp_3d::PipelineResult pipeline = mcp_3d::run_pipeline(
+        arguments, model_3d, image_model, image_generation_, generation_3d_);
+
+    const std::string encoded_glb = utils::JsonUtils::base64_encode(pipeline.glb_bytes);
+    json structured = {
+        {"mime_type", pipeline.glb_mime_type},
+        {"data_base64", encoded_glb},
+    };
+    json content = json::array({text_content_block("Generated GLB model.")});
+
+    if (pipeline.reference_generated) {
+        structured["reference_generated"] = true;
+        structured["image_model"] = image_model;
+        structured["model"] = model_3d;
+        content.push_back({
+            {"type", "image"},
+            {"data", pipeline.reference_image_base64},
+            {"mimeType", "image/png"},
+        });
+    }
+
+    return json{
+        {"content", std::move(content)},
+        {"structuredContent", std::move(structured)},
         {"isError", false},
     };
 }
@@ -1267,6 +1410,53 @@ json McpServer::tools_descriptor() {
                     {"seed",   {{"type", "integer"}}},
                     {"steps",  {{"type", "integer"}}},
                     {"cfg_scale", {{"type", "number"}}},
+                }},
+            }},
+        },
+        {
+            {"name", "lemonade_generate_3d"},
+            {"description",
+             "Create a GLB from exactly one of `image` or `prompt`. With `image`, "
+             "the existing image-to-3D server path is used directly. With `prompt`, "
+             "the server first creates one reconstruction-oriented 1024x1024 "
+             "reference image, then feeds it directly into the same 3D path. "
+             "`image_model` is optional but never auto-downloaded: when omitted, "
+             "a loaded image model is preferred, then a downloaded one."},
+            {"inputSchema", {
+                {"type", "object"},
+                {"additionalProperties", false},
+                {"oneOf", json::array({
+                    json{
+                        {"required", json::array({"image"})},
+                        {"not", json{{"required", json::array({"prompt"})}}},
+                    },
+                    json{
+                        {"required", json::array({"prompt"})},
+                        {"not", json{{"required", json::array({"image"})}}},
+                    },
+                })},
+                {"properties", {
+                    {"image", {{"type", "string"},
+                               {"description", "Base64 image bytes or a data:image/...;base64 URL."}}},
+                    {"prompt", {{"type", "string"}}},
+                    {"model", {{"type", "string"},
+                               {"description",
+                                "Optional 3D reconstruction model. Omit to reuse a "
+                                "loaded/downloaded mesh model."}}},
+                    {"image_model", {{"type", "string"},
+                                     {"description",
+                                      "Prompt path only. Exact local image-generation "
+                                      "model; never auto-downloaded."}}},
+                    {"resolution", {{"type", "integer"},
+                                    {"enum", json::array({512, 1024, 1536})},
+                                    {"description",
+                                     "3D reconstruction resolution; independent of "
+                                     "the fixed 1024x1024 reference image."}}},
+                    {"bg_removal", {{"type", "string"},
+                                    {"enum", json::array({"threshold", "birefnet"})}}},
+                    {"seed", {{"type", "integer"}}},
+                    {"uv", {{"type", "string"},
+                            {"enum", json::array({"box", "xatlas"})}}},
                 }},
             }},
         },

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -1515,10 +1515,33 @@ void Server::setup_routes(httplib::Server &web_server) {
     // Register MCP gateway (POST /mcp). NOTE: /mcp is an INTENTIONAL EXCEPTION
     // to the quad-prefix invariant (AGENTS.md #1) — the MCP spec mandates a
     // single endpoint URL.
+    auto call_mcp_generation_handler =
+        [this](const json& body,
+               void (Server::*handler)(const httplib::Request&, httplib::Response&)) {
+            httplib::Request request;
+            request.method = "POST";
+            request.body = body.dump();
+            request.headers.emplace("Content-Type", "application/json");
+            httplib::Response response;
+            (this->*handler)(request, response);
+            const int status = response.status > 0 ? response.status : 200;
+            return mcp_3d::GenerationResponse{
+                status,
+                response.get_header_value("Content-Type"),
+                std::move(response.body),
+            };
+        };
+
     auto mcp_server = std::make_shared<McpServer>(
         router_.get(),
         model_manager_.get(),
-        [this](const std::string& m) { auto_load_model_if_needed(m); });
+        [this](const std::string& m) { auto_load_model_if_needed(m); },
+        [call_mcp_generation_handler](const json& body) {
+            return call_mcp_generation_handler(body, &Server::handle_image_generations);
+        },
+        [call_mcp_generation_handler](const json& body) {
+            return call_mcp_generation_handler(body, &Server::handle_3d_generations);
+        });
     mcp_server->register_routes(web_server);
 
     // Setup static file serving for web UI

--- a/test/cpp/test_mcp_3d_orchestrator.cpp
+++ b/test/cpp/test_mcp_3d_orchestrator.cpp
@@ -1,0 +1,287 @@
+#include "lemon/mcp_3d_orchestrator.h"
+
+#include <functional>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+#include <utility>
+
+using lemon::mcp_3d::GenerationResponse;
+using lemon::mcp_3d::PipelineResult;
+using lemon::mcp_3d::json;
+
+namespace {
+
+#define CHECK_TRUE(expr)                                                        \
+    do {                                                                        \
+        if (!(expr)) {                                                          \
+            std::cerr << __func__ << ": check failed at line " << __LINE__     \
+                      << ": " #expr << std::endl;                              \
+            return false;                                                       \
+        }                                                                       \
+    } while (false)
+
+bool throws_with(const std::function<void()>& fn, const std::string& needle) {
+    try {
+        fn();
+    } catch (const std::exception& e) {
+        return std::string(e.what()).find(needle) != std::string::npos;
+    }
+    return false;
+}
+
+GenerationResponse image_ok(const std::string& b64 = "ZmFrZS1wbmc=") {
+    return GenerationResponse{
+        200,
+        "application/json",
+        json{{"data", json::array({json{{"b64_json", b64}}})}}.dump(),
+    };
+}
+
+GenerationResponse glb_ok() {
+    return GenerationResponse{200, "model/gltf-binary", std::string("glb\0payload", 11)};
+}
+
+bool test_image_only_skips_reference_generation() {
+    int image_calls = 0;
+    int reconstruction_calls = 0;
+    json seen_3d;
+    json args = {
+        {"image", "existing-image-base64"},
+        {"resolution", 1024},
+        {"bg_removal", "threshold"},
+        {"seed", 42},
+        {"uv", "xatlas"},
+    };
+
+    PipelineResult result = lemon::mcp_3d::run_pipeline(
+        args,
+        "Trellis-Model",
+        "",
+        [&](const json&) {
+            ++image_calls;
+            return image_ok();
+        },
+        [&](const json& request) {
+            ++reconstruction_calls;
+            seen_3d = request;
+            return glb_ok();
+        });
+
+    CHECK_TRUE(image_calls == 0);
+    CHECK_TRUE(reconstruction_calls == 1);
+    CHECK_TRUE(!result.reference_generated);
+    CHECK_TRUE(seen_3d["image"] == "existing-image-base64");
+    CHECK_TRUE(seen_3d["resolution"] == 1024);
+    CHECK_TRUE(seen_3d["bg_removal"] == "threshold");
+    CHECK_TRUE(seen_3d["seed"] == 42);
+    CHECK_TRUE(seen_3d["uv"] == "xatlas");
+    CHECK_TRUE(seen_3d["response_format"] == "glb");
+    return true;
+}
+
+bool test_prompt_only_generates_reference_once_and_keeps_resolutions_independent() {
+    int image_calls = 0;
+    int reconstruction_calls = 0;
+    json seen_image;
+    json seen_3d;
+    json args = {
+        {"prompt", "a small industrial centrifugal pump"},
+        {"resolution", 1536},
+        {"bg_removal", "birefnet"},
+        {"seed", 7},
+        {"uv", "box"},
+    };
+
+    PipelineResult result = lemon::mcp_3d::run_pipeline(
+        args,
+        "Trellis-Model",
+        "SD-Model",
+        [&](const json& request) {
+            ++image_calls;
+            seen_image = request;
+            return image_ok("cmVmZXJlbmNlLWltYWdl");
+        },
+        [&](const json& request) {
+            ++reconstruction_calls;
+            seen_3d = request;
+            return glb_ok();
+        });
+
+    CHECK_TRUE(image_calls == 1);
+    CHECK_TRUE(reconstruction_calls == 1);
+    CHECK_TRUE(result.reference_generated);
+    CHECK_TRUE(result.reference_image_base64 == "cmVmZXJlbmNlLWltYWdl");
+    CHECK_TRUE(seen_image["model"] == "SD-Model");
+    CHECK_TRUE(seen_image["n"] == 1);
+    CHECK_TRUE(seen_image["size"] == "1024x1024");
+    CHECK_TRUE(seen_image["response_format"] == "b64_json");
+    CHECK_TRUE(seen_image["prompt"].get<std::string>().find(
+                   "a small industrial centrifugal pump") != std::string::npos);
+    CHECK_TRUE(seen_image["prompt"].get<std::string>().find(
+                   "single centered subject") != std::string::npos);
+    CHECK_TRUE(!seen_image.contains("resolution"));
+    CHECK_TRUE(!seen_image.contains("bg_removal"));
+    CHECK_TRUE(!seen_image.contains("seed"));
+    CHECK_TRUE(!seen_image.contains("uv"));
+    CHECK_TRUE(seen_3d["image"] == "cmVmZXJlbmNlLWltYWdl");
+    CHECK_TRUE(seen_3d["resolution"] == 1536);
+    CHECK_TRUE(seen_3d["bg_removal"] == "birefnet");
+    CHECK_TRUE(seen_3d["seed"] == 7);
+    CHECK_TRUE(seen_3d["uv"] == "box");
+    return true;
+}
+
+bool test_neither_and_both_rejected_before_backends() {
+    int image_calls = 0;
+    int reconstruction_calls = 0;
+    auto image = [&](const json&) {
+        ++image_calls;
+        return image_ok();
+    };
+    auto reconstruction = [&](const json&) {
+        ++reconstruction_calls;
+        return glb_ok();
+    };
+
+    CHECK_TRUE(throws_with(
+        [&] { lemon::mcp_3d::run_pipeline(json::object(), "Trellis", "SD", image, reconstruction); },
+        "exactly one"));
+    CHECK_TRUE(throws_with(
+        [&] {
+            lemon::mcp_3d::run_pipeline(
+                json{{"image", "a"}, {"prompt", "b"}},
+                "Trellis", "SD", image, reconstruction);
+        },
+        "exactly one"));
+    CHECK_TRUE(image_calls == 0);
+    CHECK_TRUE(reconstruction_calls == 0);
+    return true;
+}
+
+bool test_reference_generation_error_stops_pipeline() {
+    int reconstruction_calls = 0;
+    CHECK_TRUE(throws_with(
+        [&] {
+            lemon::mcp_3d::run_pipeline(
+                json{{"prompt", "pump"}},
+                "Trellis",
+                "SD",
+                [](const json&) {
+                    return GenerationResponse{
+                        500,
+                        "application/json",
+                        json{{"error", json{{"message", "diffusion exploded"}}}}.dump(),
+                    };
+                },
+                [&](const json&) {
+                    ++reconstruction_calls;
+                    return glb_ok();
+                });
+        },
+        "Reference image generation failed: diffusion exploded"));
+    CHECK_TRUE(reconstruction_calls == 0);
+    return true;
+}
+
+bool test_empty_reference_image_is_clear_error() {
+    int reconstruction_calls = 0;
+    CHECK_TRUE(throws_with(
+        [&] {
+            lemon::mcp_3d::run_pipeline(
+                json{{"prompt", "pump"}},
+                "Trellis",
+                "SD",
+                [](const json&) {
+                    return GenerationResponse{
+                        200,
+                        "application/json",
+                        json{{"data", json::array()}}.dump(),
+                    };
+                },
+                [&](const json&) {
+                    ++reconstruction_calls;
+                    return glb_ok();
+                });
+        },
+        "Reference image generation failed: backend returned no image"));
+    CHECK_TRUE(reconstruction_calls == 0);
+    return true;
+}
+
+bool test_3d_error_has_stage_name() {
+    CHECK_TRUE(throws_with(
+        [&] {
+            lemon::mcp_3d::run_pipeline(
+                json{{"image", "existing"}},
+                "Trellis",
+                "",
+                [](const json&) { return image_ok(); },
+                [](const json&) {
+                    return GenerationResponse{
+                        502,
+                        "application/json",
+                        json{{"error", json{{"message", "mesh backend OOM"}}}}.dump(),
+                    };
+                });
+        },
+        "3D reconstruction failed: mesh backend OOM"));
+    return true;
+}
+
+bool test_invalid_3d_options_rejected_before_backends() {
+    const std::vector<json> invalid = {
+        json{{"prompt", "pump"}, {"resolution", 999}},
+        json{{"prompt", "pump"}, {"bg_removal", "boolean-ish"}},
+        json{{"prompt", "pump"}, {"uv", "magic"}},
+    };
+
+    for (const auto& args : invalid) {
+        int image_calls = 0;
+        int reconstruction_calls = 0;
+        const bool threw = throws_with(
+            [&] {
+                lemon::mcp_3d::run_pipeline(
+                    args,
+                    "Trellis",
+                    "SD",
+                    [&](const json&) {
+                        ++image_calls;
+                        return image_ok();
+                    },
+                    [&](const json&) {
+                        ++reconstruction_calls;
+                        return glb_ok();
+                    });
+            },
+            "must be");
+        CHECK_TRUE(threw);
+        CHECK_TRUE(image_calls == 0);
+        CHECK_TRUE(reconstruction_calls == 0);
+    }
+    return true;
+}
+
+}  // namespace
+
+int main() {
+    const std::vector<std::pair<const char*, bool (*)()>> tests = {
+        {"image-only regression", test_image_only_skips_reference_generation},
+        {"prompt orchestration", test_prompt_only_generates_reference_once_and_keeps_resolutions_independent},
+        {"xor validation", test_neither_and_both_rejected_before_backends},
+        {"reference backend failure", test_reference_generation_error_stops_pipeline},
+        {"empty reference", test_empty_reference_image_is_clear_error},
+        {"3d backend failure", test_3d_error_has_stage_name},
+        {"3d option validation", test_invalid_3d_options_rejected_before_backends},
+    };
+
+    for (const auto& [name, fn] : tests) {
+        if (!fn()) {
+            std::cerr << "FAILED: " << name << std::endl;
+            return 1;
+        }
+        std::cout << "PASS: " << name << std::endl;
+    }
+    return 0;
+}

--- a/test/server_mcp.py
+++ b/test/server_mcp.py
@@ -3,11 +3,13 @@ Integration tests for the MCP gateway endpoint (POST /mcp).
 
 Requires a Lemonade server to already be running on port 13305.
 
-Covers the JSON-RPC 2.0 envelope plus the four tools exposed by the gateway:
+Covers the JSON-RPC 2.0 envelope plus the six tools exposed by the gateway:
 - lemonade_list_models
 - lemonade_chat
 - lemonade_transcribe_audio   (smoke-tested via schema only; needs Whisper)
 - lemonade_generate_image     (smoke-tested via schema only; needs SD)
+- lemonade_generate_3d        (schema/validation only; no GPU model required)
+- lemonade_omni
 
 The "live" chat tool uses a small model so the suite stays fast.
 
@@ -220,7 +222,7 @@ class McpGatewayTests(ServerTestBase):
         self.assertEqual(body["result"], {})
 
     def test_012_tools_list(self):
-        """tools/list must include the five gateway tools, each with a schema."""
+        """tools/list must include the six gateway tools, each with a schema."""
         response = _post({"jsonrpc": "2.0", "id": 3, "method": "tools/list"})
         body = response.json()
         tools = body["result"]["tools"]
@@ -230,6 +232,7 @@ class McpGatewayTests(ServerTestBase):
             "lemonade_chat",
             "lemonade_transcribe_audio",
             "lemonade_generate_image",
+            "lemonade_generate_3d",
             "lemonade_omni",
         }
         self.assertTrue(expected.issubset(names), f"missing tools: {expected - names}")
@@ -245,6 +248,21 @@ class McpGatewayTests(ServerTestBase):
         self.assertEqual(required, {"messages"})
         self.assertIn("model", omni["inputSchema"]["properties"])
         self.assertIn("output_dir", omni["inputSchema"]["properties"])
+
+        model3d = next(t for t in tools if t["name"] == "lemonade_generate_3d")
+        schema3d = model3d["inputSchema"]
+        self.assertEqual(len(schema3d.get("oneOf", [])), 2)
+        self.assertIn("image", schema3d["properties"])
+        self.assertIn("prompt", schema3d["properties"])
+        self.assertIn("image_model", schema3d["properties"])
+        self.assertEqual(
+            schema3d["properties"]["resolution"].get("enum"), [512, 1024, 1536]
+        )
+        self.assertEqual(
+            schema3d["properties"]["bg_removal"].get("enum"),
+            ["threshold", "birefnet"],
+        )
+        self.assertEqual(schema3d["properties"]["uv"].get("enum"), ["box", "xatlas"])
 
     # ---------------------------------------------------------------------
     # tools/call error paths

--- a/test/server_mcp_smoke.py
+++ b/test/server_mcp_smoke.py
@@ -1,11 +1,12 @@
 """
-MCP gateway smoke tests — exercises each of the 5 MCP tools end-to-end.
+MCP gateway smoke tests — exercises each of the 6 MCP tools end-to-end.
 
 Two modes:
 
 * **Fast mode (default, used in CI)** — exercises each tool's dispatcher and
   validation path. Only downloads a ~180 MB GGUF for the chat tool. Whisper,
-  Stable Diffusion, and Omni are checked via their structured-error paths so
+  Stable Diffusion, prompt-to-3D, and Omni are checked via their structured-error
+  paths so
   the workflow stays runnable on a vanilla ubuntu-latest runner.
 
 * **Live mode (local opt-in)** — per-tool flags trigger real inference using
@@ -231,6 +232,15 @@ def smoke_generate_image_dispatch(mcp_url, _cfg):
     detail(f"structured error: {truncate(text, 120)}")
 
 
+def smoke_generate_3d_dispatch(mcp_url, _cfg):
+    """XOR validation must fail before model resolution or any GPU backend."""
+    result = tools_call(mcp_url, "lemonade_generate_3d", {})
+    assert result.get("isError") is True, f"expected isError: {result}"
+    text = assert_text_content(result)
+    assert "exactly one" in text.lower(), f"unexpected text: {text}"
+    detail(f"structured error: {truncate(text, 120)}")
+
+
 def smoke_omni_dispatch(mcp_url, _cfg):
     """A non-collection model must short-circuit with a structured isError."""
     result = tools_call(
@@ -395,6 +405,7 @@ def build_plan(args):
             smoke_generate_image_live if live_image else smoke_generate_image_dispatch,
         )
     )
+    smokes.append(("lemonade_generate_3d", smoke_generate_3d_dispatch))
     smokes.append(
         (
             "lemonade_omni (live)" if live_omni else "lemonade_omni",


### PR DESCRIPTION
## Summary

Adds server-side prompt-to-3D orchestration to `lemonade_generate_3d`.

The existing image-to-3D path remains supported unchanged, while MCP clients can now alternatively provide a text prompt. In that case, Lemonade:

1. resolves an already loaded or downloaded image-generation model,
2. augments the user prompt with reconstruction-oriented guidance,
3. generates a single 1024x1024 reference image,
4. passes that image directly into the existing 3D generation path,
5. returns the generated GLB together with pipeline metadata.

The two inputs are mutually exclusive: callers must provide exactly one of `image` or `prompt`.

The implementation reuses the existing server image-generation and 3D-generation paths in-process rather than duplicating backend logic or making self-HTTP requests. No model search or automatic download is introduced by this change.

The existing 3D options (`resolution`, `bg_removal`, `seed`, and `uv`) keep their current semantics. In particular, the reference image size is independent from the 3D reconstruction `resolution`.


## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_

Added GPU-independent coverage for the orchestration logic using fake/callback stages, including:

- image-only input calls 3D reconstruction once and never invokes image generation
- prompt-only input generates one reference image and passes it to 3D reconstruction
- neither `image` nor `prompt` is rejected before backend execution
- providing both is rejected before backend execution
- reference-image generation failure prevents 3D reconstruction
- empty reference-image output produces a clear error
- 3D reconstruction failures are surfaced separately from reference-generation failures
- reference generation defaults to `1024x1024` with `n = 1`
- 3D `resolution` remains independent from reference-image size
- `bg_removal` values remain the server strings `threshold` and `birefnet`
- the existing image-to-3D behavior remains covered as a regression path

MCP schema/smoke coverage is also updated for the new `prompt` and `image_model` inputs and the exactly-one-of input contract.

Optional manual E2E smoke when suitable local models are available:

`Generate a 3D model of a small industrial centrifugal pump.`

Verify that a valid reference image is produced, the returned GLB is non-empty, and the existing image-only path still succeeds.

## Documentation

- [ ] Documentation is not affected by this change.
- [x] Documentation is affected and has been updated.
- [ ] Documentation is affected but will be handled in a separate PR or issue.

## Breaking Changes

- [ ] This PR introduces breaking changes.
- [x] This PR does not introduce breaking changes.

The existing image-based `lemonade_generate_3d` contract remains supported. Prompt input is additive.

## AI-assisted contribution

Please select one:

- [x] I used AI tools for this PR.
- [ ] I did not use AI tools for this PR.

If AI tools were used:

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.