### PR TITLE
fix(server): streaming stall bound follows global_timeout (fixes #3386)

### DIFF
--- a/src/cpp/include/lemon/utils/http_client.h
+++ b/src/cpp/include/lemon/utils/http_client.h
@@ -156,8 +156,7 @@ public:
     //
     // timeout_seconds=0 uses default_timeout_seconds_. A total timeout would
     // cut off a long but healthy generation, so this bounds upstream silence
-    // instead: the transfer is aborted only after kStreamStallSeconds with no
-    // progress, which a streaming response cannot legitimately exceed.
+    // instead: aborted after the configured default timeout with no progress.
     static HttpResponse post_stream(
         const std::string& url,
         const std::string& body,

--- a/src/cpp/server/utils/http_client.cpp
+++ b/src/cpp/server/utils/http_client.cpp
@@ -39,10 +39,6 @@ namespace {
 // full request timeout.
 constexpr long kConnectTimeoutSeconds = 30;
 
-// How long a stream may deliver nothing before it is treated as dead. Well
-// above any inter-token gap, well below "never".
-constexpr long kStreamStallSeconds = 120;
-
 // Resolves the 0-means-default convention shared by every request method.
 // Without this, curl reads 0 as "no timeout" and a silent upstream parks the
 // calling httplib worker permanently.
@@ -775,10 +771,14 @@ HttpResponse HttpClient::post_stream(const std::string& url,
         throw std::runtime_error("Failed to apply HTTP security policy");
     }
     // A total timeout would kill a long but healthy generation, so an
-    // unqualified request is bounded by upstream silence instead of duration.
+    // unqualified request is bounded by upstream silence instead of duration,
+    // using the same window as the configured default timeout.
     if (timeout_seconds == 0) {
-        curl_easy_setopt(curl, CURLOPT_LOW_SPEED_LIMIT, 1L);
-        curl_easy_setopt(curl, CURLOPT_LOW_SPEED_TIME, kStreamStallSeconds);
+        const long stall_seconds = HttpClient::get_default_timeout();
+        if (stall_seconds > 0) {
+            curl_easy_setopt(curl, CURLOPT_LOW_SPEED_LIMIT, 1L);
+            curl_easy_setopt(curl, CURLOPT_LOW_SPEED_TIME, stall_seconds);
+        }
     } else {
         curl_easy_setopt(curl, CURLOPT_TIMEOUT, effective_timeout(timeout_seconds));
     }

--- a/test/cpp/test_http_client_timeout.cpp
+++ b/test/cpp/test_http_client_timeout.cpp
@@ -153,6 +153,21 @@ int main() {
                 "post_stream: explicit timeout abandons a silent upstream");
     }
 
+    // timeout_seconds=0 bounds silence with the configured default timeout.
+    {
+        const long saved = HttpClient::get_default_timeout();
+        HttpClient::set_default_timeout(2);
+        const bool returned = returns_within_ceiling([&] {
+            HttpClient::post_stream(
+                base + "/silent", "{}",
+                [](const char*, size_t) { return true; },
+                {}, 0, nullptr, policy);
+        });
+        HttpClient::set_default_timeout(saved);
+        r.check(returned,
+                "post_stream: timeout 0 bounds silence with the default timeout");
+    }
+
     // The sentinel is the only way to ask for an unbounded transfer, so it must
     // not be confused with 0.
     r.check(HttpClient::kNoTimeout != 0,


### PR DESCRIPTION
## Summary

The 120s hard-coded low-speed stall in `HttpClient::post_stream()` terminates healthy long generations: on large models (e.g. Qwen3.8-27B) prefill/reasoning can legitimately emit no SSE bytes for longer than 120s, so libcurl aborts with `CURL error: Timeout was reached` even while the backend is working. This regressed in v11.8.0 (#1860 removed the old default timeout, #3223 added the tighter silence bound); several users reported it and some reverted to 11.7 (#3386, #3415).

Per review feedback, the stall bound now follows the existing `global_timeout` instead of a hard-coded 120s:

- `post_stream(timeout=0)` bounds upstream silence with the configured default timeout (`global_timeout`, 600s default) instead of the old hard-coded 120s; no new configuration key.
- Live `global_timeout` updates already re-derive the bound through the existing `HttpClient::set_default_timeout` path.
- Test: `post_stream(0)` abandons a silent upstream within the configured default-timeout window.

Fixes #3386

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_ Full `lemonade-server-core` builds clean; `test_http_client_timeout` passes 6/6 (new check: `post_stream(timeout=0)` bounds silence with the configured default timeout); full `ctest -L cpp-ci` suite passes 68/68.

## Documentation

- [x] Documentation is not affected and does not require changes.

## Breaking Changes

- [x] This PR does not introduce breaking changes.

## AI-assisted contribution

Please select one:

- [x] I used AI tools for this PR.
- [ ] I did not use AI tools for this PR.

If AI tools were used:

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.
