### PR TITLE
feat(backends): hrx backend [experimental]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,6 +154,7 @@ include(GNUInstallDirs)
 set(LEMON_BACKENDS
     # "<recipe>|<stem>"
     "llamacpp|llamacpp"
+    "hrx|hrx"
     "whispercpp|whispercpp"
     "moonshine|moonshine"
     "kokoro|kokoro"
@@ -2508,6 +2509,12 @@ if(BUILD_TESTING AND EXISTS "${_BACKEND_MODE_CONTRACT_TEST_SRC}")
 
     include(CTest)
     add_cpp_ci_test(BackendModeContractTest CI ON COMMAND test_backend_mode_contract)
+endif()
+
+if(BUILD_TESTING AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_hrx_contract.cpp")
+    add_executable(test_hrx_contract test/cpp/test_hrx_contract.cpp)
+    target_link_libraries(test_hrx_contract PRIVATE lemonade-server-core)
+    add_cpp_ci_test(HrxContractTest CI ON COMMAND test_hrx_contract)
 endif()
 
 # Job engine pure core: the `when`/`branch` expression evaluator + reference

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,7 +154,7 @@ include(GNUInstallDirs)
 set(LEMON_BACKENDS
     # "<recipe>|<stem>"
     "llamacpp|llamacpp"
-    "hrx|hrx"
+    "llamacpp-hrx|hrx"
     "whispercpp|whispercpp"
     "moonshine|moonshine"
     "kokoro|kokoro"

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Lemonade supports multiple inference engines for LLM, speech, TTS, and image gen
   </thead>
   <tbody>
     <tr>
-      <td rowspan="10"><strong>Text generation</strong></td>
+      <td rowspan="11"><strong>Text generation</strong></td>
       <td rowspan="6"><code>llamacpp</code></td>
       <td><code>system</code></td>
       <td><code>x86_64</code>/ARM64 CPU, GPU</td>

--- a/README.md
+++ b/README.md
@@ -179,6 +179,12 @@ Lemonade supports multiple inference engines for LLM, speech, TTS, and image gen
       <td>Windows, Linux</td>
     </tr>
     <tr>
+      <td rowspan="1"><code>hrx</code> (experimental)</td>
+      <td><code>hrx</code></td>
+      <td>AMD GPUs (gfx1100, gfx1151)</td>
+      <td>Linux</td>
+    </tr>
+    <tr>
       <td rowspan="1"><code>flm</code></td>
       <td><code>npu</code></td>
       <td>XDNA2 NPU</td>

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Lemonade supports multiple inference engines for LLM, speech, TTS, and image gen
       <td>Windows, Linux</td>
     </tr>
     <tr>
-      <td rowspan="1"><code>hrx</code> (experimental)</td>
+      <td rowspan="1"><code>llamacpp-hrx</code> (experimental)</td>
       <td><code>hrx</code></td>
       <td>AMD GPUs (gfx1100, gfx1151)</td>
       <td>Linux</td>

--- a/docs/assets/models.js
+++ b/docs/assets/models.js
@@ -7,7 +7,7 @@ const RECIPE_PRIORITY = [
   'acestep',
   'ds4',
   'flm',
-  'hrx',
+  'llamacpp-hrx',
   'kokoro',
   'llamacpp',
   'moonshine',
@@ -24,7 +24,7 @@ const RECIPE_PRIORITY = [
 
 const RECIPE_DISPLAY_NAMES = {
   llamacpp: 'llama.cpp GPU',
-  hrx: 'HRX GPU (experimental)',
+  'llamacpp-hrx': 'HRX GPU (experimental)',
   whispercpp: 'whisper.cpp',
   'sd-cpp': 'stable-diffusion.cpp',
   flm: 'FastFlowLM NPU',

--- a/docs/assets/models.js
+++ b/docs/assets/models.js
@@ -7,6 +7,7 @@ const RECIPE_PRIORITY = [
   'acestep',
   'ds4',
   'flm',
+  'hrx',
   'kokoro',
   'llamacpp',
   'moonshine',
@@ -23,6 +24,7 @@ const RECIPE_PRIORITY = [
 
 const RECIPE_DISPLAY_NAMES = {
   llamacpp: 'llama.cpp GPU',
+  hrx: 'HRX GPU (experimental)',
   whispercpp: 'whisper.cpp',
   'sd-cpp': 'stable-diffusion.cpp',
   flm: 'FastFlowLM NPU',

--- a/docs/dev/backends-reference.md
+++ b/docs/dev/backends-reference.md
@@ -12,6 +12,7 @@ the generator instead. Prose outside the markers is preserved. -->
 | `acestep` | ACE-Step | yes | no | cuda, rocm, vulkan |
 | `ds4` | DwarfStar4 (experimental) | no | yes | rocm |
 | `flm` | FastFlowLM NPU | no | yes | npu |
+| `hrx` | HRX GPU (experimental) | no | yes | hrx |
 | `kokoro` | Kokoro | no | no | cpu, metal |
 | `llamacpp` | Llama.cpp GPU | yes | yes | cpu, cuda, metal, rocm, system, vulkan |
 | `moonshine` | Moonshine | no | no | cpu |
@@ -36,6 +37,7 @@ the generator instead. Prose outside the markers is preserved. -->
 | `acestep` | rocm | linux, windows | amd_gpu (gfx103X, gfx110X, gfx1150, gfx1151, gfx1152, gfx120X) |
 | `ds4` | rocm | linux | amd_gpu (gfx1151) |
 | `flm` | npu | linux, windows | amd_npu (XDNA2) |
+| `hrx` | hrx | linux | amd_gpu (gfx1100, gfx1151) |
 | `kokoro` | metal | macos | metal |
 | `kokoro` | cpu | linux, windows | cpu (x86_64) |
 | `llamacpp` | system | linux | cpu (arm64, x86_64) |
@@ -103,6 +105,13 @@ the generator instead. Prose outside the markers is preserved. -->
 |--------|----------|------|---------|-------------|
 | `ctx_size` | `--ctx-size` | SIZE | -1 | Context size for the model |
 | `flm_args` | `--flm-args` | ARGS | "" | Safe flm serve tuning args: --pmode, --prefill-chunk-len, --img-pre-resize, --socket, --q-len, --preemption |
+
+#### `hrx` — HRX GPU (experimental)
+
+| Option | CLI flag | Type | Default | Description |
+|--------|----------|------|---------|-------------|
+| `ctx_size` | `--ctx-size` | SIZE | -1 | Context size for the model |
+| `hrx_args` | `--hrx-args` | ARGS | "" | Custom arguments to pass to the HRX llama-server |
 
 #### `llamacpp` — Llama.cpp GPU
 

--- a/docs/dev/backends-reference.md
+++ b/docs/dev/backends-reference.md
@@ -12,9 +12,9 @@ the generator instead. Prose outside the markers is preserved. -->
 | `acestep` | ACE-Step | yes | no | cuda, rocm, vulkan |
 | `ds4` | DwarfStar4 (experimental) | no | yes | rocm |
 | `flm` | FastFlowLM NPU | no | yes | npu |
-| `hrx` | HRX GPU (experimental) | no | yes | hrx |
 | `kokoro` | Kokoro | no | no | cpu, metal |
 | `llamacpp` | Llama.cpp GPU | yes | yes | cpu, cuda, metal, rocm, system, vulkan |
+| `llamacpp-hrx` | HRX GPU (experimental) | no | yes | hrx |
 | `moonshine` | Moonshine | no | no | cpu |
 | `onnxruntime` | ONNX Runtime | no | no | cpu |
 | `openmoss` | OpenMOSS TTS | yes | no | cuda, rocm, vulkan |
@@ -37,7 +37,6 @@ the generator instead. Prose outside the markers is preserved. -->
 | `acestep` | rocm | linux, windows | amd_gpu (gfx103X, gfx110X, gfx1150, gfx1151, gfx1152, gfx120X) |
 | `ds4` | rocm | linux | amd_gpu (gfx1151) |
 | `flm` | npu | linux, windows | amd_npu (XDNA2) |
-| `hrx` | hrx | linux | amd_gpu (gfx1100, gfx1151) |
 | `kokoro` | metal | macos | metal |
 | `kokoro` | cpu | linux, windows | cpu (x86_64) |
 | `llamacpp` | system | linux | cpu (arm64, x86_64) |
@@ -46,6 +45,7 @@ the generator instead. Prose outside the markers is preserved. -->
 | `llamacpp` | vulkan | linux, windows | amd_gpu; cpu (arm64, x86_64) |
 | `llamacpp` | rocm | linux, windows | amd_gpu (gfx103X, gfx110X, gfx1150, gfx1151, gfx1152, gfx120X, gfx908, gfx90a, gfx942, gfx950) |
 | `llamacpp` | cpu | linux, windows | cpu (arm64, x86_64) |
+| `llamacpp-hrx` | hrx | linux | amd_gpu (gfx1100, gfx1151) |
 | `moonshine` | cpu | windows | cpu (x86_64) |
 | `moonshine` | cpu | linux | cpu (arm64, x86_64) |
 | `moonshine` | cpu | macos | cpu (arm64) |
@@ -106,13 +106,6 @@ the generator instead. Prose outside the markers is preserved. -->
 | `ctx_size` | `--ctx-size` | SIZE | -1 | Context size for the model |
 | `flm_args` | `--flm-args` | ARGS | "" | Safe flm serve tuning args: --pmode, --prefill-chunk-len, --img-pre-resize, --socket, --q-len, --preemption |
 
-#### `hrx` — HRX GPU (experimental)
-
-| Option | CLI flag | Type | Default | Description |
-|--------|----------|------|---------|-------------|
-| `ctx_size` | `--ctx-size` | SIZE | -1 | Context size for the model |
-| `hrx_args` | `--hrx-args` | ARGS | "" | Custom arguments to pass to the HRX llama-server |
-
 #### `llamacpp` — Llama.cpp GPU
 
 | Option | CLI flag | Type | Default | Description |
@@ -121,6 +114,13 @@ the generator instead. Prose outside the markers is preserved. -->
 | `llamacpp_backend` | `--llamacpp` | BACKEND | "" | LlamaCpp backend to use |
 | `llamacpp_device` | `--llamacpp-device` | DEVICES | "" | Comma-separated list of accelerator devices to use (e.g. Vulkan0) |
 | `llamacpp_args` | `--llamacpp-args` | ARGS | "" | Custom arguments to pass to llama-server |
+
+#### `llamacpp-hrx` — HRX GPU (experimental)
+
+| Option | CLI flag | Type | Default | Description |
+|--------|----------|------|---------|-------------|
+| `ctx_size` | `--ctx-size` | SIZE | -1 | Context size for the model |
+| `hrx_args` | `--hrx-args` | ARGS | "" | Custom arguments to pass to the HRX llama-server |
 
 #### `moonshine` — Moonshine
 

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -382,6 +382,13 @@ The following options are available depending on the recipe being used:
 | `--llamacpp-device DEVICES` | Comma-separated list of accelerator devices to use (e.g. Vulkan0) | `""` |
 | `--llamacpp-args ARGS` | Custom arguments to pass to llama-server | `""` |
 
+#### HRX GPU (experimental) (`hrx` recipe)
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--ctx-size SIZE` | Context size for the model | auto |
+| `--hrx-args ARGS` | Custom arguments to pass to the HRX llama-server | `""` |
+
 #### Whisper.cpp (`whispercpp` recipe)
 
 | Option | Description | Default |

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -382,7 +382,7 @@ The following options are available depending on the recipe being used:
 | `--llamacpp-device DEVICES` | Comma-separated list of accelerator devices to use (e.g. Vulkan0) | `""` |
 | `--llamacpp-args ARGS` | Custom arguments to pass to llama-server | `""` |
 
-#### HRX GPU (experimental) (`hrx` recipe)
+#### HRX GPU (experimental) (`llamacpp-hrx` recipe)
 
 | Option | Description | Default |
 |--------|-------------|---------|

--- a/docs/guide/configuration/README.md
+++ b/docs/guide/configuration/README.md
@@ -64,6 +64,10 @@ When `lemond` starts, effective configuration is resolved by deep-merging settin
   },
   "global_timeout": 600,
   "host": "localhost",
+  "hrx": {
+    "args": "",
+    "hrx_bin": "builtin"
+  },
   "inhibit_suspend": true,
   "kokoro": {
     "cpu_bin": "builtin"

--- a/docs/guide/configuration/custom-models.md
+++ b/docs/guide/configuration/custom-models.md
@@ -87,7 +87,7 @@ Supported registration flags:
 |------|-------------|
 | `--source SOURCE` | Remote registry for every checkpoint in this model: `huggingface` or `modelscope`. When omitted, the server's configured `default_model_source` applies. |
 | `--checkpoint TYPE CHECKPOINT` | Add a checkpoint entry. Repeat for multi-file models such as `main` + `mmproj` or `main` + `vae`. |
-| `--recipe RECIPE` | Recipe to associate with the new `user.*` model. Common values: <!-- BEGIN GENERATED: recipe-values -->`llamacpp`, `hrx`, `whispercpp`, `moonshine`, `kokoro`, `sd-cpp`, `flm`, `ryzenai-llm`, `vllm`, `thenoise`, `thinksound`, `acestep`, `onnxruntime`, `trellis`, `openmoss`, `collection.omni`<!-- END GENERATED: recipe-values -->. |
+| `--recipe RECIPE` | Recipe to associate with the new `user.*` model. Common values: <!-- BEGIN GENERATED: recipe-values -->`llamacpp`, `hrx`, `whispercpp`, `moonshine`, `kokoro`, `sd-cpp`, `flm`, `ryzenai-llm`, `vllm`, `thenoise`, `ds4`, `thinksound`, `acestep`, `onnxruntime`, `trellis`, `openmoss`, `collection.omni`<!-- END GENERATED: recipe-values -->. |
 | `--label LABEL` | Add a label to the new model. Repeatable. Valid labels include `chat`, `coding`, `dflash`, `embeddings`, `hot`, `mtp`, `reasoning`, `reranking`, `tool-calling`, `vision`. When no [deployment label](../../api/openai.md#model-labels) is given, the recipe's default is added — `chat` for `llamacpp`, `flm`, `ryzenai-llm` and `vllm`; `transcription` for `whispercpp`; `image` for `sd-cpp`; and so on. |
 | `--components MODEL [MODEL ...]` | Components for an omni collection (see below). Use with `--recipe collection.omni`. |
 

--- a/docs/guide/configuration/custom-models.md
+++ b/docs/guide/configuration/custom-models.md
@@ -87,7 +87,7 @@ Supported registration flags:
 |------|-------------|
 | `--source SOURCE` | Remote registry for every checkpoint in this model: `huggingface` or `modelscope`. When omitted, the server's configured `default_model_source` applies. |
 | `--checkpoint TYPE CHECKPOINT` | Add a checkpoint entry. Repeat for multi-file models such as `main` + `mmproj` or `main` + `vae`. |
-| `--recipe RECIPE` | Recipe to associate with the new `user.*` model. Common values: <!-- BEGIN GENERATED: recipe-values -->`llamacpp`, `whispercpp`, `moonshine`, `kokoro`, `sd-cpp`, `flm`, `ryzenai-llm`, `vllm`, `thenoise`, `ds4`, `thinksound`, `acestep`, `onnxruntime`, `trellis`, `openmoss`, `collection.omni`<!-- END GENERATED: recipe-values -->. |
+| `--recipe RECIPE` | Recipe to associate with the new `user.*` model. Common values: <!-- BEGIN GENERATED: recipe-values -->`llamacpp`, `hrx`, `whispercpp`, `moonshine`, `kokoro`, `sd-cpp`, `flm`, `ryzenai-llm`, `vllm`, `thenoise`, `thinksound`, `acestep`, `onnxruntime`, `trellis`, `openmoss`, `collection.omni`<!-- END GENERATED: recipe-values -->. |
 | `--label LABEL` | Add a label to the new model. Repeatable. Valid labels include `chat`, `coding`, `dflash`, `embeddings`, `hot`, `mtp`, `reasoning`, `reranking`, `tool-calling`, `vision`. When no [deployment label](../../api/openai.md#model-labels) is given, the recipe's default is added — `chat` for `llamacpp`, `flm`, `ryzenai-llm` and `vllm`; `transcription` for `whispercpp`; `image` for `sd-cpp`; and so on. |
 | `--components MODEL [MODEL ...]` | Components for an omni collection (see below). Use with `--recipe collection.omni`. |
 

--- a/docs/guide/configuration/custom-models.md
+++ b/docs/guide/configuration/custom-models.md
@@ -87,7 +87,7 @@ Supported registration flags:
 |------|-------------|
 | `--source SOURCE` | Remote registry for every checkpoint in this model: `huggingface` or `modelscope`. When omitted, the server's configured `default_model_source` applies. |
 | `--checkpoint TYPE CHECKPOINT` | Add a checkpoint entry. Repeat for multi-file models such as `main` + `mmproj` or `main` + `vae`. |
-| `--recipe RECIPE` | Recipe to associate with the new `user.*` model. Common values: <!-- BEGIN GENERATED: recipe-values -->`llamacpp`, `hrx`, `whispercpp`, `moonshine`, `kokoro`, `sd-cpp`, `flm`, `ryzenai-llm`, `vllm`, `thenoise`, `ds4`, `thinksound`, `acestep`, `onnxruntime`, `trellis`, `openmoss`, `collection.omni`<!-- END GENERATED: recipe-values -->. |
+| `--recipe RECIPE` | Recipe to associate with the new `user.*` model. Common values: <!-- BEGIN GENERATED: recipe-values -->`llamacpp`, `llamacpp-hrx`, `whispercpp`, `moonshine`, `kokoro`, `sd-cpp`, `flm`, `ryzenai-llm`, `vllm`, `thenoise`, `ds4`, `thinksound`, `acestep`, `onnxruntime`, `trellis`, `openmoss`, `collection.omni`<!-- END GENERATED: recipe-values -->. |
 | `--label LABEL` | Add a label to the new model. Repeatable. Valid labels include `chat`, `coding`, `dflash`, `embeddings`, `hot`, `mtp`, `reasoning`, `reranking`, `tool-calling`, `vision`. When no [deployment label](../../api/openai.md#model-labels) is given, the recipe's default is added — `chat` for `llamacpp`, `flm`, `ryzenai-llm` and `vllm`; `transcription` for `whispercpp`; `image` for `sd-cpp`; and so on. |
 | `--components MODEL [MODEL ...]` | Components for an omni collection (see below). Use with `--recipe collection.omni`. |
 

--- a/src/cpp/include/lemon/backends/hrx/hrx.h
+++ b/src/cpp/include/lemon/backends/hrx/hrx.h
@@ -43,10 +43,10 @@ inline const std::set<std::string>& reserved_custom_arg_flags() {
 }
 
 inline const BackendDescriptor descriptor = {
-    /*recipe*/          "hrx",
+    /*recipe*/          "llamacpp-hrx",
     /*display_name*/    "HRX GPU (experimental)",
     /*binary*/          "llama-server",
-    /*config_section*/  "",  // defaults to recipe
+    /*config_section*/  "hrx",
     /*default_device*/  DEVICE_GPU,
     /*slot_policy*/     SlotPolicy::Standard,
     /*selectable_backend*/ false,

--- a/src/cpp/include/lemon/backends/hrx/hrx.h
+++ b/src/cpp/include/lemon/backends/hrx/hrx.h
@@ -9,14 +9,6 @@ namespace lemon {
 namespace backends {
 namespace hrx {
 
-inline constexpr char kQualifiedCheckpoint[] =
-    "unsloth/Qwen3-30B-A3B-Instruct-2507-GGUF:"
-    "Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf";
-
-inline bool is_qualified_checkpoint(const std::string& checkpoint) {
-    return checkpoint == kQualifiedCheckpoint;
-}
-
 inline const std::set<std::string>& reserved_custom_arg_flags() {
     static const std::set<std::string> kReservedCustomArgFlags = {
         "-c",

--- a/src/cpp/include/lemon/backends/hrx/hrx.h
+++ b/src/cpp/include/lemon/backends/hrx/hrx.h
@@ -1,0 +1,84 @@
+#pragma once
+
+#include "lemon/backends/backend_descriptor.h"
+
+#include <set>
+#include <string>
+
+namespace lemon {
+namespace backends {
+namespace hrx {
+
+inline constexpr char kQualifiedCheckpoint[] =
+    "unsloth/Qwen3-30B-A3B-Instruct-2507-GGUF:"
+    "Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf";
+
+inline bool is_qualified_checkpoint(const std::string& checkpoint) {
+    return checkpoint == kQualifiedCheckpoint;
+}
+
+inline const std::set<std::string>& reserved_custom_arg_flags() {
+    static const std::set<std::string> kReservedCustomArgFlags = {
+        "-c",
+        "-dev",
+        "-dr",
+        "-hf",
+        "-hff",
+        "-hfr",
+        "-m",
+        "-mu",
+        "--ctx-size",
+        "--device",
+        "--docker-repo",
+        "--hf-file",
+        "--hf-repo",
+        "--jinja",
+        "--metrics",
+        "--model",
+        "--model-url",
+        "--no-jinja",
+        "--port",
+    };
+    return kReservedCustomArgFlags;
+}
+
+inline const BackendDescriptor descriptor = {
+    /*recipe*/          "hrx",
+    /*display_name*/    "HRX GPU (experimental)",
+    /*binary*/          "llama-server",
+    /*config_section*/  "",  // defaults to recipe
+    /*default_device*/  DEVICE_GPU,
+    /*slot_policy*/     SlotPolicy::Standard,
+    /*selectable_backend*/ false,
+    /*uses_ctx_size*/   true,
+    /*dynamic_models*/  false,
+    /*options*/ {
+        {"hrx_args", "--hrx-args", "", "ARGS",
+         "Custom arguments to pass to the HRX llama-server", "HRX Options"},
+    },
+    /*support*/ {
+        {"hrx", {"linux"},
+         {{"amd_gpu", {"gfx1100", "gfx1151"}}},
+         "AMD GPUs (gfx1100, gfx1151)",
+         {{"gfx1100", {/*os*/ {"linux"}, /*channels*/ {}}},
+          {"gfx1151", {/*os*/ {"linux"}, /*channels*/ {}}}}},
+    },
+    /*supported_modes*/ {"chat", "embeddings", "reranking"},
+    /*required_checkpoints*/ {"main"},
+    /*default_capabilities*/ {},
+    /*experimental*/    true,
+    /*web_display_name*/ "",
+    /*rocm_channels*/   {},
+    /*exposes_prometheus_metrics*/ true,
+    /*rocm_requires_cwsr_fix*/ false,
+    /*version_policy*/  VersionPolicy::Exact,
+    /*self_manages_downloads*/ false,
+    /*takes_args*/      true,
+    /*arg_variants*/    {},
+    /*bin_variants*/    {"hrx"},
+    /*config_extra*/    nlohmann::json::object(),
+};
+
+}  // namespace hrx
+}  // namespace backends
+}  // namespace lemon

--- a/src/cpp/include/lemon/backends/hrx/hrx.h
+++ b/src/cpp/include/lemon/backends/hrx/hrx.h
@@ -55,7 +55,7 @@ inline const BackendDescriptor descriptor = {
          {{"gfx1100", {/*os*/ {"linux"}, /*channels*/ {}}},
           {"gfx1151", {/*os*/ {"linux"}, /*channels*/ {}}}}},
     },
-    /*supported_modes*/ {"chat", "embeddings", "reranking"},
+    /*supported_modes*/ {"chat"},
     /*required_checkpoints*/ {"main"},
     /*default_capabilities*/ {},
     /*experimental*/    true,

--- a/src/cpp/include/lemon/backends/hrx/hrx_server.h
+++ b/src/cpp/include/lemon/backends/hrx/hrx_server.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "lemon/backends/backend_registry.h"
+#include "lemon/backends/llamacpp/llamacpp_server.h"
+
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace lemon {
+namespace backends {
+
+class HrxServer : public LlamaCppServer {
+public:
+    using LlamaCppServer::LlamaCppServer;
+
+    static InstallParams get_install_params(const std::string& backend,
+                                            const std::string& version);
+
+    void load(const std::string& model_name,
+              const ModelInfo& model_info,
+              const RecipeOptions& options,
+              bool do_not_upgrade = false) override;
+};
+
+namespace hrx {
+std::vector<std::string> build_server_argv(const std::string& gguf_path,
+                                           int ctx_size,
+                                           int port,
+                                           const std::string& hrx_args);
+std::vector<std::pair<std::string, std::string>> build_server_environment();
+
+std::unique_ptr<WrappedServer> create(const BackendContext& ctx);
+const BackendSpec* spec();
+const BackendOps* ops();
+constexpr uint32_t capabilities() { return capability_mask_of<HrxServer>(); }
+}  // namespace hrx
+
+}  // namespace backends
+}  // namespace lemon

--- a/src/cpp/include/lemon/backends/hrx/hrx_server.h
+++ b/src/cpp/include/lemon/backends/hrx/hrx_server.h
@@ -33,7 +33,10 @@ std::vector<std::pair<std::string, std::string>> build_server_environment();
 std::unique_ptr<WrappedServer> create(const BackendContext& ctx);
 const BackendSpec* spec();
 const BackendOps* ops();
-constexpr uint32_t capabilities() { return capability_mask_of<HrxServer>(); }
+constexpr uint32_t capabilities() {
+    return capability_mask_of<HrxServer>() &
+           ~(CAP_EMBEDDINGS | CAP_RERANKING);
+}
 }  // namespace hrx
 
 }  // namespace backends

--- a/src/cpp/resources/backend_versions.json
+++ b/src/cpp/resources/backend_versions.json
@@ -63,7 +63,7 @@
     "metal": "b10375",
     "cpu": "b10375"
   },
-  "hrx": {
+  "llamacpp-hrx": {
     "hrx": "hrx-b59"
   },
   "whispercpp": {

--- a/src/cpp/resources/backend_versions.json
+++ b/src/cpp/resources/backend_versions.json
@@ -47,6 +47,11 @@
         "b0001": {
           "ds4-b0001-linux-rocm-gfx1151-x64.tar.gz": "sha256:e63b7c9428fd10de75b3f69164eccd564a8e7261c2f9087cd8bec2b4b19a8ad1"
         }
+      },
+      "ROCm/ggml-staging-automation": {
+        "hrx-b59": {
+          "llama-hrx-b59-bin-manylinux-hrx-x64.tar.gz": "sha256:d2fe01432c372ae4382678cb80542a0c5c80a8e3862c52b3d94e77e81062f1b7"
+        }
       }
     }
   },
@@ -57,6 +62,9 @@
     "cuda": "b10397",
     "metal": "b10375",
     "cpu": "b10375"
+  },
+  "hrx": {
+    "hrx": "hrx-b59"
   },
   "whispercpp": {
     "cpu": "v1.8.4",

--- a/src/cpp/resources/defaults.json
+++ b/src/cpp/resources/defaults.json
@@ -26,6 +26,10 @@
   },
   "global_timeout": 600,
   "host": "localhost",
+  "hrx": {
+    "args": "",
+    "hrx_bin": "builtin"
+  },
   "inhibit_suspend": true,
   "kokoro": {
     "cpu_bin": "builtin"

--- a/src/cpp/resources/server_models.json
+++ b/src/cpp/resources/server_models.json
@@ -968,7 +968,7 @@
     },
     "Qwen3-30B-A3B-Instruct-2507-HRX": {
         "checkpoint": "unsloth/Qwen3-30B-A3B-Instruct-2507-GGUF:Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf",
-        "recipe": "hrx",
+        "recipe": "llamacpp-hrx",
         "suggested": true,
         "labels": [
             "chat",

--- a/src/cpp/resources/server_models.json
+++ b/src/cpp/resources/server_models.json
@@ -966,6 +966,16 @@
         ],
         "size": 17.4
     },
+    "Qwen3-30B-A3B-Instruct-2507-HRX": {
+        "checkpoint": "unsloth/Qwen3-30B-A3B-Instruct-2507-GGUF:Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf",
+        "recipe": "hrx",
+        "suggested": true,
+        "labels": [
+            "chat",
+            "tool-calling"
+        ],
+        "size": 18.6
+    },
     "Qwen3-Coder-30B-A3B-Instruct-GGUF": {
         "checkpoint": "unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF:Qwen3-Coder-30B-A3B-Instruct-Q4_K_M.gguf",
         "recipe": "llamacpp",

--- a/src/cpp/server/backends/hrx/hrx_server.cpp
+++ b/src/cpp/server/backends/hrx/hrx_server.cpp
@@ -1,0 +1,210 @@
+/**
+ * HRX reuses llama-server's protocol but supports only its local-GGUF chat
+ * startup branch. HF loading, vision/mmproj, drafting, embeddings, reranking,
+ * and generic GPU-runtime setup stay omitted because the qualified bundle owns
+ * those choices. The test-visible launch builders remain local until both HRX
+ * and llama.cpp can share a startup seam without either recipe's policy leaking
+ * into the other.
+ */
+
+#include "lemon/backends/hrx/hrx_server.h"
+
+#include "lemon/backend_manager.h"
+#include "lemon/backends/backend_ops.h"
+#include "lemon/backends/backend_utils.h"
+#include "lemon/backends/hrx/hrx.h"
+#include "lemon/model_manager.h"
+#include "lemon/utils/custom_args.h"
+#include "lemon/utils/process_manager.h"
+
+#include <lemon/utils/aixlog.hpp>
+
+#include <stdexcept>
+#include <vector>
+
+namespace lemon {
+namespace backends {
+
+namespace {
+
+void validate_supported_build_host() {
+#if !defined(__linux__) || (!defined(__x86_64__) && !defined(__amd64__))
+    throw std::runtime_error(
+        "The HRX backend is available on Linux x86-64 only");
+#endif
+}
+
+}  // namespace
+
+namespace hrx {
+
+std::vector<std::string> build_server_argv(const std::string& gguf_path,
+                                           int ctx_size,
+                                           int port,
+                                           const std::string& hrx_args) {
+    std::vector<std::string> argv = {
+        "-m", gguf_path,
+        "--ctx-size", std::to_string(ctx_size),
+        "--device", "HRX0",
+        "--port", std::to_string(port),
+        "--jinja",
+        "--metrics",
+    };
+
+    if (hrx_args.empty()) {
+        return argv;
+    }
+
+    const std::string validation_error =
+        utils::validate_custom_args(hrx_args, reserved_custom_arg_flags());
+    if (!validation_error.empty()) {
+        throw std::invalid_argument(
+            "Invalid custom HRX llama-server arguments:\n" + validation_error);
+    }
+
+    const std::vector<std::string> custom_args =
+        utils::parse_custom_args(hrx_args);
+    argv.insert(argv.end(), custom_args.begin(), custom_args.end());
+    return argv;
+}
+
+std::vector<std::pair<std::string, std::string>> build_server_environment() {
+    return {{"GGML_DISABLE_VULKAN", "1"}};
+}
+
+}  // namespace hrx
+
+InstallParams HrxServer::get_install_params(const std::string& backend,
+                                            const std::string& version) {
+    if (backend != "hrx") {
+        throw std::invalid_argument(
+            "Unsupported HRX backend '" + backend + "'; expected 'hrx'");
+    }
+
+    validate_supported_build_host();
+
+    InstallParams params;
+    params.repo = "ROCm/ggml-staging-automation";
+    params.filename =
+        "llama-" + version + "-bin-manylinux-hrx-x64.tar.gz";
+    return params;
+}
+
+void HrxServer::load(const std::string& model_name,
+                     const ModelInfo& model_info,
+                     const RecipeOptions& options,
+                     bool do_not_upgrade) {
+    (void)do_not_upgrade;
+    validate_supported_build_host();
+
+    LOG(INFO, "HRX") << "Loading model: " << model_name << std::endl;
+    LOG(DEBUG, "HRX") << "Per-model settings: "
+                       << options.to_log_string() << std::endl;
+
+    const std::string checkpoint = model_info.checkpoint();
+    if (!hrx::is_qualified_checkpoint(checkpoint)) {
+        throw std::invalid_argument(
+            "Checkpoint '" + checkpoint +
+            "' is not qualified for HRX. Qualified checkpoint: " +
+            hrx::kQualifiedCheckpoint);
+    }
+
+    backend_manager_->install_backend("hrx", "hrx");
+
+    const std::string gguf_path = model_info.resolved_path();
+    if (gguf_path.empty()) {
+        throw std::runtime_error(
+            "GGUF file not found for checkpoint: " + model_info.checkpoint());
+    }
+
+    const int ctx_size = options.get_option("ctx_size");
+    const std::string hrx_args = options.get_option("hrx_args");
+    const int backend_port = choose_port();
+    const std::string executable =
+        BackendUtils::get_backend_binary_path(*hrx::spec(), "hrx");
+    const std::vector<std::string> argv =
+        hrx::build_server_argv(gguf_path, ctx_size, backend_port, hrx_args);
+    const std::vector<std::pair<std::string, std::string>> environment =
+        hrx::build_server_environment();
+
+    const bool info_logging_enabled = log_level_ == "info";
+    const bool inherit_output = info_logging_enabled || is_debug();
+    set_process_handle(
+        utils::ProcessManager::start_process(
+            executable,
+            argv,
+            "",
+            inherit_output,
+            true,
+            environment),
+        executable,
+        argv);
+
+    if (!wait_for_ready("/health")) {
+        const ProcessHandle handle = consume_process_handle_for_cleanup();
+        if (has_process_handle(handle)) {
+            utils::ProcessManager::stop_process(handle);
+        }
+        throw std::runtime_error("HRX llama-server failed to start");
+    }
+
+    LOG(DEBUG, "HRX") << "Model loaded on port "
+                       << get_backend_port() << std::endl;
+}
+
+}  // namespace backends
+}  // namespace lemon
+
+namespace lemon {
+namespace backends {
+
+namespace {
+
+class HrxOps : public BackendOps {
+public:
+    void populate_metadata(ModelInfo& info,
+                           const BackendOpsContext& ctx) const override {
+        llamacpp::ops()->populate_metadata(info, ctx);
+    }
+
+    std::string resolve_checkpoint_path(
+        const ModelInfo& info,
+        const CheckpointResolveContext& ctx) const override {
+        return llamacpp::ops()->resolve_checkpoint_path(info, ctx);
+    }
+
+    std::string find_imported_checkpoint(
+        const std::string& import_dir) const override {
+        return llamacpp::ops()->find_imported_checkpoint(import_dir);
+    }
+
+    std::string validate_registration_checkpoint(
+        const std::string& checkpoint) const override {
+        return llamacpp::ops()->validate_registration_checkpoint(checkpoint);
+    }
+
+    std::string validate_checkpoint_file(
+        const std::string& resolved_path) const override {
+        return llamacpp::ops()->validate_checkpoint_file(resolved_path);
+    }
+};
+
+}  // namespace
+
+namespace hrx {
+
+std::unique_ptr<WrappedServer> create(const BackendContext& ctx) {
+    return make_server<HrxServer>(ctx);
+}
+
+const BackendSpec* spec() {
+    return make_spec<HrxServer>(descriptor);
+}
+
+const BackendOps* ops() {
+    return single_ops<HrxOps>();
+}
+
+}  // namespace hrx
+}  // namespace backends
+}  // namespace lemon

--- a/src/cpp/server/backends/hrx/hrx_server.cpp
+++ b/src/cpp/server/backends/hrx/hrx_server.cpp
@@ -116,7 +116,7 @@ void HrxServer::load(const std::string& model_name,
             hrx::kQualifiedCheckpoint);
     }
 
-    backend_manager_->install_backend("hrx", "hrx");
+    backend_manager_->install_backend(hrx::spec()->recipe, "hrx");
 
     const std::string gguf_path = model_info.resolved_path();
     if (gguf_path.empty()) {

--- a/src/cpp/server/backends/hrx/hrx_server.cpp
+++ b/src/cpp/server/backends/hrx/hrx_server.cpp
@@ -16,6 +16,7 @@
 #include "lemon/model_manager.h"
 #include "lemon/utils/custom_args.h"
 #include "lemon/utils/process_manager.h"
+#include "lemon/utils/recipe_arg_resolver.h"
 
 #include <lemon/utils/aixlog.hpp>
 
@@ -51,19 +52,25 @@ std::vector<std::string> build_server_argv(const std::string& gguf_path,
         "--metrics",
     };
 
-    if (hrx_args.empty()) {
-        return argv;
+    if (!hrx_args.empty()) {
+        const std::string validation_error =
+            utils::validate_custom_args(hrx_args, reserved_custom_arg_flags());
+        if (!validation_error.empty()) {
+            throw std::invalid_argument(
+                "Invalid custom HRX llama-server arguments:\n" +
+                validation_error);
+        }
     }
 
-    const std::string validation_error =
-        utils::validate_custom_args(hrx_args, reserved_custom_arg_flags());
-    if (!validation_error.empty()) {
-        throw std::invalid_argument(
-            "Invalid custom HRX llama-server arguments:\n" + validation_error);
-    }
+    // An auto slot count enables the unified KV buffer, which advertises the
+    // full ctx_size to every slot instead of dividing it. Pinning the count
+    // keeps ctx_size the context a request actually gets (llamacpp pins the
+    // same default in resolve_llamacpp_runtime_args).
+    const std::string resolved_args = utils::append_runtime_arg_defaults(
+        hrx_args, {{"--parallel 1", "--parallel", {"-np"}}});
 
     const std::vector<std::string> custom_args =
-        utils::parse_custom_args(hrx_args);
+        utils::parse_custom_args(resolved_args);
     argv.insert(argv.end(), custom_args.begin(), custom_args.end());
     return argv;
 }

--- a/src/cpp/server/backends/hrx/hrx_server.cpp
+++ b/src/cpp/server/backends/hrx/hrx_server.cpp
@@ -108,14 +108,6 @@ void HrxServer::load(const std::string& model_name,
     LOG(DEBUG, "HRX") << "Per-model settings: "
                        << options.to_log_string() << std::endl;
 
-    const std::string checkpoint = model_info.checkpoint();
-    if (!hrx::is_qualified_checkpoint(checkpoint)) {
-        throw std::invalid_argument(
-            "Checkpoint '" + checkpoint +
-            "' is not qualified for HRX. Qualified checkpoint: " +
-            hrx::kQualifiedCheckpoint);
-    }
-
     backend_manager_->install_backend(hrx::spec()->recipe, "hrx");
 
     const std::string gguf_path = model_info.resolved_path();

--- a/test/cpp/test_hrx_contract.cpp
+++ b/test/cpp/test_hrx_contract.cpp
@@ -1,4 +1,4 @@
-// Proves HRX keeps its narrow install, model-admission, and process-launch
+// Proves HRX keeps its narrow install, custom-argument, and process-launch
 // contract. These checks call the same helpers as HrxServer::load(), without
 // starting the backend or duplicating descriptor-derived data tables.
 
@@ -18,9 +18,6 @@ namespace {
 namespace hrx = lemon::backends::hrx;
 using lemon::backends::HrxServer;
 
-constexpr const char* kQualifiedCheckpoint =
-    "unsloth/Qwen3-30B-A3B-Instruct-2507-GGUF:"
-    "Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf";
 constexpr const char* kReleaseVersion = "hrx-b59";
 
 int failures = 0;
@@ -112,13 +109,6 @@ void check_admission_contract() {
             "/models/qualified.gguf", 4096, 14123, "--port=1");
     });
     check("HRX rejects an equals-form managed argument", equals_flag_rejected);
-
-    check("HRX accepts the exact qualified checkpoint",
-          hrx::is_qualified_checkpoint(kQualifiedCheckpoint));
-    check("HRX rejects a checkpoint artifact mismatch",
-          !hrx::is_qualified_checkpoint(
-              "unsloth/Qwen3-30B-A3B-Instruct-2507-GGUF:"
-              "Qwen3-30B-A3B-Instruct-2507-Q4_0.gguf"));
 }
 
 void check_installer_contract() {

--- a/test/cpp/test_hrx_contract.cpp
+++ b/test/cpp/test_hrx_contract.cpp
@@ -51,11 +51,38 @@ void check_launch_contract() {
         "--metrics",
         "--threads", "7",
         "--no-mmap",
+        "--parallel", "1",
     };
     const auto argv = hrx::build_server_argv(
         "/models/qualified.gguf", 32768, 14123, "--threads 7 --no-mmap");
     check("HRX builds the complete managed argv with a benign custom tail",
           argv == expected_argv);
+
+    const std::vector<std::string> expected_default_argv = {
+        "-m", "/models/qualified.gguf",
+        "--ctx-size", "32768",
+        "--device", "HRX0",
+        "--port", "14123",
+        "--jinja",
+        "--metrics",
+        "--parallel", "1",
+    };
+    check("HRX pins --parallel 1 when no custom args are given",
+          hrx::build_server_argv("/models/qualified.gguf", 32768, 14123, "") ==
+              expected_default_argv);
+
+    const std::vector<std::string> expected_override_argv = {
+        "-m", "/models/qualified.gguf",
+        "--ctx-size", "32768",
+        "--device", "HRX0",
+        "--port", "14123",
+        "--jinja",
+        "--metrics",
+        "-np", "2",
+    };
+    check("HRX lets a custom -np override the --parallel default",
+          hrx::build_server_argv("/models/qualified.gguf", 32768, 14123,
+                                 "-np 2") == expected_override_argv);
 
     const std::vector<std::pair<std::string, std::string>> expected_environment = {
         {"GGML_DISABLE_VULKAN", "1"},

--- a/test/cpp/test_hrx_contract.cpp
+++ b/test/cpp/test_hrx_contract.cpp
@@ -1,0 +1,136 @@
+// Proves HRX keeps its narrow install, model-admission, and process-launch
+// contract. These checks call the same helpers as HrxServer::load(), without
+// starting the backend or duplicating descriptor-derived data tables.
+
+#include "lemon/backends/hrx/hrx.h"
+#include "lemon/backends/hrx/hrx_server.h"
+
+#include <cstdio>
+#include <exception>
+#include <functional>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+
+namespace hrx = lemon::backends::hrx;
+using lemon::backends::HrxServer;
+
+constexpr const char* kQualifiedCheckpoint =
+    "unsloth/Qwen3-30B-A3B-Instruct-2507-GGUF:"
+    "Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf";
+constexpr const char* kReleaseVersion = "hrx-b59";
+
+int failures = 0;
+
+void check(const std::string& what, bool ok) {
+    std::printf("%s %s\n", ok ? "PASS" : "FAIL", what.c_str());
+    if (!ok) {
+        ++failures;
+    }
+}
+
+bool throws_exception(const std::function<void()>& operation) {
+    try {
+        operation();
+    } catch (const std::exception&) {
+        return true;
+    }
+    return false;
+}
+
+void check_launch_contract() {
+    const std::vector<std::string> expected_argv = {
+        "-m", "/models/qualified.gguf",
+        "--ctx-size", "32768",
+        "--device", "HRX0",
+        "--port", "14123",
+        "--jinja",
+        "--metrics",
+        "--threads", "7",
+        "--no-mmap",
+    };
+    const auto argv = hrx::build_server_argv(
+        "/models/qualified.gguf", 32768, 14123, "--threads 7 --no-mmap");
+    check("HRX builds the complete managed argv with a benign custom tail",
+          argv == expected_argv);
+
+    const std::vector<std::pair<std::string, std::string>> expected_environment = {
+        {"GGML_DISABLE_VULKAN", "1"},
+    };
+    check("HRX builds the exact process environment",
+          hrx::build_server_environment() == expected_environment);
+}
+
+void check_admission_contract() {
+    const std::set<std::string> expected_reserved_flags = {
+        "-c", "-dev", "-dr", "-hf", "-hff", "-hfr", "-m", "-mu",
+        "--ctx-size", "--device", "--docker-repo", "--hf-file",
+        "--hf-repo", "--jinja", "--metrics", "--model", "--model-url",
+        "--no-jinja", "--port",
+    };
+    check("HRX reserves exactly its managed flags and aliases",
+          hrx::reserved_custom_arg_flags() == expected_reserved_flags);
+
+    const bool spaced_flag_rejected = throws_exception([] {
+        (void)hrx::build_server_argv(
+            "/models/qualified.gguf", 4096, 14123, "-m replacement.gguf");
+    });
+    check("HRX rejects a space-form managed argument", spaced_flag_rejected);
+
+    const bool equals_flag_rejected = throws_exception([] {
+        (void)hrx::build_server_argv(
+            "/models/qualified.gguf", 4096, 14123, "--port=1");
+    });
+    check("HRX rejects an equals-form managed argument", equals_flag_rejected);
+
+    check("HRX accepts the exact qualified checkpoint",
+          hrx::is_qualified_checkpoint(kQualifiedCheckpoint));
+    check("HRX rejects a checkpoint artifact mismatch",
+          !hrx::is_qualified_checkpoint(
+              "unsloth/Qwen3-30B-A3B-Instruct-2507-GGUF:"
+              "Qwen3-30B-A3B-Instruct-2507-Q4_0.gguf"));
+}
+
+void check_installer_contract() {
+#if defined(__linux__) && (defined(__x86_64__) || defined(__amd64__))
+    const auto params = HrxServer::get_install_params("hrx", kReleaseVersion);
+    check("HRX installer selects the exact release repository",
+          params.repo == "ROCm/ggml-staging-automation");
+    check("HRX installer maps the version to the exact release asset",
+          params.filename ==
+              "llama-hrx-b59-bin-manylinux-hrx-x64.tar.gz");
+#else
+    const bool unsupported_host_rejected = throws_exception([] {
+        (void)HrxServer::get_install_params("hrx", kReleaseVersion);
+    });
+    check("HRX installer rejects a non-Linux-x86-64 host",
+          unsupported_host_rejected);
+#endif
+
+    const bool wrong_backend_rejected = throws_exception([] {
+        (void)HrxServer::get_install_params("rocm", kReleaseVersion);
+    });
+    check("HRX installer rejects another backend", wrong_backend_rejected);
+}
+
+}  // namespace
+
+int main() {
+    try {
+        check_launch_contract();
+        check_admission_contract();
+        check_installer_contract();
+    } catch (const std::exception& error) {
+        check(std::string("unexpected exception: ") + error.what(), false);
+    }
+
+    if (failures == 0) {
+        std::printf("\nAll HRX contract checks passed.\n");
+        return 0;
+    }
+    std::printf("\n%d HRX contract check(s) failed.\n", failures);
+    return 1;
+}


### PR DESCRIPTION
<!--
Before submitting this PR, please read:
- docs/dev/contribute.md
- docs/dev/philosophy.md
- AGENTS.md if you used an AI coding agent or AI-assisted workflow
- docs/dev/documentation.md if this PR changes user-facing or developer-facing documentation
-->

## Summary

Adds an `hrx` backend, this is an experimental llama.cpp backend making its way into llama.cpp mainline. See https://github.com/ggml-org/llama.cpp/discussions/27219 for more information. 

Currently hrx only supports `Qwen3-30B-A3B-Instruct-2507-Q4_K_M`, this will evolve rapidly but _today_ model support is limited. To avoid burdening the `llama.cpp` recipe with additional functionality to limit model support per backend, this PR introduces hrx as a separate recipe vs a `llama.cpp` backend. With a separate recipe we can scope hrx to the qualified models "for free." When hrx support advances to be competitive with other `llama.cpp` backends the hrx specific recipe will be removed and it will become a regular `llama.cpp` backend.

Hrx recipe simply wraps the existing llama.cpp recipe, so there's not much to it.

<img width="1263" height="455" alt="image" src="https://github.com/user-attachments/assets/3ced131e-558e-4998-b67c-805f77b31f63" />

## Testing

I verified locally on a W7900 `gfx1100` machine. The `llama-server` artifact is verified in CI on strix halo `gfx1151` machine ([link](https://github.com/ROCm/ggml-staging-automation/actions/runs/32521144748)).
