### PR TITLE
ci(sdcpp): A/B the ROCm runtime install method and assert the device used

### DIFF
--- a/.github/workflows/validate_sdcpp.yml
+++ b/.github/workflows/validate_sdcpp.yml
@@ -410,7 +410,10 @@ jobs:
 
           $whl = Get-ChildItem "$wheelDir\*.whl" | Select-Object -First 1
           if (-not $whl) { Write-Host "::warning::wheel download failed"; exit 0 }
-          Expand-Archive -Path $whl.FullName -DestinationPath (Join-Path $wheelDir "x") -Force
+          # Expand-Archive only accepts .zip; a wheel is a zip with another name.
+          $asZip = [System.IO.Path]::ChangeExtension($whl.FullName, ".zip")
+          Copy-Item $whl.FullName $asZip -Force
+          Expand-Archive -Path $asZip -DestinationPath (Join-Path $wheelDir "x") -Force
           $whlRocblas = Get-ChildItem -Path (Join-Path $wheelDir "x") -Recurse -Filter "rocblas.dll" -ErrorAction SilentlyContinue |
                         Select-Object -First 1
           if ($whlRocblas) {

--- a/.github/workflows/validate_sdcpp.yml
+++ b/.github/workflows/validate_sdcpp.yml
@@ -239,6 +239,105 @@ jobs:
           echo "Validation legs for ${EVENT_NAME}:"
           jq -r '.[].label' <<<"$matrix"
 
+  rocm-device-diagnostic:
+    name: ROCm device diagnostic
+    # Dispatch-only probe: does HIP see the GPU on this rig at all, and does the
+    # answer depend on the TheRock version? Deliberately has no `needs` so it
+    # starts immediately and does not involve lemonade at all.
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: [self-hosted, Windows, stx-halo, rocm, lemon-prod]
+    timeout-minutes: 60
+    steps:
+      - name: Host and driver facts
+        shell: PowerShell
+        run: |
+          $ErrorActionPreference = "Continue"
+          Write-Host "runner=$env:RUNNER_NAME  host=$(hostname)"
+
+          $proc = Get-Process -Id $PID
+          Write-Host "this process SessionId=$($proc.SessionId)  (0 = Windows service session, no desktop)"
+          Write-Host "--- interactive sessions ---"
+          query session 2>&1 | Out-String | Write-Host
+          Write-Host "--- runner service ---"
+          Get-CimInstance Win32_Service | Where-Object { $_.Name -like "*actions.runner*" } |
+            Select-Object Name, StartName, State | Format-List | Out-String | Write-Host
+
+          Write-Host "--- video controllers ---"
+          Get-CimInstance Win32_VideoController |
+            Select-Object Name, DriverVersion, DriverDate, Status, ConfigManagerErrorCode |
+            Format-List | Out-String | Write-Host
+
+          Write-Host "--- Radeon Software (Adrenalin) ---"
+          Get-ChildItem "HKLM:\SYSTEM\CurrentControlSet\Control\Class\{4d36e968-e325-11ce-bfc1-08002be10318}" -ErrorAction SilentlyContinue | ForEach-Object {
+            $pr = Get-ItemProperty $_.PSPath -ErrorAction SilentlyContinue
+            if ($pr.DriverDesc -match 'AMD|Radeon') {
+              Write-Host ("  {0}: RadeonSoftwareVersion={1}  Edition={2}  ReleaseVersion={3}" -f `
+                $pr.DriverDesc, $pr.RadeonSoftwareVersion, $pr.RadeonSoftwareEdition, $pr.ReleaseVersion)
+            }
+          }
+
+          Write-Host "--- driver-supplied HIP runtimes in System32 ---"
+          Get-ChildItem "$env:WINDIR\System32\amdhip64*.dll", "$env:WINDIR\System32\amd_comgr*.dll" -ErrorAction SilentlyContinue |
+            ForEach-Object { Write-Host ("  {0}  {1}" -f $_.Name, $_.VersionInfo.FileVersion) }
+
+          Write-Host "--- relevant env ---"
+          Get-ChildItem env: | Where-Object { $_.Name -match 'HIP|ROCR|ROCM|GPU_|HSA' } |
+            ForEach-Object { Write-Host ("  {0}={1}" -f $_.Name, $_.Value) }
+
+      - name: Enumerate HIP devices under TheRock 7.13.0 and 7.14.0
+        shell: PowerShell
+        run: |
+          $ErrorActionPreference = "Continue"
+          $root = Join-Path $env:RUNNER_TEMP "rocm-diag"
+          Remove-Item -Recurse -Force $root -ErrorAction SilentlyContinue
+          New-Item -ItemType Directory -Force -Path $root | Out-Null
+
+          # 7.13.0 is the last per-arch build and is known to have worked on this
+          # rig; 7.14.0 is the multi-arch repackaging that CI has been failing on.
+          $builds = @(
+            @{ ver = "7.13.0"; url = "https://repo.amd.com/rocm/tarball/therock-dist-windows-gfx1151-7.13.0.tar.gz" },
+            @{ ver = "7.14.0"; url = "https://repo.amd.com/rocm/tarball-multi-arch/therock-dist-windows-gfx1151-7.14.0.tar.gz" }
+          )
+
+          foreach ($b in $builds) {
+            $ver = $b.ver
+            Write-Host "===================== TheRock $ver ====================="
+            $dir = Join-Path $root $ver
+            New-Item -ItemType Directory -Force -Path $dir | Out-Null
+            $tgz = Join-Path $root "therock-$ver.tar.gz"
+
+            Write-Host "downloading $($b.url)"
+            curl.exe -sSL --retry 3 -o $tgz $b.url
+            if ($LASTEXITCODE -ne 0) { Write-Host "::warning::download failed for $ver"; continue }
+            tar -xzf $tgz -C $dir
+            if ($LASTEXITCODE -ne 0) { Write-Host "::warning::extract failed for $ver"; continue }
+
+            $bin = Join-Path $dir "bin"
+            Write-Host "--- gfx1151 device code objects present? ---"
+            $devlibs = Get-ChildItem -Recurse -Path $dir -Filter "*gfx1151*" -ErrorAction SilentlyContinue |
+                       Select-Object -First 8
+            if ($devlibs) { $devlibs | ForEach-Object { Write-Host ("  {0}" -f $_.FullName.Substring($dir.Length)) } }
+            else { Write-Host "  (none found)" }
+
+            Write-Host "--- HIP runtime shipped ---"
+            Get-ChildItem "$bin\amdhip64*.dll", "$bin\amd_comgr*.dll" -ErrorAction SilentlyContinue |
+              ForEach-Object { Write-Host ("  {0}  {1}" -f $_.Name, $_.VersionInfo.FileVersion) }
+
+            # Run TheRock's own enumeration tools with its bin dir first on PATH,
+            # so this measures HIP directly rather than anything lemonade does.
+            $saved = $env:PATH
+            $env:PATH = "$bin;$saved"
+            foreach ($tool in @("hipInfo.exe","rocminfo.exe","amdsmi_cli.exe","hipconfig.exe")) {
+              $exe = Join-Path $bin $tool
+              if (Test-Path $exe) {
+                Write-Host "--- $tool ---"
+                & $exe 2>&1 | Select-Object -First 25 | Out-String | Write-Host
+                Write-Host "  exit=$LASTEXITCODE"
+              }
+            }
+            $env:PATH = $saved
+          }
+
   build:
     name: Build Lemonade with sd-cpp pins
     needs: discover-release

--- a/.github/workflows/validate_sdcpp.yml
+++ b/.github/workflows/validate_sdcpp.yml
@@ -312,7 +312,17 @@ jobs:
             tar -xzf $tgz -C $dir
             if ($LASTEXITCODE -ne 0) { Write-Host "::warning::extract failed for $ver"; continue }
 
-            $bin = Join-Path $dir "bin"
+            # The tarballs unpack into a versioned subdirectory
+            # (therock-dist-windows-gfx1151-7.14.0rc3), so resolve bin from
+            # whatever the archive actually created.
+            $bin = Get-ChildItem -Path $dir -Recurse -Directory -Filter "bin" -ErrorAction SilentlyContinue |
+                   Where-Object { Test-Path (Join-Path $_.FullName "amdhip64_7.dll") } |
+                   Select-Object -First 1 -ExpandProperty FullName
+            if (-not $bin) {
+              $bin = Get-ChildItem -Path $dir -Recurse -Directory -Filter "bin" -ErrorAction SilentlyContinue |
+                     Select-Object -First 1 -ExpandProperty FullName
+            }
+            Write-Host "resolved bin: $bin"
             Write-Host "--- gfx1151 device code objects present? ---"
             $devlibs = Get-ChildItem -Recurse -Path $dir -Filter "*gfx1151*" -ErrorAction SilentlyContinue |
                        Select-Object -First 8

--- a/.github/workflows/validate_sdcpp.yml
+++ b/.github/workflows/validate_sdcpp.yml
@@ -388,6 +388,47 @@ jobs:
           & (Join-Path $repro "hipInfo.exe") 2>&1 | Select-Object -First 6 | Out-String | Write-Host
 
 
+      - name: Compare rocblas between the 7.14 tarball and wheel
+        shell: PowerShell
+        run: |
+          $ErrorActionPreference = "Continue"
+          $root = Join-Path $env:RUNNER_TEMP "rocm-diag"
+
+          $tarRocblas = Get-ChildItem -Path (Join-Path $root "7.14.0") -Recurse -Filter "rocblas.dll" -ErrorAction SilentlyContinue |
+                        Select-Object -First 1
+          if ($tarRocblas) {
+            Write-Host ("tarball rocblas.dll: {0} bytes  ver={1}  sha256={2}" -f `
+              $tarRocblas.Length, $tarRocblas.VersionInfo.FileVersion,
+              (Get-FileHash $tarRocblas.FullName -Algorithm SHA256).Hash)
+          } else { Write-Host "::warning::tarball rocblas.dll not found" }
+
+          # Same version, other delivery channel.
+          $wheelDir = Join-Path $root "wheel"
+          New-Item -ItemType Directory -Force -Path $wheelDir | Out-Null
+          python -m pip download "rocm-sdk-libraries==7.14.0" --no-deps --only-binary :all: `
+            --index-url https://repo.amd.com/rocm/whl-multi-arch/ -d $wheelDir 2>&1 | Select-Object -Last 3 | Out-String | Write-Host
+
+          $whl = Get-ChildItem "$wheelDir\*.whl" | Select-Object -First 1
+          if (-not $whl) { Write-Host "::warning::wheel download failed"; exit 0 }
+          Expand-Archive -Path $whl.FullName -DestinationPath (Join-Path $wheelDir "x") -Force
+          $whlRocblas = Get-ChildItem -Path (Join-Path $wheelDir "x") -Recurse -Filter "rocblas.dll" -ErrorAction SilentlyContinue |
+                        Select-Object -First 1
+          if ($whlRocblas) {
+            Write-Host ("wheel   rocblas.dll: {0} bytes  ver={1}  sha256={2}" -f `
+              $whlRocblas.Length, $whlRocblas.VersionInfo.FileVersion,
+              (Get-FileHash $whlRocblas.FullName -Algorithm SHA256).Hash)
+          } else { Write-Host "::warning::wheel rocblas.dll not found" }
+
+          Write-Host "--- Tensile/kernel data layout ---"
+          foreach ($p in @(@{n="tarball";r=(Join-Path $root "7.14.0")}, @{n="wheel";r=(Join-Path $wheelDir "x")})) {
+            $hits = Get-ChildItem -Path $p.r -Recurse -ErrorAction SilentlyContinue |
+                    Where-Object { $_.Name -match "gfx1151" -and $_.Name -match "\.(dat|co|hsaco|kpack|zlib)$" } |
+                    Select-Object -First 5
+            Write-Host ("  {0}: {1} matching kernel files" -f $p.n, (@($hits).Count))
+            $hits | ForEach-Object { Write-Host ("    {0}" -f $_.Name) }
+          }
+
+
   build:
     name: Build Lemonade with sd-cpp pins
     needs: discover-release

--- a/.github/workflows/validate_sdcpp.yml
+++ b/.github/workflows/validate_sdcpp.yml
@@ -348,6 +348,46 @@ jobs:
             $env:PATH = $saved
           }
 
+      - name: Reproduce the sd-server DLL layout
+        shell: PowerShell
+        run: |
+          $ErrorActionPreference = "Continue"
+          $root = Join-Path $env:RUNNER_TEMP "rocm-diag"
+          $bin  = Get-ChildItem -Path (Join-Path $root "7.14.0") -Recurse -Directory -Filter "bin" -ErrorAction SilentlyContinue |
+                  Where-Object { Test-Path (Join-Path $_.FullName "amdhip64_7.dll") } |
+                  Select-Object -First 1 -ExpandProperty FullName
+          if (-not $bin) { Write-Host "::error::7.14.0 bin not found"; exit 1 }
+
+          Write-Host "--- TheRock 7.14 DLLs that System32 also provides (shadowing set) ---"
+          $sys = "$env:WINDIR\System32"
+          Get-ChildItem "$bin\*.dll" | ForEach-Object {
+            $twin = Join-Path $sys $_.Name
+            if (Test-Path $twin) {
+              Write-Host ("  {0}: TheRock={1}  System32={2}" -f $_.Name,
+                $_.VersionInfo.FileVersion, (Get-Item $twin).VersionInfo.FileVersion)
+            }
+          }
+
+          # sd-server.exe lives in its own directory with only amdhip64_7.dll
+          # staged next to it and TheRock on PATH. The exe directory and System32
+          # both precede PATH in the loader search order, so any companion DLL
+          # that System32 also provides resolves to the driver's copy.
+          $repro = Join-Path $root "repro"
+          Remove-Item -Recurse -Force $repro -ErrorAction SilentlyContinue
+          New-Item -ItemType Directory -Force -Path $repro | Out-Null
+          Copy-Item "$bin\hipInfo.exe" $repro
+          Copy-Item "$bin\amdhip64_7.dll" $repro
+
+          $env:PATH = "$bin;$env:PATH"
+
+          Write-Host "--- A: sd-server layout (only amdhip64_7.dll staged) ---"
+          & (Join-Path $repro "hipInfo.exe") 2>&1 | Select-Object -First 6 | Out-String | Write-Host
+
+          Copy-Item "$bin\amd_comgr.dll" $repro -ErrorAction SilentlyContinue
+          Write-Host "--- B: same, plus TheRock amd_comgr.dll staged ---"
+          & (Join-Path $repro "hipInfo.exe") 2>&1 | Select-Object -First 6 | Out-String | Write-Host
+
+
   build:
     name: Build Lemonade with sd-cpp pins
     needs: discover-release

--- a/.github/workflows/validate_sdcpp.yml
+++ b/.github/workflows/validate_sdcpp.yml
@@ -211,19 +211,28 @@ jobs:
           # validation stays disabled until a matching runner exists.
           legs='[
             {"label":"cpu","backend":"cpu","channel":"",
+             "install_method":"auto","expect_rocm_device":false,
              "runner":["self-hosted","Windows","stx-halo","vulkan","lemon-prod"]},
             {"label":"vulkan","backend":"vulkan","channel":"",
+             "install_method":"auto","expect_rocm_device":false,
              "runner":["self-hosted","Windows","stx-halo","vulkan","lemon-prod"]},
             {"label":"rocm-stable","backend":"rocm","channel":"stable",
+             "install_method":"auto","expect_rocm_device":false,
+             "runner":["self-hosted","Windows","stx-halo","rocm","lemon-prod"]},
+            {"label":"rocm-stable-tarball","backend":"rocm","channel":"stable",
+             "install_method":"tarball","expect_rocm_device":true,
              "runner":["self-hosted","Windows","stx-halo","rocm","lemon-prod"]}
           ]'
 
           # cpp_server_build_test_release.yml already exercises sd-cpp on CPU
           # before merge, so the CPU leg only earns its ~17 minutes when it is
           # qualifying an upstream release for the update PR.
+          # rocm-stable-tarball is the A/B control for the wheel-vs-tarball ROCm
+          # runtime, so it rides the same cadence as the cpu baseline it is
+          # compared against rather than every gated PR.
           case "${EVENT_NAME}" in
             schedule|workflow_dispatch) matrix=$(jq -c '.' <<<"$legs") ;;
-            *) matrix=$(jq -c '[.[] | select(.label != "cpu")]' <<<"$legs") ;;
+            *) matrix=$(jq -c '[.[] | select(.label != "cpu" and .label != "rocm-stable-tarball")]' <<<"$legs") ;;
           esac
 
           echo "validate_matrix=${matrix}" >> "$GITHUB_OUTPUT"
@@ -372,6 +381,7 @@ jobs:
           LEMONADE_VALIDATE_SD_PROMPT: ${{ env.SDCPP_TEST_PROMPT }}
           LEMONADE_VALIDATE_SD_STEPS: ${{ env.SDCPP_TEST_STEPS }}
           LEMONADE_VALIDATE_SD_TIMEOUT: ${{ env.LEMONADE_VALIDATE_SD_TIMEOUT }}
+          LEMONADE_ROCM_INSTALL_METHOD: ${{ matrix.install_method }}
         run: |
           $ErrorActionPreference = "Stop"
           $lemondExe = (Resolve-Path "build\Release\lemond.exe").Path
@@ -434,6 +444,42 @@ jobs:
             } catch {
               Write-Host "lemond shutdown not reachable; relying on cleanup step." -ForegroundColor Yellow
             }
+          }
+
+      - name: Report which device the rocm backend actually used
+        if: always() && matrix.backend == 'rocm'
+        shell: PowerShell
+        run: |
+          $ErrorActionPreference = "Stop"
+          $label  = "${{ matrix.label }}"
+          $method = "${{ matrix.install_method }}"
+          $expect = "${{ matrix.expect_rocm_device }}" -eq "true"
+          $log    = "server-logs-$label\lemond.stderr.log"
+
+          if (Test-Path $log) {
+            $text = Get-Content $log -Raw
+          } else {
+            $text = ""
+          }
+
+          if ($text -match "no ROCm-capable device is detected") {
+            $verdict = "CPU FALLBACK"
+            $detail  = "ggml_cuda_init reported no ROCm-capable device"
+          } elseif ($text -match "ggml_cuda_init: found \d+ ROCm devices") {
+            $verdict = "ROCm GPU"
+            $line    = ($text -split "`n" | Where-Object { $_ -match "^\s*Device \d+:" } | Select-Object -First 1)
+            $detail  = if ($line) { $line.Trim() } else { "device banner present" }
+          } else {
+            $verdict = "UNKNOWN"
+            $detail  = "no ggml_cuda_init banner in $log"
+          }
+
+          Write-Host "$label (install=$method): $verdict - $detail"
+          Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "- **$label** (install=``$method``): **$verdict** - $detail"
+
+          if ($expect -and $verdict -ne "ROCm GPU") {
+            Write-Host "::error title=ROCm GPU not used::$label requested the rocm backend but got '$verdict'"
+            exit 1
           }
 
       - name: Upload validation evidence


### PR DESCRIPTION
## Summary

Adds a `rocm-stable-tarball` validation leg that pins `LEMONADE_ROCM_INSTALL_METHOD=tarball`, so the wheel and tarball ROCm runtimes are exercised on the same rig, same commit, same models. A new step reads `lemond.stderr.log` and reports whether ggml initialized a ROCm GPU or silently fell back to CPU; the tarball leg fails when it did not get a GPU.

Context: since #2768 bumped TheRock to 7.14.0, the runtime is delivered as pip wheels rather than a tarball, and on gfx1151 that build reports `ggml_cuda_init: failed to initialize ROCm: no ROCm-capable device is detected`. Every `rocm-stable` leg on main has been running on CPU while reporting success — Flux-2-Klein-4B 1024² takes ~587s on the rocm leg vs ~43s on vulkan. The one leg in the last 200 runs that did use the GPU was a merge-queue build whose base predated #2768 and therefore still installed the 7.13.0 tarball.

This leg is the control that tells us whether the delivery method or the 7.14.0 build is responsible. It rides the schedule/dispatch cadence, like the `cpu` baseline it is compared against, rather than every gated PR.

Related: #3401, #3405 (which owns making the existing leg fail loudly).

Fixes #

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_ CI-only change; no code builds. YAML and actionlint pass via pre-commit. Dispatched on this branch pinned to the currently pinned sd-cpp release so no update PR is produced; results recorded below.

## Documentation

- [x] Documentation is not affected by this change.

## Breaking Changes

- [x] This PR does not introduce breaking changes.

## AI-assisted contribution

- [x] I used AI tools for this PR.

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011QSgagaAkHY863teRf64Hi
