### PR TITLE
feat(app): router collection panel and add-model flow

### DIFF
--- a/src/app/src/renderer/ChatWindow.tsx
+++ b/src/app/src/renderer/ChatWindow.tsx
@@ -4,6 +4,7 @@ import {
   AppSettings,
   mergeWithDefaultSettings,
 } from './utils/appSettings';
+import { installModelFromForm, installModelFromJSON, readModelJSONFile } from './utils/addModel';
 import { serverFetch } from './utils/serverConfig';
 import { useModels } from './hooks/useModels';
 import { useInferenceState } from './hooks/useInferenceState';
@@ -224,25 +225,7 @@ const ChatWindow: React.FC<ChatWindowProps> = ({ isVisible, width }) => {
   const handleAddModelInstall = (data: ModelInstallData) => {
     setShowAddModelForm(false);
     setAddModelInitialValues(undefined);
-    const modelName = data.name.startsWith('user.') ? data.name : `user.${data.name}`;
-    window.dispatchEvent(new CustomEvent('installModel', {
-      detail: {
-        name: modelName,
-        registrationData: {
-          checkpoint: data.checkpoint,
-          checkpoints: data.checkpoints,
-          recipe: data.recipe,
-          // Omitted on "Automatic" so lemond applies its default_model_source.
-          ...(data.source ? { source: data.source } : {}),
-          mmproj: data.mmproj,
-          labels: data.labels,
-          reasoning: data.reasoning,
-          vision: data.vision,
-          embedding: data.embedding,
-          reranking: data.reranking,
-        },
-      },
-    }));
+    installModelFromForm(data);
   };
 
   const handleNewChat = () => {
@@ -346,18 +329,12 @@ const ChatWindow: React.FC<ChatWindowProps> = ({ isVisible, width }) => {
         type="file"
         accept=".json"
         style={{ display: 'none' }}
-        onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+        onChange={async (e: React.ChangeEvent<HTMLInputElement>) => {
           const file = e.target.files?.[0];
-          if (!file) return;
-          const reader = new FileReader();
-          reader.onload = (ev) => {
-            try {
-              const json = JSON.parse(ev.target?.result as string);
-              window.dispatchEvent(new CustomEvent('installModelFromJSON', { detail: json }));
-            } catch { /* ignore */ }
-          };
-          reader.readAsText(file);
           e.target.value = '';
+          if (!file) return;
+          const json = await readModelJSONFile(file);
+          if (json) installModelFromJSON(json);
         }}
       />
       {showAddModelForm && createPortal(

--- a/src/app/src/renderer/ModelManager.tsx
+++ b/src/app/src/renderer/ModelManager.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { Boxes, Brain, ChevronRight, Cpu, Eye, Flame, Layers, ListOrdered, Settings, SlidersHorizontal, Sparkles, SquareCode, Store, User, Wrench, XIcon } from './components/Icons';
+import { getModelJSONName } from './utils/addModel';
 import { ModelInfo, USER_MODEL_PREFIX } from './utils/modelData';
 import { CANONICAL_PREFIXES, getModelDisplayName } from './utils/modelDisplayName';
 import { ToastContainer, useToast } from './Toast';
@@ -1805,25 +1806,22 @@ const [searchQuery, setSearchQuery] = useState('');
   };
 
   const uploadModelJSON = (json: ModelJSON) => {
-    let modelName: string;
-
     if (!json.recipe) {
       showError("Invalid model JSON. Recipe is missing");
       return;
     }
 
-    if(!json.model_name && !json.id) {
+    const modelName = getModelJSONName(json);
+    if (!modelName) {
       showError("Invalid model JSON. Either model or id must be present.");
       return;
     }
-
-    modelName = json.model_name ? json.model_name : json.id as string;
 
     if (json.checkpoint && json.checkpoints) delete json.checkpoint;
     if (json.model_name) delete json.model_name;
     if(json.id) delete json.id;
 
-    handleDownloadModel(modelName as string, json as ModelRegistrationData);
+    handleDownloadModel(modelName, json as ModelRegistrationData);
   }
 
   useEffect(() => {

--- a/src/app/src/renderer/components/RouterCollectionPanel.tsx
+++ b/src/app/src/renderer/components/RouterCollectionPanel.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
+import AddModelPanel, { ModelInstallData } from '../AddModelPanel';
 import { useModels } from '../hooks/useModels';
+import { getModelJSONName, installModelFromForm, installModelFromJSON, readModelJSONFile } from '../utils/addModel';
 import { getModelDisplayName } from '../utils/modelDisplayName';
 import { serverFetch } from '../utils/serverConfig';
 import {
@@ -540,8 +542,12 @@ const RouterCollectionPanel: React.FC<RouterCollectionPanelProps> = ({
   const [confirmLlm, setConfirmLlm] = useState(false);
   const [confirmLlmTarget, setConfirmLlmTarget] = useState<'quick' | 'rules' | null>(null);
   const [lossyAcknowledged, setLossyAcknowledged] = useState(false);
+  const [newModelMenuOpen, setNewModelMenuOpen] = useState(false);
+  const [showAddModel, setShowAddModel] = useState(false);
+  const [pendingCandidate, setPendingCandidate] = useState<string | null>(null);
   const ruleSeqRef = useRef(0);
   const clfSeqRef = useRef(0);
+  const newModelFileRef = useRef<HTMLInputElement>(null);
 
   // Seed sequence counters from loaded rules/classifiers so newly generated IDs
   // never collide with existing ones (e.g. rule-1 already present on edit-open).
@@ -678,6 +684,35 @@ const RouterCollectionPanel: React.FC<RouterCollectionPanelProps> = ({
     });
     setError(null);
   };
+
+  const handleNewModelInstall = (data: ModelInstallData) => {
+    setShowAddModel(false);
+    setPendingCandidate(installModelFromForm(data));
+  };
+
+  const handleNewModelFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    e.target.value = '';
+    if (!file) return;
+    const json = await readModelJSONFile(file);
+    if (!json) { showError('That file is not valid JSON.'); return; }
+    installModelFromJSON(json);
+    setPendingCandidate(getModelJSONName(json));
+  };
+
+  // A model registered from this panel only becomes selectable once the server
+  // reports it, one `modelsUpdated` refresh after the pull finishes - so hold
+  // the id and adopt it when it appears.
+  useEffect(() => {
+    if (!pendingCandidate) return;
+    if (candidateOptions.some(o => o.id === pendingCandidate)) {
+      if (!draft.candidates.includes(pendingCandidate)) toggleCandidate(pendingCandidate);
+      setPendingCandidate(null);
+    } else if (modelsData[pendingCandidate]) {
+      showWarning(`"${displayName(pendingCandidate)}" was added, but it cannot answer chat requests, so it was not added as a candidate.`);
+      setPendingCandidate(null);
+    }
+  }, [pendingCandidate, candidateOptions, modelsData, draft.candidates]);
 
   const addClassifier = () => {
     const id = nextClassifierId();
@@ -824,12 +859,34 @@ const RouterCollectionPanel: React.FC<RouterCollectionPanelProps> = ({
         </div>
 
         <div className="form-section">
-          <label className="form-label">
-            Candidate Models *
-            <span className="settings-description" style={{ marginLeft: 6 }}>- the LLMs that can answer requests</span>
-          </label>
+          <div className="router-candidates-header">
+            <label className="form-label">
+              Candidate Models *
+              <span className="settings-description" style={{ marginLeft: 6 }}>- the LLMs that can answer requests</span>
+            </label>
+            <div className="router-new-model-wrap">
+              <button type="button" className="router-new-model-btn" onClick={() => setNewModelMenuOpen(v => !v)}>
+                + New Model
+              </button>
+              {newModelMenuOpen && (
+                <>
+                  <div className="router-new-model-backdrop" onClick={() => setNewModelMenuOpen(false)} />
+                  <div className="router-new-model-menu">
+                    <button type="button" className="router-new-model-item"
+                      onClick={() => { setNewModelMenuOpen(false); setShowAddModel(true); }}>
+                      Manually
+                    </button>
+                    <button type="button" className="router-new-model-item"
+                      onClick={() => { setNewModelMenuOpen(false); newModelFileRef.current?.click(); }}>
+                      From JSON
+                    </button>
+                  </div>
+                </>
+              )}
+            </div>
+          </div>
           {candidateOptions.length === 0 ? (
-            <div className="collection-role-empty">No compatible models found. Pull or register LLM models first.</div>
+            <div className="collection-role-empty">No compatible models found. Pull an LLM, or register one with + New Model.</div>
           ) : (
             <>
               <ModelCheckboxList
@@ -848,6 +905,11 @@ const RouterCollectionPanel: React.FC<RouterCollectionPanelProps> = ({
                 </span>
               )}
             </>
+          )}
+          {pendingCandidate && (
+            <span className="settings-description" style={{ display: 'block', marginTop: 4 }}>
+              Adding "{displayName(pendingCandidate)}" - it joins the candidate list once the server has registered it.
+            </span>
           )}
         </div>
 
@@ -1120,6 +1182,23 @@ const RouterCollectionPanel: React.FC<RouterCollectionPanelProps> = ({
           </div>
           <pre className="router-json-preview-body">{previewJson}</pre>
         </div>
+      )}
+
+      <input
+        ref={newModelFileRef}
+        type="file"
+        accept=".json,application/json"
+        className="collection-import-input"
+        onChange={handleNewModelFile}
+      />
+
+      {showAddModel && createPortal(
+        <div className="settings-overlay" onMouseDown={(e: React.MouseEvent<HTMLDivElement>) => { if (e.target === e.currentTarget) setShowAddModel(false); }}>
+          <div className="settings-modal" onMouseDown={(e: React.MouseEvent) => e.stopPropagation()}>
+            <AddModelPanel onClose={() => setShowAddModel(false)} onInstall={handleNewModelInstall} />
+          </div>
+        </div>,
+        document.body,
       )}
 
       {error && <div className="router-panel-error">{error}</div>}

--- a/src/app/src/renderer/utils/addModel.ts
+++ b/src/app/src/renderer/utils/addModel.ts
@@ -1,0 +1,59 @@
+import type { ModelInstallData } from '../AddModelPanel';
+import { USER_MODEL_PREFIX } from './modelData';
+
+/**
+ * Register a model from the Add Model form and return the id it will be
+ * registered under. The Model Manager owns the install, so the caller only
+ * needs the id to follow the model once the server reports it.
+ */
+export const installModelFromForm = (data: ModelInstallData): string => {
+  // The server only accepts registrations in the `user.` namespace.
+  const modelName = data.name.startsWith(USER_MODEL_PREFIX) ? data.name : `${USER_MODEL_PREFIX}${data.name}`;
+  window.dispatchEvent(new CustomEvent('installModel', {
+    detail: {
+      name: modelName,
+      registrationData: {
+        checkpoint: data.checkpoint,
+        checkpoints: data.checkpoints,
+        recipe: data.recipe,
+        // Omitted on "Automatic" so lemond applies its default_model_source.
+        ...(data.source ? { source: data.source } : {}),
+        mmproj: data.mmproj,
+        labels: data.labels,
+        reasoning: data.reasoning,
+        vision: data.vision,
+        embedding: data.embedding,
+        reranking: data.reranking,
+      },
+    },
+  }));
+  return modelName;
+};
+
+export const installModelFromJSON = (json: unknown): void => {
+  window.dispatchEvent(new CustomEvent('installModelFromJSON', { detail: json }));
+};
+
+/** The id a model JSON file registers under, or null when the file names none. */
+export const getModelJSONName = (json: unknown): string | null => {
+  if (!json || typeof json !== 'object' || Array.isArray(json)) return null;
+  const record = json as Record<string, unknown>;
+  if (typeof record.model_name === 'string' && record.model_name) return record.model_name;
+  if (typeof record.id === 'string' && record.id) return record.id;
+  return null;
+};
+
+/** Resolves to null on unreadable or malformed JSON. */
+export const readModelJSONFile = (file: File): Promise<unknown | null> =>
+  new Promise(resolve => {
+    const reader = new FileReader();
+    reader.onload = ev => {
+      try {
+        resolve(JSON.parse(ev.target?.result as string));
+      } catch {
+        resolve(null);
+      }
+    };
+    reader.onerror = () => resolve(null);
+    reader.readAsText(file);
+  });

--- a/src/app/styles/collection.css
+++ b/src/app/styles/collection.css
@@ -274,6 +274,73 @@
     background: var(--bg-secondary);
 }
 
+.router-candidates-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+}
+
+.router-new-model-wrap {
+    position: relative;
+    flex-shrink: 0;
+}
+
+.router-new-model-btn {
+    font-size: 0.68rem;
+    padding: 2px 7px;
+    border: 1px dashed var(--border-primary);
+    border-radius: 5px;
+    background: transparent;
+    color: var(--text-tertiary);
+    cursor: pointer;
+    white-space: nowrap;
+    transition: border-color 0.1s, color 0.1s;
+}
+
+.router-new-model-btn:hover {
+    border-color: #60a5fa;
+    color: #60a5fa;
+}
+
+/* Above the surrounding modal (z-index 10000) so the first click anywhere
+   closes the menu instead of landing on the form behind it. */
+.router-new-model-backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 10700;
+}
+
+.router-new-model-menu {
+    position: absolute;
+    top: calc(100% + 4px);
+    right: 0;
+    z-index: 10800;
+    background: var(--settings-bg, var(--bg-secondary));
+    border: 1px solid var(--border-primary);
+    border-radius: 6px;
+    padding: 4px 0;
+    min-width: 140px;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+}
+
+.router-new-model-item {
+    display: block;
+    width: 100%;
+    text-align: left;
+    padding: 5px 12px;
+    font-size: 0.75rem;
+    color: var(--text-primary);
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    transition: background 0.1s;
+}
+
+.router-new-model-item:hover {
+    background: var(--bg-alpha-1);
+}
+
 .router-candidate-row {
     display: flex;
     align-items: center;


### PR DESCRIPTION
<!--
Before submitting this PR, please read:
- docs/dev/contribute.md
- docs/dev/philosophy.md
- AGENTS.md if you used an AI coding agent or AI-assisted workflow
- docs/dev/documentation.md if this PR changes user-facing or developer-facing documentation
-->

## Summary

<!--
What does this PR change? Keep it short and specific.
For bug fixes, link the related issue and/or include exact reproduction steps.
For new features, explain how the feature works and what use case it supports.
-->
Adds a "+ New Model" button to the Candidate Models section of the Router Builder,
opening the same two entry points as the File menu — a manual form (`AddModelPanel`)
or a JSON import. The newly registered model is selected as a router candidate
automatically once the server reports it, so adding a candidate no longer means
leaving the Router Builder and losing the in-progress router.

The panel renders its own `AddModelPanel` portal instead of dispatching `openAddModel`,
because `ChatWindow` (which owns that listener) unmounts when the chat pane is hidden.
ChatWindow's inline install logic moved to `utils/addModel.ts` so both entry points
register models through one code path.

Fixes #2654<!-- issue number -->

## Scope

- [X] This PR addresses one clear issue or change.
- [X] I reviewed the full diff myself before submitting.
- [X] I removed unrelated local changes.
- [X] I kept refactoring separate unless it is required for this change.

## Testing

- [ ] Code builds without errors locally.
- [ ] I tested this change locally.
- [X] I described the testing performed below.

<!-- Describe what you tested, commands run, and results -->
_Testing details:_

- Router Builder > Candidate Models > **+ New Model** > **Manually**: register a
  llama.cpp model; it is checked as a candidate once the pull completes.
- **+ New Model** > **From JSON**: import a model JSON exported from the Model
  Manager; same result.
- Register a non-chat model (e.g. an embedding model) from the button: a warning
  toast explains it cannot route chat requests and it is not added as a candidate.
- Empty state (no compatible models registered): the button is reachable and the
  message points at it.
- Existing File > New Model paths (Manually and From JSON) still register models
  unchanged.

## Documentation

<!-- Select ONE of the following -->

- [X] Documentation is not affected by this change.
- [ ] Documentation is affected and has been updated.
- [ ] Documentation is affected but will be handled in a separate PR or issue.

## Breaking Changes

- [ ] This PR introduces breaking changes.
- [X] This PR does not introduce breaking changes.

<!-- If breaking changes, describe them and migration path -->

## AI-assisted contribution

Please select one:

- [X] I used AI tools for this PR.
- [ ] I did not use AI tools for this PR.

If AI tools were used:

<!-- Only complete this section if you checked "I used AI tools for this PR" above -->

- [X] I verified that I understand the changes.
- [X] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.
