### PR TITLE
feat(logging): report AMD GPU name and driver version at startup

### DIFF
--- a/.github/actions/install-lemonade-server-msi/action.yml
+++ b/.github/actions/install-lemonade-server-msi/action.yml
@@ -267,3 +267,28 @@ runs:
         if (Test-Path $logFile) { Get-Content $logFile -Tail 50 }
         Write-Error "Server did not start within $maxWait seconds"
         exit 1
+
+    - name: Report detected hardware
+      shell: powershell
+      run: |
+        # The AMD GPU driver version is the first thing to check when a rig
+        # starts failing inference, so surface it in the job log rather than
+        # only inside the server-log artifact.
+        $logFile = Join-Path $env:TEMP "lemonade-server.log"
+        if (-not (Test-Path $logFile)) {
+          Write-Host "::warning title=No startup log::Expected lemond's startup log at $logFile"
+          exit 0
+        }
+
+        $lines = Get-Content $logFile
+        $hit = $lines | Select-String -Pattern "Backend availability:" | Select-Object -First 1
+        if (-not $hit) {
+          Write-Host "::warning title=No hardware report::'Backend availability' not found in $logFile"
+          exit 0
+        }
+
+        Write-Host "=== Detected hardware (lemond startup) ===" -ForegroundColor Cyan
+        for ($i = $hit.LineNumber - 1; $i -lt $lines.Count; $i++) {
+          if ($i -ge $hit.LineNumber -and $lines[$i] -notmatch "\(ModelManager\)\s+- ") { break }
+          Write-Host $lines[$i]
+        }

--- a/.github/actions/install-lemonade-server-msi/action.yml
+++ b/.github/actions/install-lemonade-server-msi/action.yml
@@ -280,7 +280,7 @@ runs:
           exit 0
         }
 
-        $lines = Get-Content $logFile
+        $lines = @(Get-Content $logFile)
         $hit = $lines | Select-String -Pattern "Backend availability:" | Select-Object -First 1
         if (-not $hit) {
           Write-Host "::warning title=No hardware report::'Backend availability' not found in $logFile"

--- a/src/cpp/include/lemon/system_info.h
+++ b/src/cpp/include/lemon/system_info.h
@@ -29,6 +29,11 @@ struct GPUInfo : DeviceInfo {
     int index = -1;  // NVIDIA only: physical device index from nvidia-smi, when available
     std::string uuid;  // NVIDIA only: stable GPU UUID from nvidia-smi (preferred for CUDA_VISIBLE_DEVICES)
     std::string driver_version;
+    // AMD on Windows only: the Radeon Software release users recognize (e.g. "26.7.1")
+    // and the edition that names it (e.g. "AMD Software: Adrenalin Edition"), which are
+    // versioned separately from the WDDM driver_version above.
+    std::string software_version;
+    std::string software_edition;
     std::string compute_capability;  // NVIDIA only: "MAJOR.MINOR" from nvidia-smi (e.g. "8.6")
     double vram_gb = 0.0;
     double virtual_gb = 0.0;

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -3643,6 +3643,15 @@ std::map<std::string, ModelInfo> ModelManager::filter_models_by_backend(
             for (const auto& gpu : hardware["amd_gpu"]) {
                 if (!gpu.value("available", false)) continue;
                 std::string suffix = gpu.value("integrated", false) ? "integrated" : "discrete";
+                std::string software = gpu.value("software_version", "");
+                if (!software.empty()) {
+                    std::string edition = gpu.value("software_edition", "");
+                    const std::string edition_prefix = "AMD Software: ";
+                    if (edition.rfind(edition_prefix, 0) == 0) {
+                        edition.erase(0, edition_prefix.size());
+                    }
+                    suffix += ", " + (edition.empty() ? software : edition + " " + software);
+                }
                 std::string driver = gpu.value("driver_version", "");
                 if (!driver.empty()) suffix += ", driver " + driver;
                 LOG(INFO, "ModelManager") << "  - AMD GPU: " << gpu.value("name", "unknown")

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -3639,6 +3639,20 @@ std::map<std::string, ModelInfo> ModelManager::filter_models_by_backend(
         if (largest_mem_pool_gb > 0.0) {
             LOG(INFO, "ModelManager") << "  - Largest memory pool: " << std::fixed << std::setprecision(1) << largest_mem_pool_gb << std::endl;
         }
+        if (hardware.contains("amd_gpu") && hardware["amd_gpu"].is_array()) {
+            for (const auto& gpu : hardware["amd_gpu"]) {
+                if (!gpu.value("available", false)) continue;
+                std::string suffix = gpu.value("integrated", false) ? "integrated" : "discrete";
+                std::string driver = gpu.value("driver_version", "");
+                if (!driver.empty()) suffix += ", driver " + driver;
+                LOG(INFO, "ModelManager") << "  - AMD GPU: " << gpu.value("name", "unknown")
+                          << " (" << suffix << ")" << std::endl;
+            }
+        }
+        if (hardware.contains("amd_gpu_error")) {
+            LOG(INFO, "ModelManager") << "  - AMD GPU: detection error: "
+                      << hardware["amd_gpu_error"].get<std::string>() << std::endl;
+        }
         if (system_info.contains("devices") && system_info["devices"].contains("nvidia_gpu")) {
             const auto& nvidia_gpus = system_info["devices"]["nvidia_gpu"];
             if (nvidia_gpus.is_array()) {

--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -907,6 +907,9 @@ json SystemInfo::get_device_dict() {
             if (amd_igpu.virtual_gb > 0) {
                 gpu_json["virtual_mem_gb"] = amd_igpu.virtual_gb;
             }
+            if (!amd_igpu.driver_version.empty()) {
+                gpu_json["driver_version"] = amd_igpu.driver_version;
+            }
             gpu_json["family"] = identify_rocm_arch_from_name(amd_igpu.name);
             if (!amd_igpu.error.empty()) {
                 gpu_json["error"] = amd_igpu.error;
@@ -2798,6 +2801,9 @@ std::vector<GPUInfo> WindowsSystemInfo::detect_amd_gpus(const std::string& gpu_t
 
                 // Get driver version
                 gpu.driver_version = get_driver_version("AMD-OpenCL User Mode Driver");
+                if (gpu.driver_version.empty()) {
+                    gpu.driver_version = wmi::get_property_string(pObj, L"DriverVersion");
+                }
                 if (gpu.driver_version.empty()) {
                     gpu.driver_version = "Unknown";
                 }

--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -910,6 +910,12 @@ json SystemInfo::get_device_dict() {
             if (!amd_igpu.driver_version.empty()) {
                 gpu_json["driver_version"] = amd_igpu.driver_version;
             }
+            if (!amd_igpu.software_version.empty()) {
+                gpu_json["software_version"] = amd_igpu.software_version;
+            }
+            if (!amd_igpu.software_edition.empty()) {
+                gpu_json["software_edition"] = amd_igpu.software_edition;
+            }
             gpu_json["family"] = identify_rocm_arch_from_name(amd_igpu.name);
             if (!amd_igpu.error.empty()) {
                 gpu_json["error"] = amd_igpu.error;
@@ -933,6 +939,12 @@ json SystemInfo::get_device_dict() {
                 }
                 if (!gpu.driver_version.empty()) {
                     gpu_json["driver_version"] = gpu.driver_version;
+                }
+                if (!gpu.software_version.empty()) {
+                    gpu_json["software_version"] = gpu.software_version;
+                }
+                if (!gpu.software_edition.empty()) {
+                    gpu_json["software_edition"] = gpu.software_edition;
                 }
                 gpu_json["family"] = identify_rocm_arch_from_name(gpu.name);
                 if (!gpu.error.empty()) {
@@ -2806,6 +2818,11 @@ std::vector<GPUInfo> WindowsSystemInfo::detect_amd_gpus(const std::string& gpu_t
                 }
                 if (gpu.driver_version.empty()) {
                     gpu.driver_version = "Unknown";
+                }
+
+                gpu.software_version = wmi::get_driver_key_value_setupapi(name, L"RadeonSoftwareVersion");
+                if (!gpu.software_version.empty()) {
+                    gpu.software_edition = wmi::get_driver_key_value_setupapi(name, L"RadeonSoftwareEdition");
                 }
 
                 // Get VRAM for discrete GPUs

--- a/src/cpp/server/utils/wmi_helper.cpp
+++ b/src/cpp/server/utils/wmi_helper.cpp
@@ -248,24 +248,29 @@ uint64_t get_property_uint64(IWbemClassObject* pObj, const std::wstring& prop_na
     return result;
 }
 
-std::string get_driver_version_setupapi(const std::string& device_name_substr) {
-    // Convert search string to lowercase for case-insensitive matching
+namespace {
+
+// Walks every present device and hands the first whose friendly name (or, when
+// that is empty, its device description) contains `device_name_substr` to
+// `visit`. Matching is case-insensitive; enumeration stops when `visit` returns
+// true.
+void with_matching_device(const std::string& device_name_substr,
+                          const std::function<bool(HDEVINFO, SP_DEVINFO_DATA&)>& visit) {
     std::string needle = device_name_substr;
     std::transform(needle.begin(), needle.end(), needle.begin(), ::tolower);
 
     HDEVINFO dev_info = SetupDiGetClassDevs(NULL, NULL, NULL,
                                             DIGCF_ALLCLASSES | DIGCF_PRESENT);
     if (dev_info == INVALID_HANDLE_VALUE) {
-        return "";
+        return;
     }
 
-    std::string result;
     SP_DEVINFO_DATA dev_data = {};
     dev_data.cbSize = sizeof(SP_DEVINFO_DATA);
 
     for (DWORD i = 0; SetupDiEnumDeviceInfo(dev_info, i, &dev_data); ++i) {
-        // Get device name: prefer friendly name, fall back to device description.
-        // Always use description if friendly name is empty (common for software components).
+        // Always use the description if the friendly name is empty, which is
+        // common for software components.
         wchar_t name_buf[512] = {};
         bool got_name = SetupDiGetDeviceRegistryPropertyW(dev_info, &dev_data,
                                                           SPDRP_FRIENDLYNAME, NULL,
@@ -281,15 +286,56 @@ std::string get_driver_version_setupapi(const std::string& device_name_substr) {
             }
         }
 
-        std::string name = wstring_to_string(name_buf);
-        std::string name_lower = name;
+        std::string name_lower = wstring_to_string(name_buf);
         std::transform(name_lower.begin(), name_lower.end(), name_lower.begin(), ::tolower);
-
         if (name_lower.find(needle) == std::string::npos) {
             continue;
         }
 
-        // Found a matching device — get its driver version.
+        if (visit(dev_info, dev_data)) {
+            break;
+        }
+    }
+
+    SetupDiDestroyDeviceInfoList(dev_info);
+}
+
+std::string read_reg_string(HKEY hkey, const wchar_t* value_name) {
+    wchar_t buf[512] = {};
+    // Reserve the final element so a value that fills the buffer stays terminated.
+    DWORD size = sizeof(buf) - sizeof(wchar_t);
+    DWORD type = 0;
+    if (RegQueryValueExW(hkey, value_name, NULL, &type, (LPBYTE)buf, &size) == ERROR_SUCCESS) {
+        return wstring_to_string(buf);
+    }
+    return "";
+}
+
+// Opens HKLM\SYSTEM\CurrentControlSet\Control\Class\<SPDRP_DRIVER>, the key
+// holding the vendor's own per-adapter driver metadata. Returns NULL on failure.
+HKEY open_class_driver_key(HDEVINFO dev_info, SP_DEVINFO_DATA& dev_data) {
+    wchar_t driver_key[512] = {};
+    if (!SetupDiGetDeviceRegistryPropertyW(dev_info, &dev_data, SPDRP_DRIVER, NULL,
+                                           (PBYTE)driver_key, sizeof(driver_key), NULL)) {
+        return NULL;
+    }
+
+    std::wstring reg_path = L"SYSTEM\\CurrentControlSet\\Control\\Class\\";
+    reg_path += driver_key;
+
+    HKEY hkey = NULL;
+    if (RegOpenKeyExW(HKEY_LOCAL_MACHINE, reg_path.c_str(), 0, KEY_READ, &hkey) != ERROR_SUCCESS) {
+        return NULL;
+    }
+    return hkey;
+}
+
+} // namespace
+
+std::string get_driver_version_setupapi(const std::string& device_name_substr) {
+    std::string result;
+
+    with_matching_device(device_name_substr, [&result](HDEVINFO dev_info, SP_DEVINFO_DATA& dev_data) {
         // First try DEVPKEY_Device_DriverVersion (works for most hardware devices).
         DEVPROPTYPE prop_type = 0;
         wchar_t ver_buf[256] = {};
@@ -309,45 +355,41 @@ std::string get_driver_version_setupapi(const std::string& device_name_substr) {
                                              DICS_FLAG_GLOBAL, 0,
                                              DIREG_DEV, KEY_READ);
             if (hkey != INVALID_HANDLE_VALUE) {
-                wchar_t ver[256] = {};
-                DWORD ver_size = sizeof(ver);
-                DWORD type = 0;
-                if (RegQueryValueExW(hkey, L"DriverVersion", NULL, &type,
-                                     (LPBYTE)ver, &ver_size) == ERROR_SUCCESS) {
-                    result = wstring_to_string(ver);
-                }
+                result = read_reg_string(hkey, L"DriverVersion");
                 RegCloseKey(hkey);
             }
         }
 
-        // Second fallback: read DriverVersion from the class driver key
-        // HKLM\SYSTEM\CurrentControlSet\Control\Class\<SPDRP_DRIVER value>
+        // Second fallback: the class driver key.
         if (result.empty()) {
-            wchar_t driver_key[512] = {};
-            if (SetupDiGetDeviceRegistryPropertyW(dev_info, &dev_data,
-                                                  SPDRP_DRIVER, NULL,
-                                                  (PBYTE)driver_key, sizeof(driver_key),
-                                                  NULL)) {
-                std::wstring reg_path = L"SYSTEM\\CurrentControlSet\\Control\\Class\\";
-                reg_path += driver_key;
-                HKEY hkey = NULL;
-                if (RegOpenKeyExW(HKEY_LOCAL_MACHINE, reg_path.c_str(),
-                                  0, KEY_READ, &hkey) == ERROR_SUCCESS) {
-                    wchar_t ver[256] = {};
-                    DWORD ver_size = sizeof(ver);
-                    DWORD type = 0;
-                    if (RegQueryValueExW(hkey, L"DriverVersion", NULL, &type,
-                                        (LPBYTE)ver, &ver_size) == ERROR_SUCCESS) {
-                        result = wstring_to_string(ver);
-                    }
-                    RegCloseKey(hkey);
-                }
+            HKEY hkey = open_class_driver_key(dev_info, dev_data);
+            if (hkey) {
+                result = read_reg_string(hkey, L"DriverVersion");
+                RegCloseKey(hkey);
             }
         }
-        break;
-    }
+        return true;
+    });
 
-    SetupDiDestroyDeviceInfoList(dev_info);
+    return result;
+}
+
+std::string get_driver_key_value_setupapi(const std::string& device_name_substr,
+                                          const std::wstring& value_name) {
+    std::string result;
+
+    with_matching_device(device_name_substr, [&result, &value_name](HDEVINFO dev_info,
+                                                                    SP_DEVINFO_DATA& dev_data) {
+        HKEY hkey = open_class_driver_key(dev_info, dev_data);
+        if (hkey) {
+            result = read_reg_string(hkey, value_name.c_str());
+            RegCloseKey(hkey);
+        }
+        // Keep looking when an identically named adapter matched first but
+        // carried no value.
+        return !result.empty();
+    });
+
     return result;
 }
 

--- a/src/cpp/server/utils/wmi_helper.h
+++ b/src/cpp/server/utils/wmi_helper.h
@@ -64,6 +64,14 @@ uint64_t get_property_uint64(IWbemClassObject* pObj, const std::wstring& prop_na
 // Much faster than Win32_PnPSignedDriver WMI queries (~5-50 ms vs ~10 s).
 std::string get_driver_version_setupapi(const std::string& device_name_substr);
 
+// Reads a named value from the matched device's class driver key under
+// HKLM\SYSTEM\CurrentControlSet\Control\Class. Device matching follows the
+// same rule as get_driver_version_setupapi(). This is where AMD records the
+// Radeon Software release the user actually recognizes (RadeonSoftwareVersion,
+// e.g. "26.7.1"), as opposed to the WDDM driver version.
+std::string get_driver_key_value_setupapi(const std::string& device_name_substr,
+                                          const std::wstring& value_name);
+
 } // namespace wmi
 } // namespace lemon
 


### PR DESCRIPTION
## Summary

Logs the AMD GPU's name, Radeon Software release, and WDDM driver version at every server start, in the existing `ModelManager` backend-availability block, and echoes that block into the Windows CI job log. These are the first things worth checking when a rig starts failing inference, and today none of them are reachable without downloading the server-log artifact.

The two version numbers are unrelated and both matter: `RadeonSoftwareVersion` in the adapter's class driver key holds the release a user recognizes (`26.7.1`), while `driver_version` holds the WDDM number (`32.0.31035.1003`). Integrated AMD GPUs also never reported `driver_version` at all — the discrete branch emitted it, the integrated one dropped it — so on an APU there was nothing to print. Fixed here, along with a `Win32_VideoController.DriverVersion` fallback mirroring the NVIDIA path.

```
[Info] (ModelManager) Backend availability:
[Info] (ModelManager)   - NPU hardware: Yes
[Info] (ModelManager)   - System RAM: 64.0 GB (max model size: 51.2 GB)
[Info] (ModelManager)   - AMD GPU: AMD Radeon(TM) 8060S Graphics (integrated, Adrenalin Edition 26.7.1, driver 32.0.31035.1003)
[Info] (ModelManager)   - NVIDIA GPU: detection error: No NVIDIA discrete GPU found
```

`/system-info` gains `software_version` and `software_edition` on AMD GPU entries; `driver_version` keeps its existing meaning. The edition is read from the registry rather than hardcoded, so a PRO Edition host labels itself correctly. The SetupAPI device-enumeration loop is now shared between the driver-version and registry-value lookups instead of duplicated.

Not addressed here: on Linux the AMD GPU carries its `gfx_target_version` as its name, so the line reads
`- AMD GPU: 110501 (integrated)` there. That naming predates this PR and feeds recipe gating, so it is left alone.

Fixes #

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_

- `cmake --build --preset default --target lemond lemonade` on Linux, clean. The Windows-only code was compile-checked by CI.
- Ran `lemond` against a scratch lemonade home dir and confirmed the new line appears in the startup block. Linux populates neither version for AMD GPUs, so it correctly prints `(integrated)` with no version clause there.
- Verified end to end on eight Windows rigs via the `Test .exe - *` jobs. Every rig's reported pair matched an independent registry probe of `RadeonSoftwareVersion` / `Win32_VideoController.DriverVersion` taken beforehand, including three distinct Adrenalin releases (26.3.1, 26.7.1, 26.8.1) and two older-format ones (22.40.05.21, 24.20.10.10).

## Documentation

- [x] Documentation is not affected by this change.

## Breaking Changes

- [x] This PR does not introduce breaking changes.

## AI-assisted contribution

- [x] I used AI tools for this PR.

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011QSgagaAkHY863teRf64Hi
