### PR TITLE
feat(server): add allowed_origins to global configuration schema

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3030,6 +3030,20 @@ if(BUILD_TESTING AND EXISTS "${_CONFIG_DOWNLOAD_RATE_LIMIT_TEST_SRC}")
     )
 endif()
 
+set(_CONFIG_ALLOWED_ORIGINS_TEST_SRC
+    "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_config_allowed_origins.cpp"
+)
+if(BUILD_TESTING AND EXISTS "${_CONFIG_ALLOWED_ORIGINS_TEST_SRC}")
+    add_executable(test_config_allowed_origins
+        test/cpp/test_config_allowed_origins.cpp
+    )
+    target_link_libraries(test_config_allowed_origins PRIVATE lemonade-server-core)
+    add_dependencies(test_config_allowed_origins copy_resources)
+    add_cpp_ci_test(ConfigAllowedOriginsTest CI ON
+        COMMAND test_config_allowed_origins
+    )
+endif()
+
 set(_RUNTIME_CONFIG_BACKEND_VALIDATION_TEST_SRC
     "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_runtime_config_backend_validation.cpp"
 )

--- a/docs/guide/configuration/README.md
+++ b/docs/guide/configuration/README.md
@@ -490,7 +490,10 @@ The `LEMONADE_ADMIN_API_KEY` environment variable provides elevated access to bo
 The `allowed_origins` setting (in `config.json` or configured via `lemonade config set allowed_origins="..."`) controls which remote web origins are authorized to connect to the server (specifically for CORS headers on HTTP endpoints and origin validation on WebSocket connections).
 
 > [!WARNING]
-> The `LEMONADE_ALLOWED_ORIGINS` environment variable is **deprecated** and will be removed in a future release. If set on startup and `allowed_origins` is unset or empty in `config.json`, Lemonade automatically migrates the value into `config.json`. During the deprecation transition period, `LEMONADE_ALLOWED_ORIGINS` still takes interim precedence over `config.json` when present in the process environment.
+> The `LEMONADE_ALLOWED_ORIGINS` environment variable is **deprecated** and will be removed in a future release.
+> - **Automatic Migration**: If `LEMONADE_ALLOWED_ORIGINS` is set at startup and `allowed_origins` is unset or empty in `config.json`, Lemonade automatically migrates the value into `config.json`.
+> - **Precedence & Conflict Handling**: At startup, `LEMONADE_ALLOWED_ORIGINS` takes interim precedence over `config.json`. If both exist and differ, a warning is logged advising you to unset or remove `LEMONADE_ALLOWED_ORIGINS` to avoid shadowing your configuration file.
+> - **Runtime Updates**: Running `lemonade config set allowed_origins="..."` dynamically applies changes to the active session immediately, overriding any initial environment variable value without restarting the server.
 
 > [!NOTE]
 > `allowed_origins` specifies the **client application/web page's origin** (where the request originates), **not** the target Lemonade server URL. Non-browser HTTP clients (such as CLI tools, cURL, or server-side SDKs) do not send an `Origin` header and are not restricted by origin validation.

--- a/docs/guide/configuration/README.md
+++ b/docs/guide/configuration/README.md
@@ -44,6 +44,7 @@ When `lemond` starts, effective configuration is resolved by deep-merging settin
     "rocm_bin": "builtin",
     "vulkan_bin": "builtin"
   },
+  "allowed_origins": "",
   "auto_check_model_updates": true,
   "auto_update_models": false,
   "broadcast": true,
@@ -486,11 +487,24 @@ The `LEMONADE_ADMIN_API_KEY` environment variable provides elevated access to bo
 
 ### Allowed Origins
 
-The `LEMONADE_ALLOWED_ORIGINS` environment variable (or `allowed_origins` in server configuration) controls which remote web origins are authorized to connect to the server (specifically for CORS headers on HTTP endpoints and origin validation on WebSocket connections).
+The `allowed_origins` setting (in `config.json` or configured via `lemonade config set allowed_origins="..."`) controls which remote web origins are authorized to connect to the server (specifically for CORS headers on HTTP endpoints and origin validation on WebSocket connections).
+
+> [!WARNING]
+> The `LEMONADE_ALLOWED_ORIGINS` environment variable is **deprecated** and will be removed in a future release. If set on startup and `allowed_origins` is unset or empty in `config.json`, Lemonade automatically migrates the value into `config.json`. During the deprecation transition period, `LEMONADE_ALLOWED_ORIGINS` still takes interim precedence over `config.json` when present in the process environment.
 
 > [!NOTE]
-> `LEMONADE_ALLOWED_ORIGINS` specifies the **client application/web page's origin** (where the request originates), **not** the target Lemonade server URL. Non-browser HTTP clients (such as CLI tools, cURL, or server-side SDKs) do not send an `Origin` header and are not restricted by origin validation.
+> `allowed_origins` specifies the **client application/web page's origin** (where the request originates), **not** the target Lemonade server URL. Non-browser HTTP clients (such as CLI tools, cURL, or server-side SDKs) do not send an `Origin` header and are not restricted by origin validation.
 
+- **Configuration**:
+  - In `config.json`: `"allowed_origins": "https://app.lemonade.dev,http://localhost:3000"`
+  - Via CLI: `lemonade config set allowed_origins="https://app.lemonade.dev,http://localhost:3000"`
+- **Format**: A comma-separated list of complete origins including the scheme and optional port (e.g., `https://app.lemonade.dev,http://localhost:3000`).
+  > [!WARNING]
+  > Allowing a non-local plain-HTTP origin (e.g., `http://app.example.com`) is vulnerable to on-path modification (man-in-the-middle) and interception. It is highly recommended to use HTTPS (`https://`) for all remote/non-local allowed origins.
+- **Wildcard (`*`)**: Setting `allowed_origins` to `*` allows any origin to connect.
+- **Security Implications of `*`**:
+  > [!WARNING]
+  > Using `allowed_origins=*` permits any website running in a user's browser to make requests to your local Lemonade server. In particular, if `LEMONADE_API_KEY` is not configured, this exposes the server to unauthenticated remote access and cross-origin attacks from malicious websites. Use wildcards only for development or in secure, isolated environments.
 - **Local/Loopback, Desktop & Same-Origin Access (Zero-Configuration)**:
   - **Loopback & Subdomains**: Loopback addresses (`localhost`, `127.0.0.1`, `[::1]`, `*.localhost`) are permitted automatically.
   - **Native Desktop Apps**: Native desktop application schemes (`lemonade://`, `file://`, `app://.`, `vscode-webview://`, `jan://`, etc.) are permitted for client connections.
@@ -498,16 +512,9 @@ The `LEMONADE_ALLOWED_ORIGINS` environment variable (or `allowed_origins` in ser
 - **When Allowed Origins Must Be Configured**:
   - **Cross-Origin Web Applications**: Any external or third-party web application hosted on a different domain or port connecting to Lemonade in the browser (e.g. a web UI hosted at `https://app.lemonade.dev` or `http://localhost:3000` calling Lemonade on `http://192.168.1.50:13305`).
   - **Reverse Proxies & TLS Frontends**: Reverse proxies, tunnels, or frontends terminating TLS (e.g., `https://lemonade.example.com` or Tailscale Serve at `https://mybox.tailnet.ts.net`). Because proxies forward HTTPS requests to an HTTP server and present external hostnames not belonging to local network interfaces, their external origins must be explicitly allowlisted. (By contrast, direct access via a local Tailscale interface IP `http://100.x.y.z:13305` is zero-config).
-  - **Sandboxed Frames**: Opaque `null` origins (e.g. from sandboxed browser iframes) are rejected unless explicitly listed in `LEMONADE_ALLOWED_ORIGINS` to prevent CSWSH attacks.
+  - **Sandboxed Frames**: Opaque `null` origins (e.g. from sandboxed browser iframes) are rejected unless explicitly listed in `allowed_origins` to prevent CSWSH attacks.
   > [!NOTE]
   > When an explicit `allowed_origins` list is configured, it is authoritative: zero-configuration fallback for unlisted non-loopback LAN origins is disabled. If you access the server through both a reverse proxy and direct LAN IP in a browser, include both in `allowed_origins`.
-- **Format**: A comma-separated list of complete origins including the scheme and optional port (e.g., `https://app.lemonade.dev,http://localhost:3000`).
-  > [!WARNING]
-  > Allowing a non-local plain-HTTP origin (e.g., `http://app.example.com`) is vulnerable to on-path modification (man-in-the-middle) and interception. It is highly recommended to use HTTPS (`https://`) for all remote/non-local allowed origins.
-- **Wildcard (`*`)**: Setting the variable to `*` allows any origin to connect.
-- **Security Implications of `*`**:
-  > [!WARNING]
-  > Using `LEMONADE_ALLOWED_ORIGINS=*` permits any website running in a user's browser to make requests to your local Lemonade server. In particular, if `LEMONADE_API_KEY` is not configured, this exposes the server to unauthenticated remote access and cross-origin attacks from malicious websites. Use wildcards only for development or in secure, isolated environments.
 
 ## Model Synchronization & Auto-Updates
 

--- a/src/cpp/include/lemon/config_file.h
+++ b/src/cpp/include/lemon/config_file.h
@@ -76,6 +76,23 @@ static inline bool config_migrate(json& config,
     return true;
 }
 
+/// Migrate deprecated LEMONADE_ALLOWED_ORIGINS environment variable into config.json.
+/// If env_origins is non-empty:
+///   - If config does not contain "allowed_origins" or it is an empty string, set config["allowed_origins"] to env_origins.
+///   - If config already has a non-empty "allowed_origins", do not modify it.
+/// Returns true if the config was modified.
+static inline bool config_migrate_allowed_origins_env(json& config, const char* env_origins) {
+    if (!env_origins || *env_origins == '\0') {
+        return false;
+    }
+    if (!config.contains("allowed_origins") ||
+        (config["allowed_origins"].is_string() && config["allowed_origins"].get<std::string>().empty())) {
+        config["allowed_origins"] = std::string(env_origins);
+        return true;
+    }
+    return false;
+}
+
 // ============================================================================
 
 /// Manages reading and writing config.json in the lemonade config dir.

--- a/src/cpp/include/lemon/runtime_config.h
+++ b/src/cpp/include/lemon/runtime_config.h
@@ -44,6 +44,7 @@ public:
     long global_timeout() const;
     int max_loaded_models() const;
     int64_t download_rate_limit_bytes_per_second() const;
+    std::string allowed_origins() const;
 
     std::string models_dir() const;
     int ctx_size() const;
@@ -157,6 +158,7 @@ private:
     int get_int_opt(const char* env_name, const std::vector<std::string>& path, int default_val) const;
     double get_double_opt(const char* env_name, const std::vector<std::string>& path, double default_val) const;
     std::string get_string_opt(const char* env_name, const std::vector<std::string>& path, const std::string& default_val) const;
+    std::string allowed_origins_unlocked() const;
 
     mutable std::shared_mutex mutex_;
 
@@ -170,6 +172,7 @@ private:
     std::optional<std::string> log_file_override_;
     std::optional<int> log_max_file_size_mb_override_;
     std::optional<int> log_max_files_override_;
+    std::optional<std::string> allowed_origins_override_;
 
     // Valid log levels
     static const std::vector<std::string> valid_log_levels_;

--- a/src/cpp/include/lemon/utils/origin_utils.h
+++ b/src/cpp/include/lemon/utils/origin_utils.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "lemon/runtime_config.h"
+
 #include <algorithm>
 #include <cctype>
 #include <chrono>
@@ -362,13 +364,16 @@ inline bool is_same_origin(
 }
 
 inline std::string resolve_allowed_origins() {
+    if (auto* cfg = RuntimeConfig::global()) {
+        return cfg->allowed_origins();
+    }
     const char* env_origins = std::getenv("LEMONADE_ALLOWED_ORIGINS");
     return env_origins ? std::string(env_origins) : "";
 }
 
 inline bool is_origin_allowed(
     const std::string& origin_str,
-    const std::string& allowed_origins_env,
+    const std::string& allowed_origins,
     const std::string& host_header = "",
     const std::string& scheme = "http",
     const std::string& bound_host = "",
@@ -389,12 +394,12 @@ inline bool is_origin_allowed(
     }
 
     // Layer 2: Explicit allowed_origins set (authoritative for non-loopback origins)
-    if (!allowed_origins_env.empty()) {
-        if (allowed_origins_env == "*") {
+    if (!allowed_origins.empty()) {
+        if (allowed_origins == "*") {
             return true;
         }
 
-        std::stringstream ss(allowed_origins_env);
+        std::stringstream ss(allowed_origins);
         std::string item;
         while (std::getline(ss, item, ',')) {
             item.erase(0, item.find_first_not_of(" \t\r\n"));
@@ -425,32 +430,32 @@ inline bool is_origin_allowed(
 
 inline bool is_origin_allowed(
     const std::string& origin_str,
-    const std::string& allowed_origins_env,
+    const std::string& allowed_origins,
     const std::string& host_header,
     const std::string& scheme,
     const std::unordered_set<std::string>& self_set) {
-    return is_origin_allowed(origin_str, allowed_origins_env, host_header, scheme, "", self_set);
+    return is_origin_allowed(origin_str, allowed_origins, host_header, scheme, "", self_set);
 }
 
 inline bool is_websocket_origin_allowed(
     const std::string& origin_str,
-    const std::string& allowed_origins_env,
+    const std::string& allowed_origins,
     const std::string& host_header = "",
     const std::string& scheme = "http",
     const std::string& bound_host = "",
     const std::unordered_set<std::string>& self_set = {}) {
 
-    return is_origin_allowed(origin_str, allowed_origins_env, host_header, scheme, bound_host, self_set);
+    return is_origin_allowed(origin_str, allowed_origins, host_header, scheme, bound_host, self_set);
 }
 
 inline bool is_websocket_origin_allowed(
     const std::string& origin_str,
-    const std::string& allowed_origins_env,
+    const std::string& allowed_origins,
     const std::string& host_header,
     const std::string& scheme,
     const std::unordered_set<std::string>& self_set) {
 
-    return is_origin_allowed(origin_str, allowed_origins_env, host_header, scheme, "", self_set);
+    return is_websocket_origin_allowed(origin_str, allowed_origins, host_header, scheme, "", self_set);
 }
 
 } // namespace lemon::utils

--- a/src/cpp/resources/defaults.json
+++ b/src/cpp/resources/defaults.json
@@ -6,6 +6,7 @@
     "rocm_bin": "builtin",
     "vulkan_bin": "builtin"
   },
+  "allowed_origins": "",
   "auto_check_model_updates": true,
   "auto_update_models": false,
   "broadcast": true,

--- a/src/cpp/server/config_file.cpp
+++ b/src/cpp/server/config_file.cpp
@@ -148,12 +148,18 @@ json ConfigFile::load(const std::string& cache_dir, const std::string& config_di
     std::string effective_config_dir = config_dir.empty() ? utils::get_config_dir() : config_dir;
     fs::path config_path = utils::path_from_utf8(effective_config_dir) / "config.json";
 
-    if (!fs::exists(config_path)) {
-        return defaults;
-    }
+    const char* env_origins = std::getenv("LEMONADE_ALLOWED_ORIGINS");
 
     json loaded = load_raw(effective_config_dir);
     if (loaded.empty()) {
+        if (env_origins && *env_origins != '\0') {
+            json new_cfg = json::object({{"allowed_origins", std::string(env_origins)}});
+            LOG(WARNING) << "Migrating deprecated LEMONADE_ALLOWED_ORIGINS environment variable to config.json (allowed_origins="
+                         << env_origins << "). The LEMONADE_ALLOWED_ORIGINS environment variable is deprecated and will be removed in a future release."
+                         << std::endl;
+            save(effective_config_dir, new_cfg);
+            return utils::JsonUtils::merge(defaults, new_cfg);
+        }
         return defaults;
     }
 
@@ -172,6 +178,29 @@ json ConfigFile::load(const std::string& cache_dir, const std::string& config_di
         LOG(INFO) << "Migrating config: no_broadcast=" << loaded["no_broadcast"]
                   << " -> broadcast=" << normalized_loaded["broadcast"] << std::endl;
         migrated = true;
+    }
+
+    if (env_origins && *env_origins != '\0') {
+        if (config_migrate_allowed_origins_env(normalized_loaded, env_origins)) {
+            LOG(WARNING) << "Migrating deprecated LEMONADE_ALLOWED_ORIGINS environment variable to config.json (allowed_origins="
+                         << env_origins << "). The LEMONADE_ALLOWED_ORIGINS environment variable is deprecated and will be removed in a future release."
+                         << std::endl;
+            migrated = true;
+        } else {
+            std::string config_origins = normalized_loaded.contains("allowed_origins") && normalized_loaded["allowed_origins"].is_string()
+                                             ? normalized_loaded["allowed_origins"].get<std::string>()
+                                             : "";
+            if (config_origins != env_origins) {
+                LOG(WARNING) << "The LEMONADE_ALLOWED_ORIGINS environment variable ('" << env_origins << "') conflicts with "
+                             << "the 'allowed_origins' setting in config.json ('" << config_origins << "') and takes precedence at runtime. "
+                             << "LEMONADE_ALLOWED_ORIGINS is deprecated; please unset or remove the environment variable to use your config.json setting."
+                             << std::endl;
+            } else {
+                LOG(WARNING) << "The LEMONADE_ALLOWED_ORIGINS environment variable is deprecated and will be removed in a future release. "
+                             << "Please unset or remove LEMONADE_ALLOWED_ORIGINS as 'allowed_origins' is already configured in config.json."
+                             << std::endl;
+            }
+        }
     }
 
     if (migrated) {

--- a/src/cpp/server/runtime_config.cpp
+++ b/src/cpp/server/runtime_config.cpp
@@ -428,6 +428,24 @@ int64_t RuntimeConfig::download_rate_limit_bytes_per_second() const {
     return parsed;
 }
 
+std::string RuntimeConfig::allowed_origins_unlocked() const {
+    if (allowed_origins_override_.has_value()) {
+        return *allowed_origins_override_;
+    }
+    if (const char* env = std::getenv("LEMONADE_ALLOWED_ORIGINS")) {
+        return std::string(env);
+    }
+    if (config_.contains("allowed_origins") && config_["allowed_origins"].is_string()) {
+        return config_["allowed_origins"].get<std::string>();
+    }
+    return "";
+}
+
+std::string RuntimeConfig::allowed_origins() const {
+    std::shared_lock lock(mutex_);
+    return allowed_origins_unlocked();
+}
+
 std::string RuntimeConfig::models_dir() const {
     std::shared_lock lock(mutex_);
     return config_["models_dir"].get<std::string>();
@@ -843,6 +861,10 @@ void RuntimeConfig::validate(const std::string& key, const json& value) const {
                 "'download_rate_limit' must be a byte rate like \"512\", \"100K\", \"10M\", etc. "
                 "Use \"\" for unlimited download speed");
         }
+    } else if (key == "allowed_origins") {
+        if (!value.is_string()) {
+            throw std::invalid_argument("'allowed_origins' must be a string");
+        }
     } else if (key == "broadcast" || key == "no_broadcast" || key == "offline" ||
                key == "auto_check_model_updates" ||
                key == "auto_update_models" ||
@@ -1231,6 +1253,14 @@ void RuntimeConfig::apply_changes(const json& changes, json& applied_diff) {
             broadcast_override_ = std::nullopt;
             if (prev_effective_bcast != bcast) {
                 applied_diff["broadcast"] = bcast;
+            }
+        } else if (key == "allowed_origins") {
+            std::string prev_effective = allowed_origins_unlocked();
+            std::string new_origins = value.is_string() ? value.get<std::string>() : "";
+            config_["allowed_origins"] = new_origins;
+            allowed_origins_override_ = new_origins;
+            if (prev_effective != new_origins) {
+                applied_diff["allowed_origins"] = new_origins;
             }
         } else {
             if (!config_.contains(key) || config_[key] != value) {

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -1128,7 +1128,7 @@ void Server::setup_routes(httplib::Server &web_server) {
                 }
             } else {
                 LOG(WARNING, "Server") << "Rejected request from unauthorized origin: " << origin
-                                       << ". Set LEMONADE_ALLOWED_ORIGINS to allow this origin." << std::endl;
+                                       << ". Configure allowed_origins in config.json or via 'lemonade config set allowed_origins=...' to allow this origin." << std::endl;
                 res.status = 403;
                 res.set_content("{\"error\": \"Origin not allowed\"}", "application/json");
                 return httplib::Server::HandlerResponse::Handled;
@@ -7333,6 +7333,8 @@ void Server::apply_config_side_effects(const json& applied_changes) {
                 LOG(INFO, "Server") << "Download rate limit disabled" << std::endl;
             }
             utils::HttpClient::set_download_rate_limit(bps);
+        } else if (key == "allowed_origins") {
+            LOG(INFO, "Server") << "Allowed origins updated: " << config_->allowed_origins() << std::endl;
         } else if (key == "broadcast" || key == "no_broadcast") {
             bool bcast = config_->broadcast();
             LOG(INFO, "Server") << "Broadcast " << (bcast ? "enabled" : "disabled") << std::endl;

--- a/src/cpp/server/websocket_server.cpp
+++ b/src/cpp/server/websocket_server.cpp
@@ -1,4 +1,5 @@
 #include "lemon/router.h"
+#include "lemon/runtime_config.h"
 #include "lemon/utils/json_utils.h"
 #include "lemon/utils/network_utils.h"
 #include "lemon/utils/origin_utils.h"

--- a/test/cpp/test_config_allowed_origins.cpp
+++ b/test/cpp/test_config_allowed_origins.cpp
@@ -1,0 +1,144 @@
+#include <cstdio>
+#include <cstdlib>
+#include <stdexcept>
+#include <string>
+
+#include <nlohmann/json.hpp>
+#include <lemon/config_file.h>
+#include <lemon/runtime_config.h>
+
+#include "test_config_helpers.h"
+
+using json = nlohmann::json;
+using lemon::ConfigFile;
+using lemon::RuntimeConfig;
+using test_helpers::check;
+using test_helpers::parse_cli_args;
+using test_helpers::report_results;
+
+static void set_env_var(const char* name, const char* value) {
+#ifdef _WIN32
+    _putenv_s(name, value ? value : "");
+#else
+    if (value) {
+        setenv(name, value, 1);
+    } else {
+        unsetenv(name);
+    }
+#endif
+}
+
+static void clear_env_var(const char* name) {
+#ifdef _WIN32
+    _putenv_s(name, "");
+#else
+    unsetenv(name);
+#endif
+}
+
+static bool set_throws(const json& cfg, const json& changes) {
+    try {
+        RuntimeConfig(cfg).set(changes);
+        return false;
+    } catch (const std::invalid_argument&) {
+        return true;
+    }
+}
+
+int main() {
+    std::puts("=== RUNNING ALLOWED ORIGINS CONFIG TESTS ===");
+
+    clear_env_var("LEMONADE_ALLOWED_ORIGINS");
+
+    auto cfg_with = [](const std::string& origins) {
+        return json::object({{"allowed_origins", origins}});
+    };
+
+    // 1. Default value from empty or missing key
+    {
+        RuntimeConfig rc_empty(json::object({}));
+        check(rc_empty.allowed_origins() == "", "missing allowed_origins key defaults to empty string");
+
+        RuntimeConfig rc_default(cfg_with(""));
+        check(rc_default.allowed_origins() == "", "explicit empty string returns empty string");
+    }
+
+    // 2. Getter reads allowed_origins from config
+    {
+        RuntimeConfig rc(cfg_with("http://192.168.1.50:3000,http://dashboard.local:8080"));
+        check(rc.allowed_origins() == "http://192.168.1.50:3000,http://dashboard.local:8080",
+              "getter reads configured allowed_origins");
+
+        RuntimeConfig rc_wildcard(cfg_with("*"));
+        check(rc_wildcard.allowed_origins() == "*", "getter reads wildcard origin");
+    }
+
+    // 3. LEMONADE_ALLOWED_ORIGINS environment variable precedence
+    {
+        set_env_var("LEMONADE_ALLOWED_ORIGINS", "https://override.example.com");
+        RuntimeConfig rc(cfg_with("http://configured.example.com"));
+        check(rc.allowed_origins() == "https://override.example.com",
+              "LEMONADE_ALLOWED_ORIGINS env var overrides config value");
+        clear_env_var("LEMONADE_ALLOWED_ORIGINS");
+    }
+
+    // 4. validate()/set() accepts valid string values
+    {
+        check(!set_throws(cfg_with(""), json::object({{"allowed_origins", "http://localhost:3000"}})),
+              "set accepts valid origin string");
+        check(!set_throws(cfg_with("http://localhost:3000"), json::object({{"allowed_origins", "*"}})),
+              "set accepts wildcard origin");
+        check(!set_throws(cfg_with("http://localhost:3000"), json::object({{"allowed_origins", ""}})),
+              "set accepts empty origin string");
+    }
+
+    // 5. validate()/set() rejects non-string values
+    {
+        check(set_throws(cfg_with(""), json::object({{"allowed_origins", 123}})),
+              "rejects integer value");
+        check(set_throws(cfg_with(""), json::object({{"allowed_origins", true}})),
+              "rejects boolean value");
+        check(set_throws(cfg_with(""), json::object({{"allowed_origins", json::array({"http://localhost:3000"})}})),
+              "rejects array value");
+        check(set_throws(cfg_with(""), json::object({{"allowed_origins", json::object({{"url", "http://localhost"}})}})),
+              "rejects object value");
+    }
+
+    // 6. CLI argument parser handles allowed_origins
+    {
+        json cli_update = parse_cli_args({"allowed_origins=http://192.168.1.50:3000,http://dashboard.local:8080"});
+        check(cli_update.contains("allowed_origins"), "CLI parser parses allowed_origins key");
+        check(cli_update["allowed_origins"] == "http://192.168.1.50:3000,http://dashboard.local:8080",
+              "CLI parser preserves comma-separated string");
+    }
+
+    // 7. Dynamic updates via set()
+    {
+        RuntimeConfig rc(cfg_with("http://initial.example.com"));
+        check(rc.allowed_origins() == "http://initial.example.com", "initial origin");
+
+        rc.set(json::object({{"allowed_origins", "http://updated.example.com"}}));
+        check(rc.allowed_origins() == "http://updated.example.com", "updated origin applied");
+        check(rc.snapshot()["allowed_origins"] == "http://updated.example.com", "snapshot updated");
+
+        rc.set(json::object({{"allowed_origins", ""}}));
+        check(rc.allowed_origins() == "", "clearing origin applied");
+
+        // Runtime set overrides active environment variable for the session
+        set_env_var("LEMONADE_ALLOWED_ORIGINS", "http://env-active.example.com");
+        RuntimeConfig rc_env(cfg_with("http://cfg-initial.example.com"));
+        check(rc_env.allowed_origins() == "http://env-active.example.com", "env var takes initial precedence");
+        rc_env.set(json::object({{"allowed_origins", "http://runtime-override.example.com"}}));
+        check(rc_env.allowed_origins() == "http://runtime-override.example.com", "runtime set overrides active env var for session");
+        clear_env_var("LEMONADE_ALLOWED_ORIGINS");
+    }
+
+    // 8. base_defaults() has allowed_origins
+    {
+        json defaults = ConfigFile::base_defaults();
+        check(defaults.contains("allowed_origins"), "base_defaults() contains allowed_origins key");
+        check(defaults["allowed_origins"] == "", "base_defaults() allowed_origins is empty string");
+    }
+
+    return report_results("allowed_origins config");
+}

--- a/test/cpp/test_config_allowed_origins.cpp
+++ b/test/cpp/test_config_allowed_origins.cpp
@@ -140,5 +140,117 @@ int main() {
         check(defaults["allowed_origins"] == "", "base_defaults() allowed_origins is empty string");
     }
 
+    // 9. config_migrate_allowed_origins_env helper tests
+    {
+        json cfg_missing = json::object({{"broadcast", true}});
+        check(lemon::config_migrate_allowed_origins_env(cfg_missing, "http://a.com"),
+              "migrates when allowed_origins is missing");
+        check(cfg_missing["allowed_origins"] == "http://a.com", "allowed_origins populated");
+
+        json cfg_empty = json::object({{"allowed_origins", ""}});
+        check(lemon::config_migrate_allowed_origins_env(cfg_empty, "http://b.com"),
+              "migrates when allowed_origins is empty string");
+        check(cfg_empty["allowed_origins"] == "http://b.com", "empty string replaced");
+
+        json cfg_existing = json::object({{"allowed_origins", "http://existing.com"}});
+        check(!lemon::config_migrate_allowed_origins_env(cfg_existing, "http://new.com"),
+              "does not migrate when allowed_origins is non-empty");
+        check(cfg_existing["allowed_origins"] == "http://existing.com", "existing value preserved");
+
+        json cfg_null_env = json::object({{"allowed_origins", ""}});
+        check(!lemon::config_migrate_allowed_origins_env(cfg_null_env, nullptr),
+              "does not migrate when env var is null");
+        check(!lemon::config_migrate_allowed_origins_env(cfg_null_env, ""),
+              "does not migrate when env var is empty string");
+    }
+
+    // 10. ConfigFile::load() disk migration tests
+    {
+        namespace fs = std::filesystem;
+        fs::path temp_dir = fs::temp_directory_path() / "lemonade_test_migration_origins";
+        fs::remove_all(temp_dir);
+        fs::create_directories(temp_dir);
+
+        // Case A: Fresh dir (no config.json) with env var set -> creates config.json with allowed_origins
+        {
+            fs::path dir_a = temp_dir / "case_a";
+            fs::create_directories(dir_a);
+            set_env_var("LEMONADE_ALLOWED_ORIGINS", "http://migrated-fresh.example.com");
+
+            json loaded = ConfigFile::load(dir_a.string(), dir_a.string());
+            check(loaded["allowed_origins"] == "http://migrated-fresh.example.com",
+                  "ConfigFile::load merged fresh config has migrated allowed_origins");
+
+            json raw_on_disk = ConfigFile::load_raw(dir_a.string());
+            check(raw_on_disk["allowed_origins"] == "http://migrated-fresh.example.com",
+                  "ConfigFile::load created config.json on disk with migrated allowed_origins");
+            clear_env_var("LEMONADE_ALLOWED_ORIGINS");
+        }
+
+        // Case B: Existing config.json without allowed_origins -> writes allowed_origins to disk
+        {
+            fs::path dir_b = temp_dir / "case_b";
+            fs::create_directories(dir_b);
+            ConfigFile::save(dir_b.string(), json::object({{"broadcast", true}}));
+
+            set_env_var("LEMONADE_ALLOWED_ORIGINS", "http://migrated-missing.example.com");
+            json loaded = ConfigFile::load(dir_b.string(), dir_b.string());
+            check(loaded["allowed_origins"] == "http://migrated-missing.example.com",
+                  "ConfigFile::load updated missing field");
+
+            json raw_on_disk = ConfigFile::load_raw(dir_b.string());
+            check(raw_on_disk["allowed_origins"] == "http://migrated-missing.example.com",
+                  "ConfigFile::load persisted migrated allowed_origins to existing config.json");
+            clear_env_var("LEMONADE_ALLOWED_ORIGINS");
+        }
+
+        // Case C: Existing config.json with empty allowed_origins -> updates allowed_origins on disk
+        {
+            fs::path dir_c = temp_dir / "case_c";
+            fs::create_directories(dir_c);
+            ConfigFile::save(dir_c.string(), json::object({{"allowed_origins", ""}}));
+
+            set_env_var("LEMONADE_ALLOWED_ORIGINS", "http://migrated-empty.example.com");
+            json loaded = ConfigFile::load(dir_c.string(), dir_c.string());
+            check(loaded["allowed_origins"] == "http://migrated-empty.example.com",
+                  "ConfigFile::load updated empty field");
+
+            json raw_on_disk = ConfigFile::load_raw(dir_c.string());
+            check(raw_on_disk["allowed_origins"] == "http://migrated-empty.example.com",
+                  "ConfigFile::load persisted migrated allowed_origins to empty config.json");
+            clear_env_var("LEMONADE_ALLOWED_ORIGINS");
+        }
+
+        // Case D: Existing config.json with non-empty allowed_origins (conflicting) -> does NOT overwrite on disk
+        {
+            fs::path dir_d = temp_dir / "case_d";
+            fs::create_directories(dir_d);
+            ConfigFile::save(dir_d.string(), json::object({{"allowed_origins", "http://keep-existing.example.com"}}));
+
+            set_env_var("LEMONADE_ALLOWED_ORIGINS", "http://should-not-overwrite.example.com");
+            json loaded = ConfigFile::load(dir_d.string(), dir_d.string());
+            json raw_on_disk = ConfigFile::load_raw(dir_d.string());
+            check(raw_on_disk["allowed_origins"] == "http://keep-existing.example.com",
+                  "ConfigFile::load does not overwrite existing non-empty allowed_origins on disk");
+            clear_env_var("LEMONADE_ALLOWED_ORIGINS");
+        }
+
+        // Case E: Existing config.json with matching allowed_origins -> does not modify disk
+        {
+            fs::path dir_e = temp_dir / "case_e";
+            fs::create_directories(dir_e);
+            ConfigFile::save(dir_e.string(), json::object({{"allowed_origins", "http://matching.example.com"}}));
+
+            set_env_var("LEMONADE_ALLOWED_ORIGINS", "http://matching.example.com");
+            json loaded = ConfigFile::load(dir_e.string(), dir_e.string());
+            json raw_on_disk = ConfigFile::load_raw(dir_e.string());
+            check(raw_on_disk["allowed_origins"] == "http://matching.example.com",
+                  "ConfigFile::load preserves matching allowed_origins on disk");
+            clear_env_var("LEMONADE_ALLOWED_ORIGINS");
+        }
+
+        fs::remove_all(temp_dir);
+    }
+
     return report_results("allowed_origins config");
 }

--- a/test/server_websocket_telemetry.py
+++ b/test/server_websocket_telemetry.py
@@ -560,14 +560,14 @@ class TelemetryGuestSecurityTests(TelemetrySecurityTestBase):
         with open(self.procs[0][2], "r") as f:
             default_server_logs = f.read()
         self.assertIn(
-            "Rejected request from unauthorized origin: http://malicious.com. Set LEMONADE_ALLOWED_ORIGINS to allow this origin.",
+            "Rejected request from unauthorized origin: http://malicious.com. Configure allowed_origins in config.json or via 'lemonade config set allowed_origins=...' to allow this origin.",
             default_server_logs,
         )
 
         with open(self.procs[1][2], "r") as f:
             remote_server_logs = f.read()
         self.assertIn(
-            "Rejected request from unauthorized origin: https://unconfigured.com. Set LEMONADE_ALLOWED_ORIGINS to allow this origin.",
+            "Rejected request from unauthorized origin: https://unconfigured.com. Configure allowed_origins in config.json or via 'lemonade config set allowed_origins=...' to allow this origin.",
             remote_server_logs,
         )
 


### PR DESCRIPTION
## Summary

Adds `allowed_origins` to the global configuration schema in `config.json` and CLI (`lemonade config set allowed_origins="..."`), deprecates the `LEMONADE_ALLOWED_ORIGINS` environment variable, and unifies origin resolution across HTTP and WebSocket paths via `utils::resolve_allowed_origins()`.

**Key Behavior:**
- **Automatic Migration**: When `LEMONADE_ALLOWED_ORIGINS` is set at startup and `allowed_origins` is unset or empty in `config.json`, Lemonade automatically writes the value into `config.json` and emits a one-time migration warning.
- **Boot Precedence**: At startup, `LEMONADE_ALLOWED_ORIGINS` takes interim precedence over `config.json`. If `config.json` contains a non-empty value that conflicts with the environment variable, Lemonade warns of the conflict and instructs the user to unset `LEMONADE_ALLOWED_ORIGINS`.
- **Runtime Overrides**: Running `lemonade config set allowed_origins="..."` updates `config.json` and applies an in-memory session override immediately, allowing runtime changes to take effect even if the server was started with an environment variable set.
- **Recommended Action**: Unset or remove `LEMONADE_ALLOWED_ORIGINS` from your shell or service environment to manage allowed origins exclusively via `config.json` and the CLI.

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_
- Unit test suite `test_config_allowed_origins.cpp` (38 assertions) covering defaults, getters, setters, type rejection, CLI arg parsing, dynamic runtime updates, active environment variable overrides, and disk migration scenarios.
- Unit test suite `test_origin_utils.cpp` (79 assertions) covering same-origin resolution, LAN/mDNS detection, desktop schemes, and explicit allowlists.
- Executed full `cpp-ci` test battery via `ctest -L cpp-ci` (69/69 test suites passed).
- Executed Python WebSocket telemetry security tests via `python test/server_websocket_telemetry.py` (12/12 passed).
- Validated doc/defaults synchronization with `python3 docs/tools/gen_backend_boilerplate.py --check`.

## Documentation

- [x] Documentation is affected and has been updated.

## Breaking Changes

- [x] This PR does not introduce breaking changes.

## AI-assisted contribution

- [x] I used AI tools for this PR.
- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.
