### PR TITLE
fix(sdcpp): stage HIP runtime by version and fail validation on a CPU fallback

### DIFF
--- a/.github/scripts/render_sdcpp_pr_body.py
+++ b/.github/scripts/render_sdcpp_pr_body.py
@@ -49,6 +49,11 @@ def read_records(labels: list[str]) -> list[dict[str, Any]]:
         for item in data:
             if not isinstance(item, dict):
                 raise SystemExit(f"{path} contains a non-object record")
+            # Non-image diagnostics (e.g. the active-backend assertion) share the
+            # array but are not per-model/size results, so they must not count
+            # toward the pass tallies or the expected-image assertion.
+            if item.get("check"):
+                continue
             item.setdefault("label", label)
             item["artifact"] = f"sdcpp-validation-{label}"
             records.append(item)

--- a/.github/workflows/docs_and_style.yml
+++ b/.github/workflows/docs_and_style.yml
@@ -79,6 +79,9 @@ jobs:
       - name: Run the comment-slop unit tests
         run: python -m unittest test.test_comment_slop -v
 
+      - name: Run the sd-cpp active-backend assertion unit tests
+        run: python -m unittest test.test_sdcpp_backend_log -v
+
       - name: Run pre-commit on the changed files
         # Scoped to what the change touches; running repo-wide would fail on drift that
         # predates it and is not the contributor's to fix.

--- a/.github/workflows/validate_sdcpp.yml
+++ b/.github/workflows/validate_sdcpp.yml
@@ -33,7 +33,11 @@ env:
   # lemonade-sdk fork and may intentionally be on a different release tag.
   SDCPP_BASE_UPDATE_BACKENDS: cpu,vulkan,rocm-stable,metal
   SDCPP_CUDA_UPDATE_BACKENDS: cuda
-  SDCPP_VALIDATED_LABELS: cpu,vulkan,rocm-stable
+  # rocm-stable is omitted while its leg is non-blocking (see #3409): the update
+  # PR body asserts image evidence for every label listed here, and the leg
+  # cannot produce any. It stays in SDCPP_BASE_UPDATE_BACKENDS, so the pin is
+  # still updated and the body reports it as updated-but-not-validated.
+  SDCPP_VALIDATED_LABELS: cpu,vulkan
   SDCPP_TEST_PROMPT: "A small glass of lemonade on a clean table, product photo, high detail"
   SDCPP_TEST_MODELS: "SD-Turbo-GGUF,Flux-2-Klein-4B"
   SDCPP_TEST_SIZES: "512x256,1024x1024"
@@ -282,14 +286,22 @@ jobs:
           - label: cpu
             backend: cpu
             channel: ""
+            blocking: true
             runner: [self-hosted, Windows, stx-halo, vulkan, lemon-prod]
           - label: vulkan
             backend: vulkan
             channel: ""
+            blocking: true
             runner: [self-hosted, Windows, stx-halo, vulkan, lemon-prod]
+          # Non-blocking until #3409 is resolved: ROCm 7.14.0's rocBLAS aborts
+          # sd-server on gfx1151 (hipErrorInvalidDeviceFunction from
+          # hipblasGemmStridedBatchedEx), which is a ROCm regression this repo
+          # cannot fix. The leg still runs and reports, so the day ROCm ships a
+          # fix we see it go green and flip this back to blocking: true.
           - label: rocm-stable
             backend: rocm
             channel: stable
+            blocking: false
             runner: [self-hosted, Windows, stx-halo, rocm, lemon-prod]
           # CUDA is pinned by the updater and its assets are required by the
           # verify-cuda-assets job after this validation matrix completes.
@@ -414,7 +426,15 @@ jobs:
               $validationArgs += $channel
             }
             & $venvPython @validationArgs
-            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+            $validationExit = $LASTEXITCODE
+            if ($validationExit -ne 0) {
+              if ("${{ matrix.blocking }}" -eq "false") {
+                Write-Host "::warning title=$label validation failed (non-blocking)::Exit $validationExit. This leg does not gate merges; see issue #3409."
+                Write-Host "$label failed with exit $validationExit; not gating." -ForegroundColor Yellow
+              } else {
+                exit $validationExit
+              }
+            }
           } finally {
             try {
               Invoke-WebRequest -Uri "http://127.0.0.1:13305/internal/shutdown" `

--- a/.github/workflows/validate_sdcpp.yml
+++ b/.github/workflows/validate_sdcpp.yml
@@ -391,7 +391,9 @@ jobs:
               "--seed", "${{ env.SDCPP_TEST_SEED }}",
               "--warmup",
               "--output", "sdcpp_validation_$label.json",
-              "--images-dir", "sdcpp-images-$label"
+              "--images-dir", "sdcpp-images-$label",
+              "--server-log", $stdoutLog,
+              "--server-log", $stderrLog
             )
             foreach ($model in "${{ env.SDCPP_TEST_MODELS }}".Split(',')) {
               $model = $model.Trim()

--- a/src/cpp/server/backends/sdcpp/sdcpp_server.cpp
+++ b/src/cpp/server/backends/sdcpp/sdcpp_server.cpp
@@ -327,26 +327,16 @@ void SDServer::load(const std::string& model_name,
             std::string rocm_arch = SystemInfo::get_rocm_arch();
             if (!rocm_arch.empty()) {
                 std::vector<std::string> therock_dirs = BackendUtils::get_therock_lib_paths(rocm_arch);
-                std::string therock_bin = therock_dirs.empty() ? std::string() : therock_dirs.front();
-                if (!therock_bin.empty()) {
-                    for (auto it = therock_dirs.rbegin(); it != therock_dirs.rend(); ++it) {
-                        new_path = *it + ";" + new_path;
-                    }
-
-                    fs::path therock_dll = fs::path(therock_bin) / "amdhip64_7.dll";
-                    fs::path target_dll = exe_dir / "amdhip64_7.dll";
-                    if (fs::exists(therock_dll)) {
-                        std::error_code ec;
-                        fs::copy_file(therock_dll, target_dll, fs::copy_options::overwrite_existing, ec);
-                        if (!ec) {
-                            LOG(INFO, "SDServer") << "Copied amdhip64_7.dll from TheRock to " << path_to_utf8(target_dll) << std::endl;
-                        } else {
-                            LOG(ERROR, "SDServer") << "Failed to copy amdhip64_7.dll: " << ec.message() << std::endl;
-                        }
-                    } else {
-                        LOG(DEBUG, "SDServer") << "amdhip64_7.dll not found in TheRock at " << path_to_utf8(therock_dll) << std::endl;
-                    }
+                for (auto it = therock_dirs.rbegin(); it != therock_dirs.rend(); ++it) {
+                    new_path = *it + ";" + new_path;
                 }
+
+                // Version-aware staging: force-copying TheRock's amdhip64_7.dll
+                // shadows a newer System32 runtime (the exe dir precedes System32
+                // in the loader search order), which makes hipGetDeviceCount()
+                // return 0 and sd-server silently fall back to the CPU backend.
+                // See #3213 for the equivalent llama.cpp failure.
+                BackendUtils::stage_therock_hip_runtime(rocm_arch, exe_dir);
             }
         }
 

--- a/test/test_sdcpp_backend_log.py
+++ b/test/test_sdcpp_backend_log.py
@@ -1,0 +1,110 @@
+"""Unit tests for the sd-cpp active-backend assertion.
+
+Run with: python -m unittest test.test_sdcpp_backend_log -v
+
+The excerpts below are trimmed from the real validate_sdcpp CI artifacts of the
+run reported in #3401, where the rocm-stable leg passed while generating every
+image on CPU.
+"""
+
+import unittest
+
+from test.utils.sdcpp_backend_log import (
+    assert_active_backend,
+    find_init_failure_reasons,
+    find_initialized_devices,
+)
+
+ROCM_FELL_BACK_TO_CPU = """
+ggml_cuda_init: failed to initialize ROCm: no ROCm-capable device is detected
+[INFO ] ggml_extend_backend.cpp:545  - Found 1 backend devices:
+[DEBUG] ggml_extend_backend.cpp:548  - #0: CPU
+[DEBUG] ggml_extend_backend.cpp:395  - Initializing backend: CPU
+[DEBUG] ggml_extend_backend.cpp:590  - Using CPU backend
+"""
+
+VULKAN_ON_GPU = """
+ggml_vulkan: Found 1 Vulkan devices:
+ggml_vulkan: 0 = AMD Radeon(TM) 8060S Graphics (AMD proprietary driver) | uma: 1
+[INFO ] ggml_extend_backend.cpp:545  - Found 2 backend devices:
+[DEBUG] ggml_extend_backend.cpp:548  - #0: Vulkan0
+[DEBUG] ggml_extend_backend.cpp:548  - #1: CPU
+[DEBUG] ggml_extend_backend.cpp:395  - Initializing backend: Vulkan0
+"""
+
+ROCM_ON_GPU = """
+[INFO ] ggml_extend_backend.cpp:545  - Found 2 backend devices:
+[DEBUG] ggml_extend_backend.cpp:548  - #0: ROCm0
+[DEBUG] ggml_extend_backend.cpp:548  - #1: CPU
+[DEBUG] ggml_extend_backend.cpp:395  - Initializing backend: ROCm0
+"""
+
+
+class FindInitializedDevicesTest(unittest.TestCase):
+    def test_reads_the_selected_device(self):
+        self.assertEqual(find_initialized_devices(VULKAN_ON_GPU), ["Vulkan0"])
+
+    def test_reports_every_sd_server_instance_in_order(self):
+        # A leg loads several models, each restarting sd-server.
+        log = ROCM_ON_GPU + ROCM_FELL_BACK_TO_CPU
+        self.assertEqual(find_initialized_devices(log), ["ROCm0", "CPU"])
+
+    def test_returns_empty_without_the_marker(self):
+        self.assertEqual(find_initialized_devices("no device lines here"), [])
+
+
+class AssertActiveBackendTest(unittest.TestCase):
+    def test_accepts_the_requested_gpu_backend(self):
+        self.assertEqual(assert_active_backend("vulkan", VULKAN_ON_GPU), ["Vulkan0"])
+        self.assertEqual(assert_active_backend("rocm", ROCM_ON_GPU), ["ROCm0"])
+
+    def test_accepts_cpu_when_cpu_was_requested(self):
+        self.assertEqual(assert_active_backend("cpu", ROCM_FELL_BACK_TO_CPU), ["CPU"])
+
+    def test_rejects_the_silent_cpu_fallback(self):
+        with self.assertRaises(RuntimeError) as ctx:
+            assert_active_backend("rocm", ROCM_FELL_BACK_TO_CPU)
+        message = str(ctx.exception)
+        self.assertIn("requested backend 'rocm'", message)
+        self.assertIn("CPU", message)
+        # The job log must name why the backend did not come up.
+        self.assertIn("no ROCm-capable device is detected", message)
+
+    def test_rejects_a_fallback_on_any_model_in_the_leg(self):
+        with self.assertRaises(RuntimeError):
+            assert_active_backend("rocm", ROCM_ON_GPU + ROCM_FELL_BACK_TO_CPU)
+
+    def test_rejects_a_gpu_backend_that_is_not_the_requested_one(self):
+        with self.assertRaises(RuntimeError):
+            assert_active_backend("rocm", VULKAN_ON_GPU)
+
+    def test_rejects_a_log_without_evidence(self):
+        # No marker means the leg was never verified; that must fail, not pass.
+        with self.assertRaises(RuntimeError) as ctx:
+            assert_active_backend("rocm", "sd-server started\n")
+        self.assertIn("Initializing backend:", str(ctx.exception))
+
+    def test_rejects_an_unknown_backend(self):
+        with self.assertRaises(RuntimeError):
+            assert_active_backend("sycl", ROCM_ON_GPU)
+
+
+class FindInitFailureReasonsTest(unittest.TestCase):
+    def test_extracts_the_hip_failure(self):
+        self.assertEqual(
+            find_init_failure_reasons(ROCM_FELL_BACK_TO_CPU),
+            [
+                "ggml_cuda_init: failed to initialize ROCm: no ROCm-capable device is detected"
+            ],
+        )
+
+    def test_deduplicates_repeated_failures(self):
+        log = ROCM_FELL_BACK_TO_CPU + ROCM_FELL_BACK_TO_CPU
+        self.assertEqual(len(find_init_failure_reasons(log)), 1)
+
+    def test_is_empty_on_a_healthy_log(self):
+        self.assertEqual(find_init_failure_reasons(ROCM_ON_GPU), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/utils/sdcpp_backend_log.py
+++ b/test/utils/sdcpp_backend_log.py
@@ -1,0 +1,100 @@
+"""Assert which ggml backend sd-server actually initialized.
+
+sd-server picks its ggml device at load time and silently falls back to CPU
+when the requested GPU backend fails to come up, so a validation run that only
+checks for a decoded PNG passes while exercising the wrong backend (#3401).
+
+The evidence lives in sd-server's stdout: lemond inherits its own stdout/stderr
+handles to the child, so ggml's device lines land in whatever files the caller
+redirected lemond into. This module is deliberately dependency-free so it can
+be unit tested without a server or the HTTP client stack.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+# "ggml_extend_backend.cpp:395 - Initializing backend: Vulkan0"
+INIT_BACKEND_RE = re.compile(r"Initializing backend:\s*(\S+)")
+
+# ggml names each device after the backend that registered it. HIP builds
+# report "ROCm<n>" because GGML_CUDA_NAME is "ROCm" there.
+GGML_DEVICE_PATTERNS = {
+    "cpu": re.compile(r"CPU\d*", re.IGNORECASE),
+    "vulkan": re.compile(r"Vulkan\d*", re.IGNORECASE),
+    "rocm": re.compile(r"(?:ROCm|HIP)\d*", re.IGNORECASE),
+    "cuda": re.compile(r"CUDA\d*", re.IGNORECASE),
+    "metal": re.compile(r"Metal\d*", re.IGNORECASE),
+}
+
+# Echoed on failure so the job log names the reason the backend did not come
+# up, e.g. "ggml_cuda_init: failed to initialize ROCm: no ROCm-capable device
+# is detected".
+INIT_ERROR_RE = re.compile(
+    r"^.*(?:failed to initialize|device is detected|no usable devices|"
+    r"unable to load backend).*$",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+MAX_REPORTED_REASONS = 5
+
+
+def read_server_logs(log_paths: list[Path]) -> str:
+    """Concatenate the captured lemond/sd-server logs.
+
+    An unreadable file raises rather than degrading to an empty string: the
+    assertion must never be skipped because the evidence could not be read.
+    """
+    chunks: list[str] = []
+    for path in log_paths:
+        try:
+            chunks.append(Path(path).read_text(encoding="utf-8", errors="replace"))
+        except OSError as exc:
+            raise RuntimeError(f"could not read server log {path}: {exc}") from exc
+    return "\n".join(chunks)
+
+
+def find_initialized_devices(log_text: str) -> list[str]:
+    """Every ggml device sd-server reported initializing, in order."""
+    return INIT_BACKEND_RE.findall(log_text)
+
+
+def find_init_failure_reasons(log_text: str) -> list[str]:
+    """Deduplicated backend-initialization error lines, in order."""
+    reasons = (line.strip() for line in INIT_ERROR_RE.findall(log_text))
+    return list(dict.fromkeys(reason for reason in reasons if reason))
+
+
+def assert_active_backend(backend: str, log_text: str) -> list[str]:
+    """Fail unless every sd-server instance initialized ``backend``.
+
+    Returns the ggml devices observed. Raises RuntimeError when a device does
+    not belong to the requested backend, or when the log carries no evidence at
+    all -- passing an unverified leg is the failure this exists to prevent.
+    """
+    expected = GGML_DEVICE_PATTERNS.get(backend)
+    if expected is None:
+        raise RuntimeError(f"no ggml device pattern known for backend '{backend}'")
+
+    devices = find_initialized_devices(log_text)
+    if not devices:
+        raise RuntimeError(
+            "server log contains no 'Initializing backend:' line, so the active "
+            f"ggml backend could not be verified against the requested "
+            f"'{backend}'. sd-server only logs it when run verbosely, which "
+            "lemond does under debug logging."
+        )
+
+    mismatched = [device for device in devices if not expected.fullmatch(device)]
+    if not mismatched:
+        return devices
+
+    message = (
+        f"requested backend '{backend}' but sd-server initialized "
+        f"{sorted(set(mismatched))} (all devices seen: {devices})"
+    )
+    reasons = find_init_failure_reasons(log_text)[:MAX_REPORTED_REASONS]
+    if reasons:
+        message += ". Backend init reported: " + "; ".join(reasons)
+    raise RuntimeError(message)

--- a/test/validate_sdcpp.py
+++ b/test/validate_sdcpp.py
@@ -6,6 +6,10 @@ Lemonade to the requested sd-cpp backend, then generates deterministic PNGs for
 all requested model/size combinations. It records review evidence: model,
 backend, prompt, seed, size, generated PNG path, byte size, request wall time,
 and whether an untimed warm-up was used before collecting timings.
+
+When ``--server-log`` is given, the run also asserts that sd-server actually
+initialized the requested ggml backend, so a silent fallback to CPU fails the
+job instead of passing with the wrong backend validated.
 """
 
 from __future__ import annotations
@@ -21,6 +25,8 @@ from pathlib import Path
 from typing import Any
 
 import requests
+
+from utils.sdcpp_backend_log import assert_active_backend, read_server_logs
 
 DEFAULT_PORT = int(os.environ.get("LEMONADE_PORT", "13305"))
 DEFAULT_TIMEOUT = int(os.environ.get("LEMONADE_VALIDATE_SD_TIMEOUT", "3600"))
@@ -93,6 +99,18 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--output", default="sdcpp_validation.json")
     parser.add_argument("--images-dir", default="sdcpp-validation-images")
+    parser.add_argument(
+        "--server-log",
+        action="append",
+        type=Path,
+        default=None,
+        dest="server_logs",
+        help=(
+            "Captured lemond stdout/stderr file. May be repeated. When given, "
+            "the run fails unless sd-server initialized the requested backend, "
+            "instead of passing on a silent fallback to CPU."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -362,6 +380,34 @@ def main() -> int:
                 )
                 print(f"[FAIL] {model} {width}x{height}: {exc}", file=sys.stderr)
             results.append(record)
+
+    # Checked once at the end: sd-server's stdout is fully buffered when
+    # redirected to a file, so the early device line is only guaranteed to have
+    # reached the log after a run's worth of output has been written.
+    backend_check: dict[str, Any] = {
+        "check": "active_backend",
+        "backend": args.backend,
+        "channel": args.channel,
+        "label": label,
+        "pass": True,
+    }
+    if args.server_logs:
+        try:
+            devices = assert_active_backend(
+                args.backend, read_server_logs(args.server_logs)
+            )
+            backend_check["ggml_devices"] = devices
+            print(f"[OK] sd-server initialized {sorted(set(devices))} on {label}")
+        except Exception as exc:  # noqa: BLE001 - keep JSON on all failures
+            overall_pass = False
+            backend_check.update({"pass": False, "error": str(exc)})
+            print(f"[FAIL] active backend check on {label}: {exc}", file=sys.stderr)
+        results.append(backend_check)
+    else:
+        print(
+            "[WARN] no --server-log given; skipping the active backend check",
+            file=sys.stderr,
+        )
 
     output_path = Path(args.output)
     output_path.write_text(json.dumps(results, indent=2) + "\n", encoding="utf-8")


### PR DESCRIPTION
## Summary

The `rocm-stable` leg of the sd-cpp validation workflow has been passing while generating every image on CPU. Two independent bugs, plus a third that fixing them uncovered.

- **The ROCm backend never initialized.** `sdcpp_server.cpp` force-copies TheRock's `amdhip64_7.dll` next to `sd-server.exe`. When the AMD driver ships a newer HIP runtime in System32, that stale copy shadows it (the exe dir precedes System32 in the loader search order), `hipGetDeviceCount()` returns 0, and ggml falls back to CPU. This is #3213, fixed for llama.cpp in #3217 via `BackendUtils::stage_therock_hip_runtime()` — that PR scoped the fix to llama.cpp. This uses it for sd-cpp too.
- **Nothing checked which backend actually came up.** `validate_sdcpp.py` only asserted HTTP 200 plus a decodable PNG, so the fallback was invisible. It now asserts the active ggml backend from the captured server log via `--server-log`, which the workflow passes.
- **Uncovered by the above: ROCm 7.14.0's rocBLAS is broken on gfx1151** (#3409). The `rocm-stable` leg is therefore non-blocking, so it reports without gating merges.

Evidence from run [33084860623](https://github.com/lemonade-sdk/lemonade/actions/runs/33084860623/job/98565289531) — SD-Turbo at 1024x1024 took **105.7s** on `rocm-stable` against 159.6s on `cpu` and 10.0s on `vulkan`, with byte-identical PNGs across three consecutive runs.

## Verification on this PR

The fix works. The `rocm-stable` leg now reports:

```
[Info] (BackendUtils) System32 amdhip64_7.dll is at least as new as TheRock's; staged it at ...
ggml_cuda_init: found 1 ROCm devices (Total VRAM: 44920 MiB):
  Device 0: AMD Radeon(TM) 8060S Graphics, gfx1151 (0x1151), Wave Size: 32
[DEBUG] Initializing backend: ROCm0
... total params memory size = 1929.50MB (VRAM 1929.50MB, RAM 0.00MB)
[OK] sd-server initialized ['ROCm0'] on rocm-stable
```

Weights now land in VRAM instead of RAM, and the new assertion confirms it.

The leg still fails, on the newly visible ROCm regression. Isolated locally on a Radeon 8060S (gfx1151), holding the HIP runtime constant at the driver's `System32\amdhip64_7.dll` 10.0.3679 and varying only the rocBLAS/hipBLAS libraries:

| sd-cpp build | ROCm libraries | Result |
|---|---|---|
| `master-721-8caa3f9` | 7.13.0 | generates, ~11 it/s on GPU |
| `master-827-97d2990` (current pin) | 7.13.0 | generates on GPU |
| `master-827-97d2990` (current pin) | 7.14.0 | `hipErrorInvalidDeviceFunction` |
| `master-721-8caa3f9` | 7.14.0 | `hipErrorInvalidDeviceFunction` |
| `master-827-97d2990` | 7.14.0 + 7.13.0 Tensile kernels | `hipErrorInvalidDeviceFunction` |

It tracks the ROCm version, not the sd-cpp build, and is not the Tensile kernel data. llama.cpp is unaffected — its `rocm (stable)` and `rocm (nightly)` legs pass on the same gfx1151 runner in this PR's run. Full detail and repro in #3409.

## Notes on the assertion

- sd-server logs its ggml device selection to stdout, which lemond inherits into the files the workflow already redirects, so no new capture path was needed.
- It runs once at the end of a leg: sd-server's stdout is fully buffered when redirected to a file, so the early device line is only reliably present after a run's worth of output.
- A log with **no** evidence fails too. An unverified leg silently passing is the failure this exists to prevent.
- The pure log parsing lives in `test/utils/sdcpp_backend_log.py` so it is unit-testable without the server or `requests`.
- A matrix leg with no `blocking` value gates by default, so new legs are blocking unless explicitly opted out.

Follow-up not in scope: lemond itself still cannot see this fallback, so users get a silent CPU downgrade with no warning. Worth a separate issue.

Fixes #3401

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_

- Compiled the changed translation unit: `MSBuild lemonade-server-core.vcxproj /t:ClCompile /p:SelectedFiles=...\sdcpp_server.cpp` — clean.
- New unit tests: `python -m unittest test.test_sdcpp_backend_log -v` — 13 tests pass. Wired into the `pre-commit` job in `docs_and_style.yml`.
- Replayed the assertion against the real `sdcpp-server-logs-*` artifacts from run 33084860623: `rocm` -> FAIL with the HIP reason quoted, `vulkan` -> PASS `['Vulkan0', 'Vulkan0']`, `cpu` -> PASS `['CPU', 'CPU']`.
- Confirmed in CI on this PR that the staging fix brings up `ROCm0` with weights in VRAM (see above).
- Reproduced and isolated the ROCm 7.14.0 regression locally on gfx1151 with `sd-cli.exe`, per the matrix above.
- Verified on Windows that a file held open by `Start-Process -RedirectStandardOutput` is readable concurrently, which the in-run check depends on.
- `black` and `python tools/check_comment_slop.py` are clean.

## Documentation

- [x] Documentation is not affected by this change.

## Breaking Changes

- [x] This PR does not introduce breaking changes.

## AI-assisted contribution

- [x] I used AI tools for this PR.

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.
