### PR TITLE
fix(server): make streaming stall timeout configurable (fixes #3386, #3415)

### DIFF
--- a/docs/guide/configuration/README.md
+++ b/docs/guide/configuration/README.md
@@ -63,6 +63,7 @@ When `lemond` starts, effective configuration is resolved by deep-merging settin
     "prefer_system": false
   },
   "global_timeout": 600,
+  "stream_stall_timeout": 600,
   "host": "localhost",
   "inhibit_suspend": true,
   "kokoro": {
@@ -200,6 +201,7 @@ When `lemond` starts, effective configuration is resolved by deep-merging settin
 | `log_max_file_size_mb` | int | 10 | Max active log file size in MB before triggering rotation (steady-state footprint bounded to ~`log_max_file_size_mb * (log_max_files + 1)`) |
 | `log_max_files` | int | 5 | Max number of rotated log backup files to retain (.1 through .N); legacy oversized files are rotated into .1 and pruned over cycles |
 | `global_timeout` | int | 600 | Timeout in seconds for HTTP, inference, and readiness checks |
+| `stream_stall_timeout` | int | 600 | Seconds an unbounded streaming request may deliver no bytes before it is aborted as a dead stream (0 disables the silence bound; the backend watchdog then owns dead-backend detection). Raised from the old hard-coded 120s so long prefill / reasoning-only gaps on large models are not killed (#3386, #3415) |
 | `max_loaded_models` | int | 1 | Max models per type slot. Use -1 for unlimited |
 | `broadcast` | bool | true | Enable or disable UDP broadcasting for server discovery |
 | `extra_models_dir` | string | "" | Secondary directory recursively scanned for GGUF model files. Empty disables extra discovery; existing paths must be readable by `lemond` |

--- a/src/cpp/include/lemon/runtime_config.h
+++ b/src/cpp/include/lemon/runtime_config.h
@@ -42,6 +42,7 @@ public:
     bool broadcast() const;
     void set_broadcast_override(std::optional<bool> override_val);
     long global_timeout() const;
+    long stream_stall_timeout() const;
     int max_loaded_models() const;
     int64_t download_rate_limit_bytes_per_second() const;
 

--- a/src/cpp/include/lemon/utils/http_client.h
+++ b/src/cpp/include/lemon/utils/http_client.h
@@ -120,6 +120,21 @@ public:
         return download_rate_limit_bytes_per_second_.load();
     }
 
+    // Streaming-stall window: how long an unbounded streaming transfer may
+    // deliver no bytes before libcurl aborts it (CURLOPT_LOW_SPEED_*).
+    // Configurable via `stream_stall_timeout`; 0 disables the silence bound
+    // entirely (the backend watchdog then owns dead-backend detection).
+    // The default (600s) comfortably exceeds any legitimate prefill/thinking
+    // gap on large models — the old fixed 120s killed healthy long
+    // generations (lemonade-sdk/lemonade#3386, #3415).
+    static void set_stream_stall_seconds(long seconds) {
+        stream_stall_seconds_ = seconds;
+    }
+
+    static long get_stream_stall_seconds() {
+        return stream_stall_seconds_.load();
+    }
+
     // Simple GET request. timeout_seconds=0 (default) uses default_timeout_seconds_.
     static HttpResponse get(const std::string& url,
                            const std::map<std::string, std::string>& headers = {},
@@ -156,8 +171,8 @@ public:
     //
     // timeout_seconds=0 uses default_timeout_seconds_. A total timeout would
     // cut off a long but healthy generation, so this bounds upstream silence
-    // instead: the transfer is aborted only after kStreamStallSeconds with no
-    // progress, which a streaming response cannot legitimately exceed.
+    // instead: the transfer is aborted only after stream_stall_seconds (see
+    // set_stream_stall_seconds; 0 = disabled) with no progress.
     static HttpResponse post_stream(
         const std::string& url,
         const std::string& body,
@@ -186,6 +201,7 @@ public:
 private:
     static std::atomic<long> default_timeout_seconds_;
     static std::atomic<int64_t> download_rate_limit_bytes_per_second_;
+    static std::atomic<long> stream_stall_seconds_;
 
     // Single download attempt, may resume from offset
     static DownloadResult download_attempt(const std::string& url,

--- a/src/cpp/resources/defaults.json
+++ b/src/cpp/resources/defaults.json
@@ -25,6 +25,7 @@
     "prefer_system": false
   },
   "global_timeout": 600,
+  "stream_stall_timeout": 600,
   "host": "localhost",
   "inhibit_suspend": true,
   "kokoro": {

--- a/src/cpp/server/runtime_config.cpp
+++ b/src/cpp/server/runtime_config.cpp
@@ -410,6 +410,11 @@ long RuntimeConfig::global_timeout() const {
     return config_["global_timeout"].get<long>();
 }
 
+long RuntimeConfig::stream_stall_timeout() const {
+    std::shared_lock lock(mutex_);
+    return config_["stream_stall_timeout"].get<long>();
+}
+
 int RuntimeConfig::max_loaded_models() const {
     std::shared_lock lock(mutex_);
     return config_["max_loaded_models"].get<int>();
@@ -857,6 +862,13 @@ void RuntimeConfig::validate(const std::string& key, const json& value) const {
         }
         if (value.get<long>() <= 0) {
             throw std::invalid_argument("'global_timeout' must be positive");
+        }
+    } else if (key == "stream_stall_timeout") {
+        if (!value.is_number_integer()) {
+            throw std::invalid_argument("'stream_stall_timeout' must be an integer");
+        }
+        if (value.get<long>() < 0) {
+            throw std::invalid_argument("'stream_stall_timeout' must be >= 0 (0 disables the silence bound)");
         }
     } else if (key == "max_loaded_models") {
         if (!value.is_number_integer()) {

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -375,6 +375,10 @@ Server::Server(std::shared_ptr<RuntimeConfig> config,
     // Set global HttpClient timeout
     utils::HttpClient::set_default_timeout(config->global_timeout());
 
+    // Streaming-stall silence window (0 disables; backend watchdog then owns
+    // dead-backend detection during active streams)
+    utils::HttpClient::set_stream_stall_seconds(config->stream_stall_timeout());
+
     // Global download rate limit
     utils::HttpClient::set_download_rate_limit(config->download_rate_limit_bytes_per_second());
 

--- a/src/cpp/server/utils/http_client.cpp
+++ b/src/cpp/server/utils/http_client.cpp
@@ -30,6 +30,8 @@ std::atomic<long> HttpClient::default_timeout_seconds_{300};
 
 std::atomic<int64_t> HttpClient::download_rate_limit_bytes_per_second_{0};
 
+std::atomic<long> HttpClient::stream_stall_seconds_{600};
+
 // Serializes transfers so concurrent downloads cannot exceed the cap in aggregate.
 static std::mutex g_download_gate;
 
@@ -38,10 +40,6 @@ namespace {
 // Bounds the TCP handshake so an unroutable host cannot hold a worker for the
 // full request timeout.
 constexpr long kConnectTimeoutSeconds = 30;
-
-// How long a stream may deliver nothing before it is treated as dead. Well
-// above any inter-token gap, well below "never".
-constexpr long kStreamStallSeconds = 120;
 
 // Resolves the 0-means-default convention shared by every request method.
 // Without this, curl reads 0 as "no timeout" and a silent upstream parks the
@@ -776,9 +774,14 @@ HttpResponse HttpClient::post_stream(const std::string& url,
     }
     // A total timeout would kill a long but healthy generation, so an
     // unqualified request is bounded by upstream silence instead of duration.
+    // The silence window is configurable (stream_stall_timeout; 0 = disabled,
+    // e.g. when the caller explicitly wants no bound).
     if (timeout_seconds == 0) {
-        curl_easy_setopt(curl, CURLOPT_LOW_SPEED_LIMIT, 1L);
-        curl_easy_setopt(curl, CURLOPT_LOW_SPEED_TIME, kStreamStallSeconds);
+        const long stall_seconds = HttpClient::get_stream_stall_seconds();
+        if (stall_seconds > 0) {
+            curl_easy_setopt(curl, CURLOPT_LOW_SPEED_LIMIT, 1L);
+            curl_easy_setopt(curl, CURLOPT_LOW_SPEED_TIME, stall_seconds);
+        }
     } else {
         curl_easy_setopt(curl, CURLOPT_TIMEOUT, effective_timeout(timeout_seconds));
     }

--- a/test/cpp/test_http_client_timeout.cpp
+++ b/test/cpp/test_http_client_timeout.cpp
@@ -153,6 +153,30 @@ int main() {
                 "post_stream: explicit timeout abandons a silent upstream");
     }
 
+    // The silence bound for timeout_seconds=0 is configurable: a tiny window
+    // abandons a silent upstream quickly (the fixed 120s regression, #3386/#3415,
+    // killed healthy long prefills instead).
+    {
+        const long saved = HttpClient::get_stream_stall_seconds();
+        HttpClient::set_stream_stall_seconds(2);
+        const bool returned = returns_within_ceiling([&] {
+            HttpClient::post_stream(
+                base + "/silent", "{}",
+                [](const char*, size_t) { return true; },
+                {}, 0, nullptr, policy);
+        });
+        HttpClient::set_stream_stall_seconds(saved);
+        r.check(returned,
+                "post_stream: timeout 0 honors the configured stream-stall window");
+    }
+
+    // And the default window must be generous enough to cover long prefill gaps
+    // (the old 120s was not), while still being a finite safety net.
+    {
+        const long stall = HttpClient::get_stream_stall_seconds();
+        r.check(stall >= 600, "post_stream: default stream-stall window is >= 600s");
+    }
+
     // The sentinel is the only way to ask for an unbounded transfer, so it must
     // not be confused with 0.
     r.check(HttpClient::kNoTimeout != 0,


### PR DESCRIPTION
## Problem

`HttpClient::post_stream()` hard-codes a **120-second low-speed stall** for unbounded streaming requests (`timeout_seconds == 0`):

```cpp
constexpr long kStreamStallSeconds = 120;   // src/cpp/server/utils/http_client.cpp
...
if (timeout_seconds == 0) {
    curl_easy_setopt(curl, CURLOPT_LOW_SPEED_LIMIT, 1L);
    curl_easy_setopt(curl, CURLOPT_LOW_SPEED_TIME, kStreamStallSeconds);
}
```

On large models (Qwen3.8-27B, etc.) the **prompt-prefill / reasoning phase can legitimately emit no SSE bytes for longer than 120s** — the backend is working (token timing keeps printing) but libcurl aborts with:

```
[Error] (HttpClient) CURL error: Timeout was reached
[Error] (WrappedServer) Streaming request failed: CURL error: Timeout was reached
```

This regressed in v11.8.0: #1860 removed the old default-timeout ("5-minute hard limit", #1792) and #3223 replaced it with this tighter 120s silence bound. Users on 11.8.0/11.8.1 are hitting it with `global_timeout` set to 86400 and having to revert to 11.7 (#3386, #3415 — several reporters).

## Fix

1. **Make the stall window configurable** — `HttpClient::set_stream_stall_seconds()` / `get_stream_stall_seconds()`; `post_stream()` uses the configured value instead of a fixed constant. `0` disables the silence bound entirely.
2. **New server config `stream_stall_timeout`** (default **600s**, was hard-coded 120s), validated and wired through `RuntimeConfig` → `defaults.json` → server startup. `0` = disabled (the backend watchdog already owns dead-backend detection during active streams via `/health` probes, so a genuinely hung backend is still caught).
3. **Docs** — configuration reference row for `stream_stall_timeout`.
4. **Tests** — `post_stream(timeout=0)` honors the configured window (tiny window abandons a silent upstream), default window ≥ 600s. All 7 tests pass.

## Behavior

- Default config: streams now survive prefill/thinking gaps up to 10 min (was 120s). A dead stream is still aborted by the silence bound, and the watchdog catches truly hung backends sooner.
- Users with long-prefill workloads can raise it or set `stream_stall_timeout: 0` to disable and rely on the watchdog.
- Callers that pass an explicit positive `timeout_seconds` are unchanged.

Fixes #3386, #3415.