### PR TITLE
Fix compact chat model selector and modality display

### DIFF
--- a/src/app/src/components/ChatView.tsx
+++ b/src/app/src/components/ChatView.tsx
@@ -3634,7 +3634,10 @@ ${finalText}`
       <div className="composer" onDrop={handleDrop} onDragOver={handleDragOver}>
         <div className="composer__toolbar">
           {(modelPickerOptions.length > 0 || modelPickerOpen) && (
-            <div className="composer__model-picker" ref={modelPickerRef}>
+            <div
+              className={`composer__model-picker${currentLoadedModel ? ' composer__model-picker--loaded' : ''}`}
+              ref={modelPickerRef}
+            >
               <span className="composer__model-label">Model</span>
               <button
                 type="button"
@@ -3642,6 +3645,7 @@ ${finalText}`
                 onClick={() => { setModelPickerOpen(v => !v); setModelPickerError(null); }}
                 aria-haspopup="listbox"
                 aria-expanded={modelPickerOpen}
+                aria-label={currentModel ? `Select model, current ${currentModel}` : 'Select model'}
               >
                 {currentLoadedModel ? (
                   <span className={`composer__model-mode composer__model-mode--${modelModeBadge(currentCapability, currentRecipe)}`}>
@@ -3663,7 +3667,9 @@ ${finalText}`
                 {selectableModels.length > 0 && (
                   <span className="composer__model-button-badge">({selectableModels.length})</span>
                 )}
-                <span className="composer__model-button-caret">▾</span>
+                <span className="composer__model-button-caret" aria-hidden="true">
+                  <span className="composer__model-button-caret-glyph">▾</span>
+                </span>
               </button>
               {modelPickerOpen && (
                 <div className="composer__model-menu" role="dialog" aria-label="Search models">

--- a/src/app/src/components/ChatView.tsx
+++ b/src/app/src/components/ChatView.tsx
@@ -425,31 +425,39 @@ function modelModeBadge(capability: ModelCapability, recipe?: string | null): st
 const ModelModeIcons: React.FC<{
   capability: ModelCapability;
   recipe?: string | null;
+  imageInput?: boolean;
   audioInput?: boolean;
   size?: number;
-}> = ({ capability, recipe, audioInput = false, size = 14 }) => {
+}> = ({ capability, recipe, imageInput = false, audioInput = false, size = 14 }) => {
   const identity = identityFor(capability, recipe);
   if (identity !== capability) {
     return <CapabilityIcon capability={identity} size={size} aria-hidden="true" />;
   }
+  const showImage = imageInput && capability === 'chat';
   const showAudio = audioInput && capability === 'chat';
   return (
     <span className="capability-icon-pair" aria-hidden="true">
       <CapabilityIcon capability={capability} size={size} />
+      {showImage && <CapabilityIcon capability="image" size={Math.max(11, size - 1)} />}
       {showAudio && <CapabilityIcon capability="audio" size={Math.max(11, size - 1)} />}
     </span>
   );
 };
 
-function modelModeLabel(capability: ModelCapability, audioInput = false): string {
-  return audioInput && capability === 'chat'
-    ? 'Chat + Audio'
-    : capabilityLabel(capability);
+function modelModeLabel(capability: ModelCapability, audioInput = false, imageInput = false): string {
+  if (capability !== 'chat') return capabilityLabel(capability);
+  const inputs = [imageInput ? 'Image' : '', audioInput ? 'Audio' : ''].filter(Boolean);
+  return inputs.length > 0 ? `Chat + ${inputs.join(' + ')}` : capabilityLabel(capability);
 }
 
-function modelModeDisplayLabel(capability: ModelCapability, audioInput = false, recipe?: string | null): string {
+function modelModeDisplayLabel(
+  capability: ModelCapability,
+  audioInput = false,
+  recipe?: string | null,
+  imageInput = false,
+): string {
   const identity = identityFor(capability, recipe);
-  return identity === capability ? modelModeLabel(capability, audioInput) : capabilityLabel(identity);
+  return identity === capability ? modelModeLabel(capability, audioInput, imageInput) : capabilityLabel(identity);
 }
 
 function loadedOverviewSizeLabel(info: ModelInfo | null): string | null {
@@ -3647,14 +3655,15 @@ ${finalText}`
                 aria-expanded={modelPickerOpen}
                 aria-label={currentModel ? `Select model, current ${currentModel}` : 'Select model'}
               >
+                {!currentModel && <span className="composer__model-button-empty-label">Models</span>}
                 {currentLoadedModel ? (
                   <span className={`composer__model-mode composer__model-mode--${modelModeBadge(currentCapability, currentRecipe)}`}>
-                    <ModelModeIcons capability={currentCapability} recipe={currentRecipe} audioInput={supportsChatAudioInput} size={14} />
-                    <span>{modelModeDisplayLabel(currentCapability, supportsChatAudioInput, currentRecipe)}</span>
+                    <ModelModeIcons capability={currentCapability} recipe={currentRecipe} imageInput={supportsChatImageInput} audioInput={supportsChatAudioInput} size={14} />
+                    <span>{modelModeDisplayLabel(currentCapability, supportsChatAudioInput, currentRecipe, supportsChatImageInput)}</span>
                   </span>
-                ) : (
-                  <ModelModeIcons capability={currentCapability} recipe={currentRecipe} audioInput={supportsChatAudioInput} size={14} />
-                )}
+                ) : currentModel ? (
+                  <ModelModeIcons capability={currentCapability} recipe={currentRecipe} imageInput={supportsChatImageInput} audioInput={supportsChatAudioInput} size={14} />
+                ) : null}
                 {!currentLoadedModel && currentDefaultModel && (
                   <span className="composer__model-default-icon" title={currentDefaultModel.label} aria-label={currentDefaultModel.label}>
                   </span>

--- a/src/app/src/styles/critical.generated.css
+++ b/src/app/src/styles/critical.generated.css
@@ -2654,7 +2654,14 @@ option:checked {
   display: flex;
   align-items: center;
   gap: var(--space-2);
-}@media (max-width: 980px) {.chat--with-logs,
+}.composer__toolbar {
+    flex-wrap: nowrap;
+  }.composer__model-picker {
+    flex: 1 1 auto;
+    min-width: 0;
+  }.composer__model-button {
+    min-width: 0;
+  }@media (max-width: 980px) {.chat--with-logs,
   .chat--with-logs.rail-expanded {
     grid-template-columns: var(--rail-collapsed) 1fr;
     grid-template-areas:

--- a/src/app/src/styles/critical.generated.css
+++ b/src/app/src/styles/critical.generated.css
@@ -1818,7 +1818,10 @@ option:checked {
     grid-template-areas:
       "main"
       "composer";
-  }.rail { display: none; }.chat__inner { padding: var(--space-5) var(--space-4); overflow-x: hidden; }.composer { padding: var(--space-3) var(--space-4); }.manager__custom-actions .btn { flex: 1; justify-content: center; }.hero { padding: var(--space-8) 0 var(--space-6); }.hero__title { font-size: var(--text-2xl); }.hero__subtitle { font-size: var(--text-base); }.chips { gap: var(--space-1); }.chip { padding: 8px var(--space-3); font-size: var(--text-xs); }.active-models { grid-template-columns: 1fr; }}@media (max-width: 480px) {.composer__send,
+  }.rail { display: none;
+  }.composer__model-picker--loaded .composer__model-mode > span:not(.capability-icon-pair) {
+    display: none;
+  }.chat__inner { padding: var(--space-5) var(--space-4); overflow-x: hidden; }.composer { padding: var(--space-3) var(--space-4); }.manager__custom-actions .btn { flex: 1; justify-content: center; }.hero { padding: var(--space-8) 0 var(--space-6); }.hero__title { font-size: var(--text-2xl); }.hero__subtitle { font-size: var(--text-base); }.chips { gap: var(--space-1); }.chip { padding: 8px var(--space-3); font-size: var(--text-xs); }.active-models { grid-template-columns: 1fr; }}@media (max-width: 480px) {.composer__send,
   .composer__stop {
     width: 44px;
     height: 44px;
@@ -2557,6 +2560,8 @@ option:checked {
   color: var(--text-tertiary);
   font-weight: var(--weight-regular);
   flex-shrink: 0;
+}.composer__model-button-empty-label {
+  display: none;
 }.composer__model-option-row {
   display: flex;
   align-items: center;
@@ -2663,23 +2668,26 @@ option:checked {
     min-width: 0;
   }@media (max-width: 480px) {.composer__model-picker {
     flex: 1 1 auto;
-    min-width: 30px;
+    min-width: 0;
     order: 0;
+    container-type: inline-size;
+    container-name: compact-model-picker;
   }.composer__effective-settings {
     order: 1;
     margin-left: auto;
   }.composer__tools-toggle:not(.composer__effective-settings) { order: 2;
   }.composer__model-label,
-  .composer__model-picker:not(.composer__model-picker--loaded) .composer__model-button > :not(.composer__model-button-caret) {
+  .composer__model-picker:not(.composer__model-picker--loaded) .composer__model-default-icon,
+  .composer__model-picker:not(.composer__model-picker--loaded) .composer__model-button-badge {
     display: none;
   }.composer__model-button {
     width: max-content;
     height: 30px;
-    min-width: 30px;
-    max-width: 30px;
-    flex: 0 0 30px;
-    padding: 0;
-    justify-content: center;
+    min-width: 0;
+    max-width: 100%;
+    flex: 0 0 auto;
+    padding: 5px var(--space-2);
+    justify-content: flex-start;
     overflow: hidden;
     white-space: nowrap;
     transition:
@@ -2690,19 +2698,27 @@ option:checked {
       border-color var(--duration-fast) var(--ease-out);
   }.composer__model-picker--loaded .composer__model-button {
     max-width: min(260px, 100%);
-    flex: 0 0 auto;
-    padding: 5px var(--space-2);
-    justify-content: flex-start;
-  }.composer__model-picker--loaded .composer__model-button-name {
+  }.composer__model-button-empty-label {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: var(--text-tertiary);
+  }.composer__model-picker:not(.composer__model-picker--loaded) .composer__model-button-empty-label {
+    display: inline-flex;
+  }.composer__model-picker:not(.composer__model-picker--loaded) .composer__model-button {
+    gap: 5px;
+  }.composer__model-button-name {
     flex: 1 1 auto;
     min-width: 0;
   }.composer__model-button-caret {
-    width: 100%;
-    height: 100%;
+    width: 16px;
+    height: 16px;
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    margin-left: 0;
+    flex: 0 0 16px;
+    margin-left: auto;
     font-size: 0;
   }.composer__model-button-caret-glyph {
     width: 16px;
@@ -2711,22 +2727,25 @@ option:checked {
     align-items: center;
     justify-content: center;
     flex: 0 0 16px;
-    font-size: 16px;
+    font-size: var(--text-sm);
     line-height: 1;
     transform: rotate(0deg);
     transform-origin: 50% 50%;
     transition: transform var(--duration-base) var(--ease-out);
     will-change: transform;
-  }.composer__model-picker--loaded .composer__model-button-caret {
-    width: 16px;
-    height: 16px;
-    flex: 0 0 16px;
-    margin-left: auto;
   }.composer__model-button[aria-expanded="true"] .composer__model-button-caret-glyph {
     transform: rotate(180deg);
   }.composer__model-menu {
     right: auto;
     left: 0;
+  }}@container compact-model-picker (max-width: 215px) {.composer__model-picker--loaded .composer__model-button-badge {
+    display: none;
+  }}@container compact-model-picker (max-width: 200px) {.composer__model-picker--loaded .composer__model-button {
+    padding-block: 5px;
+    gap: 5px;
+  }.composer__model-picker--loaded .composer__model-default-icon,
+  .composer__model-picker--loaded .composer__model-button-badge {
+    display: none;
   }}@media (max-width: 980px) {.chat--with-logs,
   .chat--with-logs.rail-expanded {
     grid-template-columns: var(--rail-collapsed) 1fr;

--- a/src/app/src/styles/critical.generated.css
+++ b/src/app/src/styles/critical.generated.css
@@ -2661,7 +2661,73 @@ option:checked {
     min-width: 0;
   }.composer__model-button {
     min-width: 0;
-  }@media (max-width: 980px) {.chat--with-logs,
+  }@media (max-width: 480px) {.composer__model-picker {
+    flex: 1 1 auto;
+    min-width: 30px;
+    order: 0;
+  }.composer__effective-settings {
+    order: 1;
+    margin-left: auto;
+  }.composer__tools-toggle:not(.composer__effective-settings) { order: 2;
+  }.composer__model-label,
+  .composer__model-picker:not(.composer__model-picker--loaded) .composer__model-button > :not(.composer__model-button-caret) {
+    display: none;
+  }.composer__model-button {
+    width: max-content;
+    height: 30px;
+    min-width: 30px;
+    max-width: 30px;
+    flex: 0 0 30px;
+    padding: 0;
+    justify-content: center;
+    overflow: hidden;
+    white-space: nowrap;
+    transition:
+      max-width var(--duration-base) var(--ease-out),
+      padding var(--duration-base) var(--ease-out),
+      gap var(--duration-base) var(--ease-out),
+      background-color var(--duration-fast) var(--ease-out),
+      border-color var(--duration-fast) var(--ease-out);
+  }.composer__model-picker--loaded .composer__model-button {
+    max-width: min(260px, 100%);
+    flex: 0 0 auto;
+    padding: 5px var(--space-2);
+    justify-content: flex-start;
+  }.composer__model-picker--loaded .composer__model-button-name {
+    flex: 1 1 auto;
+    min-width: 0;
+  }.composer__model-button-caret {
+    width: 100%;
+    height: 100%;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    margin-left: 0;
+    font-size: 0;
+  }.composer__model-button-caret-glyph {
+    width: 16px;
+    height: 16px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 16px;
+    font-size: 16px;
+    line-height: 1;
+    transform: rotate(0deg);
+    transform-origin: 50% 50%;
+    transition: transform var(--duration-base) var(--ease-out);
+    will-change: transform;
+  }.composer__model-picker--loaded .composer__model-button-caret {
+    width: 16px;
+    height: 16px;
+    flex: 0 0 16px;
+    margin-left: auto;
+  }.composer__model-button[aria-expanded="true"] .composer__model-button-caret-glyph {
+    transform: rotate(180deg);
+  }.composer__model-menu {
+    right: auto;
+    left: 0;
+  }}@media (max-width: 980px) {.chat--with-logs,
   .chat--with-logs.rail-expanded {
     grid-template-columns: var(--rail-collapsed) 1fr;
     grid-template-areas:

--- a/src/app/src/styles/styles.css
+++ b/src/app/src/styles/styles.css
@@ -3811,6 +3811,9 @@ optgroup {
       "composer";
   }
   .rail { display: none; }
+  .composer__model-picker--loaded .composer__model-mode > span:not(.capability-icon-pair) {
+    display: none;
+  }
   .manager--with-rail, .backends--with-rail { grid-template-columns: 1fr; }
   .context-rail { display: none; }
   .manager__main { height: 100%; }
@@ -6023,6 +6026,10 @@ optgroup {
   flex-shrink: 0;
 }
 
+.composer__model-button-empty-label {
+  display: none;
+}
+
 .composer__model-error {
   margin-top: var(--space-2);
   padding: var(--space-2);
@@ -6148,8 +6155,10 @@ optgroup {
 @media (max-width: 480px) {
   .composer__model-picker {
     flex: 1 1 auto;
-    min-width: 30px;
+    min-width: 0;
     order: 0;
+    container-type: inline-size;
+    container-name: compact-model-picker;
   }
 
   .composer__effective-settings {
@@ -6160,18 +6169,19 @@ optgroup {
   .composer__tools-toggle:not(.composer__effective-settings) { order: 2; }
 
   .composer__model-label,
-  .composer__model-picker:not(.composer__model-picker--loaded) .composer__model-button > :not(.composer__model-button-caret) {
+  .composer__model-picker:not(.composer__model-picker--loaded) .composer__model-default-icon,
+  .composer__model-picker:not(.composer__model-picker--loaded) .composer__model-button-badge {
     display: none;
   }
 
   .composer__model-button {
     width: max-content;
     height: 30px;
-    min-width: 30px;
-    max-width: 30px;
-    flex: 0 0 30px;
-    padding: 0;
-    justify-content: center;
+    min-width: 0;
+    max-width: 100%;
+    flex: 0 0 auto;
+    padding: 5px var(--space-2);
+    justify-content: flex-start;
     overflow: hidden;
     white-space: nowrap;
     transition:
@@ -6184,23 +6194,37 @@ optgroup {
 
   .composer__model-picker--loaded .composer__model-button {
     max-width: min(260px, 100%);
-    flex: 0 0 auto;
-    padding: 5px var(--space-2);
-    justify-content: flex-start;
   }
 
-  .composer__model-picker--loaded .composer__model-button-name {
+  .composer__model-button-empty-label {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: var(--text-tertiary);
+  }
+
+  .composer__model-picker:not(.composer__model-picker--loaded) .composer__model-button-empty-label {
+    display: inline-flex;
+  }
+
+  .composer__model-picker:not(.composer__model-picker--loaded) .composer__model-button {
+    gap: 5px;
+  }
+
+  .composer__model-button-name {
     flex: 1 1 auto;
     min-width: 0;
   }
 
   .composer__model-button-caret {
-    width: 100%;
-    height: 100%;
+    width: 16px;
+    height: 16px;
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    margin-left: 0;
+    flex: 0 0 16px;
+    margin-left: auto;
     font-size: 0;
   }
 
@@ -6211,19 +6235,12 @@ optgroup {
     align-items: center;
     justify-content: center;
     flex: 0 0 16px;
-    font-size: 16px;
+    font-size: var(--text-sm);
     line-height: 1;
     transform: rotate(0deg);
     transform-origin: 50% 50%;
     transition: transform var(--duration-base) var(--ease-out);
     will-change: transform;
-  }
-
-  .composer__model-picker--loaded .composer__model-button-caret {
-    width: 16px;
-    height: 16px;
-    flex: 0 0 16px;
-    margin-left: auto;
   }
 
   .composer__model-button[aria-expanded="true"] .composer__model-button-caret-glyph {
@@ -6233,6 +6250,24 @@ optgroup {
   .composer__model-menu {
     right: auto;
     left: 0;
+  }
+}
+
+@container compact-model-picker (max-width: 215px) {
+  .composer__model-picker--loaded .composer__model-button-badge {
+    display: none;
+  }
+}
+
+@container compact-model-picker (max-width: 200px) {
+  .composer__model-picker--loaded .composer__model-button {
+    padding-block: 5px;
+    gap: 5px;
+  }
+
+  .composer__model-picker--loaded .composer__model-default-icon,
+  .composer__model-picker--loaded .composer__model-button-badge {
+    display: none;
   }
 }
 

--- a/src/app/src/styles/styles.css
+++ b/src/app/src/styles/styles.css
@@ -6132,6 +6132,19 @@ optgroup {
   z-index: 3;
 }
 
+.composer__toolbar {
+  flex-wrap: nowrap;
+}
+
+.composer__model-picker {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.composer__model-button {
+  min-width: 0;
+}
+
 @media (max-width: 768px) {
   .chat.chat--with-logs.rail-expanded,
   .chat.chat--with-logs:not(.rail-expanded) {

--- a/src/app/src/styles/styles.css
+++ b/src/app/src/styles/styles.css
@@ -6145,6 +6145,97 @@ optgroup {
   min-width: 0;
 }
 
+@media (max-width: 480px) {
+  .composer__model-picker {
+    flex: 1 1 auto;
+    min-width: 30px;
+    order: 0;
+  }
+
+  .composer__effective-settings {
+    order: 1;
+    margin-left: auto;
+  }
+
+  .composer__tools-toggle:not(.composer__effective-settings) { order: 2; }
+
+  .composer__model-label,
+  .composer__model-picker:not(.composer__model-picker--loaded) .composer__model-button > :not(.composer__model-button-caret) {
+    display: none;
+  }
+
+  .composer__model-button {
+    width: max-content;
+    height: 30px;
+    min-width: 30px;
+    max-width: 30px;
+    flex: 0 0 30px;
+    padding: 0;
+    justify-content: center;
+    overflow: hidden;
+    white-space: nowrap;
+    transition:
+      max-width var(--duration-base) var(--ease-out),
+      padding var(--duration-base) var(--ease-out),
+      gap var(--duration-base) var(--ease-out),
+      background-color var(--duration-fast) var(--ease-out),
+      border-color var(--duration-fast) var(--ease-out);
+  }
+
+  .composer__model-picker--loaded .composer__model-button {
+    max-width: min(260px, 100%);
+    flex: 0 0 auto;
+    padding: 5px var(--space-2);
+    justify-content: flex-start;
+  }
+
+  .composer__model-picker--loaded .composer__model-button-name {
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+
+  .composer__model-button-caret {
+    width: 100%;
+    height: 100%;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    margin-left: 0;
+    font-size: 0;
+  }
+
+  .composer__model-button-caret-glyph {
+    width: 16px;
+    height: 16px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 16px;
+    font-size: 16px;
+    line-height: 1;
+    transform: rotate(0deg);
+    transform-origin: 50% 50%;
+    transition: transform var(--duration-base) var(--ease-out);
+    will-change: transform;
+  }
+
+  .composer__model-picker--loaded .composer__model-button-caret {
+    width: 16px;
+    height: 16px;
+    flex: 0 0 16px;
+    margin-left: auto;
+  }
+
+  .composer__model-button[aria-expanded="true"] .composer__model-button-caret-glyph {
+    transform: rotate(180deg);
+  }
+
+  .composer__model-menu {
+    right: auto;
+    left: 0;
+  }
+}
+
 @media (max-width: 768px) {
   .chat.chat--with-logs.rail-expanded,
   .chat.chat--with-logs:not(.rail-expanded) {

--- a/src/app/tests/a11y.spec.ts
+++ b/src/app/tests/a11y.spec.ts
@@ -3046,6 +3046,28 @@ test.describe('Chat toolbar accessibility', () => {
     await expect(page.getByRole('button', { name: 'Effective settings' })).toBeVisible();
   });
 
+  test('A186b — Logs remains beside Effective Settings at narrow widths', async ({ page }) => {
+    await page.setViewportSize({ width: 851, height: 800 });
+    await goToChatWithLoadedModel(page);
+
+    const settings = page.getByRole('button', { name: 'Effective settings' });
+    const logs = page.getByRole('button', { name: /Logs/i });
+
+    for (const width of [851, 480]) {
+      await page.setViewportSize({ width, height: 800 });
+      const [settingsBox, logsBox] = await Promise.all([
+        settings.boundingBox(),
+        logs.boundingBox(),
+      ]);
+
+      expect(settingsBox).not.toBeNull();
+      expect(logsBox).not.toBeNull();
+      expect(Math.abs(logsBox!.y - settingsBox!.y)).toBeLessThan(2);
+      expect(logsBox!.x).toBeGreaterThan(settingsBox!.x + settingsBox!.width);
+      expect(logsBox!.x + logsBox!.width).toBeLessThanOrEqual(width);
+    }
+  });
+
   test('A187 — add menu exposes one unified tools entry and is keyboard-operable', async ({ page }) => {
     await goToChatWithLoadedModel(page);
     const addBtn = page.getByRole('button', { name: /Add files, photos, or tools/i });

--- a/src/app/tests/a11y.spec.ts
+++ b/src/app/tests/a11y.spec.ts
@@ -3035,6 +3035,32 @@ test.describe('Chat toolbar accessibility', () => {
     await page.waitForTimeout(300);
   }
 
+  async function goToChatWithoutLoadedModel(page: Page): Promise<void> {
+    await page.route('**/api/v1/health**', async route =>
+      route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({ status: 'ok', version: 'test', all_models_loaded: [] }),
+      }),
+    );
+    await page.route('**/api/v1/models**', async route =>
+      route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({
+          data: [{
+            id: 'Llama-3.1-8B-Instruct',
+            name: 'Llama-3.1-8B-Instruct',
+            labels: ['chat'],
+            recipe: 'llamacpp',
+            downloaded: true,
+          }],
+        }),
+      }),
+    );
+    await page.goto('/');
+    await page.waitForSelector('.chat');
+    await page.waitForTimeout(300);
+  }
+
   test('A186 — composer toolbar retains model selector, settings, add menu, and Logs buttons', async ({ page }) => {
     await goToChatWithLoadedModel(page);
     // Model picker button is present (model is loaded so it appears)
@@ -3048,12 +3074,13 @@ test.describe('Chat toolbar accessibility', () => {
 
   test('A186b — Logs remains beside Effective Settings at narrow widths', async ({ page }) => {
     await page.setViewportSize({ width: 851, height: 800 });
-    await goToChatWithLoadedModel(page);
+    await goToChatWithLoadedModel(page, ['text', 'image', 'audio']);
 
     const settings = page.getByRole('button', { name: 'Effective settings' });
     const logs = page.getByRole('button', { name: /Logs/i });
+    const modelButton = page.getByRole('button', { name: 'Select model, current Llama-3.1-8B-Instruct' });
 
-    for (const width of [851, 480]) {
+    for (const width of [851, 480, 400, 320]) {
       await page.setViewportSize({ width, height: 800 });
       const [settingsBox, logsBox] = await Promise.all([
         settings.boundingBox(),
@@ -3066,6 +3093,118 @@ test.describe('Chat toolbar accessibility', () => {
       expect(logsBox!.x).toBeGreaterThan(settingsBox!.x + settingsBox!.width);
       expect(logsBox!.x + logsBox!.width).toBeLessThanOrEqual(width);
     }
+
+    const waitForModelSelectorMotion = () => modelButton.evaluate(async element => {
+      await Promise.all(element.getAnimations().map(animation => animation.finished.catch(() => undefined)));
+    });
+
+    await page.setViewportSize({ width: 480, height: 800 });
+    await waitForModelSelectorMotion();
+    await expect(page.locator('.composer__model-label')).toBeHidden();
+    await expect(page.locator('.composer__model-picker')).toHaveClass(/composer__model-picker--loaded/);
+    await expect(page.locator('.composer__model-mode')).toBeVisible();
+    await expect(page.locator('.composer__model-button-name')).toBeVisible();
+    await expect(page.locator('.composer__model-button-badge')).toBeVisible();
+    expect(await modelButton.evaluate(element => getComputedStyle(element).transitionProperty)).toContain('max-width');
+    const [compactSettingsBox, compactLogsBox, compactModelBox] = await Promise.all([
+      settings.boundingBox(),
+      logs.boundingBox(),
+      modelButton.boundingBox(),
+    ]);
+    expect(compactSettingsBox).not.toBeNull();
+    expect(compactLogsBox).not.toBeNull();
+    expect(compactModelBox).not.toBeNull();
+    expect(compactModelBox!.width).toBeGreaterThan(30);
+    expect(compactSettingsBox!.x).toBeGreaterThan(compactModelBox!.x + compactModelBox!.width);
+    expect(compactLogsBox!.x).toBeGreaterThan(compactSettingsBox!.x + compactSettingsBox!.width);
+    const compactCaret = page.locator('.composer__model-button-caret');
+    const compactCaretGlyph = page.locator('.composer__model-button-caret-glyph');
+    await expect(compactCaret).toHaveText('▾');
+    await expect(compactCaretGlyph).toHaveCSS('font-size', '16px');
+    await expect(compactCaretGlyph).toHaveCSS('width', '16px');
+    await expect(compactCaretGlyph).toHaveCSS('height', '16px');
+    await expect(compactCaretGlyph).toHaveCSS('transform-origin', '8px 8px');
+    await expect(compactCaretGlyph).toHaveCSS('transition-property', 'transform');
+    const compactCaretBox = await compactCaret.boundingBox();
+    expect(compactCaretBox).not.toBeNull();
+    expect(
+      (compactModelBox!.x + compactModelBox!.width) - (compactCaretBox!.x + compactCaretBox!.width),
+    ).toBeLessThanOrEqual(10);
+    await page.setViewportSize({ width: 400, height: 800 });
+    await waitForModelSelectorMotion();
+    const narrowerCompactModelBox = await modelButton.boundingBox();
+    expect(narrowerCompactModelBox).not.toBeNull();
+    expect(Math.abs(narrowerCompactModelBox!.width - compactModelBox!.width)).toBeLessThanOrEqual(2);
+    const closedCaretTransform = await compactCaretGlyph.evaluate(element => getComputedStyle(element).transform);
+    const expectCaretCenterFixed = async () => {
+      const [containerBox, glyphBox] = await Promise.all([
+        compactCaret.boundingBox(),
+        compactCaretGlyph.boundingBox(),
+      ]);
+      expect(containerBox).not.toBeNull();
+      expect(glyphBox).not.toBeNull();
+      expect(Math.abs(
+        (containerBox!.x + containerBox!.width / 2) - (glyphBox!.x + glyphBox!.width / 2),
+      )).toBeLessThan(0.5);
+      expect(Math.abs(
+        (containerBox!.y + containerBox!.height / 2) - (glyphBox!.y + glyphBox!.height / 2),
+      )).toBeLessThan(0.5);
+    };
+    await expectCaretCenterFixed();
+
+    await page.setViewportSize({ width: 320, height: 800 });
+    await modelButton.click();
+    await expect(modelButton).toHaveAttribute('aria-expanded', 'true');
+    const modelMenu = page.getByRole('dialog', { name: 'Search models' });
+    await expect(modelMenu).toBeVisible();
+    const modelMenuBox = await modelMenu.boundingBox();
+    expect(modelMenuBox).not.toBeNull();
+    expect(modelMenuBox!.x).toBeGreaterThanOrEqual(0);
+    expect(modelMenuBox!.x + modelMenuBox!.width).toBeLessThanOrEqual(320);
+    await page.waitForTimeout(100);
+    await expectCaretCenterFixed();
+    await page.waitForTimeout(150);
+    const openCaretTransform = await compactCaretGlyph.evaluate(element => getComputedStyle(element).transform);
+    expect(openCaretTransform).not.toBe(closedCaretTransform);
+    await modelButton.click();
+    await expect(modelButton).toHaveAttribute('aria-expanded', 'false');
+    await page.waitForTimeout(100);
+    await expectCaretCenterFixed();
+    await page.waitForTimeout(150);
+    expect(await compactCaretGlyph.evaluate(element => getComputedStyle(element).transform)).toBe(closedCaretTransform);
+  });
+
+  test('A186c — compact model selector collapses to only the caret when no model is loaded', async ({ page }) => {
+    await page.setViewportSize({ width: 320, height: 800 });
+    await goToChatWithoutLoadedModel(page);
+
+    const picker = page.locator('.composer__model-picker');
+    const modelButton = page.locator('.composer__model-button');
+    const caret = page.locator('.composer__model-button-caret');
+    const glyph = page.locator('.composer__model-button-caret-glyph');
+
+    await expect(picker).not.toHaveClass(/composer__model-picker--loaded/);
+    await expect(page.locator('.composer__model-label')).toBeHidden();
+    await expect(page.locator('.composer__model-button-name')).toBeHidden();
+    await expect(modelButton).toHaveCSS('width', '30px');
+    await expect(modelButton).toHaveCSS('height', '30px');
+    await expect(caret).toHaveText('▾');
+
+    const visibleDirectChildren = await modelButton.locator(':scope > *').evaluateAll(elements =>
+      elements
+        .filter(element => {
+          const style = getComputedStyle(element);
+          return style.display !== 'none' && style.visibility !== 'hidden';
+        })
+        .map(element => element.className),
+    );
+    expect(visibleDirectChildren).toEqual(['composer__model-button-caret']);
+
+    const [buttonBox, glyphBox] = await Promise.all([modelButton.boundingBox(), glyph.boundingBox()]);
+    expect(buttonBox).not.toBeNull();
+    expect(glyphBox).not.toBeNull();
+    expect(Math.abs((buttonBox!.x + buttonBox!.width / 2) - (glyphBox!.x + glyphBox!.width / 2))).toBeLessThan(0.5);
+    expect(Math.abs((buttonBox!.y + buttonBox!.height / 2) - (glyphBox!.y + glyphBox!.height / 2))).toBeLessThan(0.5);
   });
 
   test('A187 — add menu exposes one unified tools entry and is keyboard-operable', async ({ page }) => {

--- a/src/app/tests/a11y.spec.ts
+++ b/src/app/tests/a11y.spec.ts
@@ -3079,30 +3079,63 @@ test.describe('Chat toolbar accessibility', () => {
     const settings = page.getByRole('button', { name: 'Effective settings' });
     const logs = page.getByRole('button', { name: /Logs/i });
     const modelButton = page.getByRole('button', { name: 'Select model, current Llama-3.1-8B-Instruct' });
+    const modelCaretGlyph = page.locator('.composer__model-button-caret-glyph');
+    const standardCaretFontSize = await modelCaretGlyph.evaluate(element => getComputedStyle(element).fontSize);
+    const waitForModelSelectorMotion = () => modelButton.evaluate(async element => {
+      await Promise.all(element.getAnimations().map(animation => animation.finished.catch(() => undefined)));
+    });
 
-    for (const width of [851, 480, 400, 320]) {
+    for (const width of [851, 480, 400, 360, 320]) {
       await page.setViewportSize({ width, height: 800 });
-      const [settingsBox, logsBox] = await Promise.all([
+      if (width <= 480) {
+        await expect.poll(async () => {
+          const [modelBox, settingsBox] = await Promise.all([
+            modelButton.boundingBox(),
+            settings.boundingBox(),
+          ]);
+          return modelBox && settingsBox
+            ? Math.abs(modelBox.y - settingsBox.y)
+            : Number.POSITIVE_INFINITY;
+        }).toBeLessThan(2);
+      }
+      const [settingsBox, logsBox, modelBox] = await Promise.all([
         settings.boundingBox(),
         logs.boundingBox(),
+        modelButton.boundingBox(),
       ]);
 
       expect(settingsBox).not.toBeNull();
       expect(logsBox).not.toBeNull();
+      expect(modelBox).not.toBeNull();
+      if (width <= 480) {
+        expect(Math.abs(modelBox!.y - settingsBox!.y)).toBeLessThan(2);
+      }
       expect(Math.abs(logsBox!.y - settingsBox!.y)).toBeLessThan(2);
       expect(logsBox!.x).toBeGreaterThan(settingsBox!.x + settingsBox!.width);
       expect(logsBox!.x + logsBox!.width).toBeLessThanOrEqual(width);
     }
 
-    const waitForModelSelectorMotion = () => modelButton.evaluate(async element => {
-      await Promise.all(element.getAnimations().map(animation => animation.finished.catch(() => undefined)));
-    });
+    const rail = page.locator('.rail');
+    const modelModeLabel = page.locator('.composer__model-mode > span:not(.capability-icon-pair)');
+
+    await page.setViewportSize({ width: 769, height: 800 });
+    await waitForModelSelectorMotion();
+    await expect(rail).toBeVisible();
+    await expect(modelModeLabel).toBeVisible();
+
+    await page.setViewportSize({ width: 768, height: 800 });
+    await waitForModelSelectorMotion();
+    await expect(rail).toBeHidden();
+    await expect(modelModeLabel).toBeHidden();
 
     await page.setViewportSize({ width: 480, height: 800 });
     await waitForModelSelectorMotion();
     await expect(page.locator('.composer__model-label')).toBeHidden();
     await expect(page.locator('.composer__model-picker')).toHaveClass(/composer__model-picker--loaded/);
+    await expect(page.locator('.composer__model-button-empty-label')).toBeHidden();
     await expect(page.locator('.composer__model-mode')).toBeVisible();
+    await expect(modelModeLabel).toBeHidden();
+    await expect(modelModeLabel).toHaveText('Chat + Image + Audio');
     await expect(page.locator('.composer__model-button-name')).toBeVisible();
     await expect(page.locator('.composer__model-button-badge')).toBeVisible();
     expect(await modelButton.evaluate(element => getComputedStyle(element).transitionProperty)).toContain('max-width');
@@ -3118,9 +3151,9 @@ test.describe('Chat toolbar accessibility', () => {
     expect(compactSettingsBox!.x).toBeGreaterThan(compactModelBox!.x + compactModelBox!.width);
     expect(compactLogsBox!.x).toBeGreaterThan(compactSettingsBox!.x + compactSettingsBox!.width);
     const compactCaret = page.locator('.composer__model-button-caret');
-    const compactCaretGlyph = page.locator('.composer__model-button-caret-glyph');
+    const compactCaretGlyph = modelCaretGlyph;
     await expect(compactCaret).toHaveText('▾');
-    await expect(compactCaretGlyph).toHaveCSS('font-size', '16px');
+    await expect(compactCaretGlyph).toHaveCSS('font-size', standardCaretFontSize);
     await expect(compactCaretGlyph).toHaveCSS('width', '16px');
     await expect(compactCaretGlyph).toHaveCSS('height', '16px');
     await expect(compactCaretGlyph).toHaveCSS('transform-origin', '8px 8px');
@@ -3135,6 +3168,25 @@ test.describe('Chat toolbar accessibility', () => {
     const narrowerCompactModelBox = await modelButton.boundingBox();
     expect(narrowerCompactModelBox).not.toBeNull();
     expect(Math.abs(narrowerCompactModelBox!.width - compactModelBox!.width)).toBeLessThanOrEqual(2);
+
+    await page.setViewportSize({ width: 360, height: 800 });
+    await waitForModelSelectorMotion();
+    const intermediatePickerBox = await page.locator('.composer__model-picker').boundingBox();
+    expect(intermediatePickerBox).not.toBeNull();
+    expect(intermediatePickerBox!.width).toBeGreaterThan(200);
+    expect(intermediatePickerBox!.width).toBeLessThanOrEqual(240);
+    await expect(page.locator('.composer__model-button-empty-label')).toBeHidden();
+    await expect(modelModeLabel).toBeHidden();
+    await expect(page.locator('.composer__model-button-name')).toBeVisible();
+    const compactModeIcons = page.locator('.composer__model-mode .app-icon');
+    expect(await compactModeIcons.count()).toBe(3);
+    const expectedModeIconSizes = ['14px', '13px', '13px'];
+    for (const [index, icon] of (await compactModeIcons.all()).entries()) {
+      await expect(icon).toHaveCSS('width', expectedModeIconSizes[index]);
+      await expect(icon).toHaveCSS('height', expectedModeIconSizes[index]);
+      await expect(icon).toHaveCSS('border-radius', '0px');
+    }
+
     const closedCaretTransform = await compactCaretGlyph.evaluate(element => getComputedStyle(element).transform);
     const expectCaretCenterFixed = async () => {
       const [containerBox, glyphBox] = await Promise.all([
@@ -3153,6 +3205,18 @@ test.describe('Chat toolbar accessibility', () => {
     await expectCaretCenterFixed();
 
     await page.setViewportSize({ width: 320, height: 800 });
+    await waitForModelSelectorMotion();
+    await expect(page.locator('.composer__model-button-empty-label')).toHaveCount(0);
+    await expect(page.locator('.composer__model-mode')).toBeVisible();
+    await expect(modelModeLabel).toBeHidden();
+    expect(await compactModeIcons.count()).toBe(3);
+    await expect(page.locator('.composer__model-button-name')).toBeVisible();
+    await expect(page.locator('.composer__model-button-name')).toHaveText('Llama-3.1-8B-Instruct');
+    await expect(page.locator('.composer__model-button-badge')).toBeHidden();
+    const overflowModelBox = await modelButton.boundingBox();
+    expect(overflowModelBox).not.toBeNull();
+    expect(overflowModelBox!.width).toBeGreaterThan(30);
+    await expect(modelButton).toHaveCSS('gap', '5px');
     await modelButton.click();
     await expect(modelButton).toHaveAttribute('aria-expanded', 'true');
     const modelMenu = page.getByRole('dialog', { name: 'Search models' });
@@ -3161,6 +3225,7 @@ test.describe('Chat toolbar accessibility', () => {
     expect(modelMenuBox).not.toBeNull();
     expect(modelMenuBox!.x).toBeGreaterThanOrEqual(0);
     expect(modelMenuBox!.x + modelMenuBox!.width).toBeLessThanOrEqual(320);
+    expect(modelMenuBox!.y + modelMenuBox!.height).toBeLessThanOrEqual(overflowModelBox!.y);
     await page.waitForTimeout(100);
     await expectCaretCenterFixed();
     await page.waitForTimeout(150);
@@ -3174,7 +3239,7 @@ test.describe('Chat toolbar accessibility', () => {
     expect(await compactCaretGlyph.evaluate(element => getComputedStyle(element).transform)).toBe(closedCaretTransform);
   });
 
-  test('A186c — compact model selector collapses to only the caret when no model is loaded', async ({ page }) => {
+  test('A186c — compact unloaded model selector retains the selected model name', async ({ page }) => {
     await page.setViewportSize({ width: 320, height: 800 });
     await goToChatWithoutLoadedModel(page);
 
@@ -3185,9 +3250,24 @@ test.describe('Chat toolbar accessibility', () => {
 
     await expect(picker).not.toHaveClass(/composer__model-picker--loaded/);
     await expect(page.locator('.composer__model-label')).toBeHidden();
-    await expect(page.locator('.composer__model-button-name')).toBeHidden();
-    await expect(modelButton).toHaveCSS('width', '30px');
+    const modelModeIcons = modelButton.locator(':scope > .capability-icon-pair .app-icon, :scope > .app-icon');
+    expect(await modelModeIcons.count()).toBe(1);
+    await expect(modelModeIcons.first()).toHaveCSS('width', '14px');
+    await expect(modelModeIcons.first()).toHaveCSS('height', '14px');
+    await expect(modelModeIcons.first()).toHaveCSS('border-radius', '0px');
+    const [iconColor, buttonColor] = await Promise.all([
+      modelModeIcons.first().evaluate(element => getComputedStyle(element).color),
+      modelButton.evaluate(element => getComputedStyle(element).color),
+    ]);
+    expect(iconColor).toBe(buttonColor);
+    const modelName = page.locator('.composer__model-button-name');
+    await expect(modelName).toBeVisible();
+    const selectedModelName = (await modelName.innerText()).trim();
+    expect(selectedModelName.length).toBeGreaterThan(0);
     await expect(modelButton).toHaveCSS('height', '30px');
+    await expect(modelButton).toHaveCSS('gap', '5px');
+    await expect(modelButton).toContainText(selectedModelName);
+    await expect(modelButton).not.toContainText('Models');
     await expect(caret).toHaveText('▾');
 
     const visibleDirectChildren = await modelButton.locator(':scope > *').evaluateAll(elements =>
@@ -3198,13 +3278,30 @@ test.describe('Chat toolbar accessibility', () => {
         })
         .map(element => element.className),
     );
-    expect(visibleDirectChildren).toEqual(['composer__model-button-caret']);
+    expect(visibleDirectChildren).toEqual([
+      'capability-icon-pair',
+      'composer__model-button-name',
+      'composer__model-button-caret',
+    ]);
 
-    const [buttonBox, glyphBox] = await Promise.all([modelButton.boundingBox(), glyph.boundingBox()]);
+    const [buttonBox, caretBox, glyphBox] = await Promise.all([
+      modelButton.boundingBox(),
+      caret.boundingBox(),
+      glyph.boundingBox(),
+    ]);
     expect(buttonBox).not.toBeNull();
+    expect(caretBox).not.toBeNull();
     expect(glyphBox).not.toBeNull();
-    expect(Math.abs((buttonBox!.x + buttonBox!.width / 2) - (glyphBox!.x + glyphBox!.width / 2))).toBeLessThan(0.5);
-    expect(Math.abs((buttonBox!.y + buttonBox!.height / 2) - (glyphBox!.y + glyphBox!.height / 2))).toBeLessThan(0.5);
+    expect(buttonBox!.width).toBeGreaterThan(30);
+    expect(Math.abs((caretBox!.x + caretBox!.width / 2) - (glyphBox!.x + glyphBox!.width / 2))).toBeLessThan(0.5);
+    expect(Math.abs((caretBox!.y + caretBox!.height / 2) - (glyphBox!.y + glyphBox!.height / 2))).toBeLessThan(0.5);
+
+    await modelButton.click();
+    const modelMenu = page.getByRole('dialog', { name: 'Search models' });
+    await expect(modelMenu).toBeVisible();
+    const modelMenuBox = await modelMenu.boundingBox();
+    expect(modelMenuBox).not.toBeNull();
+    expect(modelMenuBox!.y + modelMenuBox!.height).toBeLessThanOrEqual(buttonBox!.y);
   });
 
   test('A187 — add menu exposes one unified tools entry and is keyboard-operable', async ({ page }) => {

--- a/src/app/tests/chat-audio-capability.runtime.cjs
+++ b/src/app/tests/chat-audio-capability.runtime.cjs
@@ -186,10 +186,16 @@ assert.match(chatViewSource, /const ModelModeIcons:/,
   'chat UI must use a paired model-mode icon component');
 assert.match(chatViewSource, /<CapabilityIcon capability="audio"/,
   'paired mode icons must include the Audio glyph');
+assert.match(chatViewSource, /<CapabilityIcon capability="image"/,
+  'paired mode icons must include the Image glyph when Chat accepts images');
 assert.match(chatViewSource, /const showAudio = audioInput && capability === 'chat'/,
   'the paired Audio icon must only decorate Chat mode, not Omni collections');
-assert.match(chatViewSource, /currentLoadedModel \? \([\s\S]*composer__model-mode--\$\{modelModeBadge\(currentCapability, currentRecipe\)\}[\s\S]*modelModeDisplayLabel\(currentCapability, supportsChatAudioInput, currentRecipe\)/,
+assert.match(chatViewSource, /const showImage = imageInput && capability === 'chat'/,
+  'the paired Image icon must only decorate Chat mode, not Omni collections');
+assert.match(chatViewSource, /currentLoadedModel \? \([\s\S]*composer__model-mode--\$\{modelModeBadge\(currentCapability, currentRecipe\)\}[\s\S]*modelModeDisplayLabel\(currentCapability, supportsChatAudioInput, currentRecipe, supportsChatImageInput\)/,
   'the active model pill must include the colored mode label only for the currently loaded model');
+assert.match(chatViewSource, /\) : currentModel \? \(\s*<ModelModeIcons/,
+  'an unloaded selected model must render modality icons outside the colored mode wrapper');
 assert.doesNotMatch(chatViewSource, /composer__mode-badge--interactive/,
   'the redundant standalone mode pill must not remain in the chat composer');
 assert.match(stylesSource, /\.composer__model-mode--chat \{ color: var\(--cap-chat\); \}/,


### PR DESCRIPTION
## Summary

This keeps the chat model selector, Effective Settings, and Logs controls on one row at narrow widths while making the selected model and its supported input modalities easier to understand.

The model selector now:

- shows Chat with Image and Audio modality icons when the selected chat model supports those inputs
- keeps the selected model name visible when that model is not currently loaded
- hides the longer mode label when the Models rail collapses, while retaining the modality icons
- uses container-aware compaction so the model name, status badge, and caret remain stable from desktop down to 320 px

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

Testing details:

- git diff --check
- npm.cmd run typecheck
- npm.cmd run test:chat-audio
- npm.cmd run test:ui-regressions
- npm.cmd run build:renderer
- Playwright A186 responsive group using installed Chrome: 3 passed
- Browser assertions cover 851, 769, 768, 480, 400, 360, and 320 px states, loaded Chat + Image + Audio display, unloaded selected-model display, same-row containment, menu positioning, and caret alignment.

## Documentation

- [x] Documentation is not affected by this change.
- [ ] Documentation is affected and has been updated.
- [ ] Documentation is affected but will be handled in a separate PR or issue.

## Breaking Changes

- [ ] This PR introduces breaking changes.
- [x] This PR does not introduce breaking changes.

## AI-assisted contribution

Please select one:

- [x] I used AI tools for this PR.
- [ ] I did not use AI tools for this PR.

If AI tools were used:

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.
