### PR TITLE
fix(ci): resolve the newest llama.cpp nightly tag instead of /releases/latest

### DIFF
--- a/.github/workflows/validate_llamacpp.yml
+++ b/.github/workflows/validate_llamacpp.yml
@@ -49,7 +49,17 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          RELEASE=$(gh api repos/ggml-org/llama.cpp/releases/latest --jq '.tag_name')
+          set -euo pipefail
+          # Upstream's semver releases (v0.3.0) are what /releases/latest now
+          # returns, and they carry no binaries -- the bNNNN nightlies hold the
+          # assets and are flagged as prereleases.
+          TAGS=$(gh api repos/ggml-org/llama.cpp/releases \
+            --jq '.[] | select(.draft | not) | .tag_name')
+          RELEASE=$(printf '%s\n' "$TAGS" | grep -m1 -E '^b[0-9]+$' || true)
+          if [ -z "$RELEASE" ]; then
+            echo "::error::No bNNNN release found in ggml-org/llama.cpp."
+            exit 1
+          fi
           echo "Latest llama.cpp release: $RELEASE"
           echo "release=$RELEASE" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary

`/releases/latest` on `ggml-org/llama.cpp` no longer returns a build tag: upstream adopted semver and flagged its `bNNNN` nightlies as prereleases, so the call returns `v0.3.0`, which carries no binaries and fails the workflow's `^b[0-9]+$` guard. This scans the release list for the newest `bNNNN` tag instead — the same value `/releases/latest` used to return — so pinning behavior is unchanged.

Fixes #3446

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_

CI-only change; no C++ affected. Verified against the live GitHub API:

- Ran the patched step body verbatim → resolved `b10723`, exit 0.
- Ran the workflow's own "Verify expected asset families" script against real asset lists for `b10723` / `b1319` / `b10711` → all six backends report assets complete, all missing counts `0`, eligible updates `vulkan,cpu,metal` + `rocm-nightly` + `rocm-stable,cuda`. The downstream `^b[0-9]+$` guards now pass.
- Workflow YAML parses; pre-commit workflow validators pass.

Workflow run against this branch: https://github.com/lemonade-sdk/lemonade/actions/runs/33417876658

## Documentation

- [x] Documentation is not affected by this change.

## Breaking Changes

- [x] This PR does not introduce breaking changes.

## AI-assisted contribution

- [x] I used AI tools for this PR.

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.
