### PR TITLE
ci(sdcpp): run the CPU validation leg only on schedule/workflow_dispatch

### DIFF
--- a/.github/workflows/validate_sdcpp.yml
+++ b/.github/workflows/validate_sdcpp.yml
@@ -60,6 +60,7 @@ jobs:
       base_update_backends: ${{ steps.assets.outputs.base_update_backends }}
       cuda_update_backends: ${{ steps.assets.outputs.cuda_update_backends }}
       update_backends: ${{ steps.assets.outputs.update_backends }}
+      validate_matrix: ${{ steps.matrix.outputs.validate_matrix }}
     steps:
       - uses: actions/checkout@v5
 
@@ -195,6 +196,40 @@ jobs:
           echo "Will update base sd-cpp pins: ${SDCPP_BASE_UPDATE_BACKENDS} -> ${BASE_RELEASE}"
           echo "Will update CUDA sd-cpp pins later after validation: ${SDCPP_CUDA_UPDATE_BACKENDS} -> ${{ steps.release.outputs.cuda_release }}"
 
+      - name: Build validation matrix
+        id: matrix
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          # SDCPP_TEST_MODELS peaks at ~18 GB resident, so these legs never needed
+          # the 128gb runner; the sd-cpp suite in cpp_server_build_test_release.yml
+          # already runs on hosts with no size label at all.
+          #
+          # CUDA is pinned by the updater and its assets are required by the
+          # verify-cuda-assets job after this validation matrix completes, but
+          # validation stays disabled until a matching runner exists.
+          legs='[
+            {"label":"cpu","backend":"cpu","channel":"",
+             "runner":["self-hosted","Windows","stx-halo","vulkan","lemon-prod"]},
+            {"label":"vulkan","backend":"vulkan","channel":"",
+             "runner":["self-hosted","Windows","stx-halo","vulkan","lemon-prod"]},
+            {"label":"rocm-stable","backend":"rocm","channel":"stable",
+             "runner":["self-hosted","Windows","stx-halo","rocm","lemon-prod"]}
+          ]'
+
+          # cpp_server_build_test_release.yml already exercises sd-cpp on CPU
+          # before merge, so the CPU leg only earns its ~17 minutes when it is
+          # qualifying an upstream release for the update PR.
+          case "${EVENT_NAME}" in
+            schedule|workflow_dispatch) matrix=$(jq -c '.' <<<"$legs") ;;
+            *) matrix=$(jq -c '[.[] | select(.label != "cpu")]' <<<"$legs") ;;
+          esac
+
+          echo "validate_matrix=${matrix}" >> "$GITHUB_OUTPUT"
+          echo "Validation legs for ${EVENT_NAME}:"
+          jq -r '.[].label' <<<"$matrix"
+
   build:
     name: Build Lemonade with sd-cpp pins
     needs: discover-release
@@ -275,29 +310,7 @@ jobs:
     strategy:
       fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:
-        # SDCPP_TEST_MODELS peaks at ~18 GB resident, so these legs never needed
-        # the 128gb runner; the sd-cpp suite in cpp_server_build_test_release.yml
-        # already runs on hosts with no size label at all.
-        include:
-          - label: cpu
-            backend: cpu
-            channel: ""
-            runner: [self-hosted, Windows, stx-halo, vulkan, lemon-prod]
-          - label: vulkan
-            backend: vulkan
-            channel: ""
-            runner: [self-hosted, Windows, stx-halo, vulkan, lemon-prod]
-          - label: rocm-stable
-            backend: rocm
-            channel: stable
-            runner: [self-hosted, Windows, stx-halo, rocm, lemon-prod]
-          # CUDA is pinned by the updater and its assets are required by the
-          # verify-cuda-assets job after this validation matrix completes.
-          # Validation stays disabled until a matching runner exists.
-          # - label: cuda
-          #   backend: cuda
-          #   channel: ""
-          #   runner: [self-hosted, Windows, 128gb, cuda]
+        include: ${{ fromJSON(needs.discover-release.outputs.validate_matrix) }}
     steps:
       - name: Prepare Windows runner for long paths and stale workspace caches
         if: runner.os == 'Windows'


### PR DESCRIPTION
## Summary

Implements @fl0rianr's suggestion in #3403: drop the `Validate cpu` leg from the merge-queue and PR paths, keep it for `schedule` / `workflow_dispatch`. The C++ inference workflow already exercises sd-cpp on CPU on both Windows and Linux before merge, so the full 2-model / 2-size CPU validation is duplicate coverage there — but it still has value when qualifying a new upstream sd-cpp release and generating the evidence for the update PR.

The matrix moves from a static `include:` list into a `discover-release` output so the leg list is single-sourced and the event-based filter is explicit.

Fixes #3403

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_ Dispatched this branch to confirm the CPU leg still runs on `workflow_dispatch`: [run 33114885723](https://github.com/lemonade-sdk/lemonade/actions/runs/33114885723). The `Discover stable-diffusion.cpp releases` job prints `Validation legs for workflow_dispatch: cpu, vulkan, rocm-stable`, and the [Validate cpu](https://github.com/lemonade-sdk/lemonade/actions/runs/33114885723/job/98669869560) leg is scheduled as expected. (Inputs were pinned to the currently-pinned releases, `master-827-97d2990` / `master-827-e2329c3`, so the run re-validates the existing pins instead of opening an auto-update PR for upstream `master-829-0a565f2`.)

Locally, extracted the new `Build validation matrix` step and ran it against each trigger. `schedule` and `workflow_dispatch` emit `cpu, vulkan, rocm-stable`; `merge_group` and `pull_request` emit `vulkan, rocm-stable`. Verified the `schedule` output is deep-equal to the static matrix it replaces, and that `$GITHUB_OUTPUT` gets a single line (a multi-line value would silently break the `fromJSON`). YAML validated.

`create-pr` consumes `SDCPP_VALIDATED_LABELS: cpu,vulkan,rocm-stable` and only runs on `schedule` / `workflow_dispatch`, where the CPU leg is still present, so that value stays accurate. `validation-gate` aggregates the `validate` job as a whole and needs no change.

## Documentation

- [x] Documentation is not affected by this change.

## Breaking Changes

- [ ] This PR introduces breaking changes.
- [x] This PR does not introduce breaking changes.

## AI-assisted contribution

- [x] I used AI tools for this PR.

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.
