### PR TITLE
fix(gui3): move setLogLevel off the retired /v1/log-level route

### DIFF
--- a/src/app/src/api.ts
+++ b/src/app/src/api.ts
@@ -1916,10 +1916,12 @@ class LemonadeAPI {
   }
 
   async setLogLevel(level: string): Promise<{ status: string; level: string }> {
-    return this._json<{ status: string; level: string }>('/api/v1/log-level', {
-      method: 'POST',
-      body: { level },
-    });
+    const data = await this.setRuntimeConfig({ log_level: level });
+    const updated = (data.updated as Record<string, unknown> | undefined) ?? {};
+    return {
+      status: String(data.status ?? 'success'),
+      level: typeof updated.log_level === 'string' ? updated.log_level : level,
+    };
   }
 
   // ── Log stream (WebSocket) ──────────────────────────────────────


### PR DESCRIPTION
## Summary

`main` branch removed 4 undocumented endpoints. I did a sweep of the GUI code and found that there is only 1 instance of any of those being used. This PR migrates that 1 instance.

Deliberately not in scope: any non-gui code. 

Fixes #3389 

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

Confirmed the server gets the signal:

<img width="2388" height="1146" alt="image" src="https://github.com/user-attachments/assets/30e81db0-e21f-40f0-a19e-94dee0fc6edb" />


_Testing details:_

- `npx tsc --noEmit -p tsconfig.json` in `src/app` — clean.
- Verified the replacement contract against this branch's server: `POST /internal/set` routes to `handle_config_set` → `RuntimeConfig::set`, which handles the `log_level` key (`server.cpp`, `reconfigure_application_logging`) and returns `{"status":"success","updated":{...}}` (`runtime_config.cpp`). The new return value reads `updated.log_level` and falls back to the requested level.
- `setLogLevel`'s return type is unchanged, so its only caller (`LogViewer.tsx:278`) needs no change.

## Documentation

- [x] Documentation is not affected by this change.

## Breaking Changes

- [x] This PR does not introduce breaking changes.

## AI-assisted contribution

Please select one:

- [x] I used AI tools for this PR.

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.
