### PR TITLE
fix(anthropic): resolve model aliases on /v1/messages and the Ollama endpoints

### DIFF
--- a/src/cpp/include/lemon/ollama_api.h
+++ b/src/cpp/include/lemon/ollama_api.h
@@ -16,7 +16,10 @@ using json = nlohmann::json;
 
 class OllamaApi : public std::enable_shared_from_this<OllamaApi> {
 public:
-    OllamaApi(Router* router, ModelManager* model_manager);
+    using AliasResolver = std::function<std::string(const std::string&)>;
+
+    OllamaApi(Router* router, ModelManager* model_manager,
+              AliasResolver resolve_alias);
 
     // Must be called on a shared_ptr instance (uses shared_from_this internally)
     void register_routes(httplib::Server& server);
@@ -24,6 +27,7 @@ public:
 private:
     Router* router_;
     ModelManager* model_manager_;
+    AliasResolver resolve_alias_;
 
     // Endpoint handlers
     void handle_chat(const httplib::Request& req, httplib::Response& res);
@@ -44,6 +48,8 @@ private:
     void auto_load_model(const std::string& model, const json& request_options = json::object());
     static json extract_auto_load_options(const json& request);
     std::string normalize_model_name(const std::string& name);
+    // Not called from show/pull/delete: resolving there would act on the target.
+    void resolve_request_model(json& request_json);
     json build_ollama_model_entry(const std::string& id, const ModelInfo& info);
     json convert_openai_chat_to_ollama(const json& openai_response, const std::string& model);
     json convert_openai_delta_to_ollama(const json& openai_chunk, const std::string& model);

--- a/src/cpp/server/anthropic_api.cpp
+++ b/src/cpp/server/anthropic_api.cpp
@@ -1143,6 +1143,7 @@ void OllamaApi::handle_anthropic_messages(const httplib::Request& req, httplib::
         auto request_json = json::parse(req.body);
         std::vector<std::string> warnings;
 
+        resolve_request_model(request_json);
         std::string model = normalize_model_name(request_json.value("model", ""));
         if (model.empty()) {
             res.status = 400;

--- a/src/cpp/server/ollama_api.cpp
+++ b/src/cpp/server/ollama_api.cpp
@@ -149,8 +149,10 @@ static void map_ollama_options(const json& ollama_request, json& openai_req) {
     }
 }
 
-OllamaApi::OllamaApi(Router* router, ModelManager* model_manager)
-    : router_(router), model_manager_(model_manager) {
+OllamaApi::OllamaApi(Router* router, ModelManager* model_manager,
+                     AliasResolver resolve_alias)
+    : router_(router), model_manager_(model_manager),
+      resolve_alias_(std::move(resolve_alias)) {
 }
 
 void OllamaApi::register_routes(httplib::Server& server) {
@@ -232,6 +234,22 @@ std::string OllamaApi::normalize_model_name(const std::string& name) {
         return name.substr(0, name.size() - suffix.size());
     }
     return name;
+}
+
+// Once per request: a second lookup downstream could see a concurrent alias edit.
+void OllamaApi::resolve_request_model(json& request_json) {
+    if (!resolve_alias_ || !request_json.contains("model") ||
+        !request_json["model"].is_string()) {
+        return;
+    }
+    const std::string normalized = normalize_model_name(request_json["model"].get<std::string>());
+    if (normalized.empty()) {
+        return;
+    }
+    const std::string resolved = resolve_alias_(normalized);
+    if (resolved != request_json["model"].get<std::string>()) {
+        request_json["model"] = resolved;
+    }
 }
 
 // ============================================================================
@@ -710,6 +728,7 @@ void OllamaApi::handle_chat(const httplib::Request& req, httplib::Response& res)
     try {
         auto request_json = json::parse(req.body);
 
+        resolve_request_model(request_json);
         std::string model = normalize_model_name(request_json.value("model", ""));
         if (model.empty()) {
             res.status = 400;
@@ -846,6 +865,7 @@ void OllamaApi::handle_generate(const httplib::Request& req, httplib::Response& 
     try {
         auto request_json = json::parse(req.body);
 
+        resolve_request_model(request_json);
         std::string model = normalize_model_name(request_json.value("model", ""));
         if (model.empty()) {
             res.status = 400;
@@ -1307,6 +1327,7 @@ void OllamaApi::handle_embed(const httplib::Request& req, httplib::Response& res
     try {
         auto request_json = json::parse(req.body);
 
+        resolve_request_model(request_json);
         std::string model = normalize_model_name(request_json.value("model", ""));
         if (model.empty()) {
             res.status = 400;
@@ -1377,6 +1398,7 @@ void OllamaApi::handle_embeddings(const httplib::Request& req, httplib::Response
     try {
         auto request_json = json::parse(req.body);
 
+        resolve_request_model(request_json);
         std::string model = normalize_model_name(request_json.value("model", ""));
         if (model.empty()) {
             res.status = 400;

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -1509,7 +1509,9 @@ void Server::setup_routes(httplib::Server &web_server) {
     });
 
     // Register Ollama-compatible API routes
-    auto ollama_api = std::make_shared<OllamaApi>(router_.get(), model_manager_.get());
+    auto ollama_api = std::make_shared<OllamaApi>(
+        router_.get(), model_manager_.get(),
+        [this](const std::string& m) { return resolve_alias_target(m); });
     ollama_api->register_routes(web_server);
 
     // Register MCP gateway (POST /mcp). NOTE: /mcp is an INTENTIONAL EXCEPTION

--- a/test/test_ollama.py
+++ b/test/test_ollama.py
@@ -23,6 +23,7 @@ except ImportError:
 
 from utils.server_base import (
     ServerTestBase,
+    _auth_headers,
     model_recipe_options,
     run_server_tests,
     unload_all_models,
@@ -854,6 +855,94 @@ class OllamaTests(ServerTestBase):
         self.assertIn("message_start", event_types)
         self.assertIn("content_block_start", event_types)
         self.assertIn("message_stop", event_types)
+
+    def test_025b_anthropic_messages_resolves_alias(self):
+        """A registered alias must work on /v1/messages like any other surface."""
+        self.ensure_model_pulled()
+
+        alias_name = "test-anthropic-alias"
+        internal_url = f"{OLLAMA_BASE_URL}/internal"
+
+        add_res = requests.post(
+            f"{internal_url}/aliases",
+            json={"alias": alias_name, "target": ENDPOINT_TEST_MODEL},
+            headers=_auth_headers(),
+            timeout=TIMEOUT_DEFAULT,
+        )
+        self.assertEqual(add_res.status_code, 200, add_res.text)
+        self.addCleanup(
+            requests.delete,
+            f"{internal_url}/aliases/{requests.utils.quote(alias_name)}",
+            headers=_auth_headers(),
+            timeout=TIMEOUT_DEFAULT,
+        )
+
+        payload = {
+            "model": alias_name,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [{"type": "text", "text": "Say hello"}],
+                }
+            ],
+            "max_tokens": 16,
+            "stream": False,
+        }
+
+        response = requests.post(
+            f"{OLLAMA_BASE_URL}/v1/messages?beta=true",
+            json=payload,
+            timeout=TIMEOUT_MODEL_OPERATION,
+        )
+        self.assertEqual(response.status_code, 200, response.text)
+        self.assertEqual(response.json().get("type"), "message")
+
+        # The same alias on the OpenAI surface has always worked; the two
+        # surfaces must not disagree about whether the model exists.
+        chat_response = requests.post(
+            f"{OLLAMA_BASE_URL}/api/v1/chat/completions",
+            json={
+                "model": alias_name,
+                "messages": [{"role": "user", "content": "Say hello"}],
+                "max_tokens": 16,
+            },
+            timeout=TIMEOUT_MODEL_OPERATION,
+        )
+        self.assertEqual(chat_response.status_code, 200, chat_response.text)
+
+    def test_025c_ollama_chat_resolves_alias(self):
+        """POST /api/chat shares the alias resolution path with /v1/messages."""
+        self.ensure_model_pulled()
+
+        alias_name = "test-ollama-chat-alias"
+        internal_url = f"{OLLAMA_BASE_URL}/internal"
+
+        add_res = requests.post(
+            f"{internal_url}/aliases",
+            json={"alias": alias_name, "target": ENDPOINT_TEST_MODEL},
+            headers=_auth_headers(),
+            timeout=TIMEOUT_DEFAULT,
+        )
+        self.assertEqual(add_res.status_code, 200, add_res.text)
+        self.addCleanup(
+            requests.delete,
+            f"{internal_url}/aliases/{requests.utils.quote(alias_name)}",
+            headers=_auth_headers(),
+            timeout=TIMEOUT_DEFAULT,
+        )
+
+        response = requests.post(
+            f"{OLLAMA_BASE_URL}/api/chat",
+            json={
+                "model": alias_name,
+                "messages": [{"role": "user", "content": "Say hello"}],
+                "stream": False,
+                "options": {"num_predict": 10},
+            },
+            timeout=TIMEOUT_MODEL_OPERATION,
+        )
+        self.assertEqual(response.status_code, 200, response.text)
+        self.assertTrue(response.json().get("done"))
 
     def test_026_anthropic_messages_tool_calling(self):
         """Test Anthropic-compatible tool calling maps to tool_use blocks."""


### PR DESCRIPTION
## Summary

`POST /v1/messages` returned 404 for a registered alias while the same alias
succeeded on `/v1/chat/completions`. Alias resolution lives in
`Server::normalize_and_resolve_request_model`, which only the OpenAI-surface
handlers call, and `OllamaApi` (which serves `/api/*` and `POST /v1/messages`)
held no reference to `AliasManager`. `OllamaApi` now takes an `AliasResolver`
callback and resolves the request model once per request, mirroring what
`Server` already does.

Fixes #3433

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

The Ollama endpoints (`/api/chat`, `/api/generate`, `/api/embed`,
`/api/embeddings`) are fixed by the same change. They are methods on the same
class reached through the same unresolved name, so fixing only `/v1/messages`
would have meant special-casing one method of `OllamaApi` against its siblings.

Why a second helper rather than teaching `normalize_model_name` to resolve, which
would be a smaller diff: its three remaining callers are `handle_show`,
`handle_delete` and `handle_pull`. `POST /api/delete {"name": "<alias>"}` would
then delete the target model, which is a bad surprise for "delete the alias".
`pull` would be harmless and `show` would arguably improve, but the set resolved
here deliberately matches the set `Server::normalize_and_resolve_request_model`
already resolves (inference, load, unload) rather than widening it in a bug fix.

Resolution happens once, in the handler, rather than at each point that reads the
model name. Resolving in both the handler and the converter would read mutable
alias state twice, so an alias edited between the two reads could load one model
and route the request to another.

Two disclosures rather than changes:

- Responses now echo the resolved model name, not the requested alias. That
  matches what `/v1/chat/completions` already does for an alias, but it is a new
  behaviour on the Ollama compatibility layer, where upstream Ollama echoes the
  name it was given.
- `/api/show` returns 404 for an alias and `/api/tags` omits it, while
  `/api/v1/models` and `/api/v1/models/{id}` expose it. That behaviour predates
  this change, but this PR makes the asymmetry visible: chat, generate and embed
  now resolve while show does not. I have not verified whether the Ollama CLI
  probes `/api/show` before chatting, which would make it user-visible for
  `ollama run <alias>`. Happy to fold it in if you want it here rather than in a
  separate issue.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_

Built with `cmake --preset default` on Linux/GCC.

- `ctest -L cpp-ci`: 67/67 pass.
- `python test/test_ollama.py`: 32/32 pass, including two new tests,
  `test_025b_anthropic_messages_resolves_alias` and
  `test_025c_ollama_chat_resolves_alias`. Both fail before this change.

Containers built from `main` and from this branch, alias
`ALIAS -> Tiny-Test-Model-GGUF`:

| request | main | this branch |
|---|---|---|
| `POST /v1/messages` with alias | 404 `model 'ALIAS' not found, try pulling it first` | 200 |
| `POST /api/chat` with alias | 404, same message | 200 |
| `POST /v1/messages` with target id | 200 | 200 |
| `POST /api/v1/chat/completions` with alias | 200 | 200 |

Also run against a live server with a 35B llamacpp/ROCm model behind an alias:
`/v1/messages` streaming and non-streaming, `/api/chat`, `/api/generate`, and a
chained alias all resolve to the final target.

## Documentation

- [x] Documentation is not affected by this change.

`docs/guide/configuration/custom-models.md:341` already states that an alias in
"any API request" resolves to its target. This change makes the implementation
match.

## Breaking Changes

- [x] This PR does not introduce breaking changes.

Requests that previously returned 404 now succeed. Nothing that previously
succeeded changes behaviour.

## AI-assisted contribution

- [x] I used AI tools for this PR.

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.

I am not a C++ developer. I read every line of this diff and checked that it
stays within what the PR describes, and I tested the result end to end on my own
hardware against a 35B llamacpp/ROCm model behind an alias. I also ran Claude
Code's `/code-review` on the branch, and followed contribute.md and AGENTS.md. I
cannot judge idiomatic C++ at review depth.