### PR TITLE
ci: test PPA package upgrade path (config + model persistence)

### DIFF
--- a/.github/actions/start-lemond-service/action.yml
+++ b/.github/actions/start-lemond-service/action.yml
@@ -1,0 +1,88 @@
+name: 'Start lemond (systemd emulation)'
+description: >-
+  Launch the installed lemond binary the way its systemd unit would, without
+  systemd. Parses the installed lemond.service for its Directory= and
+  Environment= settings, recreates those directories, and runs lemond as the
+  lemonade service user so path resolution matches a real service install.
+inputs:
+  port:
+    description: 'Port to serve on'
+    required: false
+    default: '13305'
+  log-name:
+    description: 'Log file name under RUNNER_TEMP (so capture-server-logs can find it)'
+    required: false
+    default: 'lemonade-server.log'
+runs:
+  using: "composite"
+  steps:
+    - name: Start lemond as the service user
+      shell: bash
+      run: |
+        set -e
+        PORT="${{ inputs.port }}"
+        LOG="$RUNNER_TEMP/${{ inputs.log-name }}"
+
+        UNIT=/usr/lib/systemd/system/lemond.service
+        [ -f "$UNIT" ] || UNIT=/lib/systemd/system/lemond.service
+        if [ ! -f "$UNIT" ]; then
+          echo "ERROR: lemond.service unit not found (looked in /usr/lib and /lib)"
+          exit 1
+        fi
+        echo "Emulating systemd environment from $UNIT"
+
+        # systemd derives these absolute paths from the *Directory= names and
+        # exports STATE_DIRECTORY / CACHE_DIRECTORY / RUNTIME_DIRECTORY. Mirror it.
+        state_name=$(grep -oP '^StateDirectory=\K.*'   "$UNIT" | head -n1 || true)
+        cache_name=$(grep -oP '^CacheDirectory=\K.*'   "$UNIT" | head -n1 || true)
+        run_name=$(grep   -oP '^RuntimeDirectory=\K.*' "$UNIT" | head -n1 || true)
+
+        env_args=()
+        [ -n "$state_name" ] && STATE_DIR="/var/lib/$state_name"   && env_args+=( "STATE_DIRECTORY=$STATE_DIR" )
+        [ -n "$cache_name" ] && CACHE_DIR="/var/cache/$cache_name" && env_args+=( "CACHE_DIRECTORY=$CACHE_DIR" )
+        [ -n "$run_name"   ] && RUN_DIR="/run/$run_name"           && env_args+=( "RUNTIME_DIRECTORY=$RUN_DIR" )
+
+        # HOME must match the service user's passwd home (path resolution uses it).
+        HOME_DIR=$(getent passwd lemonade | cut -d: -f6)
+        [ -n "$HOME_DIR" ] || HOME_DIR="${STATE_DIR:-/var/lib/lemonade}"
+        env_args+=( "HOME=$HOME_DIR" )
+
+        # Forward every Environment= entry from the unit (e.g. HF_HOME=...).
+        hf_home=""
+        while IFS= read -r line; do
+          [ -n "$line" ] || continue
+          env_args+=( "$line" )
+          case "$line" in HF_HOME=*) hf_home="${line#HF_HOME=}" ;; esac
+        done < <(grep -oP '^Environment=\K.*' "$UNIT" || true)
+
+        # Recreate the writable dirs systemd would provision on start.
+        for d in "$STATE_DIR" "$CACHE_DIR" "$RUN_DIR" "$hf_home"; do
+          [ -n "$d" ] || continue
+          mkdir -p "$d"
+          chown -R lemonade:lemonade "$d" 2>/dev/null || true
+        done
+
+        echo "Launching: runuser -u lemonade -- env ${env_args[*]} /usr/bin/lemond --port $PORT"
+        runuser -u lemonade -- env "${env_args[@]}" /usr/bin/lemond --port "$PORT" > "$LOG" 2>&1 &
+        LEMOND_PID=$!
+        echo "LEMOND_PID=$LEMOND_PID" >> "$GITHUB_ENV"
+
+        for i in $(seq 1 30); do
+          if curl -sf "http://127.0.0.1:$PORT/live" > /dev/null 2>&1; then
+            echo "lemond is healthy on port $PORT (PID $LEMOND_PID)"
+            echo "LEMONADE_PORT=$PORT" >> "$GITHUB_ENV"
+            echo "LEMONADE_HOST=127.0.0.1" >> "$GITHUB_ENV"
+            exit 0
+          fi
+          if ! kill -0 "$LEMOND_PID" 2>/dev/null; then
+            echo "ERROR: lemond exited before becoming ready"
+            echo "=== log ==="
+            cat "$LOG" 2>/dev/null || true
+            exit 1
+          fi
+          echo "Waiting for lemond... ($i/30)"
+          sleep 2
+        done
+        echo "ERROR: lemond did not become ready in time"
+        tail -50 "$LOG" 2>/dev/null || true
+        exit 1

--- a/.github/workflows/launchpad-ppa.yml
+++ b/.github/workflows/launchpad-ppa.yml
@@ -226,6 +226,148 @@ jobs:
           path: ${{ steps.build_binary.outputs.output-dir }}/*.deb
           retention-days: 30
 
+  upgrade-test:
+    name: Upgrade test (${{ matrix.codename }})
+    needs: [prepare-matrix, package]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    # Needs the binary .deb, which only builds in the merge queue or on a
+    # ci:distros-labelled PR (see the `package` job's build steps).
+    if: github.event_name == 'merge_group' || contains(github.event.pull_request.labels.*.name, 'ci:distros')
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - release: "26.04"
+            codename: resolute
+    container:
+      image: ghcr.io/lemonade-sdk/lemonade/build-environment:ubuntu${{ matrix.release }}
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    env:
+      HF_TOKEN: ${{ secrets.HUGGINGFACE_ACCESS_TOKEN }}
+      DEBIAN_FRONTEND: noninteractive
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Configure git safe directory
+        run: git config --global --add safe.directory $(pwd)
+
+      - name: Download new build (.deb)
+        uses: actions/download-artifact@v7
+        with:
+          name: lemonade-${{ matrix.codename }}-deb
+          path: new-deb
+
+      - name: Install prerequisites
+        shell: bash
+        run: |
+          set -e
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            ca-certificates curl procps software-properties-common util-linux
+
+      - name: Install last stable from PPA
+        id: stable
+        shell: bash
+        run: |
+          set -e
+          add-apt-repository -y ppa:lemonade-team/stable
+          apt-get update
+          apt-get install -y lemonade-server
+          echo "Installed stable version: $(dpkg-query -W -f='${Version}' lemonade-server)"
+
+      - name: Start stable lemond
+        uses: ./.github/actions/start-lemond-service
+        with:
+          port: '13305'
+          log-name: 'lemonade-server-stable.log'
+
+      - name: Seed config and download a model
+        shell: bash
+        run: |
+          set -e
+          # Persist a benign, non-default config value (does not affect binding).
+          lemonade config set log_level=debug
+
+          # Download the purpose-built tiny CI model, retrying transient HF errors.
+          ok=false
+          for a in 1 2 3; do
+            if lemonade pull Tiny-Test-Model-GGUF; then ok=true; break; fi
+            echo "pull attempt $a failed; retrying..."; sleep 10
+          done
+          $ok
+
+          echo "=== baseline downloaded models ==="
+          lemonade list --downloaded
+          lemonade list --downloaded | grep 'Tiny-Test-Model-GGUF' | grep -q 'Yes'
+          echo "Baseline model present."
+
+      - name: Stop stable lemond
+        shell: bash
+        run: |
+          pkill -u lemonade -f '/usr/bin/lemond' || true
+          for i in $(seq 1 15); do
+            curl -sf http://127.0.0.1:13305/live >/dev/null 2>&1 || break
+            sleep 1
+          done
+
+      - name: Upgrade to the new build
+        shell: bash
+        run: |
+          set -e
+          DEB=$(ls new-deb/lemonade-server_*_amd64.deb 2>/dev/null | head -n1)
+          if [ -z "$DEB" ]; then
+            echo "ERROR: new lemonade-server .deb not found"; ls -la new-deb; exit 1
+          fi
+          echo "Upgrading to $DEB"
+          # git-describe versions can sort below the stable tag, so allow downgrades.
+          apt-get install -y --allow-downgrades "./$DEB" \
+            || { apt-get -f install -y; apt-get install -y --allow-downgrades "./$DEB"; }
+          echo "Upgraded version: $(dpkg-query -W -f='${Version}' lemonade-server)"
+
+      - name: Start upgraded lemond
+        uses: ./.github/actions/start-lemond-service
+        with:
+          port: '13305'
+          log-name: 'lemonade-server.log'
+
+      - name: Assert config and model survived the upgrade
+        shell: bash
+        run: |
+          set -e
+          echo "=== health ==="
+          curl -sf "http://127.0.0.1:${LEMONADE_PORT:-13305}/api/v1/health"; echo
+
+          echo "=== config after upgrade ==="
+          lemonade config
+          if ! lemonade config | grep -qiE 'log_level.*debug'; then
+            echo "FAIL: log_level=debug did not survive the upgrade"; exit 1
+          fi
+
+          echo "=== downloaded models after upgrade ==="
+          lemonade list --downloaded
+          if ! lemonade list --downloaded | grep 'Tiny-Test-Model-GGUF' | grep -q 'Yes'; then
+            echo "FAIL: Tiny-Test-Model-GGUF was lost during the upgrade"; exit 1
+          fi
+          echo "PASS: config and model survived the upgrade."
+
+      - name: Capture server logs
+        if: always()
+        uses: ./.github/actions/capture-server-logs
+        with:
+          artifact-name: upgrade-test-logs-${{ matrix.codename }}
+
+      - name: Print stable-run log
+        if: always()
+        shell: bash
+        run: |
+          echo "=== stable run log ==="
+          cat "$RUNNER_TEMP/lemonade-server-stable.log" 2>/dev/null || echo "(none)"
+
   upload-stable:
     name: Upload (Stable)
     strategy:
@@ -259,7 +401,7 @@ jobs:
   # to run on ordinary pull request pushes.
   gate:
     name: Launchpad PPA builds
-    needs: [prepare-matrix, package, package-arm64]
+    needs: [prepare-matrix, package, package-arm64, upgrade-test]
     if: always()
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

CI builds the PPA `.deb` but never installs or upgrade-tests it, which let the 11.7.0→11.8.0 FHS-split regression (#3387 / #3394) — lost config + models on upgrade — merge undetected.

This adds an `upgrade-test` job to `.github/workflows/launchpad-ppa.yml` that exercises the real upgrade path per #3395:
1. Installs the last stable release from `ppa:lemonade-team/stable`.
2. Sets a config value (`lemonade config set log_level=debug`) and downloads a model (`lemonade pull Tiny-Test-Model-GGUF`, ~0.18 GB).
3. Installs the freshly-built `.deb` over it.
4. Asserts the upgraded server is healthy and that the config value and the model both survived.

A new composite action `.github/actions/start-lemond-service` launches `lemond` the way its systemd unit would — it parses the installed `lemond.service` for `StateDirectory`/`CacheDirectory`/`RuntimeDirectory`/`Environment=` (e.g. `HF_HOME`) and runs `lemond` as the `lemonade` user with that environment (no positional cache dir). This reproduces the systemd service layout where the migration logic lives, which the existing `install-lemonade-deb` (extract-only) and `test-lemonade-debian13-smoke` (positional cache dir) jobs do not. It re-reads the unit for each installed version, so the stable run and the upgraded run each use their own declared layout.

Fixes #3395

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [ ] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_
- Validated both YAML files and ran the repo's pre-commit GitHub Actions / Workflows validators (pass).
- Simulated the unit-file parsing in the composite action against `data/lemond.service.in`: resolves `STATE_DIRECTORY=/var/lib/lemonade`, `CACHE_DIRECTORY=/var/cache/lemonade`, `RUNTIME_DIRECTORY=/run/lemonade`, forwards `HF_HOME`, and safely no-ops the directives a pre-3028 unit omits.
- End-to-end validation requires GitHub Actions (real `apt` install + PPA + model pull), which cannot run locally. To run the job on this PR, apply the **`ci:distros`** label (the binary `.deb` and this job are gated to the merge queue / `ci:distros`, matching the existing distro jobs).

Notes for reviewers:
- Coverage is `noble` (24.04) and `resolute` (26.04).
- The job's ability to reproduce the *specific* #3394 bug depends on the current stable's layout. If the current stable predates the FHS split, this job will fail on `main` until the migration fix (#3393) lands; if stable is already ≥11.8, it passes today and guards future layout changes. Either way it is a lasting guard against upgrade data loss.

## Documentation

- [x] Documentation is not affected by this change.

## Breaking Changes

- [x] This PR does not introduce breaking changes.

## AI-assisted contribution

Please select one:

- [x] I used AI tools for this PR.

If AI tools were used:

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.