### PR TITLE
RFC: Request to cleanup and harden core

### DIFF
--- a/docs/dev/core-hardening-analysis.md
+++ b/docs/dev/core-hardening-analysis.md
@@ -1,0 +1,242 @@
+# Core Hardening — Current-State Analysis
+
+This document records the current structural state of the C++ codebase as the baseline for
+the core-hardening effort (see `core-hardening-plan.md`). Every claim below was verified
+against the tree at the branch point; file:line references are from that snapshot and will
+drift as the plan lands.
+
+## 1. Executive summary
+
+The codebase has one real library (`lemonade-server-core`, an OBJECT library) and four
+executables, but the CLI and tray bypass the library and recompile server sources by
+relative path. There is no typed JSON anywhere on the API surface: ~4,000+ string-keyed
+JSON operations, zero round-tripping DTOs outside the job engine, and several live bug
+classes caused directly by that. The HTTP layer has no handler abstraction: `server.cpp`
+is an 8,277-line translation unit containing the route table, ~60 handler bodies,
+static-file serving, and a download job manager, with a ~40-line
+auto-load/validate/error-map preamble copy-pasted across 13 inference handlers. The
+Anthropic and Ollama compatibility layers are hand-written json→json translators bolted
+onto a single `OllamaApi` class, each independently reimplementing SSE parsing, error
+shaping, and response unwrapping.
+
+The good news: the backend layer already demonstrates the target architecture. The
+descriptor + registry + factory system (`backend_descriptor.h`, `backend_registry.h`),
+the capability interfaces with a compile-time `capability_mask_of<T>()`
+(`server_capabilities.h:154`), the shared `WrappedServer::forward_*` / `StreamingProxy`
+proxy layer, and the strict path-reporting parser in `routing_policy_parser.cpp` are all
+in-repo precedents for exactly the patterns the hardening generalizes.
+
+## 2. Build & target structure
+
+### 2.1 Targets today
+
+| Target | Kind | Sources |
+|---|---|---|
+| `lemonade-server-core` | OBJECT library (`CMakeLists.txt:1091`) | ~100 TUs: the 51-entry `SOURCES_CORE` list, platform sources, backend registry |
+| `lemond` | exe (`CMakeLists.txt:1096`) | only `server/main.cpp`; links server-core |
+| `lemonade` (CLI) | exe (`src/cpp/cli/CMakeLists.txt:70`) | ~24 TUs; does **not** link server-core |
+| `lemonade-tray` (macOS/Linux) | exe (`tray/CMakeLists.txt:215,236`) | ~9 TUs; no server-core |
+| `LemonadeServer` (Windows) | exe (`tray/CMakeLists.txt:174`) | tray sources + **all of server-core** (embeds the server) |
+| 82 test executables | `add_cpp_ci_test` | three linking styles, see 2.3 |
+
+### 2.2 The duplication problem
+
+There is no `src/cpp/common/`. Shared utility code lives under `src/cpp/server/utils/`
+and the CLI/tray **reach into it by relative path and recompile it**:
+
+- Compiled into 3 targets each: `path_utils.cpp`, `url_utils.cpp`, `json_utils.cpp`,
+  `platform/path_*.cpp`, `process_manager.cpp` (+ its platform files),
+  `backend_descriptor_registry.cpp`.
+- Compiled into 2: `http_client.cpp` (1,409 L), `recipe_options.cpp`,
+  `model_registry.cpp`.
+- Compiled into **12 targets**: `routing_policy.cpp` (server-core + 11 test exes).
+  `routing_policy_parser.cpp` into 5, `directory_watcher.cpp` into 3.
+- `cli/main.cpp:830–940` **reimplements** the UDP beacon listener inline even though it
+  includes `network_beacon.h` — the `.cpp` just isn't in the CLI's source list.
+
+Consequences: layering is unenforced (nothing stops a "utility" from growing a server
+dependency), incremental builds recompile the same code up to 12×, and because
+`lemonade-server-core` is an OBJECT library, the 50 tests that link it each absorb all
+~100 object files — a change to `server.cpp` relinks all 50.
+
+### 2.3 Test linking styles (all three exist)
+
+1. Link all of server-core (50 targets) — heavyweight, relink-the-world.
+2. Recompile a hand-picked subset of server sources (18 targets) — fast and isolated,
+   but the source lists are maintained by hand in the root CMakeLists.
+3. Header-only (14 targets) — the payoff of logic-in-headers units like `gguf_reader.h`
+   (481 L), `auto_tune.h` (332 L), `job_expr.h` (320 L), `origin_utils.h`,
+   `custom_args.h`.
+
+Style 2 and 3 are what a proper library split makes the default: tests link the small
+library they exercise.
+
+## 3. HTTP layer
+
+### 3.1 Server side — no handler abstraction
+
+- `server.cpp` is 8,277 lines: `setup_routes` alone is ~429 lines (`:1099–1528`),
+  `setup_static_files` ~362, plus ~60 `handle_*` member functions declared in
+  `server.h:107–260`.
+- **Quad-prefix registration exists in three idioms**: `register_get`/`register_post`
+  lambdas (`:1150`, `:1158` — the POST variant also hand-writes four identical 405-GET
+  bodies and a hardcoded `endpoint != "jobs"` special case), a
+  `for (const char* prefix : {...})` loop (`:1215`, `:1369`), and four regex routes
+  written out four times verbatim each (`:1201`, `:1230`, `:1278`, `:1498`).
+- **The 13× preamble**: `auto_load_model_if_needed(...)` + identical
+  try/catch → `create_model_error` → `get_http_status_from_error` → `set_content` →
+  span-error block appears at 13 call sites (`:3965, :4101, :4223, :4283, :4388, :4710,
+  :4778, :5030, :5167, :5221, :5323, :5651`). `:3961–3990` and `:4219–4247` are the same
+  code with a different span label.
+- **Live inconsistency bug**: `parse_required_json_body` (`:5717`) is used by only 7 of
+  ~32 body-parsing handlers; the other 25 call `json::parse(req.body)` raw. Malformed
+  JSON to `/v1/chat/completions` → 400; the same body to `/v1/embeddings` → 500.
+- **Three overlapping error mechanisms**: anon-namespace helpers in server.cpp
+  (`:117, :155, :162, :222`), `ErrorResponse::create/from_exception`
+  (`error_types.h:120`), and inline raw-string JSON literals. A `bad_request` lambda is
+  redefined identically at `:3107`, `:5740`, `:5980`. Aggregates: 94 `catch`, 114
+  `res.status = 400`, 293 `"application/json"` literals in one file.
+- **SSE framing is hand-constructed** (`"data: " + dump() + "\n\n"`) in ~10 files
+  (router.cpp ×4, wrapped_server.cpp ×2, collection_orchestrator.cpp,
+  streaming_proxy.cpp, cloud_server.cpp ×3).
+- **Middleware**: exactly one `set_pre_routing_handler` (`:1101` — logging, CORS, auth).
+  No exception handler, so an escaping exception becomes httplib's default 500 instead
+  of a JSON error.
+- **Four parallel route registries** on the same `httplib::Server` (`Server`,
+  `OllamaApi`, `McpServer`, `McpClientManager`), each with private copies of
+  set-json/set-error/parse-body helpers (`mcp_client.cpp:71,:76,:82`;
+  `anthropic_api.cpp:161,:209`; `ollama_api.cpp:95`).
+
+### 3.2 Client side — three unrelated HTTP stacks
+
+1. **CLI**: `LemonadeClient` (`cli/lemonade_client.cpp`, 1,724 L) over cpp-httplib —
+   `make_client`, `make_request`, hand-rolled SSE frame splitter. Genuinely shared
+   within the CLI.
+2. **Tray**: `tray_ui.cpp:179` is a near line-for-line copy of `LemonadeClient`'s
+   bootstrap (same TLS guard, IPv6 bracketing, URL assembly); the env-var → bearer
+   header block is pasted twice there and a third time in `tray/main.cpp:82–112`.
+3. **Server outbound**: `lemon::utils::HttpClient` (libcurl, 1,409 L) — HF downloads,
+   backend forwarding, telemetry. One CLI file crosses stacks
+   (`cli/recipe_import.cpp:180`).
+
+### 3.3 What is already good
+
+`WrappedServer::forward_request/forward_get_request/forward_multipart_request/
+forward_streaming_request` + `StreamingProxy` form a real shared proxy layer; per-backend
+code mostly parameterizes it. Outliers: `CloudServer` (1,098 L, reimplements streaming
+against `HttpClient` directly) and `Router::chat_completion_stream` /
+`completion_stream` / `responses_stream` (`router.cpp:2539, :2693, :2808` — ~110-line
+near-clones). Small duplications inside `wrapped_server.cpp` itself: the ~10-line
+"backend dead → watchdog reset → throw" preamble ×4 and the catch-tail ×2.
+
+## 4. JSON layer
+
+### 4.1 Scale
+
+`nlohmann/json.hpp` in 51 of 264 files; roughly 4,000+ string-keyed operations. Top
+offenders: `server.cpp` ~578, `ollama_api.cpp` ~350, `router.cpp` ~312,
+`cli/lemonade_client.cpp` ~281, `model_manager.cpp` ~269, `runtime_config.cpp` ~259,
+`system_info.cpp` ~228, `anthropic_api.cpp` ~198. `json::parse` appears 165× (7 use the
+non-throwing form). The dominant idiom is `operator[]` + `contains()` — the
+silent-miss-prone combination; `.at()` is nearly unused.
+
+### 4.2 No typed DTOs
+
+Zero occurrences of `NLOHMANN_DEFINE_TYPE_*`, `adl_serializer`, or free
+`to_json/from_json` pairs. The only true round-tripping DTO family is
+`jobs/job_types.h` (`Job`/`StepRecord`/`Case`). Everything else is serialize-only
+one-offs (`Telemetry::to_json`, `CostInfo::to_json`, `model_info_to_json`, …) with no
+compile-time link between producer and consumer.
+
+### 4.3 Live bug classes caused by stringly typing
+
+- **`"stream"` handled three different ways**: fully guarded (`server.cpp:3637`);
+  unguarded `contains && get<bool>()` at `:4009, :4145, :4816, :5668` — a client sending
+  `"stream": "true"` throws `type_error.302` out of the handler; `.value("stream",
+  false)` elsewhere — and Ollama defaults it to **true** (`ollama_api.cpp:755`) while
+  everything else defaults false.
+- **`choices[0]` unwrap duplicated 13+ times with divergent guards**; some omit
+  `is_array()`; `router.cpp:2574` indexes a non-const json so a missing `"delta"`
+  silently materializes null and downstream `contains("content")` quietly yields
+  nothing.
+- **Silent degradation**: `JsonUtils::get_or_default` (38× in model_manager.cpp) means a
+  renamed registry field becomes `""`/`0.0` with no diagnostic.
+- **Asymmetric pairs**: registry ingest (`model_manager.cpp:2943` and a near-identical
+  ~70-line clone at `:3022`) vs. `model_info_to_json` (`server.cpp:3189`) use different
+  key sets; `mcp_client.h` parse/serialize likewise.
+- **`ordered_json` boundary**: the job engine's `ordered_json` forces
+  dump-then-reparse at `server.cpp:438` and `:467`.
+- **Key constants**: none. `"model"` in 30 files, `"error"` 235 sites, `"ctx_size"` in
+  20 files.
+
+### 4.4 The in-repo gold standard
+
+`routing_policy_parser.cpp:17–62` (`require_object`, `reject_unknown_keys`,
+`required_field`, path-reporting errors, typed `RoutePolicy` output, schema files locked
+by `test/test_schema_lock.py`) is the only strict parser in the tree and the model to
+generalize. nlohmann is pinned at ≥ 3.11.3 (`CMakeLists.txt:214`), which supports
+everything a compile-time field-list codec needs — no dependency bump required.
+
+## 5. Protocol compatibility layers (Anthropic / Ollama)
+
+The Anthropic Messages endpoint is implemented as methods on `OllamaApi`
+(`anthropic_api.cpp:401` `OllamaApi::register_anthropic_routes`) — it lives there for no
+structural reason. Both compat layers decompose into the same four pieces, hand-rolled
+twice:
+
+1. **Request remap in** — `convert_anthropic_to_openai_chat` (`anthropic_api.cpp:407`,
+   ~290 lines), `convert_ollama_to_openai_chat` / `_completion`.
+2. **Dispatch** — the same Router call and auto-load logic as the OpenAI handlers.
+3. **Response remap out** — `convert_openai_chat_to_anthropic` (`:699`),
+   `convert_openai_chat_to_ollama`.
+4. **Stream transcode** — `stream_openai_sse_to_anthropic_sse` (`:805`, ~330 lines) and
+   `stream_sse_to_ndjson`, both re-implementing SSE parse/buffer around a per-protocol
+   event emitter; plus per-protocol error shaping (`set_anthropic_error_response`,
+   `send_backend_error`).
+
+The OpenAI-native handlers in server.cpp are the same pipeline with an identity remap.
+This is the textbook CRTP-adapter shape: one base owns parse → resolve → dispatch →
+stream/buffered branch → SSE framing → error mapping; a derived adapter supplies only
+the remap functions and its route table. A future protocol becomes one remap file.
+
+## 6. Where CRTP genuinely fits — and where it doesn't
+
+**Fits:**
+
+- **JSON codec** — `JsonEntity<Derived>` (or free-function reflection over a
+  `Derived::fields()` constexpr descriptor list): generates `to_json`/`from_json`/
+  strict-validate at compile time from a single field declaration; no string keys at
+  call sites; unknown-key and type errors carry JSON-pointer paths. C++17-compatible
+  (member-pointer + name descriptor tuples; no C++26 reflection needed).
+- **Endpoint handlers** — `Endpoint<Derived>`: Derived declares its typed Request/
+  Response DTOs, path, and a `handle(Context&, Request) -> Result` body; the base owns
+  body parse, validation, auto-load, error mapping, SSE vs. buffered, quad-prefix +
+  405-GET registration. Zero virtual dispatch; the route table stores type-erased
+  thunks generated per-Derived.
+- **Protocol adapters** — `ProtocolAdapter<Derived>` as described in §5. OpenAI is the
+  identity adapter; Anthropic and Ollama become pure remaps of their existing
+  conversion functions, retyped to canonical DTOs.
+- **Backend mixins** — small shared behaviors (e.g. body-mutating streaming forwarders
+  currently overridden in llamacpp/vllm/fastflowlm) can be CRTP mixins over the
+  existing classes.
+
+**Does not fit (keep virtual):**
+
+- `WrappedServer` at the Router boundary. The Router holds heterogeneous
+  `unique_ptr<WrappedServer>` collections, does LRU/eviction over them, and
+  `supports_capability<T>` uses `dynamic_cast`. That is inherent runtime polymorphism;
+  forcing CRTP there would mean type erasure that re-invents vtables. The existing
+  descriptor/registry/factory + capability-mask design is already the right shape —
+  the hardening builds on it rather than replacing it.
+
+## 7. Inventory of assets to build on
+
+| Asset | Location | Role in hardening |
+|---|---|---|
+| Backend descriptor + factory registry | `backends/backend_descriptor.h`, `backend_registry.h` | pattern for endpoint/adapter registries |
+| Capability interfaces + compile-time mask | `server_capabilities.h` | precedent for compile-time contract checks |
+| `forward_*` + `StreamingProxy` | `wrapped_server.h/.cpp`, `streaming_proxy.*` | the proxy layer the adapter base dispatches into |
+| Strict parser discipline | `routing_policy_parser.cpp` + schemas + `test_schema_lock.py` | model for the JSON codec's error reporting |
+| Round-trip DTOs | `jobs/job_types.h` | proves the DTO style works in-tree |
+| Header-only logic units | `gguf_reader.h`, `auto_tune.h`, `job_expr.h`, `custom_args.h`, … | already library-shaped; move as-is |
+| `add_cpp_ci_test` + `cpp-ci-tests` | root CMakeLists | test registration stays; linking gets cheaper |

--- a/docs/dev/core-hardening-plan.md
+++ b/docs/dev/core-hardening-plan.md
@@ -100,13 +100,63 @@ generate:
 - `from_json_lenient` — defaults applied, used only where today's behavior must be
   preserved during migration.
 
-Supported field kinds: scalars, `std::optional<T>`, `std::vector<T>`, `std::map`,
-nested `LEMON_JSON` types, enums declared with `LEMON_ENUM` (the X-macro enum +
-wire-name mechanism defined in `core-hardening-standards.md` §2, which also delivers
-the central vocabulary header `include/lemon/core/vocab.h` in this phase), `JsonValue`
-(escape hatch for genuinely dynamic subtrees — content parts, tool arguments), and
-renamed keys via `lemon::json::named<&T::member>("wire_name")` for the few wire names
-that aren't valid identifiers.
+Supported field kinds: scalars, `std::optional<T>`, `JsonOptional<T>` (tri-state, see
+below), `std::vector<T>`, `std::map`, nested `LEMON_JSON` types, enums declared with
+`LEMON_ENUM` (the X-macro enum + wire-name mechanism defined in
+`core-hardening-standards.md` §2, which also delivers the central vocabulary header
+`include/lemon/core/vocab.h` in this phase), `JsonValue` (escape hatch for genuinely
+dynamic subtrees — content parts, tool arguments), and renamed keys via
+`lemon::json::named<&T::member>("wire_name")` for the few wire names that aren't valid
+identifiers.
+
+### Tri-state fields: `JsonOptional<T>`
+
+`std::optional<T>` conflates two wire states that this API surface must distinguish:
+**key absent** and **key present with `null`** (OpenAI's `"stop": null` vs. omitted,
+nullable telemetry like `cache_tokens`, and PATCH-style partial config updates where
+"not mentioned" must not clobber and `null` means "clear"). `JsonOptional<T>` is the
+codec's tri-state field type — unset / explicitly null / value — adapted from the
+donor implementation vendored at `docs/dev/reference/json_optional_reference.md`
+(bitfield flags for `is_set`/`is_null`, an `adl_serializer` that exploits the fact
+that `from_json` only runs when the key exists, and `underlying_type_t`/trait helpers
+the codec's field loop dispatches on).
+
+Uniform free-function queries are part of the API, overloaded across all three field
+kinds so call sites don't care which one a DTO chose:
+
+```cpp
+is_set(req.temperature)      // JsonOptional: was the key present at all?
+is_null(req.stop)            // JsonOptional: present and explicitly null?
+has_value(req.model)         // T (always true) / optional / JsonOptional
+```
+
+Adaptation notes against the reference (deliberate deltas, recorded so review happens
+once):
+
+1. **Unset must omit the key on serialize.** The reference's `SAFE_JSON_TO` /
+   `adl_serializer::to_json` emit `null` for an unset field, so unset → null after one
+   round trip and the tri-state collapses. An `adl_serializer` *cannot* omit a key (it
+   only sees the value slot), so tri-state emission lives in the codec's field loop —
+   which knows the key — with the serializer kept only for nested/non-codec contexts:
+   unset → key omitted, null → `"key": null`, value → serialized value. This is what
+   makes round trips lossless.
+2. **Single source of truth for state.** The reference stores `is_null` alongside
+   `value.has_value()`, which can drift (and its default constructor starts as
+   `is_set=0, is_null=1`). The adaptation derives null-ness from
+   `is_set && !value.has_value()` where possible, keeps the flag byte only for
+   `is_set`, and `static_assert`s the invariants in tests.
+3. **Portability of the flag bits.** The anonymous-struct-in-union bitfield is a
+   compiler extension (accepted by MSVC, GCC, and AppleClang — the three compilers CI
+   requires — but warned under `-Wpedantic`). The adaptation keeps the same public
+   API but may back it with a plain flags byte + accessors if the warning budget
+   demands; either way the layout stays one byte.
+4. Small API trims: one `has_value()` (const), `value_or` takes by const-ref,
+   implicit `operator const T&` (which throws on unset) becomes explicit `get()` /
+   `operator*` only, and `[[nodiscard]]` per the standards doc. The pqxx block is
+   inert here and dropped from the adapted header.
+
+`std::optional<T>` remains the right type for plain omit-or-value fields where `null`
+has no distinct meaning; DTO declarations choose per field.
 
 C++17-only (member-pointer tuples + folds), header-only, works with the pinned
 nlohmann ≥ 3.11.3, and interoperates with plain `nlohmann::json` at the edges. The

--- a/docs/dev/core-hardening-plan.md
+++ b/docs/dev/core-hardening-plan.md
@@ -1,6 +1,7 @@
 # Core Hardening — Plan
 
-Companion to `core-hardening-analysis.md`. Goal: split the tree into layered libraries
+Companion to `core-hardening-analysis.md` and `core-hardening-standards.md`. Goal:
+split the tree into layered libraries
 with thin executables, put a compile-time typed JSON codec under the whole API surface,
 and rebuild HTTP handling around CRTP endpoint and protocol-adapter bases so a compat
 layer (Anthropic, Ollama, future protocols) is only a remap.
@@ -100,7 +101,9 @@ generate:
   preserved during migration.
 
 Supported field kinds: scalars, `std::optional<T>`, `std::vector<T>`, `std::map`,
-nested `LEMON_JSON` types, enums via a `LEMON_JSON_ENUM` name table, `JsonValue`
+nested `LEMON_JSON` types, enums declared with `LEMON_ENUM` (the X-macro enum +
+wire-name mechanism defined in `core-hardening-standards.md` §2, which also delivers
+the central vocabulary header `include/lemon/core/vocab.h` in this phase), `JsonValue`
 (escape hatch for genuinely dynamic subtrees — content parts, tool arguments), and
 renamed keys via `lemon::json::named<&T::member>("wire_name")` for the few wire names
 that aren't valid identifiers.
@@ -246,7 +249,9 @@ class OllamaAdapter    : ProtocolAdapter<OllamaAdapter> { /* NDJSON framing */ }
   3 and are called out as such) before each phase, replay after.
 - CI grep gates added incrementally: no `#include "../server/` from cli/ or tray/; no
   `json::parse(req.body)` outside the endpoint base; no `"data: "` framing outside
-  `SseWriter`; DTO wire-key lock tests.
+  `SseWriter`; DTO wire-key lock tests; the coding-standards gates from
+  `core-hardening-standards.md` §4 (no new `std::pair<bool`, no stringly bools, enum
+  wire names covered by the lock tests).
 - Distro constraints respected: `BUILD_TESTING=OFF` still builds no test targets; the
   web-app package.json split and system-nlohmann ≥ 3.11.3 path are untouched;
   `add_cpp_ci_test` remains the only test registration mechanism.

--- a/docs/dev/core-hardening-plan.md
+++ b/docs/dev/core-hardening-plan.md
@@ -79,8 +79,8 @@ no manually written `j["key"]` anywhere at call sites:
 struct ChatMessage {
     ChatRole role;                                    // LEMON_ENUM
     OneOf<std::string, std::vector<ContentPart>> content;
-    std::optional<std::string> name;
-    std::optional<std::vector<ToolCall>> tool_calls;
+    JsonOptional<std::string> name;
+    JsonOptional<std::vector<ToolCall>> tool_calls;
 
     LEMON_JSON(ChatMessage, role, content, name, tool_calls);
 };
@@ -91,7 +91,8 @@ of `field_descriptor{member-pointer, name}` (names from preprocessor stringifica
 compile-time, spelled once, never at a use site). Over that tuple, fold expressions
 generate:
 
-- `to_json(const T&) -> json` — omits empty `std::optional`, emits declared order.
+- `to_json(const T&) -> json` — omits unset `JsonOptional` fields, emits declared
+  order.
 - `from_json_strict(const json&) -> Expected<T, ParseError>` — type-checked per field,
   `ParseError` carries a JSON-pointer path (`/messages/2/tool_calls/0/id`) and reason;
   policy enum for unknown keys: `Reject` (config, registry) or `Preserve` (API bodies —
@@ -100,8 +101,9 @@ generate:
 - `from_json_lenient` — defaults applied, used only where today's behavior must be
   preserved during migration.
 
-Supported field kinds: scalars, `std::optional<T>`, `JsonOptional<T>` (tri-state, see
-below), `std::vector<T>`, `std::map`, nested `LEMON_JSON` types, enums declared with
+Supported field kinds: scalars, `JsonOptional<T>` (tri-state — the sole optionality
+type in the JSON layer, see below), `std::vector<T>`, `std::map`, nested
+`LEMON_JSON` types, enums declared with
 `LEMON_ENUM` (the X-macro enum + wire-name mechanism defined in
 `core-hardening-standards.md` §2, which also delivers the central vocabulary header
 `include/lemon/core/vocab.h` in this phase), `OneOf`/`TaggedOneOf` sum types and
@@ -146,8 +148,11 @@ using JsonTree = std::variant<std::nullptr_t, bool, int64_t, double, std::string
 // JsonTree<0>: scalars only. Typical: using ToolArgs = JsonTree<8>;
 ```
 
-(Spelled here as the concept; the implementation wraps the variant in a class template
-so the recursion terminates cleanly and accessors return `std::optional`.) Every level
+(Spelled here as the concept; the implementation wraps the variant in a class
+template so the recursion terminates cleanly. Object-key lookups return the tri-state
+— `tree.at("key")` yields a `JsonOptional`-shaped result distinguishing absent /
+null / value, queried with the same `is_set`/`is_null`/`has_value` free functions as
+DTO fields.) Every level
 is a real variant — exhaustively visitable, no stringly `type()` checks — and a
 document deeper than the bound is a `ParseError` at the offending path rather than
 unbounded recursion on hostile input, which also gives the parser a hard nesting limit
@@ -200,8 +205,17 @@ once):
    `operator*` only, and `[[nodiscard]]` per the standards doc. The pqxx block is
    inert here and dropped from the adapted header.
 
-`std::optional<T>` remains the right type for plain omit-or-value fields where `null`
-has no distinct meaning; DTO declarations choose per field.
+**Anything JSON-related uses `JsonOptional<T>` — without exception.** Every
+non-required field of every wire DTO, `JsonTree` object lookups, and codec results
+share the tri-state; `std::optional` never appears in a JSON-facing declaration. The
+rule is unconditional rather than per-field because of passthrough fidelity: lemond
+is a proxy, and with `std::optional` a client's `"name": null` and an absent `"name"`
+both collapse to `nullopt` and re-serialize as *omitted* — the proxy silently
+rewrites the request on its way to the backend. Tri-state fields make forwarding
+byte-faithful by construction, and one universal rule is greppable (a CI gate rejects
+`std::optional` inside `lemon-api`) where a per-field judgment call is not. Outside
+the JSON layer — function returns, internal state — `std::optional` remains the
+right type per §1 of the standards doc.
 
 C++17-only (member-pointer tuples + folds), header-only, works with the pinned
 nlohmann ≥ 3.11.3, and interoperates with plain `nlohmann::json` at the edges. The

--- a/docs/dev/core-hardening-plan.md
+++ b/docs/dev/core-hardening-plan.md
@@ -1,0 +1,271 @@
+# Core Hardening — Plan
+
+Companion to `core-hardening-analysis.md`. Goal: split the tree into layered libraries
+with thin executables, put a compile-time typed JSON codec under the whole API surface,
+and rebuild HTTP handling around CRTP endpoint and protocol-adapter bases so a compat
+layer (Anthropic, Ollama, future protocols) is only a remap.
+
+Every phase is independently landable, keeps all four executables building on all three
+platforms, and keeps the existing Python integration tests green. Phases are ordered so
+each one makes the next one mechanical.
+
+## Target library layout
+
+```
+src/cpp/
+  core/            → lemon-core        (STATIC)  paths, process, strings, url, logging,
+                                                 error types, platform abstractions,
+                                                 archive, beacon, single_instance
+  json/            → lemon-json        (header-only INTERFACE)  field descriptors, codec,
+                                                 strict parser, JSON-pointer errors
+  net/             → lemon-net         (STATIC)  HttpClient (libcurl), ApiClient
+                                                 (httplib, the one true loopback/remote
+                                                 client), SSE reader/writer, multipart
+  api/             → lemon-api         (STATIC)  typed DTOs shared by server, CLI, tray:
+                                                 chat/completions/embeddings/rerank,
+                                                 stream deltas, errors, model info,
+                                                 config, health/system-info
+  serverlib/       → lemon-server     (STATIC)  router, model manager, backends,
+                                                 endpoints/, adapters/, jobs, websocket
+  server/main.cpp  → lemond            (exe)     thin main
+  cli/             → lemonade          (exe)     thin: arg parsing + lemon-net + lemon-api
+  tray/            → lemonade-tray / LemonadeServer (exe)  thin: UI + lemon-net + lemon-api
+```
+
+Dependency rule, enforced by `target_link_libraries` visibility (a lower layer never
+links a higher one):
+
+```
+core ← json ← net ← api ← serverlib
+```
+
+STATIC rather than OBJECT so tests link only the layer they exercise, the layering is
+enforced by the linker, and a change to `server.cpp` stops relinking 50 test binaries.
+(`lemonade-server-core` OBJECT lib is dissolved into `lemon-*`.)
+
+## Phase 0 — Library skeleton and mechanical moves (no behavior change)
+
+1. Create the five library targets; move `src/cpp/server/utils/` → `src/cpp/core/` and
+   `src/cpp/server/utils/platform/` → `src/cpp/core/platform/` (headers from
+   `include/lemon/utils/` follow). Move `network_beacon.*`, `single_instance.h`,
+   `error_types.h`, logging into `core/`. Move `http_client.*`, `streaming_proxy.*`
+   into `net/`.
+2. CLI and tray: delete every relative-path recompile
+   (`cli/CMakeLists.txt:18–47`, `tray/CMakeLists.txt:128–150`) and link `lemon-core` /
+   `lemon-net` instead. Delete the inline beacon re-implementation in
+   `cli/main.cpp:830–940` in favor of the real `network_beacon.cpp`.
+3. Tests: routing-suite and other "hand-picked subset" tests (18 targets) link the new
+   small libraries instead of listing sources; the 50 server-core tests link
+   `lemon-server`.
+4. Unify the three HTTP client bootstraps now (it is pure motion): promote
+   `LemonadeClient`'s `make_client`/bearer/IPv6/TLS logic into `lemon::net::ApiClient`;
+   CLI keeps `LemonadeClient` as a thin veneer over it; tray drops its two copies
+   (`tray_ui.cpp:179`, `tray/main.cpp:82–112`).
+
+Exit: zero `.cpp` compiled into more than one product target; `ctest` and Python suites
+green; per-target TU counts recorded in the PR description.
+
+## Phase 1 — lemon-json: compile-time codec
+
+The codec is the foundation for phases 2–4, so it lands first with its own unit tests.
+
+### Design
+
+A single declaration per type; keys are derived from member names at compile time —
+no manually written `j["key"]` anywhere at call sites:
+
+```cpp
+struct ChatMessage {
+    std::string role;
+    JsonValue content;                       // string | content-part array (raw passthrough)
+    std::optional<std::string> name;
+    std::optional<std::vector<ToolCall>> tool_calls;
+
+    LEMON_JSON(ChatMessage, role, content, name, tool_calls);
+};
+```
+
+`LEMON_JSON(...)` expands to a `static constexpr auto lemon_fields()` returning a tuple
+of `field_descriptor{member-pointer, name}` (names from preprocessor stringification —
+compile-time, spelled once, never at a use site). Over that tuple, fold expressions
+generate:
+
+- `to_json(const T&) -> json` — omits empty `std::optional`, emits declared order.
+- `from_json_strict(const json&) -> Expected<T, ParseError>` — type-checked per field,
+  `ParseError` carries a JSON-pointer path (`/messages/2/tool_calls/0/id`) and reason;
+  policy enum for unknown keys: `Reject` (config, registry) or `Preserve` (API bodies —
+  unknown keys are captured into a `json extras` member and re-emitted, so passthrough
+  to backends keeps fields we don't model).
+- `from_json_lenient` — defaults applied, used only where today's behavior must be
+  preserved during migration.
+
+Supported field kinds: scalars, `std::optional<T>`, `std::vector<T>`, `std::map`,
+nested `LEMON_JSON` types, enums via a `LEMON_JSON_ENUM` name table, `JsonValue`
+(escape hatch for genuinely dynamic subtrees — content parts, tool arguments), and
+renamed keys via `lemon::json::named<&T::member>("wire_name")` for the few wire names
+that aren't valid identifiers.
+
+C++17-only (member-pointer tuples + folds), header-only, works with the pinned
+nlohmann ≥ 3.11.3, and interoperates with plain `nlohmann::json` at the edges. The
+`ordered_json`/`json` job-engine boundary gets a direct converter to end the
+dump-then-reparse at `server.cpp:438/:467`.
+
+### First DTO wave (in `lemon-api`)
+
+Ordered by leverage:
+
+1. `ErrorBody` / `ApiError` — replaces the three error mechanisms; one
+   `to_http_status()` mapping.
+2. `ChatCompletionRequest/Response`, `Choice`, `Usage`, `StreamChunk`/`StreamDelta` —
+   ends the 13× divergent `choices[0]` unwrap and the four unguarded
+   `["stream"].get<bool>()` sites.
+3. `EmbeddingsRequest/Response`, `RerankRequest/Response`, `CompletionRequest`.
+4. `ModelInfo` wire form — one symmetric codec replacing the duplicated ~70-line ingest
+   blocks (`model_manager.cpp:2943`, `:3022`) and `model_info_to_json`
+   (`server.cpp:3189`).
+5. `config.json` / `RuntimeConfig` schema, `backend_versions.json` schema — strict,
+   unknown-key-rejecting (per the routing-policy precedent).
+6. Health / system-info structs — `system_info.h` types gain codecs instead of the
+   hand-built dict functions.
+
+Tests: round-trip property tests per DTO; a schema-lock-style test asserting the wire
+key set of each DTO (renames become deliberate).
+
+## Phase 2 — lemon-server endpoints: CRTP handler framework
+
+### Design
+
+```cpp
+struct ApiContext {                 // owned by Server, passed by ref
+    Router& router;
+    ModelManager& models;
+    RuntimeConfig& config;
+    Telemetry& telemetry;
+};
+
+template <typename Derived>
+class Endpoint {
+public:
+    // Base owns: body parse via Derived::Request codec (uniform 400 with pointer
+    // path), auto-load preamble, dispatch, ApiError → status/body mapping, SSE vs
+    // buffered branch, span lifecycle, quad-prefix + auto-405-GET registration.
+    static void register_routes(httplib::Server& s, ApiContext& ctx);
+protected:
+    // Derived provides, checked at compile time (static_assert on detection idiom):
+    //   static constexpr const char* path();            // "chat/completions"
+    //   using Request  = ...;  using Response = ...;    // LEMON_JSON DTOs
+    //   static constexpr bool streamable = ...;
+    //   Result handle(ApiContext&, Request&&);          // buffered
+    //   void   handle_stream(ApiContext&, Request&&, SseWriter&);  // if streamable
+};
+```
+
+- One `register_quad(server, method, path, thunk)` helper replaces all three
+  registration idioms, the four hand-written 405 bodies, and the four verbatim regex
+  quadruplicates.
+- `SseWriter` in `lemon-net` becomes the only place `"data: ...\n\n"` framing exists;
+  `SseReader` the only SSE parser (replacing the copies in `lemonade_client.cpp`,
+  `ollama_api.cpp`, `anthropic_api.cpp`, `cloud_server.cpp`).
+- An `set_exception_handler` is installed so an escaping exception is a JSON 500, not
+  httplib's default.
+- Endpoints live one-per-file under `serverlib/endpoints/`; `server.cpp` shrinks to
+  listener setup, middleware, static files, and endpoint registration.
+
+### Migration order
+
+1. Extract the error module and `register_quad`; port the non-inference endpoints
+   (health, models, system-info, pull/delete/load/unload) — highest count, simplest
+   shapes.
+2. Port the inference endpoints (chat/completions/embeddings/rerank/classify/responses)
+   onto the shared auto-load preamble — deletes the 13× block.
+3. Standardize body parsing: `parse_required_json_body` semantics become the base-class
+   default, fixing the 400-vs-500 inconsistency across the remaining 25 handlers.
+4. Move the download-job manager and static-file serving out of `server.cpp` into their
+   own files.
+
+Exit: `server.cpp` < ~1,000 lines; zero raw `json::parse(req.body)` in handlers; a CI
+grep gate forbids `req.body` and `["` string-key access inside `endpoints/`.
+
+## Phase 3 — Protocol adapters: compat layers as pure remaps
+
+```cpp
+template <typename Derived>
+class ProtocolAdapter {
+    // Base owns the full pipeline: parse → Derived::map_request → model resolve /
+    // auto-load → Router dispatch → (buffered) Derived::map_response |
+    // (streaming) canonical-delta loop feeding Derived::Transcoder → SSE/NDJSON
+    // framing per Derived::framing() → Derived::map_error on any failure.
+};
+
+class OpenAiAdapter    : ProtocolAdapter<OpenAiAdapter> { /* identity remap */ };
+class AnthropicAdapter : ProtocolAdapter<AnthropicAdapter> {
+    ChatCompletionRequest map_request(const AnthropicMessagesRequest&, Warnings&);
+    AnthropicMessagesResponse map_response(const ChatCompletionResponse&, Warnings&);
+    struct Transcoder {   // canonical deltas in, Anthropic events out
+        void on_start(...); void on_text(...); void on_tool_delta(...);
+        void on_stop(StopInfo);
+    };
+    AnthropicError map_error(const ApiError&);
+    static constexpr auto routes = ...;   // POST /api/messages, /v1/messages
+};
+class OllamaAdapter    : ProtocolAdapter<OllamaAdapter> { /* NDJSON framing */ };
+```
+
+- The canonical delta stream (`StreamDelta` from lemon-api) is produced once by the
+  router streaming path; transcoders never see SSE text, only typed deltas — the ~330
+  lines of `stream_openai_sse_to_anthropic_sse` reduce to the event-emission logic.
+- Anthropic moves out of `OllamaApi` into its own adapter; the existing conversion
+  functions become the bodies of `map_request`/`map_response`, retyped to DTOs (this is
+  a port, not a rewrite — the mapping rules and warning behavior are preserved
+  verbatim, including the Anthropic upstream passthrough path).
+- Divergent-behavior inventory (stream default true for Ollama, warning accumulation,
+  Ollama's auto-load options) is expressed as adapter traits, not re-derived.
+- A new protocol = one adapter file with remaps + a transcoder; conformance is a
+  fixture suite replayed through all adapters against golden wire outputs.
+
+## Phase 4 — Streaming/router cleanup and remaining consolidation
+
+1. Collapse `Router::chat_completion_stream` / `completion_stream` /
+   `responses_stream` (~110-line near-clones) into one parameterized implementation
+   producing canonical deltas.
+2. Fold the ×4 "backend dead → watchdog reset → throw" preamble and ×2 catch-tail in
+   `wrapped_server.cpp` into a private helper; give `CloudServer` the shared
+   `SseReader` instead of its private reassembly.
+3. Sweep remaining stringly hotspots onto DTOs: `runtime_config.cpp` getters over the
+   typed config, `telemetry.cpp` OTLP chains, `backend_manager.cpp` version chains,
+   CLI (`lemonade_client.cpp`, `bench.cpp`, `chat_repl.cpp`) onto lemon-api DTOs —
+   which also makes CLI/tray output shapes compile-time-checked against the server.
+
+## Verification & guardrails (every phase)
+
+- Build all presets (`default`, `windows`, `debug`), `ctest -L cpp-ci`, and the Python
+  suites `server_cli2.py` / `server_endpoints.py` (plus `server_llm.py` when routing or
+  streaming paths are touched).
+- Behavioral parity: capture golden request/response fixtures for every public endpoint
+  (including the malformed-JSON status codes, which change deliberately in Phase 2 step
+  3 and are called out as such) before each phase, replay after.
+- CI grep gates added incrementally: no `#include "../server/` from cli/ or tray/; no
+  `json::parse(req.body)` outside the endpoint base; no `"data: "` framing outside
+  `SseWriter`; DTO wire-key lock tests.
+- Distro constraints respected: `BUILD_TESTING=OFF` still builds no test targets; the
+  web-app package.json split and system-nlohmann ≥ 3.11.3 path are untouched;
+  `add_cpp_ci_test` remains the only test registration mechanism.
+
+## Explicit non-goals
+
+- No change to the `WrappedServer` virtual hierarchy at the Router boundary (see
+  analysis §6) — the descriptor/registry/factory system is kept and imitated, not
+  replaced.
+- No wire-format changes to any public API (except the documented 400-vs-500 fix).
+- No new third-party dependencies; no C++ standard bump.
+- Tauri/web frontend untouched.
+
+## Sequencing summary
+
+| Phase | Deliverable | Depends on | Rough size |
+|---|---|---|---|
+| 0 | 5 libraries, thin exes, one client bootstrap | — | mostly mechanical, large diff / low risk |
+| 1 | lemon-json codec + first DTO wave + tests | 0 | new code, no callers broken |
+| 2 | Endpoint CRTP base, server.cpp dismantled | 1 | many small PRs, one endpoint family each |
+| 3 | ProtocolAdapter, Anthropic/Ollama as remaps | 1, 2 | port of existing conversions |
+| 4 | Router stream unification, long-tail sweeps | 2, 3 | incremental |

--- a/docs/dev/core-hardening-plan.md
+++ b/docs/dev/core-hardening-plan.md
@@ -77,8 +77,8 @@ no manually written `j["key"]` anywhere at call sites:
 
 ```cpp
 struct ChatMessage {
-    std::string role;
-    JsonValue content;                       // string | content-part array (raw passthrough)
+    ChatRole role;                                    // LEMON_ENUM
+    OneOf<std::string, std::vector<ContentPart>> content;
     std::optional<std::string> name;
     std::optional<std::vector<ToolCall>> tool_calls;
 
@@ -95,8 +95,8 @@ generate:
 - `from_json_strict(const json&) -> Expected<T, ParseError>` — type-checked per field,
   `ParseError` carries a JSON-pointer path (`/messages/2/tool_calls/0/id`) and reason;
   policy enum for unknown keys: `Reject` (config, registry) or `Preserve` (API bodies —
-  unknown keys are captured into a `json extras` member and re-emitted, so passthrough
-  to backends keeps fields we don't model).
+  unknown keys are captured into a `JsonTree` extras member and re-emitted, so
+  passthrough to backends keeps fields we don't model).
 - `from_json_lenient` — defaults applied, used only where today's behavior must be
   preserved during migration.
 
@@ -104,10 +104,55 @@ Supported field kinds: scalars, `std::optional<T>`, `JsonOptional<T>` (tri-state
 below), `std::vector<T>`, `std::map`, nested `LEMON_JSON` types, enums declared with
 `LEMON_ENUM` (the X-macro enum + wire-name mechanism defined in
 `core-hardening-standards.md` §2, which also delivers the central vocabulary header
-`include/lemon/core/vocab.h` in this phase), `JsonValue` (escape hatch for genuinely
-dynamic subtrees — content parts, tool arguments), and renamed keys via
-`lemon::json::named<&T::member>("wire_name")` for the few wire names that aren't valid
-identifiers.
+`include/lemon/core/vocab.h` in this phase), `OneOf`/`TaggedOneOf` sum types and
+`JsonTree<MaxDepth>` bounded dynamic trees (see below — there is no raw-`json` escape
+hatch in DTOs), and renamed keys via `lemon::json::named<&T::member>("wire_name")` for
+the few wire names that aren't valid identifiers.
+
+### Static types for "dynamic" shapes: `OneOf` and `JsonTree<MaxDepth>`
+
+DTO fields never hold raw `nlohmann::json`. The two situations that tempt an escape
+hatch get static types instead:
+
+**Closed alternatives → `OneOf<Ts...>` / `TaggedOneOf<"tag", Ts...>`.** Most
+"dynamic" wire shapes are actually a small closed set: chat `content` is
+`string | ContentPart[]`; a content part is text/image/audio discriminated by its
+`"type"` field; `stop` is `string | string[]`. These become codec-integrated
+`std::variant`s:
+
+```cpp
+struct TextPart  { std::string text;  LEMON_JSON(TextPart, text); };
+struct ImagePart { ImageUrl image_url; LEMON_JSON(ImagePart, image_url); };
+using ContentPart = TaggedOneOf<"type",
+    Alt<"text", TextPart>, Alt<"image_url", ImagePart>, Alt<"input_audio", AudioPart>>;
+```
+
+`TaggedOneOf` parses by reading the discriminator once and dispatching to the matching
+alternative's codec (unknown tag → `ParseError` with the path and the list of valid
+tags); untagged `OneOf` discriminates structurally (JSON type, then shape) in declared
+order. Serialization re-emits the tag. Consumers use `std::visit`, so handling is
+exhaustive at compile time — adding an alternative breaks every switch that ignores
+it, the same guarantee the standards doc demands from `LEMON_ENUM` switches.
+
+**Genuinely open data → `JsonTree<MaxDepth>`.** Tool-call `arguments`, `metadata`
+maps, and `Preserve`-policy extras are user-defined and cannot be closed. They use a
+statically-typed value tree whose recursion depth is a compile-time bound:
+
+```cpp
+template <size_t Depth>
+using JsonTree = std::variant<std::nullptr_t, bool, int64_t, double, std::string,
+                              std::vector<JsonTree<Depth - 1>>,
+                              std::map<std::string, JsonTree<Depth - 1>>>;
+// JsonTree<0>: scalars only. Typical: using ToolArgs = JsonTree<8>;
+```
+
+(Spelled here as the concept; the implementation wraps the variant in a class template
+so the recursion terminates cleanly and accessors return `std::optional`.) Every level
+is a real variant — exhaustively visitable, no stringly `type()` checks — and a
+document deeper than the bound is a `ParseError` at the offending path rather than
+unbounded recursion on hostile input, which also gives the parser a hard nesting limit
+for free. Converters to/from `nlohmann::json` exist only at the transport edge and in
+the codec internals; application code above the codec never sees a raw `json` value.
 
 ### Tri-state fields: `JsonOptional<T>`
 
@@ -213,9 +258,59 @@ protected:
 };
 ```
 
-- One `register_quad(server, method, path, thunk)` helper replaces all three
-  registration idioms, the four hand-written 405 bodies, and the four verbatim regex
-  quadruplicates.
+### Descriptors, factories, and contracts
+
+Endpoints are registered the way backends already are — a declarative descriptor bound
+to a factory in a generated registry, not imperative calls in a 429-line function
+(mirroring `BackendDescriptor` / `BackendRegistration` / `all_registrations()`):
+
+```cpp
+struct EndpointDescriptor {          // what the endpoint is — data, no behavior
+    std::string_view path;           // "chat/completions"
+    HttpMethod      method;
+    AuthLevel       auth;            // Public | ApiKey | Admin (replaces the
+                                     // path-prefix classification in authenticate_request)
+    bool            streamable;
+    bool            quad_prefixed;   // false only for the documented exceptions
+};
+
+struct EndpointRegistration {
+    const EndpointDescriptor* descriptor;
+    RegisterFn register_fn;          // type-erased thunk from Endpoint<Derived>
+};
+const std::vector<EndpointRegistration>& all_endpoint_registrations();
+```
+
+`Server::setup_routes` shrinks to iterating that list. Contracts are enforced at both
+compile time and test time:
+
+- **Compile time**, inside `Endpoint<Derived>`: `static_assert`s (detection idiom)
+  that `Derived::Request` / `Response` are `LEMON_JSON` types, that `handle` /
+  `handle_stream` match the descriptor's `streamable` flag, and that the path is
+  declared. A malformed endpoint fails to compile, not to route.
+- **Test time**, an `EndpointContractTest` in the style of `BackendModeContractTest`:
+  sweeps `all_endpoint_registrations()` asserting quad-prefix coverage (invariant #1),
+  auto-405 for wrong methods, auth classification matching the descriptor, and that no
+  two descriptors claim a path/method pair.
+
+The same descriptor/factory/contract pattern applies to the **non-HTTP message
+dispatchers**, which are stringly today: MCP JSON-RPC methods
+(`method == "tools/call"` string chains, `mcp_server.cpp:321`), WebSocket realtime
+event types (raw `"type"` string literals throughout `realtime_session.cpp`), and job
+engine ops — which already have a runtime factory registry
+(`register_op("system_info", lambda)`, `job_ops.cpp:28`) but with untyped `json`
+in/out. Each gets a `MessageHandler<Derived>` base over the same machinery: the
+dispatch key comes from a `LEMON_ENUM` vocabulary, payloads are `LEMON_JSON` DTOs, and
+a registry + contract test replaces the if/else chains. (HTTP endpoints land in this
+phase; the MCP/realtime/job-op ports are Phase 4 items.)
+
+`ProtocolAdapter` route tables (Phase 3) register through the same registry with
+`quad_prefixed = false`, so the documented exceptions are declared data instead of
+special cases.
+
+- One `register_quad(server, method, path, thunk)` helper (driven by the registry)
+  replaces all three registration idioms, the four hand-written 405 bodies, and the
+  four verbatim regex quadruplicates.
 - `SseWriter` in `lemon-net` becomes the only place `"data: ...\n\n"` framing exists;
   `SseReader` the only SSE parser (replacing the copies in `lemonade_client.cpp`,
   `ollama_api.cpp`, `anthropic_api.cpp`, `cloud_server.cpp`).
@@ -288,6 +383,10 @@ class OllamaAdapter    : ProtocolAdapter<OllamaAdapter> { /* NDJSON framing */ }
    typed config, `telemetry.cpp` OTLP chains, `backend_manager.cpp` version chains,
    CLI (`lemonade_client.cpp`, `bench.cpp`, `chat_repl.cpp`) onto lemon-api DTOs —
    which also makes CLI/tray output shapes compile-time-checked against the server.
+4. Port the non-HTTP message dispatchers onto `MessageHandler<Derived>` registries
+   (Phase 2 §Descriptors): MCP JSON-RPC methods and tool calls, WebSocket realtime
+   event types, and the job engine's op registry — enum-keyed dispatch, `LEMON_JSON`
+   payloads, contract tests over each registry.
 
 ## Verification & guardrails (every phase)
 

--- a/docs/dev/core-hardening-standards.md
+++ b/docs/dev/core-hardening-standards.md
@@ -1,0 +1,137 @@
+# Core Hardening — Coding Standards
+
+Companion to `core-hardening-analysis.md` and `core-hardening-plan.md`. These rules
+apply to all new code immediately and to existing code as the plan's phases touch it.
+Each rule cites real instances found in the tree so the migration targets are concrete.
+
+## 1. Returning "maybe a value"
+
+### Rule
+
+- A function that may or may not produce a value returns `std::optional<T>`.
+- A function that produces a value **or a reason it couldn't** returns
+  `Expected<T, E>` (the `lemon-json` `ParseError` result type from Phase 1 generalizes
+  to `lemon::Expected` in `lemon-core`).
+- `std::pair<bool, T>`, `bool f(T& out)`, and sentinel values (`-1`, `""`, `nullptr`
+  where a value was expected) are not acceptable for new code.
+
+`std::optional` is already used in 50 files — this codifies existing practice, not a
+new idiom.
+
+### Current violations to migrate
+
+| Pattern | Instance | Replacement |
+|---|---|---|
+| `std::pair<bool, T>` | `tray_ui.h:68` `fetch_server_state()` → `std::pair<bool, std::vector<LoadedModelInfo>>` | `std::optional<std::vector<LoadedModelInfo>>` |
+| bool + out-param | `model_types.h:134` `find_deployment_mode(labels, ModelType& out)`, `:180` `deployment_mode_of(label, ModelType& out)` | `std::optional<ModelType>` |
+| bool + **two** out-params | `websocket_server.h:155` `authenticate_connection(wsi, std::string& out_token, bool& out_authenticated)` | return a small struct or `std::optional<AuthResult>` |
+| bool + out-param | `gguf_reader.h:198` `read_gguf_metadata(GgufMetadata& out, path)` | `std::optional<GgufMetadata>` (or `Expected` with a parse reason) |
+| bool + out-param + side-channel response | `server.h:308–309` `parse_n_from_form(req, res, json& out)` / `extract_image_from_form` | absorbed by the Phase 2 endpoint base (typed request parsing) |
+| bool + out-param | `job_manager.h:31` `remove(id, bool& active_out)`, `recipe_import.h:30` `list_remote_recipe_directories(vector& out, ...)` | `std::optional` / `Expected` |
+
+Sentinel precedent worth noting: `Telemetry::cache_tokens = -1` meaning "not reported"
+(`wrapped_server.h:45`) needed a comment and a special JSON-null rendering to stay
+safe — exactly the cost `std::optional<int>` removes.
+
+## 2. Enums over raw strings
+
+### Rule
+
+Any closed vocabulary — a value that is compared with `== "literal"`, switched on, or
+validated against a known set — is an `enum class`, not a `std::string`. Strings are
+for open-ended user data, never for states, modes, kinds, levels, or variants.
+
+### The measured problem
+
+Top enum-like string comparisons in the tree today: `== "rocm"` ×22, `== "system"` ×16,
+`== "true"` ×13 (a **stringly boolean**), `== "rocm-stable"` ×12, `== "cloud"` ×12,
+`== "auto"` ×9, plus job statuses (`"completed"`, `"cancelled"`), log levels
+(`log_level_ == "debug" || log_level_ == "trace"` in `wrapped_server.h:104`), model
+modes (`"chat"`, `"embed"`, `"image"`), and boolean-ish `"yes"`/`"false"` ×9.
+
+Existing enums show the cost of hand-rolled conversion: `model_state_to_string`,
+`model_type_to_string`, `device_type_to_string` (`model_types.h:37,:83,:98`),
+`slot_policy_to_string` (`backend_descriptor.h:37`) — 12 files carry one-way
+`*_to_string` converters, and the reverse direction, where it exists at all, is a
+bool+out-param (`deployment_mode_of`). `BackendOption::type_name`
+(`backend_descriptor.h:18`) is a stringly enum — `"ARGS" | "SIZE" | "BACKEND" | "BOOL"`
+spelled as literals across 13 files.
+
+### The mechanism: `LEMON_ENUM` + one vocabulary header
+
+A single X-macro declaration in `lemon-core` generates everything both directions:
+
+```cpp
+// include/lemon/core/enum.h provides the machinery; a vocabulary is declared once:
+LEMON_ENUM(RocmChannel,
+    (Stable,  "rocm-stable"),
+    (Nightly, "rocm-nightly"));
+```
+
+expands to:
+
+- `enum class RocmChannel { Stable, Nightly };`
+- `constexpr std::string_view to_string(RocmChannel)` — total, switch-generated, no
+  fallthrough default.
+- `constexpr std::optional<RocmChannel> rocm_channel_from_string(std::string_view)` —
+  the parse direction returns `optional`, per rule 1.
+- `constexpr std::array<RocmChannel, N> values` + `count` — iteration for CLI help,
+  validation messages, and exhaustive tests.
+- Integration with the Phase 1 JSON codec: a `LEMON_ENUM` type is directly usable as a
+  DTO field; wire serialization uses the declared wire name, and an unknown wire value
+  is a `ParseError` with a JSON-pointer path — never a silent default.
+
+**The vocabulary file.** Cross-cutting pre-defined types and keys live in one header,
+`include/lemon/core/vocab.h`, so the closed vocabularies of the system are declared in
+a single reviewable place: `LlamaBackendVariant` (vulkan/rocm/metal/cpu/cuda),
+`RocmChannel`, `ConfigScope` (system/user), `JobStatus`, `LogLevel`,
+`BackendOptionType` (replacing the `"ARGS"|"SIZE"|"BACKEND"|"BOOL"` strings),
+`DeploymentMode` (chat/embeddings/reranking/…), and the wire-stable names for the
+existing `ModelState` / `ModelType` / `DeviceType` / `SlotPolicy` enums (whose
+hand-rolled converters are then deleted). Subsystem-local enums stay in their own
+headers using the same macro; `vocab.h` is only for vocabularies shared across layers.
+
+### Why not magic_enum (as the primary mechanism)
+
+`magic_enum` was considered and is deliberately **not** the wire mechanism:
+
+1. **Wire names are not identifiers.** `"rocm-stable"`, `"rocm-nightly"`, `"sd-cpp"`
+   contain dashes; magic_enum derives names from C++ identifiers, so every such value
+   needs a hand-written `customize::enum_name` specialization — at which point the
+   names are hand-maintained anyway, without the single-declaration guarantee.
+2. **Wire stability.** magic_enum couples the serialized form to the C++ identifier: a
+   rename refactor silently changes the API/config wire format. `LEMON_ENUM` makes the
+   wire name an explicit, reviewable string that a wire-key lock test can pin.
+3. It relies on compiler pretty-function parsing with a bounded value range
+   (±128 by default) and adds a third-party dependency the plan's non-goals exclude.
+
+magic_enum remains a fine optional convenience for **debug-only** printing of
+third-party or internal enums; if that need materializes it can be vendored like
+`aixlog.hpp` — but nothing on a wire, in a config file, or in a user-facing message
+may depend on it.
+
+## 3. Booleans and small rules that follow
+
+- **No stringly bools.** `"true"/"false"/"yes"` comparisons (13+ sites) become real
+  `bool` at the parse boundary (the JSON codec / CLI11 does the conversion; inner code
+  never sees the string).
+- **Multi-flag results are structs.** Two or more related out-params or a
+  `pair`/`tuple` of unnamed values become a named struct with named fields
+  (`authenticate_connection` above; `ProcessInfo` in `wrapped_server.h:415` is the
+  existing good example).
+- **`[[nodiscard]]`** on every `optional`/`Expected`/status-returning function added
+  under this standard, so an ignored failure is a compiler warning.
+- **`std::string_view`** for non-owning read-only string parameters in new `lemon-core`
+  / `lemon-json` code (matching `deployment_mode_of`'s existing signature style).
+- **Enum exhaustiveness**: switches over `LEMON_ENUM` types omit `default:` so adding
+  an enumerator produces `-Wswitch` warnings at every site that must handle it.
+
+## 4. Enforcement
+
+- New-code enforcement starts immediately via review; migration of the instances
+  listed above is folded into the plan's phases (rule 1 items land with the phase that
+  touches their file; the vocabulary header lands in Phase 1 alongside the JSON codec,
+  since the codec consumes it).
+- CI grep gates (added with Phase 1): no new `std::pair<bool`, no `== "true"` /
+  `== "false"` outside parse boundaries, and the wire-key lock tests cover enum wire
+  names exactly as they cover DTO field names.

--- a/docs/dev/core-hardening-standards.md
+++ b/docs/dev/core-hardening-standards.md
@@ -33,6 +33,31 @@ Sentinel precedent worth noting: `Telemetry::cache_tokens = -1` meaning "not rep
 (`wrapped_server.h:45`) needed a comment and a special JSON-null rendering to stay
 safe — exactly the cost `std::optional<int>` removes.
 
+### 1a. Tri-state wire fields: `JsonOptional<T>`
+
+On the wire, "key absent" and "key present with `null`" are different states, and
+`std::optional<T>` can only represent one of them. DTO fields where that distinction
+carries meaning (nullable API fields like `"stop": null`, PATCH-style partial updates
+where absent = leave alone and null = clear, nullable telemetry) use
+`JsonOptional<T>` — unset / null / value — defined in `lemon-json` and adapted from
+the donor implementation in `docs/dev/reference/json_optional_reference.md` (see the
+plan's Phase 1 for the adaptation deltas: unset omits the key on serialize, single
+source of truth for the flags, bitfield portability).
+
+Call sites use the uniform free-function queries, overloaded across `T`,
+`std::optional<T>`, and `JsonOptional<T>` so a DTO can change a field's kind without
+rewriting its readers:
+
+```cpp
+if (is_set(req.temperature)) { ... }   // key was present at all
+if (is_null(req.stop))       { ... }   // present and explicitly null
+if (has_value(req.model))    { ... }   // present with a real value
+```
+
+`std::optional<T>` remains correct for plain omit-or-value fields and for everything
+outside the wire layer; `JsonOptional<T>` is a wire-DTO type, not a general-purpose
+maybe.
+
 ## 2. Enums over raw strings
 
 ### Rule

--- a/docs/dev/core-hardening-standards.md
+++ b/docs/dev/core-hardening-standards.md
@@ -36,13 +36,18 @@ safe — exactly the cost `std::optional<int>` removes.
 ### 1a. Tri-state wire fields: `JsonOptional<T>`
 
 On the wire, "key absent" and "key present with `null`" are different states, and
-`std::optional<T>` can only represent one of them. DTO fields where that distinction
-carries meaning (nullable API fields like `"stop": null`, PATCH-style partial updates
-where absent = leave alone and null = clear, nullable telemetry) use
-`JsonOptional<T>` — unset / null / value — defined in `lemon-json` and adapted from
+`std::optional<T>` can only represent one of them. **Anything JSON-related uses
+`JsonOptional<T>`** — unset / null / value — defined in `lemon-json` and adapted from
 the donor implementation in `docs/dev/reference/json_optional_reference.md` (see the
 plan's Phase 1 for the adaptation deltas: unset omits the key on serialize, single
-source of truth for the flags, bitfield portability).
+source of truth for the flags, bitfield portability). The rule is unconditional:
+every non-required wire-DTO field, every `JsonTree` object lookup, every codec result
+carries the tri-state, and `std::optional` never appears in a JSON-facing
+declaration. Beyond correctness for null-meaningful fields (`"stop": null`,
+PATCH-style updates where absent = leave alone and null = clear, nullable telemetry),
+the universal rule keeps proxy forwarding byte-faithful — `std::optional` would
+collapse a client's explicit `null` into an omitted key on re-serialization — and is
+mechanically enforceable where a per-field choice is not.
 
 Call sites use the uniform free-function queries, overloaded across `T`,
 `std::optional<T>`, and `JsonOptional<T>` so a DTO can change a field's kind without
@@ -54,9 +59,10 @@ if (is_null(req.stop))       { ... }   // present and explicitly null
 if (has_value(req.model))    { ... }   // present with a real value
 ```
 
-`std::optional<T>` remains correct for plain omit-or-value fields and for everything
-outside the wire layer; `JsonOptional<T>` is a wire-DTO type, not a general-purpose
-maybe.
+`std::optional<T>` remains correct for everything outside the JSON layer — function
+returns, internal state, lookups (§1); `JsonOptional<T>` is the JSON-layer type, not
+a general-purpose maybe. The boundary is the codec: below it (DTOs, trees, parse
+results) tri-state; above it, plain `optional`.
 
 ## 2. Enums over raw strings
 
@@ -158,5 +164,6 @@ may depend on it.
   touches their file; the vocabulary header lands in Phase 1 alongside the JSON codec,
   since the codec consumes it).
 - CI grep gates (added with Phase 1): no new `std::pair<bool`, no `== "true"` /
-  `== "false"` outside parse boundaries, and the wire-key lock tests cover enum wire
-  names exactly as they cover DTO field names.
+  `== "false"` outside parse boundaries, no `std::optional` in `lemon-api` DTO
+  declarations (JSON layer is `JsonOptional`-only, §1a), and the wire-key lock tests
+  cover enum wire names exactly as they cover DTO field names.

--- a/docs/dev/reference/json_optional_reference.md
+++ b/docs/dev/reference/json_optional_reference.md
@@ -1,0 +1,299 @@
+# JsonOptional — donor reference implementation
+
+Design reference for the tri-state JSON field type described in
+`core-hardening-plan.md` Phase 1 and `core-hardening-standards.md` §1a.
+Not compiled into any target; the lemon-json `JsonOptional<T>` is adapted
+from this with the deltas recorded in the plan (key omission on unset,
+flag/value invariant, bitfield portability). The pqxx section is inert in
+this tree and kept for completeness.
+
+```cpp
+
+#include <optional>
+#include <type_traits>
+#include <nlohmann/json.hpp>
+
+template<typename T>
+class JsonOptional {
+public:
+    using type = T;
+    union {
+        uint8_t _raw_flags = 0; // Initialize to 0
+        struct {
+            bool is_set  : 1; // Bit 0 (Directly accessible!)
+            bool is_null : 1; // Bit 1 (Directly accessible!)
+            uint8_t _pad : 6;
+        };
+    };
+    std::optional<T> value; // The actual value, which can be nullopt
+
+    // --- Constructors ---
+
+    JsonOptional() {
+        is_set = 0;
+        is_null = 1;
+        value = std::nullopt;
+    }
+
+    JsonOptional(const JsonOptional&) = default;
+    JsonOptional(JsonOptional&&) = default;
+
+    // Allow implicit construction from optional
+    JsonOptional(const std::optional<T>& opt) : value(opt) {
+        is_set = true;
+        is_null = (opt == std::nullopt);
+    }
+
+    // Allow implicit construction from value T
+    JsonOptional(const T& val) : value(val) {
+        is_set = true;
+        is_null = false;
+    }
+
+    // 1. Assign std::nullopt explicitly
+    JsonOptional<T>& operator=(std::nullopt_t) {
+        is_set = true;
+        is_null = true;
+        value = std::nullopt;
+        return *this;
+    }
+
+    // 2. Templated Assignment: Handles T, const T&, optional<T>, and const char*
+    // This uses SFINAE to avoid blocking the default copy/move constructors
+    template <typename U,
+              typename = std::enable_if_t<
+                  !std::is_same_v<std::decay_t<U>, JsonOptional<T>>
+              >>
+    JsonOptional<T>& operator=(U&& newValue) {
+        // Forward the assignment to the internal std::optional
+        // This lets std::optional handle the logic of converting const char* to std::string
+        value = std::forward<U>(newValue);
+
+        is_set = true;
+        is_null = !value.has_value();
+        return *this;
+    }
+
+    // 3. Keep default copy/move assignments so the class can be copied
+    JsonOptional& operator=(const JsonOptional&) = default;
+    JsonOptional& operator=(JsonOptional&&) = default;
+
+    // --- Helpers ---
+
+    bool is_unset() const { return !is_set; }
+    bool has_value() const { return is_set && !is_null; }
+
+    T value_or(T val) {
+        if(!is_set || (is_set && is_null))
+            return val;
+        else
+            return this->get();
+    }
+
+    T& get() {
+        return value.value();
+    }
+
+    const T& get() const {
+        return value.value();
+    }
+
+    void set(T field) {
+        is_set = true;
+        is_null = false;
+        value = field;
+    }
+
+    JsonOptional<T>& set(JsonOptional<T> field) {
+        is_set = field.is_set;
+        is_null = field.is_null;
+        value = field.value;
+        return *this;
+    }
+
+    // --- Conversion Operators ---
+
+    // Allow implicit conversion to the underlying type T
+    operator const T&() const {
+        return value.value();
+    }
+
+    // Allow implicit conversion to std::optional<T>
+    operator const std::optional<T>&() const {
+        return value;
+    }
+
+    // Allow implicit boolean checks
+    explicit operator bool() const {
+        return value.has_value();
+    }
+
+    // --- Access Operators ---
+
+    const T& operator*() const { return *value; }
+    T& operator*() { return *value; }
+
+    const T* operator->() const { return &value.value(); }
+    T* operator->() { return &value.value(); }
+};
+
+template <typename T> struct is_jsonoptional : std::false_type {};
+template <typename U> struct is_jsonoptional<JsonOptional<U>> : std::true_type {};
+
+// is_optional
+template <typename T> struct is_optional : std::false_type {};
+template <typename U> struct is_optional<std::optional<U>> : std::true_type {};
+// underlying_type: Gets the 'T' from JsonOptional<T>, optional<T>, or T
+template <typename T>
+struct underlying_type { using type = T; };
+
+template <typename U>
+struct underlying_type<std::optional<U>> { using type = U; };
+
+template <typename U>
+struct underlying_type<JsonOptional<U>> { using type = U; };
+
+// The alias that should be used in the macros
+template <typename T>
+using underlying_type_t = typename underlying_type<T>::type;
+
+#define SAFE_JSON_TO(field) \
+    if (nlohmann_json_t.field.is_set && !nlohmann_json_t.field.is_null && nlohmann_json_t.field.value.has_value()) { \
+        nlohmann_json_j[#field] = nlohmann_json_t.field.value.value(); \
+    } else { \
+        nlohmann_json_j[#field] = nullptr; \
+    }
+
+#define NLOHMANN_DEFINE_SAFE_INTRUSIVE(Type, ...) \
+    friend void to_json(nlohmann::json& nlohmann_json_j, const Type& nlohmann_json_t) { \
+        nlohmann_json_j = nlohmann::json::object(); \
+        NLOHMANN_JSON_EXPAND( \
+            NLOHMANN_JSON_PASTE( \
+                SAFE_JSON_TO, \
+                __VA_ARGS__ \
+            ) \
+        ); \
+    } \
+    friend void from_json(const nlohmann::json& nlohmann_json_j, Type& nlohmann_json_t) { \
+        NLOHMANN_JSON_EXPAND( \
+            NLOHMANN_JSON_PASTE( \
+                SAFE_JSON_FROM_FIELD_HELPER_PASTE_HELPER, \
+                __VA_ARGS__ \
+            ) \
+        ); \
+    }
+
+/* --- You must also adjust your helper macros to match the standard signature --- */
+
+/* Intermediate helper: Re-injects the C++ object variable name (nlohmann_json_t) */
+#define SAFE_JSON_FROM_FIELD_HELPER_PASTE_HELPER(field) \
+    SAFE_JSON_FROM_FIELD_HELPER(nlohmann_json_t, field)
+
+/* Final helper: Uses nlohmann_json_j (the input JSON) and nlohmann_json_t (the C++ object) */
+#define SAFE_JSON_FROM_FIELD_HELPER(obj, field) \
+    if (nlohmann_json_j.contains(#field)) { \
+        if (!nlohmann_json_j.at(#field).is_null()) { \
+            nlohmann_json_j.at(#field).get_to(obj.field); \
+        } else { \
+            obj.field = std::nullopt; \
+        } \
+    }
+
+namespace nlohmann {
+    template <typename T>
+    struct adl_serializer<JsonOptional<T>> {
+        // --- from_json: How to convert json TO JsonOptional<T> ---
+        static void from_json(const json& j, JsonOptional<T>& settable) {
+            // This function is ONLY called by the library if the
+            // key *actually exists* in the JSON object.
+            // Therefore, we can confidently set this to true.
+            settable.is_set = true;
+            if (j.is_null()) {
+                // CRITICAL: do NOT deserialize a null. Previously the value
+                // extraction below ran unconditionally (the if/else only set the
+                // flag), so JsonOptional<number> hit adl_serializer<T>::from_json
+                // on a null and threw type_error.302 ("must be number, but is
+                // null"). That aborted the server whenever a nullable numeric
+                // column came back null.
+                settable.is_null = 1;
+                settable.value = std::nullopt;
+            } else {
+                settable.is_null = 0;
+                // Directly extract the value using the serializer
+                T temp;
+                nlohmann::adl_serializer<T>::from_json(j, temp);
+                settable.value = temp;
+            }
+        }
+
+        static void to_json(json& j, const JsonOptional<T>& settable) {
+            if (settable.is_set && !settable.is_null && settable.value.has_value()) {
+                j = settable.value.value();
+            } else {
+                j = nullptr;
+            }
+        }
+    };
+} // namespace nlohmann
+
+// Specialization for nlohmann::json to avoid infinite recursion
+namespace nlohmann {
+    template <>
+    struct adl_serializer<JsonOptional<nlohmann::json>> {
+        static void from_json(const json& j, JsonOptional<nlohmann::json>& settable) {
+            settable.is_set = true;
+            settable.is_null = j.is_null();
+            settable.value = j;
+        }
+        static void to_json(json& j, const JsonOptional<nlohmann::json>& settable) {
+            if (settable.is_set && !settable.is_null && settable.value.has_value()) {
+                j = settable.value.value();
+            } else {
+                j = nullptr;
+            }
+        }
+    };
+} // namespace nlohmann
+
+#ifdef KANA_JSONOPTIONAL_HAS_PQXX
+namespace pqxx {
+  template<typename T>
+  struct nullness<JsonOptional<T>> {
+    static constexpr bool has_null = true;
+    static constexpr bool always_null = false;
+
+    static bool is_null(const JsonOptional<T> &obj) noexcept {
+      return !obj.has_value();
+    }
+
+    static JsonOptional<T> null() {
+      JsonOptional<T> j_opt;
+      j_opt = std::nullopt;
+      return j_opt;
+    }
+  };
+
+  template<typename T>
+  struct string_traits<JsonOptional<T>> {
+    static constexpr bool has_null() { return true; }
+
+    [[nodiscard]] static JsonOptional<T> from_string(std::string_view text) {
+      auto opt = string_traits<std::optional<T>>::from_string(text);
+      return JsonOptional<T>(opt);
+    }
+
+    static zview to_string(const JsonOptional<T>& obj) {
+      return string_traits<std::optional<T>>::to_string(obj.value);
+    }
+
+    static char *into_buf(char *begin, char *end, const JsonOptional<T> &obj) {
+      return string_traits<std::optional<T>>::into_buf(begin, end, obj.value);
+    }
+
+    static std::size_t size_buffer(const JsonOptional<T> &obj) noexcept {
+      return string_traits<std::optional<T>>::size_buffer(obj.value);
+    }
+  };
+}
+#endif // KANA_JSONOPTIONAL_HAS_PQXX
+```


### PR DESCRIPTION
## Summary

#### HUMAN WRITTEN
I opened this up as a RFC to get a discussion regarding some proposed changes, this is not meant to get merged but to get reviewed, I don't expect it all to get done at once but this is one path to clean stuff up, stabilize our core, and standardize it.

ANALYSIS IS BEING TRIAGED BY ME CURRENTLY.


#### AI WRITTEN
RFC — no code changes. Adds two developer docs proposing a phased hardening of the C++ core:

- `docs/dev/core-hardening-analysis.md` — verified current state: build-target duplication (CLI/tray recompiling server sources, `routing_policy.cpp` compiled 12×), the 8,277-line `server.cpp` with no handler abstraction, ~4,000+ string-keyed JSON operations with zero round-trip DTOs, three unrelated HTTP client stacks, and the hand-rolled Anthropic/Ollama compat translators — plus the in-repo assets to build on (backend descriptor/factory registry, capability masks, `StreamingProxy`, the routing-policy strict parser).
- `docs/dev/core-hardening-plan.md` — five independently landable phases:
  0. Layered static libraries (`lemon-core ← lemon-json ← lemon-net ← lemon-api ← lemon-server`) with thin executables; one shared HTTP client bootstrap.
  1. Compile-time typed JSON codec (`LEMON_JSON(...)`, C++17, keys derived from member names — no string keys at call sites) + first DTO wave, including tri-state `JsonOptional<T>` fields (key absent vs explicit null vs value, with uniform `is_set`/`is_null`/`has_value` free-function queries; donor reference vendored under `docs/dev/reference/`).
  2. CRTP `Endpoint<Derived>` handler base owning parse/auto-load/dispatch/error-map/SSE; single quad-prefix registration helper; `server.cpp` < ~1,000 lines.
  3. CRTP `ProtocolAdapter<Derived>`: OpenAI as the identity adapter; Anthropic and Ollama become pure remaps (request/response mapping + a typed-delta stream transcoder) and Anthropic moves out of `OllamaApi`.
  4. Router stream-clone collapse and long-tail stringly-JSON sweeps.
- `docs/dev/core-hardening-standards.md` — coding standards adopted with the RFC: `std::optional`/`Expected` over `std::pair<bool,T>`, out-params, and sentinel values (current violations inventoried); `enum class` over raw-string vocabularies via a `LEMON_ENUM` X-macro with explicit wire names and a central `vocab.h` vocabulary header; rationale for not using magic_enum as the wire mechanism.

One deliberate behavior change is called out in the plan: unifying malformed-JSON handling fixes today's 400-vs-500 inconsistency across endpoints. Feedback wanted on the library boundaries, the codec design, and phase ordering before implementation starts.

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_ Documentation-only change (two new files under `docs/dev/`); no source, build, or CI files touched, so no build or test impact. Markdown proofread; all file:line references in the analysis were verified against the tree at the branch point (latest `main`, 50280abf).

## Documentation

- [x] Documentation is affected and has been updated.

## Breaking Changes

- [x] This PR does not introduce breaking changes.

## AI-assisted contribution

Please select one:

- [x] I used AI tools for this PR.

If AI tools were used:

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.

