### PR TITLE
Fix(#3336) improve validate llamacpp.py

### DIFF
--- a/test/validate_llamacpp.py
+++ b/test/validate_llamacpp.py
@@ -27,7 +27,7 @@ import tempfile
 
 import requests
 
-from utils.server_base import unload_all_models, wait_for_server
+from utils.server_base import _auth_headers, unload_all_models, wait_for_server
 from utils.test_models import PORT, TIMEOUT_DEFAULT
 
 TIMEOUT_HEALTH = 60
@@ -61,6 +61,11 @@ def collect_server_logs(output_dir):
 
 def request_json(method, url, timeout, **kwargs):
     """Perform an HTTP request and parse the JSON response when present."""
+    api_key = _auth_headers()
+    if api_key: 
+        headers = kwargs.get("headers", {})
+        headers.update(api_key)
+        kwargs["headers"] = headers
     response = requests.request(method, url, timeout=timeout, **kwargs)
     body = {}
     if response.content:

--- a/test/validate_llamacpp.py
+++ b/test/validate_llamacpp.py
@@ -61,12 +61,10 @@ def collect_server_logs(output_dir):
 
 def request_json(method, url, timeout, **kwargs):
     """Perform an HTTP request and parse the JSON response when present."""
-    api_key = _auth_headers()
-    if api_key: 
-        headers = kwargs.get("headers", {})
-        headers.update(api_key)
-        kwargs["headers"] = headers
-    response = requests.request(method, url, timeout=timeout, **kwargs)
+    auth_headers = _auth_headers()
+    headers = {**(kwargs.get("headers") or {}), **auth_headers}
+    request_kwargs = { **kwargs, "headers" : headers}
+    response = requests.request(method, url, timeout=timeout, **request_kwargs)
     body = {}
     if response.content:
         try:

--- a/test/validate_llamacpp.py
+++ b/test/validate_llamacpp.py
@@ -63,7 +63,7 @@ def request_json(method, url, timeout, **kwargs):
     """Perform an HTTP request and parse the JSON response when present."""
     auth_headers = _auth_headers()
     headers = {**(kwargs.get("headers") or {}), **auth_headers}
-    request_kwargs = { **kwargs, "headers" : headers}
+    request_kwargs = {**kwargs, "headers": headers}
     response = requests.request(method, url, timeout=timeout, **request_kwargs)
     body = {}
     if response.content:

--- a/test/validate_vllm.py
+++ b/test/validate_vllm.py
@@ -62,7 +62,7 @@ def request_json(method, url, timeout, **kwargs):
     """Perform an HTTP request and parse the JSON response when present."""
     auth_headers = _auth_headers()
     headers = {**(kwargs.get("headers") or {}), **auth_headers}
-    request_kwargs = { **kwargs, "headers" : headers}
+    request_kwargs = {**kwargs, "headers": headers}
     response = requests.request(method, url, timeout=timeout, **request_kwargs)
     body = {}
     if response.content:

--- a/test/validate_vllm.py
+++ b/test/validate_vllm.py
@@ -60,12 +60,10 @@ def collect_server_logs(output_dir):
 
 def request_json(method, url, timeout, **kwargs):
     """Perform an HTTP request and parse the JSON response when present."""
-    api_key = _auth_headers()
-    if api_key: 
-        headers = kwargs.get("headers", {})
-        headers.update(api_key)
-        kwargs["headers"] = headers
-    response = requests.request(method, url, timeout=timeout, **kwargs)
+    auth_headers = _auth_headers()
+    headers = {**(kwargs.get("headers") or {}), **auth_headers}
+    request_kwargs = { **kwargs, "headers" : headers}
+    response = requests.request(method, url, timeout=timeout, **request_kwargs)
     body = {}
     if response.content:
         try:

--- a/test/validate_vllm.py
+++ b/test/validate_vllm.py
@@ -26,7 +26,7 @@ import tempfile
 
 import requests
 
-from utils.server_base import unload_all_models, wait_for_server
+from utils.server_base import _auth_headers, unload_all_models, wait_for_server
 from utils.test_models import PORT, TIMEOUT_DEFAULT
 
 TIMEOUT_HEALTH = 60
@@ -60,6 +60,11 @@ def collect_server_logs(output_dir):
 
 def request_json(method, url, timeout, **kwargs):
     """Perform an HTTP request and parse the JSON response when present."""
+    api_key = _auth_headers()
+    if api_key: 
+        headers = kwargs.get("headers", {})
+        headers.update(api_key)
+        kwargs["headers"] = headers
     response = requests.request(method, url, timeout=timeout, **kwargs)
     body = {}
     if response.content:


### PR DESCRIPTION
## Summary

This PR fixes #3336 : Testing: Improve validate_llamacpp.py
I have added  the _auth_headers to the request_json function  to get LEMONADE_ADMIN_API_KEY or LEMONADE_API_KEY  and then pass it to the headers  of request. I saw  validate_vllm.py had the same issue so I added the same solution to it.

The solution was  add the _auth_headers function call and check if the returned dictionary was not empty. If it was NOT empty, I update the headers dictionary in **kwargs with the returned value.

<img width="672" height="304" alt="image" src="https://github.com/user-attachments/assets/46aab0df-7146-41b1-bcbe-276a91dff19a" />


Fixes #3336 

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [ ] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_

I called it without my changes and it failed:

<img width="1241" height="178" alt="image" src="https://github.com/user-attachments/assets/0bdae96a-6a77-411f-8f79-5a2a9577709a" />

Then I applied the changes and it worked
<img width="1233" height="387" alt="image" src="https://github.com/user-attachments/assets/a5c95003-468c-40dc-9f42-d471bf74c591" />


I used the same  testing with validate_vllm.py
Without changes:
<img width="1224" height="156" alt="image" src="https://github.com/user-attachments/assets/fbe44d99-38bd-41f3-81b5-dc5976075b3a" />

With changes:

<img width="1526" height="112" alt="image" src="https://github.com/user-attachments/assets/2592a89d-85fc-4775-aa88-8fa44c2c7643" />

## Documentation

- [x] Documentation is not affected by this change.
- [ ] Documentation is affected and has been updated.
- [ ] Documentation is affected but will be handled in a separate PR or issue.

## Breaking Changes

- [ ] This PR introduces breaking changes.
- [x] This PR does not introduce breaking changes.

## AI-assisted contribution

Please select one:

- [ ] I used AI tools for this PR.
- [x] I did not use AI tools for this PR.
