### PR TITLE
fix(routing): don't drop the whole router policy over one hardware-filtered classifier

### DIFF
--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -3037,16 +3037,19 @@ void ModelManager::build_cache() {
         }
     }
 
-    // Snapshot every known model's type before hardware filtering removes some
-    // of them from all_models (#2748): a router's classifier component can name
-    // a model this host can't run right now (no NPU, insufficient memory, not
-    // yet downloaded), which must not be indistinguishable from a name that
-    // isn't a model at all. The routing-policy resolver below falls back to
-    // this so that case still resolves a type and parses; the classifier then
-    // fails at evaluate() time instead, where on_error already applies per rule.
+    // Snapshot type + bare-name alias before hardware filtering removes some
+    // models from all_models (#2748): the resolver below falls back to this so
+    // a router referencing a currently-unavailable model still parses; that
+    // classifier then fails only at evaluate() time, where on_error applies.
     std::map<std::string, ModelType> pre_filter_types;
+    std::map<std::string, std::string> pre_filter_bare_aliases;
     for (const auto& [name, info] : all_models) {
         pre_filter_types[name] = info.type;
+        std::string bare = name;
+        if (auto canon = parse_canonical_id(name)) {
+            bare = canon->bare_name;
+        }
+        pre_filter_bare_aliases.emplace(bare, name);
     }
 
     // Step 2: Filter by backend availability. This is the full-registry pass, so
@@ -3099,23 +3102,22 @@ void ModelManager::build_cache() {
     cache_valid_ = true;
 
     // Parse each collection.router model's routing policy now, while the cache
-    // and its alias map are fully built and the lock is still held. The parser's
-    // component resolver needs only alias resolution, which is a direct lookup
-    // into public_model_aliases_ here - exactly what resolve_model_name() does,
-    // minus its own build_cache()+lock. Calling resolve_model_name() here would
-    // re-lock this non-recursive mutex and deadlock, so the lookup is inlined.
+    // and its alias map are fully built and the lock is still held (inlined
+    // rather than resolve_model_name()/get_model_info(), which would re-lock
+    // this non-recursive mutex). Both resolvers fall back to the pre-filter
+    // snapshots above (#2748) so a component this host can't run right now
+    // still resolves and the policy still parses; that classifier then fails
+    // only at evaluate() time, where on_error already applies.
     RoutingPolicyParseOptions policy_options;
     policy_options.resolve_component =
-        [this](const std::string& name) -> std::optional<std::string> {
+        [this, &pre_filter_bare_aliases](const std::string& name) -> std::optional<std::string> {
         auto it = public_model_aliases_.find(name);
-        return it != public_model_aliases_.end() ? it->second : name;
+        if (it != public_model_aliases_.end()) {
+            return it->second;
+        }
+        auto pre_it = pre_filter_bare_aliases.find(name);
+        return pre_it != pre_filter_bare_aliases.end() ? pre_it->second : name;
     };
-    // Direct lookup into the map already being built, same rationale as
-    // resolve_component above: models_cache_ is populated and the lock is
-    // still held, so this avoids re-entering get_model_info()'s own locking.
-    // Falls back to pre_filter_types (#2748) for a component this host
-    // currently can't run: its type is still known, so the policy still
-    // parses instead of being dropped whole over one unavailable classifier.
     policy_options.get_model_type = [this, &pre_filter_types](
                                          const std::string& name) -> std::optional<ModelType> {
         auto it = models_cache_.find(name);

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -3037,6 +3037,18 @@ void ModelManager::build_cache() {
         }
     }
 
+    // Snapshot every known model's type before hardware filtering removes some
+    // of them from all_models (#2748): a router's classifier component can name
+    // a model this host can't run right now (no NPU, insufficient memory, not
+    // yet downloaded), which must not be indistinguishable from a name that
+    // isn't a model at all. The routing-policy resolver below falls back to
+    // this so that case still resolves a type and parses; the classifier then
+    // fails at evaluate() time instead, where on_error already applies per rule.
+    std::map<std::string, ModelType> pre_filter_types;
+    for (const auto& [name, info] : all_models) {
+        pre_filter_types[name] = info.type;
+    }
+
     // Step 2: Filter by backend availability. This is the full-registry pass, so
     // it also refreshes the recipe availability side table used to hide backends
     // that have nothing runnable on this host.
@@ -3101,9 +3113,18 @@ void ModelManager::build_cache() {
     // Direct lookup into the map already being built, same rationale as
     // resolve_component above: models_cache_ is populated and the lock is
     // still held, so this avoids re-entering get_model_info()'s own locking.
-    policy_options.get_model_type = [this](const std::string& name) -> std::optional<ModelType> {
+    // Falls back to pre_filter_types (#2748) for a component this host
+    // currently can't run: its type is still known, so the policy still
+    // parses instead of being dropped whole over one unavailable classifier.
+    policy_options.get_model_type = [this, &pre_filter_types](
+                                         const std::string& name) -> std::optional<ModelType> {
         auto it = models_cache_.find(name);
-        return it != models_cache_.end() ? std::optional<ModelType>(it->second.type) : std::nullopt;
+        if (it != models_cache_.end()) {
+            return it->second.type;
+        }
+        auto pre_it = pre_filter_types.find(name);
+        return pre_it != pre_filter_types.end() ? std::optional<ModelType>(pre_it->second)
+                                                : std::nullopt;
     };
     for (auto& [name, info] : models_cache_) {
         if (!is_router_collection_recipe(info.recipe)) {

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -2787,6 +2787,40 @@ void ModelManager::download_from_huggingface_engine(
     download_from_registry_engine(info, progress_callback);
 }
 
+// Bare name -> winning canonical cache key, by source precedence (Registered
+// > Imported > Builtin), same rule as rebuild_public_model_aliases_locked()
+// but over every known model, not just hardware-filtering survivors (#2748):
+// a bare name must not silently resolve to a lower-precedence model just
+// because the true winner is temporarily unavailable.
+static std::map<std::string, std::string> compute_bare_name_precedence(
+    const std::map<std::string, ModelInfo>& models) {
+    struct Candidate {
+        std::string cache_key;
+        ModelSource source;
+    };
+    std::map<std::string, std::vector<Candidate>> by_bare;
+    for (const auto& [cache_key, info] : models) {
+        ModelSource source;
+        std::string bare;
+        if (auto canon = parse_canonical_id(cache_key)) {
+            source = canon->source;
+            bare = canon->bare_name;
+        } else {
+            source = ModelSource::Builtin;
+            bare = cache_key;
+        }
+        by_bare[bare].push_back({cache_key, source});
+    }
+    std::map<std::string, std::string> winners;
+    for (auto& [bare, entries] : by_bare) {
+        std::sort(entries.begin(), entries.end(), [](const Candidate& a, const Candidate& b) {
+            return precedence_rank(a.source) < precedence_rank(b.source);
+        });
+        winners[bare] = entries.front().cache_key;
+    }
+    return winners;
+}
+
 void ModelManager::build_cache() {
     std::lock_guard<std::mutex> lock(models_cache_mutex_);
 
@@ -3037,20 +3071,14 @@ void ModelManager::build_cache() {
         }
     }
 
-    // Snapshot type + bare-name alias before hardware filtering removes some
-    // models from all_models (#2748): the resolver below falls back to this so
-    // a router referencing a currently-unavailable model still parses; that
-    // classifier then fails only at evaluate() time, where on_error applies.
+    // Pre-filter snapshots for the routing-policy resolver below (#2748); see
+    // compute_bare_name_precedence() for why the alias needs its own pass.
     std::map<std::string, ModelType> pre_filter_types;
-    std::map<std::string, std::string> pre_filter_bare_aliases;
     for (const auto& [name, info] : all_models) {
         pre_filter_types[name] = info.type;
-        std::string bare = name;
-        if (auto canon = parse_canonical_id(name)) {
-            bare = canon->bare_name;
-        }
-        pre_filter_bare_aliases.emplace(bare, name);
     }
+    const std::map<std::string, std::string> pre_filter_bare_aliases =
+        compute_bare_name_precedence(all_models);
 
     // Step 2: Filter by backend availability. This is the full-registry pass, so
     // it also refreshes the recipe availability side table used to hide backends
@@ -3101,22 +3129,20 @@ void ModelManager::build_cache() {
 
     cache_valid_ = true;
 
-    // Parse each collection.router model's routing policy now, while the cache
-    // and its alias map are fully built and the lock is still held (inlined
-    // rather than resolve_model_name()/get_model_info(), which would re-lock
-    // this non-recursive mutex). Both resolvers fall back to the pre-filter
-    // snapshots above (#2748) so a component this host can't run right now
-    // still resolves and the policy still parses; that classifier then fails
-    // only at evaluate() time, where on_error already applies.
+    // Parse each collection.router model's routing policy while the cache and
+    // alias map are built and the lock is held (avoids re-locking via
+    // resolve_model_name()/get_model_info()). public_model_aliases_ only
+    // backstops what the precedence map doesn't cover (e.g. an
+    // extra_models_dir input_alias).
     RoutingPolicyParseOptions policy_options;
     policy_options.resolve_component =
         [this, &pre_filter_bare_aliases](const std::string& name) -> std::optional<std::string> {
-        auto it = public_model_aliases_.find(name);
-        if (it != public_model_aliases_.end()) {
-            return it->second;
-        }
         auto pre_it = pre_filter_bare_aliases.find(name);
-        return pre_it != pre_filter_bare_aliases.end() ? pre_it->second : name;
+        if (pre_it != pre_filter_bare_aliases.end()) {
+            return pre_it->second;
+        }
+        auto it = public_model_aliases_.find(name);
+        return it != public_model_aliases_.end() ? it->second : name;
     };
     policy_options.get_model_type = [this, &pre_filter_types](
                                          const std::string& name) -> std::optional<ModelType> {

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -2787,18 +2787,26 @@ void ModelManager::download_from_huggingface_engine(
     download_from_registry_engine(info, progress_callback);
 }
 
-// Bare name -> winning canonical cache key, by source precedence (Registered
-// > Imported > Builtin), same rule as rebuild_public_model_aliases_locked()
-// but over every known model, not just hardware-filtering survivors (#2748):
-// a bare name must not silently resolve to a lower-precedence model just
-// because the true winner is temporarily unavailable.
-static std::map<std::string, std::string> compute_bare_name_precedence(
-    const std::map<std::string, ModelInfo>& models) {
-    struct Candidate {
+// Every alias form rebuild_public_model_aliases_locked() computes -- bare
+// name (by source precedence), builtin.<X>, and ModelInfo::input_aliases --
+// as a pure function of an arbitrary model set, so it can also run against
+// the pre-filter set (#2748): a component's alias must resolve the same way
+// whether or not its model currently survives hardware filtering. See that
+// function's own doc comment for what each field means.
+struct ModelAliasMaps {
+    std::map<std::string, std::string> public_model_aliases;
+    std::map<std::string, std::string> canonical_public_names;
+};
+
+static ModelAliasMaps compute_model_alias_maps(const std::map<std::string, ModelInfo>& models) {
+    ModelAliasMaps result;
+
+    struct Entry {
         std::string cache_key;
         ModelSource source;
     };
-    std::map<std::string, std::vector<Candidate>> by_bare;
+    std::map<std::string, std::vector<Entry>> by_bare;
+
     for (const auto& [cache_key, info] : models) {
         ModelSource source;
         std::string bare;
@@ -2811,14 +2819,70 @@ static std::map<std::string, std::string> compute_bare_name_precedence(
         }
         by_bare[bare].push_back({cache_key, source});
     }
-    std::map<std::string, std::string> winners;
+
     for (auto& [bare, entries] : by_bare) {
-        std::sort(entries.begin(), entries.end(), [](const Candidate& a, const Candidate& b) {
+        std::sort(entries.begin(), entries.end(), [](const Entry& a, const Entry& b) {
             return precedence_rank(a.source) < precedence_rank(b.source);
         });
-        winners[bare] = entries.front().cache_key;
+
+        const Entry& winner = entries.front();
+        result.public_model_aliases[bare] = winner.cache_key;
+
+        const auto winner_it = models.find(winner.cache_key);
+        const bool winner_is_prefixed_collection =
+            winner.source != ModelSource::Builtin &&
+            winner_it != models.end() &&
+            is_model_collection_recipe(winner_it->second.recipe);
+        result.canonical_public_names[winner.cache_key] =
+            winner_is_prefixed_collection ? canonical_id(winner.source, bare) : bare;
+
+        for (size_t i = 1; i < entries.size(); ++i) {
+            const Entry& shadowed = entries[i];
+            std::string canonical = canonical_id(shadowed.source, bare);
+            result.canonical_public_names[shadowed.cache_key] = canonical;
+            if (canonical != shadowed.cache_key) {
+                result.public_model_aliases[canonical] = shadowed.cache_key;
+            }
+        }
     }
-    return winners;
+
+    for (const auto& [cache_key, _info] : models) {
+        if (parse_canonical_id(cache_key)) continue;
+        std::string canonical = canonical_id(ModelSource::Builtin, cache_key);
+        result.public_model_aliases.try_emplace(canonical, cache_key);
+    }
+
+    auto source_for_cache_key = [](const std::string& cache_key) {
+        if (auto canon = parse_canonical_id(cache_key)) {
+            return canon->source;
+        }
+        return ModelSource::Builtin;
+    };
+
+    for (const auto& [cache_key, info] : models) {
+        for (const auto& alias : info.input_aliases) {
+            if (parse_canonical_id(alias)) {
+                if (models.find(alias) == models.end()) {
+                    result.public_model_aliases[alias] = cache_key;
+                }
+            } else {
+                auto existing = result.public_model_aliases.find(alias);
+                if (existing == result.public_model_aliases.end()) {
+                    result.public_model_aliases[alias] = cache_key;
+                    continue;
+                }
+
+                if (source_for_cache_key(existing->second) == ModelSource::Builtin) {
+                    std::string builtin_canonical = canonical_id(ModelSource::Builtin, alias);
+                    result.canonical_public_names[existing->second] = builtin_canonical;
+                    result.public_model_aliases[builtin_canonical] = existing->second;
+                    result.public_model_aliases[alias] = cache_key;
+                }
+            }
+        }
+    }
+
+    return result;
 }
 
 void ModelManager::build_cache() {
@@ -3072,13 +3136,14 @@ void ModelManager::build_cache() {
     }
 
     // Pre-filter snapshots for the routing-policy resolver below (#2748); see
-    // compute_bare_name_precedence() for why the alias needs its own pass.
+    // compute_model_alias_maps() for why the alias needs the full algorithm
+    // rather than a plain bare-name map.
     std::map<std::string, ModelType> pre_filter_types;
     for (const auto& [name, info] : all_models) {
         pre_filter_types[name] = info.type;
     }
-    const std::map<std::string, std::string> pre_filter_bare_aliases =
-        compute_bare_name_precedence(all_models);
+    const std::map<std::string, std::string> pre_filter_aliases =
+        compute_model_alias_maps(all_models).public_model_aliases;
 
     // Step 2: Filter by backend availability. This is the full-registry pass, so
     // it also refreshes the recipe availability side table used to hide backends
@@ -3131,18 +3196,14 @@ void ModelManager::build_cache() {
 
     // Parse each collection.router model's routing policy while the cache and
     // alias map are built and the lock is held (avoids re-locking via
-    // resolve_model_name()/get_model_info()). public_model_aliases_ only
-    // backstops what the precedence map doesn't cover (e.g. an
-    // extra_models_dir input_alias).
+    // resolve_model_name()/get_model_info()). pre_filter_aliases is computed
+    // over all_models, a strict superset of models_cache_, so it alone
+    // covers everything public_model_aliases_ would (#2748).
     RoutingPolicyParseOptions policy_options;
     policy_options.resolve_component =
-        [this, &pre_filter_bare_aliases](const std::string& name) -> std::optional<std::string> {
-        auto pre_it = pre_filter_bare_aliases.find(name);
-        if (pre_it != pre_filter_bare_aliases.end()) {
-            return pre_it->second;
-        }
-        auto it = public_model_aliases_.find(name);
-        return it != public_model_aliases_.end() ? it->second : name;
+        [&pre_filter_aliases](const std::string& name) -> std::optional<std::string> {
+        auto it = pre_filter_aliases.find(name);
+        return it != pre_filter_aliases.end() ? it->second : name;
     };
     policy_options.get_model_type = [this, &pre_filter_types](
                                          const std::string& name) -> std::optional<ModelType> {
@@ -6410,103 +6471,14 @@ std::set<std::string> ModelManager::recipes_with_all_models_filtered() {
 //       fetch, and chat (the bare name still resolves via public_model_aliases_)
 //     - shadowed cache keys → canonical-prefixed ID (user.X / extra.X / builtin.X)
 //
-// Precedence: Registered > Imported > Builtin.
+// Precedence: Registered > Imported > Builtin. The algorithm itself is
+// compute_model_alias_maps(), shared with build_cache()'s pre-filter
+// resolver snapshot (#2748); this just runs it against models_cache_ and
+// commits the result to member state.
 void ModelManager::rebuild_public_model_aliases_locked() {
-    public_model_aliases_.clear();
-    canonical_public_names_.clear();
-
-    struct Entry {
-        std::string cache_key;
-        ModelSource source;
-    };
-    std::map<std::string, std::vector<Entry>> by_bare;
-
-    for (const auto& [cache_key, info] : models_cache_) {
-        ModelSource source;
-        std::string bare;
-        if (auto canon = parse_canonical_id(cache_key)) {
-            source = canon->source;
-            bare = canon->bare_name;
-        } else {
-            // Unprefixed cache keys are built-ins (server_models.json).
-            source = ModelSource::Builtin;
-            bare = cache_key;
-        }
-        by_bare[bare].push_back({cache_key, source});
-    }
-
-    for (auto& [bare, entries] : by_bare) {
-        std::sort(entries.begin(), entries.end(),
-                  [](const Entry& a, const Entry& b) {
-                      return precedence_rank(a.source) < precedence_rank(b.source);
-                  });
-
-        const Entry& winner = entries.front();
-        public_model_aliases_[bare] = winner.cache_key;
-
-        // Collections registered under a prefixed namespace (user.* / extra.*)
-        // must list with their prefix so the id emitted by /v1/models matches the
-        // id used for registration, fetch, and chat. The bare name still resolves
-        // via the alias above, preserving dual-id (bare + prefixed) invocation.
-        const auto winner_it = models_cache_.find(winner.cache_key);
-        const bool winner_is_prefixed_collection =
-            winner.source != ModelSource::Builtin &&
-            winner_it != models_cache_.end() &&
-            is_model_collection_recipe(winner_it->second.recipe);
-        canonical_public_names_[winner.cache_key] =
-            winner_is_prefixed_collection ? canonical_id(winner.source, bare) : bare;
-
-        for (size_t i = 1; i < entries.size(); ++i) {
-            const Entry& shadowed = entries[i];
-            std::string canonical = canonical_id(shadowed.source, bare);
-            canonical_public_names_[shadowed.cache_key] = canonical;
-            if (canonical != shadowed.cache_key) {
-                public_model_aliases_[canonical] = shadowed.cache_key;
-            }
-        }
-    }
-
-    // Always accept builtin.<X> as an input alias for the bare cache key,
-    // even when no other source shadows the built-in.
-    for (const auto& [cache_key, _info] : models_cache_) {
-        if (parse_canonical_id(cache_key)) continue;
-        std::string canonical = canonical_id(ModelSource::Builtin, cache_key);
-        public_model_aliases_.try_emplace(canonical, cache_key);
-    }
-
-    // A split extra_models_dir folder should show only its variant models in
-    // /models. Keep the old folder name working for existing scripts, but only
-    // as an input alias. Do not let that alias replace a user model or another
-    // real extra model with the same name.
-    auto source_for_cache_key = [](const std::string& cache_key) {
-        if (auto canon = parse_canonical_id(cache_key)) {
-            return canon->source;
-        }
-        return ModelSource::Builtin;
-    };
-
-    for (const auto& [cache_key, info] : models_cache_) {
-        for (const auto& alias : info.input_aliases) {
-            if (parse_canonical_id(alias)) {
-                if (models_cache_.find(alias) == models_cache_.end()) {
-                    public_model_aliases_[alias] = cache_key;
-                }
-            } else {
-                auto existing = public_model_aliases_.find(alias);
-                if (existing == public_model_aliases_.end()) {
-                    public_model_aliases_[alias] = cache_key;
-                    continue;
-                }
-
-                if (source_for_cache_key(existing->second) == ModelSource::Builtin) {
-                    std::string builtin_canonical = canonical_id(ModelSource::Builtin, alias);
-                    canonical_public_names_[existing->second] = builtin_canonical;
-                    public_model_aliases_[builtin_canonical] = existing->second;
-                    public_model_aliases_[alias] = cache_key;
-                }
-            }
-        }
-    }
+    ModelAliasMaps computed = compute_model_alias_maps(models_cache_);
+    public_model_aliases_ = std::move(computed.public_model_aliases);
+    canonical_public_names_ = std::move(computed.canonical_public_names);
 }
 
 } // namespace lemon

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -3024,6 +3024,37 @@ static ModelAliasMaps compute_model_alias_maps(const std::map<std::string, Model
     return result;
 }
 
+// Both routing-policy parse sites resolve a component the same way: alias
+// first, falling back to the name as authored; then a primary type lookup
+// with one fallback tier behind it. #2748 was that shape drifting between
+// them, so they are built from here rather than hand-written twice. Only the
+// tiers differ -- which model set each consults, and what the fallback is.
+struct RoutingResolutionTiers {
+    std::function<std::optional<std::string>(const std::string&)> alias;
+    std::function<std::optional<ModelType>(const std::string&)> type;
+    std::function<std::optional<ModelType>(const std::string&)> type_fallback;
+};
+
+static RoutingPolicyParseOptions make_routing_parse_options(RoutingResolutionTiers tiers) {
+    RoutingPolicyParseOptions options;
+    options.resolve_component =
+        [tiers](const std::string& name) -> std::optional<std::string> {
+        if (tiers.alias) {
+            if (auto resolved = tiers.alias(name)) return *resolved;
+        }
+        // An unresolvable name stays as authored so component-role validation
+        // can still report it by the name the author actually wrote.
+        return name;
+    };
+    options.get_model_type = [tiers](const std::string& name) -> std::optional<ModelType> {
+        if (tiers.type) {
+            if (auto type = tiers.type(name)) return type;
+        }
+        return tiers.type_fallback ? tiers.type_fallback(name) : std::nullopt;
+    };
+    return options;
+}
+
 void ModelManager::build_cache() {
     std::lock_guard<std::mutex> lock(models_cache_mutex_);
 
@@ -3276,13 +3307,23 @@ void ModelManager::build_cache() {
 
     // Pre-filter snapshots for the routing-policy resolver below (#2748); see
     // compute_model_alias_maps() for why the alias needs the full algorithm
-    // rather than a plain bare-name map.
+    // rather than a plain bare-name map. Only router collections read them and
+    // the alias rebuild is O(n log n) over the whole registry, so a host with
+    // no router collection -- the common case, across ~15 build_cache() call
+    // sites -- pays nothing.
+    const bool needs_routing_snapshots =
+        std::any_of(all_models.begin(), all_models.end(), [](const auto& entry) {
+            return is_router_collection_recipe(entry.second.recipe);
+        });
+
     std::map<std::string, ModelType> pre_filter_types;
-    for (const auto& [name, info] : all_models) {
-        pre_filter_types[name] = info.type;
+    std::map<std::string, std::string> pre_filter_aliases;
+    if (needs_routing_snapshots) {
+        for (const auto& [name, info] : all_models) {
+            pre_filter_types[name] = info.type;
+        }
+        pre_filter_aliases = compute_model_alias_maps(all_models).public_model_aliases;
     }
-    const std::map<std::string, std::string> pre_filter_aliases =
-        compute_model_alias_maps(all_models).public_model_aliases;
 
     // Step 2: Filter by backend availability. This is the full-registry pass, so
     // it also refreshes the recipe availability side table used to hide backends
@@ -3338,22 +3379,32 @@ void ModelManager::build_cache() {
     // resolve_model_name()/get_model_info()). pre_filter_aliases is computed
     // over all_models, a strict superset of models_cache_, so it alone
     // covers everything public_model_aliases_ would (#2748).
-    RoutingPolicyParseOptions policy_options;
-    policy_options.resolve_component =
+    //
+    // Components only the pre-filter tier can resolve are unavailable on this
+    // host: a classifier bound to one takes its on_error path on every
+    // request. Recorded here, where that is known, and reported per collection
+    // below so the operator sees degraded routing instead of silence (#2748).
+    std::set<std::string> unavailable_components;
+
+    RoutingPolicyParseOptions policy_options = make_routing_parse_options({
         [&pre_filter_aliases](const std::string& name) -> std::optional<std::string> {
-        auto it = pre_filter_aliases.find(name);
-        return it != pre_filter_aliases.end() ? it->second : name;
-    };
-    policy_options.get_model_type = [this, &pre_filter_types](
-                                         const std::string& name) -> std::optional<ModelType> {
-        auto it = models_cache_.find(name);
-        if (it != models_cache_.end()) {
+            auto it = pre_filter_aliases.find(name);
+            if (it == pre_filter_aliases.end()) return std::nullopt;
+            return it->second;
+        },
+        [this](const std::string& name) -> std::optional<ModelType> {
+            auto it = models_cache_.find(name);
+            if (it == models_cache_.end()) return std::nullopt;
             return it->second.type;
-        }
-        auto pre_it = pre_filter_types.find(name);
-        return pre_it != pre_filter_types.end() ? std::optional<ModelType>(pre_it->second)
-                                                : std::nullopt;
-    };
+        },
+        [&pre_filter_types, &unavailable_components](
+            const std::string& name) -> std::optional<ModelType> {
+            auto it = pre_filter_types.find(name);
+            if (it == pre_filter_types.end()) return std::nullopt;
+            unavailable_components.insert(name);
+            return it->second;
+        },
+    });
     for (auto& [name, info] : models_cache_) {
         if (!is_router_collection_recipe(info.recipe)) {
             continue;
@@ -3369,12 +3420,27 @@ void ModelManager::build_cache() {
         if (routing_it != info.extras.end()) {
             doc["routing"] = routing_it->second;
         }
+        unavailable_components.clear();
         try {
             info.route_policy = std::make_shared<const RoutePolicy>(
                 parse_route_policy_collection(doc, policy_options));
         } catch (const std::exception& e) {
             LOG(WARNING, "ModelManager") << "Failed to parse routing policy for '"
                                          << name << "': " << e.what() << std::endl;
+        }
+        if (!unavailable_components.empty()) {
+            std::ostringstream joined;
+            bool first = true;
+            for (const auto& component : unavailable_components) {
+                if (!first) joined << ", ";
+                joined << component;
+                first = false;
+            }
+            LOG(WARNING, "ModelManager")
+                << "Routing policy for '" << name << "' references component(s) "
+                << "unavailable on this host: " << joined.str()
+                << ". Any classifier bound to them will fall back to its on_error "
+                << "result on every request." << std::endl;
         }
     }
 
@@ -6377,39 +6443,44 @@ std::optional<std::string> ModelManager::validate_collection_request(
         }
     }
     if (is_router_collection_recipe(model_data.value("recipe", std::string()))) {
-        RoutingPolicyParseOptions options;
-        options.resolve_component = [this](const std::string& name) -> std::optional<std::string> {
-            try {
-                return resolve_model_name(name);
-            } catch (...) {
-                // Inline collection imports may reference components that are
-                // defined in the same JSON but not registered yet. Keep those
-                // names stable so parser component-role validation can still
-                // compare them against the authored components array.
-                return name;
-            }
-        };
-        options.get_model_type = [this, &find_inline_def](const std::string& name) -> std::optional<ModelType> {
-            try {
-                return get_model_info(name).type;
-            } catch (...) {
-                // Not registered yet - the name may match an inline `models[]`
-                // definition in this same request; derive its type from that
-                // definition's declared labels (absent labels default to LLM,
-                // same as everywhere else). Only nullopt if no definition
-                // exists at all - that's the "truly unknown" case.
+        // Same resolution shape as build_cache()'s, differing only in its
+        // tiers: this one resolves live and falls back to the request's own
+        // inline `models[]`, because an import validates names that are not
+        // registered yet. Unresolvable names are kept as authored by
+        // make_routing_parse_options, so component-role validation can still
+        // compare them against the authored components array.
+        RoutingPolicyParseOptions options = make_routing_parse_options({
+            [this](const std::string& name) -> std::optional<std::string> {
+                try {
+                    return resolve_model_name(name);
+                } catch (...) {
+                    return std::nullopt;
+                }
+            },
+            [this](const std::string& name) -> std::optional<ModelType> {
+                try {
+                    return get_model_info(name).type;
+                } catch (...) {
+                    return std::nullopt;
+                }
+            },
+            [this, &find_inline_def](const std::string& name) -> std::optional<ModelType> {
+                // Not registered - the name may match an inline `models[]`
+                // definition in this same request. Derive the type exactly as
+                // register_user_model() would once that definition is
+                // registered, so validation and runtime cannot disagree
+                // (absent labels default to LLM, same as everywhere else).
+                // nullopt only when no definition exists at all - the
+                // "truly unknown" case.
                 const json* def = find_inline_def(bare_component_name(name));
                 if (!def) {
                     return std::nullopt;
                 }
-                // Derive the type exactly as register_user_model() would once
-                // this inline definition is registered, so validation and
-                // runtime cannot disagree.
                 std::set<std::string> label_set = normalized_definition_labels(*def);
                 return get_model_type_from_labels(
                     std::vector<std::string>(label_set.begin(), label_set.end()));
-            }
-        };
+            },
+        });
         try {
             // Strip pull-protocol keys (stream, subscribe, do_not_upgrade, …)
             // that the client merges into the body but the policy parser does

--- a/test/cpp/test_model_manager_collection_validation.cpp
+++ b/test/cpp/test_model_manager_collection_validation.cpp
@@ -286,6 +286,54 @@ static void test_backend_capability_over_chat_indicator(ModelManager& manager) {
           !manager.validate_collection_request("user.RouterKit", llama_clf_bare).has_value());
 }
 
+// #2748: a classifier component needing hardware this host lacks (ryzenai-llm,
+// reliably unsupported on any CI host) must not take the whole router policy
+// down at cache-build time -- only that classifier should fail, at evaluate()
+// time, where its own on_error already applies. Registered standalone first,
+// since register_user_model doesn't auto-register a collection's inline
+// `models[]` (only the real import/pull path does), so it still goes through
+// build_cache()'s hardware filtering like any other model.
+static void test_filtered_classifier_component_does_not_drop_policy(ModelManager& manager) {
+    manager.register_user_model(
+        "user.npu-clf",
+        json{{"model_name", "user.npu-clf"}, {"recipe", "ryzenai-llm"},
+             {"checkpoint", "example/npu-clf"}});
+
+    json doc = {
+        {"model_name", "user.RouterFiltered"},
+        {"version", "1"},
+        {"recipe", "collection.router"},
+        {"components", {"local", "remote", "user.npu-clf"}},
+        {"routing", {
+            {"candidates", {"local", "remote"}},
+            {"default_model", "local"},
+            {"classifiers", {{
+                {"id", "clf"},
+                {"type", "classifier"},
+                {"model", "user.npu-clf"},
+                {"labels", {"A", "B"}},
+                {"default_label", "A"},
+            }}},
+            {"rules", {{
+                {"id", "clf-rule"},
+                {"match", {{"classifier", "clf"}, {"min_score", 0.5}}},
+                {"route_to", "local"},
+            }, {
+                {"id", "code-remote"},
+                {"match", {{"keywords_any", {"def ", "stack trace"}}}},
+                {"route_to", "remote"},
+            }}},
+        }},
+    };
+
+    manager.register_user_model("user.RouterFiltered", doc);
+
+    auto info = manager.get_model_info("user.RouterFiltered");
+    check("router policy still parses when a classifier component is "
+          "hardware-filtered (#2748)",
+          info.route_policy != nullptr);
+}
+
 static void test_register_preserves_routing(ModelManager& manager) {
     json doc = valid_router_collection();
     manager.register_user_model("user.RouterKit", doc);
@@ -304,6 +352,7 @@ int main() {
     test_rejects_bad_routing(manager);
     test_inline_capability_matches_registration(manager);
     test_backend_capability_over_chat_indicator(manager);
+    test_filtered_classifier_component_does_not_drop_policy(manager);
     test_register_preserves_routing(manager);
 
     fs::remove_all(temp);

--- a/test/cpp/test_model_manager_collection_validation.cpp
+++ b/test/cpp/test_model_manager_collection_validation.cpp
@@ -334,6 +334,52 @@ static void test_filtered_classifier_component_does_not_drop_policy(ModelManager
           info.route_policy != nullptr);
 }
 
+// #2748 follow-up: resolve_component's own pre-filter fallback must bridge a
+// bare name to its canonical id too, not just get_model_type's -- otherwise
+// the declared-component check rejects the policy before get_model_type ever
+// runs. Here `components` lists the canonical id but the classifier
+// references the bare name, the opposite pairing from the test above.
+static void test_filtered_classifier_bare_name_resolves_through_alias(ModelManager& manager) {
+    manager.register_user_model(
+        "user.npu-clf2",
+        json{{"model_name", "user.npu-clf2"}, {"recipe", "ryzenai-llm"},
+             {"checkpoint", "example/npu-clf2"}});
+
+    json doc = {
+        {"model_name", "user.RouterFilteredBare"},
+        {"version", "1"},
+        {"recipe", "collection.router"},
+        {"components", {"local", "remote", "user.npu-clf2"}},
+        {"routing", {
+            {"candidates", {"local", "remote"}},
+            {"default_model", "local"},
+            {"classifiers", {{
+                {"id", "clf"},
+                {"type", "classifier"},
+                {"model", "npu-clf2"},
+                {"labels", {"A", "B"}},
+                {"default_label", "A"},
+            }}},
+            {"rules", {{
+                {"id", "clf-rule"},
+                {"match", {{"classifier", "clf"}, {"min_score", 0.5}}},
+                {"route_to", "local"},
+            }, {
+                {"id", "code-remote"},
+                {"match", {{"keywords_any", {"def ", "stack trace"}}}},
+                {"route_to", "remote"},
+            }}},
+        }},
+    };
+
+    manager.register_user_model("user.RouterFilteredBare", doc);
+
+    auto info = manager.get_model_info("user.RouterFilteredBare");
+    check("router policy still parses when the classifier references the "
+          "filtered component by its bare name (#2748)",
+          info.route_policy != nullptr);
+}
+
 static void test_register_preserves_routing(ModelManager& manager) {
     json doc = valid_router_collection();
     manager.register_user_model("user.RouterKit", doc);
@@ -353,6 +399,7 @@ int main() {
     test_inline_capability_matches_registration(manager);
     test_backend_capability_over_chat_indicator(manager);
     test_filtered_classifier_component_does_not_drop_policy(manager);
+    test_filtered_classifier_bare_name_resolves_through_alias(manager);
     test_register_preserves_routing(manager);
 
     fs::remove_all(temp);

--- a/test/cpp/test_model_manager_collection_validation.cpp
+++ b/test/cpp/test_model_manager_collection_validation.cpp
@@ -2,6 +2,7 @@
 // collection.router policy loading (#2383).
 
 #include "lemon/model_manager.h"
+#include "lemon/routing_policy.h"
 #include "lemon/utils/path_utils.h"
 
 #include <chrono>
@@ -286,6 +287,37 @@ static void test_backend_capability_over_chat_indicator(ModelManager& manager) {
           !manager.validate_collection_request("user.RouterKit", llama_clf_bare).has_value());
 }
 
+// What #2748 actually promises is that the REST of the policy keeps working,
+// not merely that parsing did not abort. Evaluate the parsed policy with no
+// classifier backend wired up -- the runtime situation on a host missing the
+// hardware -- and assert the unrelated keyword rule still routes while the
+// classifier rule falls back through its on_error (match_false by default).
+static void check_unrelated_rules_survive(const char* label,
+                                          const lemon::ModelInfo& info) {
+    if (info.route_policy == nullptr) {
+        check(label, false);
+        return;
+    }
+    lemon::RoutingPolicyEngine engine(*info.route_policy, lemon::ClassifierServices{});
+
+    lemon::RouteContext code;
+    code.input = "def foo(): pass";
+    code.params.chars = code.input.size();
+    const lemon::Decision code_decision = engine.route(code, /*want_trace=*/false);
+
+    lemon::RouteContext plain;
+    plain.input = "hello there";
+    plain.params.chars = plain.input.size();
+    const lemon::Decision plain_decision = engine.route(plain, /*want_trace=*/false);
+
+    check(label,
+          code_decision.route_to == "remote" &&
+          code_decision.matched_rule == "code-remote" &&
+          !code_decision.default_used &&
+          plain_decision.route_to == "local" &&
+          plain_decision.default_used);
+}
+
 // #2748: a classifier needing unavailable hardware (ryzenai-llm) must not
 // drop the whole policy -- only that classifier fails, at evaluate() time,
 // via its own on_error. Registered standalone since register_user_model
@@ -331,6 +363,10 @@ static void test_filtered_classifier_component_does_not_drop_policy(ModelManager
     check("router policy still parses when a classifier component is "
           "hardware-filtered (#2748)",
           info.route_policy != nullptr);
+    check_unrelated_rules_survive(
+        "deterministic rule still routes and the filtered classifier's rule "
+        "falls back, with the component named canonically (#2748)",
+        info);
 }
 
 // #2748 follow-up: `components` lists the canonical id, classifier
@@ -376,6 +412,10 @@ static void test_filtered_classifier_bare_name_resolves_through_alias(ModelManag
     check("router policy still parses when the classifier references the "
           "filtered component by its bare name (#2748)",
           info.route_policy != nullptr);
+    check_unrelated_rules_survive(
+        "deterministic rule still routes and the filtered classifier's rule "
+        "falls back, via the bare-name alias (#2748)",
+        info);
 }
 
 // #2748 follow-up: builtin.<X> is a distinct alias form from the bare name,
@@ -420,6 +460,10 @@ static void test_filtered_classifier_builtin_prefixed_alias_resolves(ModelManage
     check("router policy still parses when the classifier references a "
           "filtered builtin via its builtin.<X> alias (#2748)",
           info2.route_policy != nullptr);
+    check_unrelated_rules_survive(
+        "deterministic rule still routes and the filtered classifier's rule "
+        "falls back, via the builtin.<X> alias (#2748)",
+        info2);
 }
 
 static void test_register_preserves_routing(ModelManager& manager) {

--- a/test/cpp/test_model_manager_collection_validation.cpp
+++ b/test/cpp/test_model_manager_collection_validation.cpp
@@ -286,18 +286,17 @@ static void test_backend_capability_over_chat_indicator(ModelManager& manager) {
           !manager.validate_collection_request("user.RouterKit", llama_clf_bare).has_value());
 }
 
-// #2748: a classifier component needing hardware this host lacks (ryzenai-llm,
-// reliably unsupported on any CI host) must not take the whole router policy
-// down at cache-build time -- only that classifier should fail, at evaluate()
-// time, where its own on_error already applies. Registered standalone first,
-// since register_user_model doesn't auto-register a collection's inline
-// `models[]` (only the real import/pull path does), so it still goes through
-// build_cache()'s hardware filtering like any other model.
+// #2748: a classifier needing unavailable hardware (ryzenai-llm) must not
+// drop the whole policy -- only that classifier fails, at evaluate() time,
+// via its own on_error. Registered standalone since register_user_model
+// doesn't auto-register a collection's inline `models[]`.
 static void test_filtered_classifier_component_does_not_drop_policy(ModelManager& manager) {
     manager.register_user_model(
         "user.npu-clf",
         json{{"model_name", "user.npu-clf"}, {"recipe", "ryzenai-llm"},
              {"checkpoint", "example/npu-clf"}});
+    check("npu-clf is actually hardware-filtered on this host (test premise)",
+          !manager.model_exists("user.npu-clf"));
 
     json doc = {
         {"model_name", "user.RouterFiltered"},
@@ -334,16 +333,15 @@ static void test_filtered_classifier_component_does_not_drop_policy(ModelManager
           info.route_policy != nullptr);
 }
 
-// #2748 follow-up: resolve_component's own pre-filter fallback must bridge a
-// bare name to its canonical id too, not just get_model_type's -- otherwise
-// the declared-component check rejects the policy before get_model_type ever
-// runs. Here `components` lists the canonical id but the classifier
-// references the bare name, the opposite pairing from the test above.
+// #2748 follow-up: `components` lists the canonical id, classifier
+// references the bare name -- the opposite pairing from the test above.
 static void test_filtered_classifier_bare_name_resolves_through_alias(ModelManager& manager) {
     manager.register_user_model(
         "user.npu-clf2",
         json{{"model_name", "user.npu-clf2"}, {"recipe", "ryzenai-llm"},
              {"checkpoint", "example/npu-clf2"}});
+    check("npu-clf2 is actually hardware-filtered on this host (test premise)",
+          !manager.model_exists("user.npu-clf2"));
 
     json doc = {
         {"model_name", "user.RouterFilteredBare"},

--- a/test/cpp/test_model_manager_collection_validation.cpp
+++ b/test/cpp/test_model_manager_collection_validation.cpp
@@ -378,6 +378,50 @@ static void test_filtered_classifier_bare_name_resolves_through_alias(ModelManag
           info.route_policy != nullptr);
 }
 
+// #2748 follow-up: builtin.<X> is a distinct alias form from the bare name,
+// added only by compute_model_alias_maps()'s builtin.<X> pass. Uses a real
+// builtin (ryzenai-llm, reliably filtered on any non-NPU CI host) so no
+// registration is needed to test it.
+static void test_filtered_classifier_builtin_prefixed_alias_resolves(ModelManager& manager) {
+    check("Qwen2.5-0.5B-Instruct-CPU is actually hardware-filtered on this "
+          "host (test premise)",
+          !manager.model_exists("Qwen2.5-0.5B-Instruct-CPU"));
+
+    json doc = {
+        {"model_name", "user.RouterFilteredBuiltin"},
+        {"version", "1"},
+        {"recipe", "collection.router"},
+        {"components", {"local", "remote", "Qwen2.5-0.5B-Instruct-CPU"}},
+        {"routing", {
+            {"candidates", {"local", "remote"}},
+            {"default_model", "local"},
+            {"classifiers", {{
+                {"id", "clf"},
+                {"type", "classifier"},
+                {"model", "builtin.Qwen2.5-0.5B-Instruct-CPU"},
+                {"labels", {"A", "B"}},
+                {"default_label", "A"},
+            }}},
+            {"rules", {{
+                {"id", "clf-rule"},
+                {"match", {{"classifier", "clf"}, {"min_score", 0.5}}},
+                {"route_to", "local"},
+            }, {
+                {"id", "code-remote"},
+                {"match", {{"keywords_any", {"def ", "stack trace"}}}},
+                {"route_to", "remote"},
+            }}},
+        }},
+    };
+
+    manager.register_user_model("user.RouterFilteredBuiltin", doc);
+
+    auto info2 = manager.get_model_info("user.RouterFilteredBuiltin");
+    check("router policy still parses when the classifier references a "
+          "filtered builtin via its builtin.<X> alias (#2748)",
+          info2.route_policy != nullptr);
+}
+
 static void test_register_preserves_routing(ModelManager& manager) {
     json doc = valid_router_collection();
     manager.register_user_model("user.RouterKit", doc);
@@ -398,6 +442,7 @@ int main() {
     test_backend_capability_over_chat_indicator(manager);
     test_filtered_classifier_component_does_not_drop_policy(manager);
     test_filtered_classifier_bare_name_resolves_through_alias(manager);
+    test_filtered_classifier_builtin_prefixed_alias_resolves(manager);
     test_register_preserves_routing(manager);
 
     fs::remove_all(temp);


### PR DESCRIPTION
## Summary

`ModelManager::build_cache()`'s routing-policy resolver only consulted the post-filter `models_cache_`, so a classifier component whose backend needs hardware this host lacks (no NPU, insufficient memory, not yet downloaded) was indistinguishable from a name that isn't a model at all. The parser threw "unresolvable type" and the entire policy was dropped, including unrelated deterministic rules that had nothing to do with the unavailable classifier.

Snapshot every model's type before `filter_models_by_backend()` removes some of them, and fall back to that snapshot in the resolver. A filtered classifier's type is still known, so the policy still parses; that specific classifier now fails only at `evaluate()` time, where its own `on_error` already applies — the existing, correct mechanism for an unavailable backend, just no longer bypassed by a parse-time abort.

Fixes #2748 (the two confirmed bugs: `build_cache`'s no-fallback resolver, and the "policy silently dropped" consequence of its asymmetry with `validate_collection_request`'s inline-model fallback). The lower-priority "worth a look" items from that issue are unrelated to this fix: one (display inconsistency across `ollama_api.cpp`/CLI) was already resolved as a side effect of #3099; the other (telemetry for silent classifier fail-open) is untouched here.

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_
Added a regression test (`test_model_manager_collection_validation.cpp`) that registers a `collection.router` whose classifier is backed by a `ryzenai-llm` model (reliably hardware-unsupported on any CI host) alongside an unrelated deterministic rule, and asserts `route_policy != nullptr` after `build_cache()` runs. Verified the test actually catches the bug: reverted just the `model_manager.cpp` fix and confirmed the same test fails via `ctest` (0/1 passing), then restored it (1/1 passing). Ran the full `cpp-ci` suite via `ctest -L cpp-ci` on WSL/GCC — 66/66 pass. Built and ran the affected test binary natively on MSVC (VS 2026) — passes. `tools/check_comment_slop.py` is clean against `main`.

## Documentation

- [x] Documentation is not affected by this change.

## Breaking Changes

- [x] This PR does not introduce breaking changes.

## AI-assisted contribution

- [x] I used AI tools for this PR.

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.