### PR TITLE
feat(metrics): relate model aliases to their target in /metrics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3222,6 +3222,13 @@ if(BUILD_TESTING AND EXISTS "${_ANTHROPIC_ERROR_TEST_SRC}")
     add_cpp_ci_test(AnthropicErrorTest CI ON COMMAND test_anthropic_error)
 endif()
 
+set(_METRICS_ALIASES_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_metrics_aliases.cpp")
+if(BUILD_TESTING AND EXISTS "${_METRICS_ALIASES_TEST_SRC}")
+    add_executable(test_metrics_aliases test/cpp/test_metrics_aliases.cpp)
+    target_link_libraries(test_metrics_aliases PRIVATE lemonade-server-core)
+    add_cpp_ci_test(MetricsAliasesTest CI ON COMMAND test_metrics_aliases)
+endif()
+
 set(_ANTHROPIC_RELAY_HEADERS_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_anthropic_relay_headers.cpp")
 if(BUILD_TESTING AND EXISTS "${_ANTHROPIC_RELAY_HEADERS_TEST_SRC}")
     add_executable(test_anthropic_relay_headers test/cpp/test_anthropic_relay_headers.cpp)

--- a/docs/guide/configuration/custom-models.md
+++ b/docs/guide/configuration/custom-models.md
@@ -347,6 +347,18 @@ When an alias is specified in any API request (e.g., `/v1/chat/completions`, `/v
 
 Every registered alias is exposed as an independent model entry in `/v1/models`, `/v1/models/{id}`, and `lemonade list`. Alias entries set `id` to the alias name while sharing the target model's recipe, downloaded status, and backend configuration.
 
+#### Alias Mapping in `/metrics`
+
+`/metrics` emits one `lemonade_model_alias_info{alias,model_name}` sample per registered alias, present whether or not the target model has been loaded. Alias chains collapse to the final target, and unresolvable or cyclic aliases are omitted so `/metrics` never advertises a mapping the inference APIs would refuse to follow.
+
+Model series stay labeled with the canonical `model_name` only — they are not duplicated under the alias — so cumulative counters remain single-counted. Join the mapping onto them to query by alias:
+
+```promql
+lemonade_model_loaded * on(model_name) group_right lemonade_model_alias_info
+```
+
+The `lemonade_model_*` series are built from the Router's snapshot of models it has observed, so a model that has not been loaded in the current process has no series for the mapping to join onto. The `lemonade_model_alias_info` sample is present either way, so an alias that resolves but joins to nothing indicates a target that is not currently tracked, while an absent sample indicates the alias is not registered.
+
 ### Five reference cases
 
 | Sources                                         | `/v1/models` ids                                      | Resolution                                                                 |

--- a/src/cpp/include/lemon/prometheus_metrics.h
+++ b/src/cpp/include/lemon/prometheus_metrics.h
@@ -1,6 +1,9 @@
 #pragma once
 
+#include <functional>
+#include <map>
 #include <string>
+#include <unordered_map>
 
 #include "router.h"
 
@@ -13,6 +16,14 @@ struct SystemMetrics {
     double npu_percent = -1.0;
 };
 
-std::string build_prometheus_metrics(Router& router, const SystemMetrics& system_metrics);
+using MetricsAliasMap = std::map<std::string, std::string>;
+
+// `resolve` returns "" when the alias does not resolve; those entries are dropped.
+MetricsAliasMap build_metrics_alias_map(
+    const std::unordered_map<std::string, std::string>& raw_aliases,
+    const std::function<std::string(const std::string&)>& resolve);
+
+std::string build_prometheus_metrics(Router& router, const SystemMetrics& system_metrics,
+                                     const MetricsAliasMap& aliases = {});
 
 } // namespace lemon

--- a/src/cpp/server/prometheus_metrics.cpp
+++ b/src/cpp/server/prometheus_metrics.cpp
@@ -8,11 +8,13 @@
 #include <cmath>
 #include <cstdint>
 #include <cstdio>
+#include <functional>
 #include <iomanip>
 #include <map>
 #include <set>
 #include <sstream>
 #include <string>
+#include <unordered_map>
 
 #include <httplib.h>
 
@@ -314,7 +316,23 @@ void append_llamacpp_backend_metrics(PrometheusBuilder& metrics,
 
 } // namespace
 
-std::string build_prometheus_metrics(Router& router, const SystemMetrics& system_metrics) {
+MetricsAliasMap build_metrics_alias_map(
+    const std::unordered_map<std::string, std::string>& raw_aliases,
+    const std::function<std::string(const std::string&)>& resolve) {
+    MetricsAliasMap mapping;
+    if (!resolve) return mapping;
+
+    for (const auto& entry : raw_aliases) {
+        if (entry.first.empty()) continue;
+        std::string target = resolve(entry.first);
+        if (target.empty() || target == entry.first) continue;
+        mapping[entry.first] = target;
+    }
+    return mapping;
+}
+
+std::string build_prometheus_metrics(Router& router, const SystemMetrics& system_metrics,
+                                     const MetricsAliasMap& aliases) {
     PrometheusBuilder metrics;
 
     metrics.describe("lemonade_server_up", "Whether the Lemonade server is running.", "gauge");
@@ -343,6 +361,12 @@ std::string build_prometheus_metrics(Router& router, const SystemMetrics& system
     metrics.describe("lemonade_model_output_tokens_total", "Cumulative output tokens observed for a model.", "counter");
     metrics.describe("lemonade_model_prompt_tokens_total", "Cumulative prompt tokens observed for a model.", "counter");
     metrics.describe("lemonade_model_cache_tokens_total", "Cumulative prompt tokens served from the backend prefix cache for a model.", "counter");
+    metrics.describe("lemonade_model_alias_info", "Mapping from a registered alias to the model name it resolves to; always 1.", "gauge");
+
+    for (const auto& entry : aliases) {
+        metrics.sample("lemonade_model_alias_info",
+                       {{"alias", entry.first}, {"model_name", entry.second}}, 1.0);
+    }
 
     for (const auto& model : model_metrics) {
         std::map<std::string, std::string> labels = {

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -6848,7 +6848,21 @@ void Server::handle_metrics(const httplib::Request& req, httplib::Response& res)
         system_metrics.vram_gb = get_vram_usage();
         system_metrics.npu_percent = get_npu_utilization();
 
-        res.set_content(build_prometheus_metrics(*router_, system_metrics),
+        MetricsAliasMap aliases;
+        if (alias_manager_) {
+            aliases = build_metrics_alias_map(
+                alias_manager_->get_all_aliases(),
+                [this](const std::string& alias) -> std::string {
+                    auto target = alias_manager_->resolve_alias(alias);
+                    if (!target.has_value()) return "";
+                    return model_manager_
+                        ? model_manager_->get_public_model_name(
+                              model_manager_->resolve_model_name(*target))
+                        : *target;
+                });
+        }
+
+        res.set_content(build_prometheus_metrics(*router_, system_metrics, aliases),
                         "text/plain; version=0.0.4; charset=utf-8");
     } catch (const std::exception& e) {
         LOG(ERROR, "Server") << "ERROR in handle_metrics: " << e.what() << std::endl;

--- a/test/cpp/test_metrics_aliases.cpp
+++ b/test/cpp/test_metrics_aliases.cpp
@@ -1,0 +1,101 @@
+#include "lemon/prometheus_metrics.h"
+
+#include <cstdio>
+#include <string>
+#include <unordered_map>
+
+using lemon::build_metrics_alias_map;
+using lemon::MetricsAliasMap;
+
+struct TestResult {
+    int passed = 0;
+    int failed = 0;
+
+    void check(bool condition, const std::string& name) {
+        printf("[%s] %s\n", condition ? "PASS" : "FAIL", name.c_str());
+        if (condition) {
+            ++passed;
+        } else {
+            ++failed;
+        }
+    }
+};
+
+// Stands in for AliasManager::resolve_alias followed by the public-name lookup:
+// a chain walk that yields an empty string for anything unresolvable.
+static std::string fake_resolve(
+        const std::unordered_map<std::string, std::string>& aliases,
+        const std::string& alias) {
+    std::string current = alias;
+    for (int hop = 0; hop < 10; ++hop) {
+        auto it = aliases.find(current);
+        if (it == aliases.end()) {
+            return current == alias ? "" : current;
+        }
+        if (it->second == alias) return "";
+        current = it->second;
+    }
+    return "";
+}
+
+static MetricsAliasMap map_for(const std::unordered_map<std::string, std::string>& aliases) {
+    return build_metrics_alias_map(aliases, [&aliases](const std::string& alias) {
+        return fake_resolve(aliases, alias);
+    });
+}
+
+static void test_alias_maps_to_target(TestResult& r) {
+    MetricsAliasMap mapping = map_for({{"coding", "Qwen3-8B-GGUF"}});
+
+    r.check(mapping.size() == 1, "one entry per resolvable alias");
+    r.check(mapping["coding"] == "Qwen3-8B-GGUF", "alias maps to its target model");
+}
+
+static void test_chained_alias_reports_final_target(TestResult& r) {
+    MetricsAliasMap mapping = map_for({{"hop", "coding"}, {"coding", "Qwen3-8B-GGUF"}});
+
+    r.check(mapping.size() == 2, "every alias in a chain is exposed");
+    r.check(mapping["hop"] == "Qwen3-8B-GGUF",
+            "a chained alias maps to the model, not to the intermediate alias");
+}
+
+static void test_multiple_aliases_share_a_target(TestResult& r) {
+    MetricsAliasMap mapping =
+        map_for({{"coding", "Qwen3-8B-GGUF"}, {"default", "Qwen3-8B-GGUF"}});
+
+    r.check(mapping.size() == 2, "both aliases are exposed");
+    r.check(mapping["coding"] == mapping["default"],
+            "aliases of one model agree on the target");
+}
+
+static void test_unresolvable_aliases_are_dropped(TestResult& r) {
+    // A cycle is what AliasManager reports as unresolvable; /metrics must not
+    // advertise a mapping that inference would refuse to follow.
+    r.check(map_for({{"a", "b"}, {"b", "a"}}).empty(), "cyclic aliases are dropped");
+    r.check(map_for({}).empty(), "no aliases produces no mapping");
+
+    MetricsAliasMap no_resolver = build_metrics_alias_map({{"coding", "Qwen3-8B-GGUF"}}, nullptr);
+    r.check(no_resolver.empty(), "a missing resolver produces no mapping");
+
+    MetricsAliasMap empty_key = build_metrics_alias_map(
+        {{"", "Qwen3-8B-GGUF"}},
+        [](const std::string&) { return std::string("Qwen3-8B-GGUF"); });
+    r.check(empty_key.empty(), "an empty alias name is dropped");
+
+    MetricsAliasMap self = build_metrics_alias_map(
+        {{"coding", "coding"}},
+        [](const std::string& alias) { return alias; });
+    r.check(self.empty(), "an alias resolving to itself is dropped");
+}
+
+int main() {
+    TestResult r;
+
+    test_alias_maps_to_target(r);
+    test_chained_alias_reports_final_target(r);
+    test_multiple_aliases_share_a_target(r);
+    test_unresolvable_aliases_are_dropped(r);
+
+    printf("\n%d passed, %d failed\n", r.passed, r.failed);
+    return r.failed == 0 ? 0 : 1;
+}

--- a/test/server_endpoints.py
+++ b/test/server_endpoints.py
@@ -659,6 +659,91 @@ class EndpointTests(ServerTestBase):
         )
         print("[OK] /metrics returned Prometheus text with loaded model samples")
 
+    def test_002c_metrics_expose_model_aliases(self):
+        """Aliases must be relatable to their target model in /metrics."""
+        alias_name = "test-metrics-alias"
+        hop_alias = "test-metrics-hop-alias"
+
+        for alias, target in (
+            (alias_name, ENDPOINT_TEST_MODEL),
+            (hop_alias, alias_name),
+        ):
+            add_res = requests.post(
+                f"{self.internal_url}/aliases",
+                json={"alias": alias, "target": target},
+                headers=_auth_headers(),
+                timeout=TIMEOUT_DEFAULT,
+            )
+            self.assertEqual(add_res.status_code, 200, add_res.text)
+            self.addCleanup(
+                requests.delete,
+                f"{self.internal_url}/aliases/{requests.utils.quote(alias)}",
+                headers=_auth_headers(),
+                timeout=TIMEOUT_DEFAULT,
+            )
+
+        load_res = requests.post(
+            f"{self.base_url}/load",
+            json={"model_name": ENDPOINT_TEST_MODEL},
+            timeout=TIMEOUT_MODEL_OPERATION,
+        )
+        self.assertEqual(load_res.status_code, 200, load_res.text)
+
+        response = requests.get(
+            f"http://localhost:{PORT}/metrics", timeout=TIMEOUT_DEFAULT
+        )
+        self.assertEqual(response.status_code, 200)
+
+        values = {}
+        for family in text_string_to_metric_families(response.text):
+            for sample in family.samples:
+                values.setdefault(sample.name, []).append((sample.labels, sample.value))
+
+        self.assertIn(
+            "lemonade_model_alias_info",
+            values,
+            "no series relates an alias to a model",
+        )
+        alias_targets = {
+            labels.get("alias"): labels.get("model_name")
+            for labels, value in values["lemonade_model_alias_info"]
+            if value == 1.0
+        }
+        self.assertEqual(alias_targets.get(alias_name), ENDPOINT_TEST_MODEL)
+        self.assertEqual(
+            alias_targets.get(hop_alias),
+            ENDPOINT_TEST_MODEL,
+            "a chained alias must report the final model, not the intermediate alias",
+        )
+
+        # The mapping is only useful if it joins onto the model series, so the
+        # target it names must be the label the model series actually carries.
+        loaded_by_name = {}
+        for labels, value in values.get("lemonade_model_loaded", []):
+            name = labels.get("model_name")
+            loaded_by_name[name] = max(loaded_by_name.get(name, 0.0), value)
+        self.assertEqual(loaded_by_name.get(ENDPOINT_TEST_MODEL), 1.0)
+        for alias in (alias_name, hop_alias):
+            target = alias_targets[alias]
+            self.assertIn(
+                target,
+                loaded_by_name,
+                f"alias {alias} points at {target}, which has no model series",
+            )
+
+        # An alias is a name for a model, not a second model: it must not create
+        # duplicate model series or double-count the cumulative counters.
+        self.assertNotIn(alias_name, loaded_by_name)
+        self.assertNotIn(
+            alias_name,
+            [
+                labels.get("model_name")
+                for labels, _ in values.get("lemonade_model_requests_total", [])
+            ],
+        )
+
+        print("[OK] /metrics relates aliases to their target model")
+
     def test_002b_cache_and_routing_metrics_series(self):
         """Cache-effectiveness and route-stability series exist in /metrics and /stats."""
         response = requests.get(


### PR DESCRIPTION
## Summary

Every `lemonade_model_*` series carries the canonical model name, because the
rows come from the Router snapshot, which is canonical by construction. No series
related an alias to the model it names, so a readiness check written against an
alias could not tell "not loaded yet" from "no such model". `/metrics` now emits
`lemonade_model_alias{alias,model_name}`, one sample per registered alias,
present whether or not the target has ever been loaded.

Fixes #3413

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

Notes on the shape, since it was a real choice:

- An info-metric rather than duplicated series. An alias is a name for a model,
  not a second model. Emitting `lemonade_model_loaded` again under the alias name
  would make an alias indistinguishable from a model and would corrupt `count()`
  and `sum()` over those series. The mapping joins instead:
  `lemonade_model_loaded * on(model_name) group_right lemonade_model_alias`.
- Counters are not mirrored, so cumulative totals stay single-counted.
- Chains collapse to the final model. Unresolvable and cyclic aliases are
  omitted.
- An alias whose target does not exist locally is still exported. `POST
  /internal/aliases` does not require the target to be pulled, and the docs say
  an alias may target a model before it exists, so the row is deliberate: it is
  what distinguishes "this alias names a model that is not loaded" from "no such
  alias". It joins to nothing until the target is first loaded.
- Known limitation, same root: an alias whose target has never been loaded has no
  `lemonade_model_loaded` row to join against, because the Router only reports
  models it has observed. Emitting `loaded=0` for every registered model would
  change what `/metrics` means, so it is not in scope here.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_

Built with `cmake --preset default` on Linux/GCC.

- `ctest -L cpp-ci`: 68/68 pass, including the new `MetricsAliasesTest`
  (`test/cpp/test_metrics_aliases.cpp`) covering a single alias, a chained alias,
  several aliases sharing a target, a cyclic alias, an empty alias name, a
  self-referential alias, and a null resolver.
- `python test/server_endpoints.py`: the new
  `test_002c_metrics_expose_model_aliases` passes. It asserts the mapping exists
  for a plain and a chained alias, that the target it names is a label the model
  series actually carries, and that the alias appears in neither
  `lemonade_model_loaded` nor the cumulative counters.
- Both new tests fail before this change.
- One unrelated failure in that suite,
  `test_012d_cloud_install_then_auth_then_chat` (`models_discovered: 0 != 1`),
  reproduces identically on unmodified `main` in the same environment. It needs a
  reachable cloud provider.

`curl -s $BASE/metrics | grep alias` returns nothing on `main`. On this branch:

```
lemonade_model_alias{alias="ALIAS",model_name="Tiny-Test-Model-GGUF"} 1
```

Also run against a live server with a 35B llamacpp/ROCm model behind an alias.
The mapping is present while no model is loaded, which is the case the issue is
about. Once loaded, the join from alias to target to `lemonade_model_loaded`
resolves to 1. A chained alias reports the final model, and an alias to a
never-loaded model still appears.

## Documentation

docs/guide/configuration/custom-models.md gains an "Alias Mapping in /metrics" subsection under the alias docs, explaining lemonade_model_alias_info and how to join it onto the model series.

## Breaking Changes

- [x] This PR does not introduce breaking changes.

A new metric family is added. No existing series, label, or value changes.

## AI-assisted contribution

- [x] I used AI tools for this PR.

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.

I am not a C++ developer. I read every line of this diff and checked that it
stays within what the PR describes, and I tested the result end to end on my own
hardware against a 35B llamacpp/ROCm model behind an alias. I also ran Claude
Code's `/code-review` on the branch, and followed contribute.md and AGENTS.md. I
cannot judge idiomatic C++ at review depth.
