### PR TITLE
ci(sdcpp): raise lemond global_timeout to 3600s for validation legs

### DIFF
--- a/.github/workflows/validate_sdcpp.yml
+++ b/.github/workflows/validate_sdcpp.yml
@@ -372,6 +372,10 @@ jobs:
           New-Item -ItemType Directory -Force -Path $logsDir | Out-Null
           New-Item -ItemType Directory -Force -Path $cacheDir | Out-Null
 
+          # A 1024x1024 CPU generation runs 419-520s against lemond's 600s default.
+          Set-Content -Path (Join-Path $cacheDir "config.json") `
+            -Value '{"global_timeout": 3600}' -Encoding utf8
+
           $stdoutLog = Join-Path $PWD "$logsDir\lemond.stdout.log"
           $stderrLog = Join-Path $PWD "$logsDir\lemond.stderr.log"
 


### PR DESCRIPTION
## Summary

The sd-cpp validation legs start `lemond` against a fresh CI cache dir, so they inherit the default `global_timeout` of 600s. The `Validate cpu` leg's Flux-2-Klein-4B 1024x1024 generation runs **419-520s across 11 recent runs** (mean 471s, max 520s) — only 13% below that ceiling. This writes `{"global_timeout": 3600}` into the cache dir before launching `lemond`, giving the CPU leg real headroom.

This is a CI-side configuration change only; no server behavior changes.

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_ Verified against a local `lemond` that a partial `config.json` in the cache dir is deep-merged with defaults and takes effect — `lemonade --port <p> config` reports `global_timeout 3600` (and `1` for a control run written with `{"global_timeout": 1}`). Also confirmed the file the workflow writes is parsed correctly with a UTF-8 BOM and CRLF line endings, since `Set-Content -Encoding utf8` under Windows PowerShell 5.1 emits a BOM. YAML validated.

## Documentation

- [x] Documentation is not affected by this change.

## Breaking Changes

- [ ] This PR introduces breaking changes.
- [x] This PR does not introduce breaking changes.

## AI-assisted contribution

- [x] I used AI tools for this PR.

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.
