### PR TITLE
fix(mcp): resolve model aliases in tool calls

### DIFF
--- a/src/cpp/include/lemon/mcp_server.h
+++ b/src/cpp/include/lemon/mcp_server.h
@@ -22,8 +22,10 @@ using json = nlohmann::json;
 class McpServer : public std::enable_shared_from_this<McpServer> {
 public:
     using EnsureLoadedFn = std::function<void(const std::string&)>;
+    using AliasResolver = std::function<std::string(const std::string&)>;
 
-    McpServer(Router* router, ModelManager* model_manager, EnsureLoadedFn ensure_loaded);
+    McpServer(Router* router, ModelManager* model_manager, EnsureLoadedFn ensure_loaded,
+              AliasResolver resolve_alias);
     ~McpServer();
 
     // Must be called on a shared_ptr instance — handlers capture shared_from_this().
@@ -46,7 +48,7 @@ private:
     json tool_list_models(const json& arguments);
 
     // Resolve which model a tool should use when `model` is omitted. Precedence:
-    //   1. an explicit `model` argument always wins;
+    //   1. an explicit `model` argument always wins, resolved through aliases;
     //   2. a model of the right type that's already LOADED (zero cost);
     //   3. a model of the right type that's already DOWNLOADED (no network);
     //   4. the tool's hard-coded default, but only when the caller passed
@@ -60,6 +62,8 @@ private:
         const char* type_str,
         const char* default_model,
         bool allow_download);
+
+    std::string resolve_requested_model(const std::string& model) const;
 
     static json text_content_block(const std::string& text);
     static json make_error_response(const json& id, int code, const std::string& message);
@@ -76,6 +80,7 @@ private:
     Router* router_;
     ModelManager* model_manager_;
     EnsureLoadedFn ensure_loaded_;
+    AliasResolver resolve_alias_;
 };
 
 }  // namespace lemon

--- a/src/cpp/server/mcp_server.cpp
+++ b/src/cpp/server/mcp_server.cpp
@@ -215,10 +215,12 @@ std::string unique_token() {
 
 }  // namespace
 
-McpServer::McpServer(Router* router, ModelManager* model_manager, EnsureLoadedFn ensure_loaded)
+McpServer::McpServer(Router* router, ModelManager* model_manager, EnsureLoadedFn ensure_loaded,
+                     AliasResolver resolve_alias)
     : router_(router),
       model_manager_(model_manager),
-      ensure_loaded_(std::move(ensure_loaded)) {}
+      ensure_loaded_(std::move(ensure_loaded)),
+      resolve_alias_(std::move(resolve_alias)) {}
 
 McpServer::~McpServer() = default;
 
@@ -440,6 +442,10 @@ json McpServer::make_needs_model_result(const char* type_str,
     };
 }
 
+std::string McpServer::resolve_requested_model(const std::string& model) const {
+    return resolve_alias_ ? resolve_alias_(model) : model;
+}
+
 std::variant<std::string, json> McpServer::resolve_model_for_tool(
         const json& arguments,
         ModelType want_type,
@@ -449,7 +455,7 @@ std::variant<std::string, json> McpServer::resolve_model_for_tool(
     // 1. Explicit model argument always wins.
     if (arguments.contains("model") && arguments["model"].is_string() &&
         !arguments["model"].get<std::string>().empty()) {
-        return arguments["model"].get<std::string>();
+        return resolve_requested_model(arguments["model"].get<std::string>());
     }
 
     // 2. Reuse a model of the right type that's already loaded \u2014 zero cost.
@@ -815,7 +821,7 @@ json McpServer::tool_omni(const json& arguments) {
     std::string model;
     if (arguments.contains("model") && arguments["model"].is_string() &&
         !arguments["model"].get<std::string>().empty()) {
-        model = arguments["model"].get<std::string>();
+        model = resolve_requested_model(arguments["model"].get<std::string>());
     } else {
         for (const auto& [name, info] : model_manager_->get_downloaded_models()) {
             if (is_omni_collection_recipe(info.recipe)) {

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -1518,7 +1518,8 @@ void Server::setup_routes(httplib::Server &web_server) {
     auto mcp_server = std::make_shared<McpServer>(
         router_.get(),
         model_manager_.get(),
-        [this](const std::string& m) { auto_load_model_if_needed(m); });
+        [this](const std::string& m) { auto_load_model_if_needed(m); },
+        [this](const std::string& m) { return resolve_alias_target(m); });
     mcp_server->register_routes(web_server);
 
     // Setup static file serving for web UI

--- a/test/server_mcp.py
+++ b/test/server_mcp.py
@@ -25,7 +25,11 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 import requests  # noqa: E402
 
-from utils.server_base import ServerTestBase, run_server_tests  # noqa: E402
+from utils.server_base import (  # noqa: E402
+    ServerTestBase,
+    run_server_tests,
+)
+from utils.server_base import _auth_headers as _admin_auth_headers  # noqa: E402
 from utils.test_models import (  # noqa: E402
     ENDPOINT_TEST_MODEL,
     PORT,
@@ -420,6 +424,47 @@ class McpGatewayTests(ServerTestBase):
         self.assertEqual(content[0]["type"], "text")
         # Some tiny test models emit empty strings — just assert the shape.
         self.assertIsInstance(content[0]["text"], str)
+
+    def test_031_chat_tool_resolves_alias(self):
+        """An explicit `model` argument must be resolved through aliases."""
+        alias_name = "test-mcp-alias"
+        internal_url = f"http://localhost:{PORT}/internal"
+
+        add_res = requests.post(
+            f"{internal_url}/aliases",
+            json={"alias": alias_name, "target": ENDPOINT_TEST_MODEL},
+            headers=_admin_auth_headers(),
+            timeout=TIMEOUT_DEFAULT,
+        )
+        self.assertEqual(add_res.status_code, 200, add_res.text)
+        self.addCleanup(
+            requests.delete,
+            f"{internal_url}/aliases/{requests.utils.quote(alias_name)}",
+            headers=_admin_auth_headers(),
+            timeout=TIMEOUT_DEFAULT,
+        )
+
+        response = _post(
+            {
+                "jsonrpc": "2.0",
+                "id": 11,
+                "method": "tools/call",
+                "params": {
+                    "name": "lemonade_chat",
+                    "arguments": {
+                        "model": alias_name,
+                        "messages": [
+                            {"role": "user", "content": "Say hello in 3 words."},
+                        ],
+                        "max_tokens": 16,
+                    },
+                },
+            },
+            timeout=TIMEOUT_MODEL_OPERATION,
+        )
+        body = response.json()
+        self.assertNotIn("error", body, msg=str(body))
+        self.assertFalse(body["result"]["isError"], msg=str(body["result"]))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Passing a registered alias as the `model` argument of an MCP tool call failed
with "Model not found", while the same alias succeeded on
`/v1/chat/completions`. `McpServer::resolve_model_for_tool` returned an explicit
`model` argument verbatim, `tool_omni` reimplemented that precedence inline with
the same gap, and `McpServer` held no reference to `AliasManager`. `McpServer`
now takes an `AliasResolver` callback bound to `Server::resolve_alias_target`,
applied through one helper that both call sites share.

Fixes #3434

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

The resolver parameter is required rather than defaulted, matching the sibling
`EnsureLoadedFn`, so a future construction site cannot silently omit it and
reintroduce this bug without a compile error. Both call sites go through one
private helper rather than repeating the resolution inline, since `tool_omni`
duplicating the precedence rule is why the gap existed in two places.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_

Built with `cmake --preset default` on Linux/GCC.

- `ctest -L cpp-ci`: 67/67 pass.
- `python test/server_mcp.py`: 19/19 pass, including the new
  `test_031_chat_tool_resolves_alias`, which registers an alias and calls
  `lemonade_chat` with it. It fails before this change.

Containers built from `main` and from this branch, alias
`ALIAS -> Tiny-Test-Model-GGUF`, calling `lemonade_chat`:

- main: `{"result":{"content":[{"text":"Error: Model not found: ALIAS"}],"isError":true}}`
- this branch: `isError:false`

Server log on main, showing the alias reaching the load path unresolved:

```
(McpServer) tools/call: lemonade_chat
(Server) Auto-loading model: ALIAS
(McpServer) Tool 'lemonade_chat' failed: Model not found: ALIAS
```

Also run against a live server with a 35B llamacpp/ROCm model behind an alias:
`lemonade_chat` succeeds through the alias and through a chained alias,
resolving to the final target.

`tool_omni` is patched for the same gap but is not covered by a regression test,
since it needs an Omni collection model that is not available in the test
environment.

## Documentation

- [x] Documentation is not affected by this change.

`docs/guide/configuration/custom-models.md:341` already states that an alias in
"any API request" resolves to its target. This change makes the implementation
match.

## Breaking Changes

- [x] This PR does not introduce breaking changes.

Tool calls that previously failed now succeed. A tool call naming a real model id
is unaffected, since a non-alias name resolves to itself.

## AI-assisted contribution

- [x] I used AI tools for this PR.

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.

I am not a C++ developer. I read every line of this diff and checked that it
stays within what the PR describes, and I tested the result end to end on my own
hardware against a 35B llamacpp/ROCm model behind an alias. I also ran Claude
Code's `/code-review` on the branch, and followed contribute.md and AGENTS.md. I
cannot judge idiomatic C++ at review depth.
