### PR TITLE
Minor follow-up cleanup to #3330

### DIFF
--- a/src/cpp/server/routing_policy.cpp
+++ b/src/cpp/server/routing_policy.cpp
@@ -355,7 +355,9 @@ private:
             {"metadata", std::move(metadata)},
         };
         // Withheld entirely (not just disclaimed) unless expose_request_features_
-        // is set — currently only the routing.router sugar's synthesized classifier.
+        // is set. When constructed through the policy parser this is only the
+        // routing.router sugar's synthesized classifier; the make_classifier(s)
+        // helpers default it to true for direct callers.
         if (expose_request_features_) {
             payload["has_tools"] = request.params.has_tools;
             payload["has_images"] = request.params.has_images;

--- a/src/cpp/server/routing_policy.cpp
+++ b/src/cpp/server/routing_policy.cpp
@@ -354,8 +354,8 @@ private:
             {"chars", request.params.chars},
             {"metadata", std::move(metadata)},
         };
-        // Withheld entirely (not just disclaimed) unless the policy actually
-        // has a use for these fields — see expose_request_features_.
+        // Withheld entirely (not just disclaimed) unless expose_request_features_
+        // is set — currently only the routing.router sugar's synthesized classifier.
         if (expose_request_features_) {
             payload["has_tools"] = request.params.has_tools;
             payload["has_images"] = request.params.has_images;

--- a/test/cpp/test_routing_policy_llm_router.cpp
+++ b/test/cpp/test_routing_policy_llm_router.cpp
@@ -245,7 +245,7 @@ static void capture_judge_exchange(ClassifierPtr judge, std::string* seen_prompt
     judge->evaluate(ClassifierContext{make_route("do it"), svc});
 }
 
-static void test_author_classifier_never_serializes_request_features() {
+static void test_parsed_author_classifier_never_serializes_request_features() {
     for (bool feature_rule : {false, true}) {
         RoutePolicy policy = parse_l0a(classifier_collection(feature_rule));
         std::string seen_prompt, seen_payload;
@@ -501,7 +501,7 @@ int main() {
     test_classifier_structured_choice();
     test_classifier_receives_structured_context();
     test_classifier_prompt_carries_contract();
-    test_author_classifier_never_serializes_request_features();
+    test_parsed_author_classifier_never_serializes_request_features();
     test_2789_regression_judge_never_sees_leaked_tool_signal();
     test_router_sugar_always_exposes_request_features();
     test_classifier_fenced_json_is_tolerated();

--- a/test/cpp/test_routing_policy_llm_router.cpp
+++ b/test/cpp/test_routing_policy_llm_router.cpp
@@ -245,7 +245,7 @@ static void capture_judge_exchange(ClassifierPtr judge, std::string* seen_prompt
     judge->evaluate(ClassifierContext{make_route("do it"), svc});
 }
 
-static void test_feature_serialization_opt_in() {
+static void test_author_classifier_never_serializes_request_features() {
     for (bool feature_rule : {false, true}) {
         RoutePolicy policy = parse_l0a(classifier_collection(feature_rule));
         std::string seen_prompt, seen_payload;
@@ -501,7 +501,7 @@ int main() {
     test_classifier_structured_choice();
     test_classifier_receives_structured_context();
     test_classifier_prompt_carries_contract();
-    test_feature_serialization_opt_in();
+    test_author_classifier_never_serializes_request_features();
     test_2789_regression_judge_never_sees_leaked_tool_signal();
     test_router_sugar_always_exposes_request_features();
     test_classifier_fenced_json_is_tolerated();


### PR DESCRIPTION
## Summary

Two minor, non-functional follow-up cleanups to #3330 (`fix(routing): llm classifier no longer treats has_tools as risk`), raised as non-blocking nits during review:
- The inline comment in `build_context_payload()` still said the fields were withheld "unless the policy actually has a use for these fields," implying a general policy-driven decision. They're actually exposed only when `expose_request_features_` is set — currently just the `routing.router` sugar's synthesized classifier. Reworded to match.
- Renamed `test_feature_serialization_opt_in` → `test_author_classifier_never_serializes_request_features`. Since #3330 removed the sibling-rule opt-in path, normal classifiers never receive the fields, so the old "opt_in" name was misleading about what the test asserts.

No behavior change — comment and test-name only.