### PR TITLE
fix(server): report backend streams that end without any SSE event

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3215,6 +3215,13 @@ if(BUILD_TESTING AND EXISTS "${_STREAMING_HEARTBEAT_TEST_SRC}")
     add_cpp_ci_test(StreamingHeartbeatTest CI ON COMMAND test_streaming_heartbeat)
 endif()
 
+set(_STREAMING_SILENT_STREAM_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_streaming_silent_stream.cpp")
+if(BUILD_TESTING AND EXISTS "${_STREAMING_SILENT_STREAM_TEST_SRC}")
+    add_executable(test_streaming_silent_stream test/cpp/test_streaming_silent_stream.cpp)
+    target_link_libraries(test_streaming_silent_stream PRIVATE lemonade-server-core)
+    add_cpp_ci_test(StreamingSilentStreamTest CI ON COMMAND test_streaming_silent_stream)
+endif()
+
 set(_CLOUD_DISCOVERY_POLICY_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_cloud_discovery_policy.cpp")
 if(BUILD_TESTING AND EXISTS "${_CLOUD_DISCOVERY_POLICY_TEST_SRC}")
     add_executable(test_cloud_discovery_policy test/cpp/test_cloud_discovery_policy.cpp)

--- a/src/cpp/include/lemon/streaming_proxy.h
+++ b/src/cpp/include/lemon/streaming_proxy.h
@@ -66,7 +66,11 @@ public:
         std::function<void()> on_chunk = nullptr
     );
 
-    static void process_sse_lines(std::string& line_buffer, std::function<void(const std::string&)> line_callback);
+    // Splits on all three SSE line terminators (LF, CRLF, CR). A trailing CR is
+    // held back until the next chunk disambiguates it from a split CRLF, so the
+    // final line of a CR-terminated stream needs end_of_stream to be dispatched.
+    static void process_sse_lines(std::string& line_buffer, std::function<void(const std::string&)> line_callback,
+                                  bool end_of_stream = false);
 
     static TelemetryData parse_telemetry(const std::string& buffer);
 

--- a/src/cpp/server/streaming_proxy.cpp
+++ b/src/cpp/server/streaming_proxy.cpp
@@ -135,7 +135,10 @@ void StreamingProxy::forward_sse_stream(
         }
 
         std::string json_str;
-        if (line.find("data:") == 0) {
+        if (line == "data") {
+            // A field name with no colon carries an empty value in SSE.
+            has_pending_data_field = true;
+        } else if (line.find("data:") == 0) {
             json_str = line.substr(5);
             // The single space after the colon is optional in SSE.
             if (!json_str.empty() && json_str.front() == ' ') {
@@ -218,6 +221,10 @@ void StreamingProxy::forward_sse_stream(
             return false;
         }
     );
+
+    // A CR held back as a possible split CRLF terminates its line once no more
+    // bytes can arrive, so the last event of a CR-terminated stream still counts.
+    process_sse_lines(line_buffer, process_line, true);
 
     const bool client_disconnected =
         result.curl_code == CURLE_WRITE_ERROR ||
@@ -492,14 +499,25 @@ StreamingProxy::TelemetryData StreamingProxy::parse_telemetry(const std::string&
     return telemetry;
 }
 
-void StreamingProxy::process_sse_lines(std::string& line_buffer, std::function<void(const std::string&)> line_callback) {
+void StreamingProxy::process_sse_lines(std::string& line_buffer, std::function<void(const std::string&)> line_callback,
+                                       bool end_of_stream) {
     size_t pos;
-    while ((pos = line_buffer.find('\n')) != std::string::npos) {
-        std::string line = line_buffer.substr(0, pos);
-        line_buffer.erase(0, pos + 1);
-        if (!line.empty() && line.back() == '\r') {
-            line.pop_back();
+    while ((pos = line_buffer.find_first_of("\r\n")) != std::string::npos) {
+        size_t terminator_length = 1;
+        if (line_buffer[pos] == '\r') {
+            if (pos + 1 == line_buffer.size()) {
+                // The LF of a CRLF split across chunks may still be in flight,
+                // and consuming the CR now would invent a blank line that
+                // terminates the event early.
+                if (!end_of_stream) {
+                    return;
+                }
+            } else if (line_buffer[pos + 1] == '\n') {
+                terminator_length = 2;
+            }
         }
+        std::string line = line_buffer.substr(0, pos);
+        line_buffer.erase(0, pos + terminator_length);
         line_callback(line);
     }
 }

--- a/src/cpp/server/streaming_proxy.cpp
+++ b/src/cpp/server/streaming_proxy.cpp
@@ -120,12 +120,19 @@ void StreamingProxy::forward_sse_stream(
     std::string error_body;
     static constexpr size_t max_error_body = 64 * 1024;
 
-    auto process_line = [&telemetry](const std::string& line) {
+    // Chunk boundaries are arbitrary, so whether the stream carried any event
+    // at all is decided per reassembled line rather than per received chunk.
+    bool has_data_event = false;
+
+    auto process_line = [&telemetry, &has_data_event](const std::string& line) {
         std::string json_str;
         if (line.find("data: ") == 0) {
             json_str = line.substr(6);
         } else if (line.find("ChatCompletionChunk: ") == 0) {
             json_str = line.substr(21);
+        }
+        if (!json_str.empty()) {
+            has_data_event = true;
         }
         if (!json_str.empty() && json_str != "[DONE]") {
             try {
@@ -261,6 +268,23 @@ void StreamingProxy::forward_sse_stream(
             // adapters downstream would have to guess one.
             payload["error"]["status_code"] = status;
         }
+        const std::string event = "data: " + payload.dump() + "\n\n";
+        sink.write(event.data(), event.size());
+    }
+
+    // A backend that closed a 200 event-stream without ever emitting a data
+    // event produced no response at all. Synthesizing [DONE] below would report
+    // that failure to the client as an empty but successful completion.
+    if (!stream_error && !has_data_event) {
+        static constexpr const char* empty_stream_message =
+            "Backend closed the stream without producing a response";
+        LOG(ERROR, "StreamingProxy") << empty_stream_message << std::endl;
+        telemetry.error_message = empty_stream_message;
+        stream_error = true;
+
+        const json payload{{"error", {{"message", empty_stream_message},
+                                      {"type", "backend_error"},
+                                      {"status_code", 502}}}};
         const std::string event = "data: " + payload.dump() + "\n\n";
         sink.write(event.data(), event.size());
     }

--- a/src/cpp/server/streaming_proxy.cpp
+++ b/src/cpp/server/streaming_proxy.cpp
@@ -121,17 +121,30 @@ void StreamingProxy::forward_sse_stream(
     static constexpr size_t max_error_body = 64 * 1024;
 
     // Chunk boundaries are arbitrary, so whether the stream carried any event
-    // at all is decided per reassembled line rather than per received chunk.
+    // at all is decided per reassembled line rather than per received chunk. An
+    // event only counts once its blank-line terminator arrives: a data field cut
+    // off before that is discarded by the client, so it delivered nothing.
     bool has_data_event = false;
+    bool has_pending_data_field = false;
 
-    auto process_line = [&telemetry, &has_data_event](const std::string& line) {
+    auto process_line = [&telemetry, &has_data_event, &has_pending_data_field](const std::string& line) {
+        if (line.empty()) {
+            has_data_event = has_data_event || has_pending_data_field;
+            has_pending_data_field = false;
+            return;
+        }
+
         std::string json_str;
-        if (line.find("data: ") == 0) {
-            json_str = line.substr(6);
+        if (line.find("data:") == 0) {
+            json_str = line.substr(5);
+            // The single space after the colon is optional in SSE.
+            if (!json_str.empty() && json_str.front() == ' ') {
+                json_str.erase(0, 1);
+            }
+            has_pending_data_field = true;
         } else if (line.find("ChatCompletionChunk: ") == 0) {
             json_str = line.substr(21);
-        }
-        if (!json_str.empty()) {
+            // Not SSE, so there is no blank-line terminator to wait for.
             has_data_event = true;
         }
         if (!json_str.empty() && json_str != "[DONE]") {

--- a/src/cpp/server/streaming_proxy.cpp
+++ b/src/cpp/server/streaming_proxy.cpp
@@ -4,6 +4,7 @@
 #include <chrono>
 #include <cstring>
 #include <stdexcept>
+#include <string_view>
 #include <curl/curl.h>
 #include <lemon/utils/aixlog.hpp>
 
@@ -77,6 +78,26 @@ void extract_telemetry_from_chunk(const nlohmann::json& chunk, StreamingProxy::T
     }
 }
 
+struct Field {
+    std::string_view name;
+    std::string_view value;
+};
+
+// Everything before the first colon names the field and the rest is its value,
+// minus the optional single space that may follow the colon. A line with no
+// colon is a field name carrying an empty value.
+Field parse_field(std::string_view line) {
+    const auto colon = line.find(':');
+    if (colon == std::string_view::npos) {
+        return {line, {}};
+    }
+    std::string_view value = line.substr(colon + 1);
+    if (!value.empty() && value.front() == ' ') {
+        value.remove_prefix(1);
+    }
+    return {line.substr(0, colon), value};
+}
+
 std::string lower_copy(std::string s) {
     std::transform(s.begin(), s.end(), s.begin(),
                    [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
@@ -134,25 +155,24 @@ void StreamingProxy::forward_sse_stream(
             return;
         }
 
-        std::string json_str;
-        if (line == "data") {
-            // A field name with no colon carries an empty value in SSE.
+        if (line.front() == ':') {
+            // SSE comment, such as the heartbeat.
+            return;
+        }
+
+        const Field field = parse_field(line);
+        if (field.name == "data") {
             has_pending_data_field = true;
-        } else if (line.find("data:") == 0) {
-            json_str = line.substr(5);
-            // The single space after the colon is optional in SSE.
-            if (!json_str.empty() && json_str.front() == ' ') {
-                json_str.erase(0, 1);
-            }
-            has_pending_data_field = true;
-        } else if (line.find("ChatCompletionChunk: ") == 0) {
-            json_str = line.substr(21);
+        } else if (field.name == "ChatCompletionChunk") {
             // Not SSE, so there is no blank-line terminator to wait for.
             has_data_event = true;
+        } else {
+            return;
         }
-        if (!json_str.empty() && json_str != "[DONE]") {
+
+        if (!field.value.empty() && field.value != "[DONE]") {
             try {
-                auto chunk = json::parse(json_str);
+                auto chunk = json::parse(field.value.begin(), field.value.end());
                 extract_telemetry_from_chunk(chunk, telemetry);
             } catch (...) {}
         }
@@ -324,9 +344,8 @@ void StreamingProxy::forward_sse_stream(
         LOG(INFO, "Server") << "Streaming completed - 200 OK" << std::endl;
 
         if (!line_buffer.empty()) {
-            if (line_buffer.back() == '\r') {
-                line_buffer.pop_back();
-            }
+            // Whatever is left is an unterminated final line: the end-of-stream
+            // pass above already consumed every CR and LF.
             process_line(line_buffer);
         }
 
@@ -467,16 +486,14 @@ StreamingProxy::TelemetryData StreamingProxy::parse_telemetry(const std::string&
     json last_chunk_with_usage;
 
     while (std::getline(stream, line)) {
-        std::string json_str;
-        if (line.find("data: ") == 0) {
-            json_str = line.substr(6);
-        } else if (line.find("ChatCompletionChunk: ") == 0) {
-            json_str = line.substr(21);
+        const Field field = parse_field(line);
+        if (field.name != "data" && field.name != "ChatCompletionChunk") {
+            continue;
         }
 
-        if (!json_str.empty() && json_str != "[DONE]") {
+        if (!field.value.empty() && field.value != "[DONE]") {
             try {
-                auto chunk = json::parse(json_str);
+                auto chunk = json::parse(field.value.begin(), field.value.end());
                 bool has_usage = chunk.contains("usage") || chunk.contains("timings");
                 if (!has_usage && chunk.contains("response") && chunk["response"].is_object()) {
                     has_usage = chunk["response"].contains("usage") || chunk["response"].contains("timings");

--- a/test/cpp/test_streaming_silent_stream.cpp
+++ b/test/cpp/test_streaming_silent_stream.cpp
@@ -122,6 +122,33 @@ static void test_stream_without_done_marker_still_completes() {
     check(result.error_message.empty(), "missing [DONE]: telemetry reports success");
 }
 
+// SSE makes the space after the colon optional, so a backend that omits it is
+// still delivering events.
+static void test_data_field_without_space_counts_as_an_event() {
+    const StreamResult result = run_proxy([](httplib::DataSink& sink) {
+        const std::string chunk = "data:{\"choices\":[{\"delta\":{\"content\":\"Hello\"}}]}\n\n";
+        sink.write(chunk.data(), chunk.size());
+    });
+
+    check(contains(result.downstream, "Hello"), "no space after colon: content is forwarded");
+    check(contains(result.downstream, "data: [DONE]"), "no space after colon: marker is synthesized");
+    check(!contains(result.downstream, "\"error\""), "no space after colon: no error event");
+    check(result.error_message.empty(), "no space after colon: telemetry reports success");
+}
+
+// A data field is only dispatched once its blank line arrives, so a stream cut
+// off before that leaves the client with nothing to show.
+static void test_unterminated_event_is_reported_as_an_error() {
+    const StreamResult result = run_proxy([](httplib::DataSink& sink) {
+        const std::string chunk = "data: {\"choices\":[{\"delta\":{\"content\":\"Hello\"}}]}\n";
+        sink.write(chunk.data(), chunk.size());
+    });
+
+    check(contains(result.downstream, "\"error\""), "unterminated event: event carries an error object");
+    check(!contains(result.downstream, "[DONE]"), "unterminated event: no [DONE] claims success");
+    check(!result.error_message.empty(), "unterminated event: telemetry records the failure");
+}
+
 static void test_complete_stream_is_unchanged() {
     const StreamResult result = run_proxy([](httplib::DataSink& sink) {
         const std::string chunk = "data: {\"choices\":[{\"delta\":{\"content\":\"Hello\"}}]}\n\n";
@@ -139,6 +166,8 @@ int main() {
     test_empty_stream_is_reported_as_an_error();
     test_unframed_backend_output_is_reported_as_an_error();
     test_stream_without_done_marker_still_completes();
+    test_data_field_without_space_counts_as_an_event();
+    test_unterminated_event_is_reported_as_an_error();
     test_complete_stream_is_unchanged();
 
     if (g_failures == 0) {

--- a/test/cpp/test_streaming_silent_stream.cpp
+++ b/test/cpp/test_streaming_silent_stream.cpp
@@ -1,0 +1,150 @@
+#include <cstdio>
+#include <functional>
+#include <string>
+#include <thread>
+
+#include <httplib.h>
+#include <lemon/streaming_proxy.h>
+
+static int g_failures = 0;
+
+static void check(bool condition, const char* name) {
+    if (condition) {
+        std::printf("[PASS] %s\n", name);
+    } else {
+        std::printf("[FAIL] %s\n", name);
+        ++g_failures;
+    }
+}
+
+namespace {
+
+struct StreamResult {
+    std::string downstream;
+    std::string error_message;
+    bool done_called = false;
+};
+
+// Runs one SSE proxy request against a mock backend whose response body is
+// produced by backend_body, and reports what reached the client.
+StreamResult run_proxy(const std::function<void(httplib::DataSink&)>& backend_body) {
+    httplib::Server backend;
+    backend.Post("/v1/chat/completions",
+        [&](const httplib::Request&, httplib::Response& res) {
+            res.set_chunked_content_provider(
+                "text/event-stream",
+                [&](size_t, httplib::DataSink& sink) {
+                    backend_body(sink);
+                    sink.done();
+                    return false;
+                });
+        });
+
+    StreamResult result;
+
+    const int port = backend.bind_to_any_port("127.0.0.1");
+    if (port <= 0) {
+        std::printf("[FAIL] failed to bind mock backend\n");
+        ++g_failures;
+        return result;
+    }
+
+    std::thread backend_thread([&backend]() { backend.listen_after_bind(); });
+    backend.wait_until_ready();
+
+    httplib::DataSink downstream;
+    downstream.write = [&result](const char* data, size_t len) {
+        result.downstream.append(data, len);
+        return true;
+    };
+    downstream.done = [&result]() { result.done_called = true; };
+    downstream.is_writable = []() { return true; };
+
+    lemon::StreamingProxy::forward_sse_stream(
+        "http://127.0.0.1:" + std::to_string(port) + "/v1/chat/completions",
+        R"({"model":"test-model","stream":true})",
+        downstream,
+        [&result](const lemon::StreamingProxy::TelemetryData& telemetry) {
+            result.error_message = telemetry.error_message;
+        },
+        10,
+        nullptr,
+        0
+    );
+
+    backend.stop();
+    backend_thread.join();
+    return result;
+}
+
+bool contains(const std::string& haystack, const std::string& needle) {
+    return haystack.find(needle) != std::string::npos;
+}
+
+}  // namespace
+
+// A backend that answers 200 text/event-stream and then closes without emitting
+// a single event has failed the request, even though the transport was clean.
+static void test_empty_stream_is_reported_as_an_error() {
+    const StreamResult result = run_proxy([](httplib::DataSink&) {});
+
+    check(contains(result.downstream, "data: {"), "empty stream: client receives a framed data event");
+    check(contains(result.downstream, "\"error\""), "empty stream: event carries an error object");
+    check(!contains(result.downstream, "[DONE]"), "empty stream: no [DONE] claims success");
+    check(!result.error_message.empty(), "empty stream: telemetry records the failure");
+    check(result.done_called, "empty stream: response is terminated");
+}
+
+// Backends log their own failures into the already-committed 200 stream. Those
+// bytes are not SSE, so the client still needs a framed error event.
+static void test_unframed_backend_output_is_reported_as_an_error() {
+    const StreamResult result = run_proxy([](httplib::DataSink& sink) {
+        const std::string noise = "backend: model arena alloc failed: out of memory\n";
+        sink.write(noise.data(), noise.size());
+    });
+
+    check(contains(result.downstream, "\"error\""), "unframed output: event carries an error object");
+    check(!contains(result.downstream, "[DONE]"), "unframed output: no [DONE] claims success");
+    check(!result.error_message.empty(), "unframed output: telemetry records the failure");
+}
+
+// A backend that streamed content but omitted [DONE] served a real response, so
+// the marker is still synthesized rather than turned into an error.
+static void test_stream_without_done_marker_still_completes() {
+    const StreamResult result = run_proxy([](httplib::DataSink& sink) {
+        const std::string chunk = "data: {\"choices\":[{\"delta\":{\"content\":\"Hello\"}}]}\n\n";
+        sink.write(chunk.data(), chunk.size());
+    });
+
+    check(contains(result.downstream, "Hello"), "missing [DONE]: content is forwarded");
+    check(contains(result.downstream, "data: [DONE]"), "missing [DONE]: marker is synthesized");
+    check(!contains(result.downstream, "\"error\""), "missing [DONE]: no error event");
+    check(result.error_message.empty(), "missing [DONE]: telemetry reports success");
+}
+
+static void test_complete_stream_is_unchanged() {
+    const StreamResult result = run_proxy([](httplib::DataSink& sink) {
+        const std::string chunk = "data: {\"choices\":[{\"delta\":{\"content\":\"Hello\"}}]}\n\n";
+        sink.write(chunk.data(), chunk.size());
+        const std::string done = "data: [DONE]\n\n";
+        sink.write(done.data(), done.size());
+    });
+
+    check(contains(result.downstream, "Hello"), "complete stream: content is forwarded");
+    check(!contains(result.downstream, "\"error\""), "complete stream: no error event");
+    check(result.error_message.empty(), "complete stream: telemetry reports success");
+}
+
+int main() {
+    test_empty_stream_is_reported_as_an_error();
+    test_unframed_backend_output_is_reported_as_an_error();
+    test_stream_without_done_marker_still_completes();
+    test_complete_stream_is_unchanged();
+
+    if (g_failures == 0) {
+        std::printf("All silent stream tests passed.\n");
+        return 0;
+    }
+    std::printf("%d silent stream test(s) failed.\n", g_failures);
+    return 1;
+}

--- a/test/cpp/test_streaming_silent_stream.cpp
+++ b/test/cpp/test_streaming_silent_stream.cpp
@@ -2,6 +2,7 @@
 #include <functional>
 #include <string>
 #include <thread>
+#include <vector>
 
 #include <httplib.h>
 #include <lemon/streaming_proxy.h>
@@ -149,6 +150,56 @@ static void test_unterminated_event_is_reported_as_an_error() {
     check(!result.error_message.empty(), "unterminated event: telemetry records the failure");
 }
 
+// SSE terminates lines with LF, CRLF or a bare CR, so a stream that uses CR
+// carries real events and must not be classified as empty.
+static void test_cr_terminated_stream_counts_as_an_event() {
+    const StreamResult result = run_proxy([](httplib::DataSink& sink) {
+        const std::string chunk = "data: {\"choices\":[{\"delta\":{\"content\":\"Hello\"}}]}\r\r";
+        sink.write(chunk.data(), chunk.size());
+    });
+
+    check(contains(result.downstream, "Hello"), "CR terminators: content is forwarded");
+    check(contains(result.downstream, "data: [DONE]"), "CR terminators: marker is synthesized");
+    check(!contains(result.downstream, "\"error\""), "CR terminators: no error event");
+    check(result.error_message.empty(), "CR terminators: telemetry reports success");
+}
+
+// A field name with no colon is an empty-valued field, so "data" alone still
+// completes an event.
+static void test_data_field_without_colon_counts_as_an_event() {
+    const StreamResult result = run_proxy([](httplib::DataSink& sink) {
+        const std::string chunk = "data\n\n";
+        sink.write(chunk.data(), chunk.size());
+    });
+
+    check(contains(result.downstream, "data: [DONE]"), "bare data field: marker is synthesized");
+    check(!contains(result.downstream, "\"error\""), "bare data field: no error event");
+    check(result.error_message.empty(), "bare data field: telemetry reports success");
+}
+
+// Chunk boundaries are arbitrary, so a CRLF may be split between two reads. The
+// parser has to wait for the LF instead of reporting an extra blank line, which
+// would terminate the event before its data field arrived.
+static void test_line_parser_handles_every_terminator() {
+    std::vector<std::string> lines;
+    auto collect = [&lines](const std::string& line) { lines.push_back(line); };
+
+    std::string buffer = "lf\ncrlf\r\ncr\rsplit\r";
+    lemon::StreamingProxy::process_sse_lines(buffer, collect);
+    check(lines == std::vector<std::string>({"lf", "crlf", "cr"}),
+          "line parser: LF, CRLF and CR each end a line");
+    check(buffer == "split\r", "line parser: a trailing CR is held for its possible LF");
+
+    buffer += "\nlast\r";
+    lemon::StreamingProxy::process_sse_lines(buffer, collect);
+    check(lines == std::vector<std::string>({"lf", "crlf", "cr", "split"}),
+          "line parser: a CRLF split across chunks is one terminator");
+
+    lemon::StreamingProxy::process_sse_lines(buffer, collect, true);
+    check(lines == std::vector<std::string>({"lf", "crlf", "cr", "split", "last"}),
+          "line parser: end of stream releases the held CR");
+}
+
 static void test_complete_stream_is_unchanged() {
     const StreamResult result = run_proxy([](httplib::DataSink& sink) {
         const std::string chunk = "data: {\"choices\":[{\"delta\":{\"content\":\"Hello\"}}]}\n\n";
@@ -168,6 +219,9 @@ int main() {
     test_stream_without_done_marker_still_completes();
     test_data_field_without_space_counts_as_an_event();
     test_unterminated_event_is_reported_as_an_error();
+    test_cr_terminated_stream_counts_as_an_event();
+    test_data_field_without_colon_counts_as_an_event();
+    test_line_parser_handles_every_terminator();
     test_complete_stream_is_unchanged();
 
     if (g_failures == 0) {

--- a/test/cpp/test_streaming_silent_stream.cpp
+++ b/test/cpp/test_streaming_silent_stream.cpp
@@ -9,11 +9,11 @@
 
 static int g_failures = 0;
 
-static void check(bool condition, const char* name) {
+static void check(bool condition, const std::string& name) {
     if (condition) {
-        std::printf("[PASS] %s\n", name);
+        std::printf("[PASS] %s\n", name.c_str());
     } else {
-        std::printf("[FAIL] %s\n", name);
+        std::printf("[FAIL] %s\n", name.c_str());
         ++g_failures;
     }
 }
@@ -26,16 +26,18 @@ struct StreamResult {
     bool done_called = false;
 };
 
-// Runs one SSE proxy request against a mock backend whose response body is
-// produced by backend_body, and reports what reached the client.
-StreamResult run_proxy(const std::function<void(httplib::DataSink&)>& backend_body) {
+// Runs one SSE proxy request against a mock backend that answers 200
+// text/event-stream with backend_body, and reports what reached the client.
+StreamResult run_proxy(const std::string& backend_body) {
     httplib::Server backend;
     backend.Post("/v1/chat/completions",
         [&](const httplib::Request&, httplib::Response& res) {
             res.set_chunked_content_provider(
                 "text/event-stream",
                 [&](size_t, httplib::DataSink& sink) {
-                    backend_body(sink);
+                    if (!backend_body.empty()) {
+                        sink.write(backend_body.data(), backend_body.size());
+                    }
                     sink.done();
                     return false;
                 });
@@ -82,99 +84,92 @@ bool contains(const std::string& haystack, const std::string& needle) {
     return haystack.find(needle) != std::string::npos;
 }
 
+size_t count(const std::string& haystack, const std::string& needle) {
+    size_t total = 0;
+    for (size_t pos = haystack.find(needle); pos != std::string::npos;
+         pos = haystack.find(needle, pos + needle.size())) {
+        ++total;
+    }
+    return total;
+}
+
+// A stream that delivered an event is forwarded as the backend sent it and
+// terminated with [DONE], never rewritten into an error.
+void expect_accepted(const std::string& name, const std::string& backend_body,
+                     const std::string& content) {
+    const StreamResult result = run_proxy(backend_body);
+
+    if (!content.empty()) {
+        check(contains(result.downstream, content), name + ": content is forwarded");
+    }
+    check(contains(result.downstream, "data: [DONE]"), name + ": stream ends with [DONE]");
+    check(!contains(result.downstream, "\"error\""), name + ": no error event");
+    check(result.error_message.empty(), name + ": telemetry reports success");
+}
+
+// A stream that delivered nothing produced no response at all, so the client
+// gets a framed error event rather than a [DONE] reporting empty success.
+void expect_rejected(const std::string& name, const std::string& backend_body) {
+    const StreamResult result = run_proxy(backend_body);
+
+    check(contains(result.downstream, "data: {"), name + ": client receives a framed data event");
+    check(contains(result.downstream, "\"error\""), name + ": event carries an error object");
+    check(!contains(result.downstream, "[DONE]"), name + ": no [DONE] claims success");
+    check(!result.error_message.empty(), name + ": telemetry records the failure");
+    check(result.done_called, name + ": response is terminated");
+}
+
+const std::string kEvent = R"(data: {"choices":[{"delta":{"content":"Hello"}}]})";
+
 }  // namespace
 
-// A backend that answers 200 text/event-stream and then closes without emitting
-// a single event has failed the request, even though the transport was clean.
-static void test_empty_stream_is_reported_as_an_error() {
-    const StreamResult result = run_proxy([](httplib::DataSink&) {});
+static void test_delivered_events_are_forwarded() {
+    expect_accepted("LF terminators", kEvent + "\n\n", "Hello");
 
-    check(contains(result.downstream, "data: {"), "empty stream: client receives a framed data event");
-    check(contains(result.downstream, "\"error\""), "empty stream: event carries an error object");
-    check(!contains(result.downstream, "[DONE]"), "empty stream: no [DONE] claims success");
-    check(!result.error_message.empty(), "empty stream: telemetry records the failure");
-    check(result.done_called, "empty stream: response is terminated");
+    // SSE makes the space after the colon optional.
+    expect_accepted("no space after the colon",
+                    R"(data:{"choices":[{"delta":{"content":"Hello"}}]})"
+                    "\n\n",
+                    "Hello");
+
+    // SSE also ends lines with CRLF or a bare CR.
+    expect_accepted("CR terminators", kEvent + "\r\r", "Hello");
+
+    // A field name with no colon carries an empty value, so "data" alone still
+    // completes an event.
+    expect_accepted("bare data field", "data\n\n", "");
+
+    // This backend prefix is not SSE: it has no blank-line terminator, and like
+    // any field its value need not be preceded by a space.
+    expect_accepted("ChatCompletionChunk without a space",
+                    R"(ChatCompletionChunk:{"choices":[{"delta":{"content":"Hello"}}]})"
+                    "\n",
+                    "Hello");
 }
 
-// Backends log their own failures into the already-committed 200 stream. Those
-// bytes are not SSE, so the client still needs a framed error event.
-static void test_unframed_backend_output_is_reported_as_an_error() {
-    const StreamResult result = run_proxy([](httplib::DataSink& sink) {
-        const std::string noise = "backend: model arena alloc failed: out of memory\n";
-        sink.write(noise.data(), noise.size());
-    });
+static void test_streams_that_delivered_nothing_are_errors() {
+    expect_rejected("empty stream", "");
 
-    check(contains(result.downstream, "\"error\""), "unframed output: event carries an error object");
-    check(!contains(result.downstream, "[DONE]"), "unframed output: no [DONE] claims success");
-    check(!result.error_message.empty(), "unframed output: telemetry records the failure");
+    // Backends log their own failures into the already committed 200 stream.
+    // Those bytes are not SSE, so the client still needs a framed error event.
+    expect_rejected("unframed backend output", "backend: model arena alloc failed: out of memory\n");
+
+    // A data field only reaches the client once its blank line arrives, so a
+    // stream cut off before that showed nothing.
+    expect_rejected("unterminated event", kEvent + "\n");
+
+    // A comment is not an event, so the heartbeat must not pass for a response.
+    expect_rejected("comment only", ": ping\n\n");
 }
 
-// A backend that streamed content but omitted [DONE] served a real response, so
-// the marker is still synthesized rather than turned into an error.
-static void test_stream_without_done_marker_still_completes() {
-    const StreamResult result = run_proxy([](httplib::DataSink& sink) {
-        const std::string chunk = "data: {\"choices\":[{\"delta\":{\"content\":\"Hello\"}}]}\n\n";
-        sink.write(chunk.data(), chunk.size());
-    });
+// A backend that sent its own [DONE] has already terminated the stream.
+static void test_backend_done_marker_is_not_duplicated() {
+    const StreamResult result = run_proxy(kEvent + "\n\n" + "data: [DONE]\n\n");
 
-    check(contains(result.downstream, "Hello"), "missing [DONE]: content is forwarded");
-    check(contains(result.downstream, "data: [DONE]"), "missing [DONE]: marker is synthesized");
-    check(!contains(result.downstream, "\"error\""), "missing [DONE]: no error event");
-    check(result.error_message.empty(), "missing [DONE]: telemetry reports success");
-}
-
-// SSE makes the space after the colon optional, so a backend that omits it is
-// still delivering events.
-static void test_data_field_without_space_counts_as_an_event() {
-    const StreamResult result = run_proxy([](httplib::DataSink& sink) {
-        const std::string chunk = "data:{\"choices\":[{\"delta\":{\"content\":\"Hello\"}}]}\n\n";
-        sink.write(chunk.data(), chunk.size());
-    });
-
-    check(contains(result.downstream, "Hello"), "no space after colon: content is forwarded");
-    check(contains(result.downstream, "data: [DONE]"), "no space after colon: marker is synthesized");
-    check(!contains(result.downstream, "\"error\""), "no space after colon: no error event");
-    check(result.error_message.empty(), "no space after colon: telemetry reports success");
-}
-
-// A data field is only dispatched once its blank line arrives, so a stream cut
-// off before that leaves the client with nothing to show.
-static void test_unterminated_event_is_reported_as_an_error() {
-    const StreamResult result = run_proxy([](httplib::DataSink& sink) {
-        const std::string chunk = "data: {\"choices\":[{\"delta\":{\"content\":\"Hello\"}}]}\n";
-        sink.write(chunk.data(), chunk.size());
-    });
-
-    check(contains(result.downstream, "\"error\""), "unterminated event: event carries an error object");
-    check(!contains(result.downstream, "[DONE]"), "unterminated event: no [DONE] claims success");
-    check(!result.error_message.empty(), "unterminated event: telemetry records the failure");
-}
-
-// SSE terminates lines with LF, CRLF or a bare CR, so a stream that uses CR
-// carries real events and must not be classified as empty.
-static void test_cr_terminated_stream_counts_as_an_event() {
-    const StreamResult result = run_proxy([](httplib::DataSink& sink) {
-        const std::string chunk = "data: {\"choices\":[{\"delta\":{\"content\":\"Hello\"}}]}\r\r";
-        sink.write(chunk.data(), chunk.size());
-    });
-
-    check(contains(result.downstream, "Hello"), "CR terminators: content is forwarded");
-    check(contains(result.downstream, "data: [DONE]"), "CR terminators: marker is synthesized");
-    check(!contains(result.downstream, "\"error\""), "CR terminators: no error event");
-    check(result.error_message.empty(), "CR terminators: telemetry reports success");
-}
-
-// A field name with no colon is an empty-valued field, so "data" alone still
-// completes an event.
-static void test_data_field_without_colon_counts_as_an_event() {
-    const StreamResult result = run_proxy([](httplib::DataSink& sink) {
-        const std::string chunk = "data\n\n";
-        sink.write(chunk.data(), chunk.size());
-    });
-
-    check(contains(result.downstream, "data: [DONE]"), "bare data field: marker is synthesized");
-    check(!contains(result.downstream, "\"error\""), "bare data field: no error event");
-    check(result.error_message.empty(), "bare data field: telemetry reports success");
+    check(contains(result.downstream, "Hello"), "backend [DONE]: content is forwarded");
+    check(count(result.downstream, "data: [DONE]") == 1, "backend [DONE]: marker is not duplicated");
+    check(!contains(result.downstream, "\"error\""), "backend [DONE]: no error event");
+    check(result.error_message.empty(), "backend [DONE]: telemetry reports success");
 }
 
 // Chunk boundaries are arbitrary, so a CRLF may be split between two reads. The
@@ -200,29 +195,11 @@ static void test_line_parser_handles_every_terminator() {
           "line parser: end of stream releases the held CR");
 }
 
-static void test_complete_stream_is_unchanged() {
-    const StreamResult result = run_proxy([](httplib::DataSink& sink) {
-        const std::string chunk = "data: {\"choices\":[{\"delta\":{\"content\":\"Hello\"}}]}\n\n";
-        sink.write(chunk.data(), chunk.size());
-        const std::string done = "data: [DONE]\n\n";
-        sink.write(done.data(), done.size());
-    });
-
-    check(contains(result.downstream, "Hello"), "complete stream: content is forwarded");
-    check(!contains(result.downstream, "\"error\""), "complete stream: no error event");
-    check(result.error_message.empty(), "complete stream: telemetry reports success");
-}
-
 int main() {
-    test_empty_stream_is_reported_as_an_error();
-    test_unframed_backend_output_is_reported_as_an_error();
-    test_stream_without_done_marker_still_completes();
-    test_data_field_without_space_counts_as_an_event();
-    test_unterminated_event_is_reported_as_an_error();
-    test_cr_terminated_stream_counts_as_an_event();
-    test_data_field_without_colon_counts_as_an_event();
+    test_delivered_events_are_forwarded();
+    test_streams_that_delivered_nothing_are_errors();
+    test_backend_done_marker_is_not_duplicated();
     test_line_parser_handles_every_terminator();
-    test_complete_stream_is_unchanged();
 
     if (g_failures == 0) {
         std::printf("All silent stream tests passed.\n");


### PR DESCRIPTION
Reported by @pdittaro in https://github.com/lemonade-sdk/lemonade/issues/2826#issuecomment-5473886885, on `ds4:rocm`.

A backend that commits a `200 text/event-stream`, fails internally, and then closes the response *cleanly* leaves curl reporting `CURLE_OK` and status 200, so every error branch in `forward_sse_stream()` is skipped. The success branch then synthesizes `data: [DONE]` and logs `Streaming completed - 200 OK`, turning a failed generation into a well-formed empty stream a client cannot tell apart from a model with nothing to say. #2975 covered the non-200 path, and the `CURLE_PARTIAL_FILE`/`CURLE_RECV_ERROR` branch only fires when the connection is cut abnormally.

A 200 stream that never carried a single SSE data event now ends with a framed `data: {"error": ...}` event instead of the synthetic marker, and records the failure in telemetry. A stream that carried events but omitted `[DONE]` keeps today's behavior. Nothing in `forward_sse_stream()` is backend-aware, so this covers every backend, not just ds4.

`test_streaming_silent_stream.cpp` drives a mock backend through the empty stream, an unframed error body, a truncated-but-non-empty stream, and a clean stream. Without the fix its first two cases fail with exactly the log lines from the report.
