### PR TITLE
fix(http): streaming stall timeout respects global_timeout

### DIFF
--- a/docs/guide/configuration/README.md
+++ b/docs/guide/configuration/README.md
@@ -203,7 +203,7 @@ When `lemond` starts, effective configuration is resolved by deep-merging settin
 | `log_file` | string | "auto" | File logging mode: "auto" (console-only for direct server runs, lemonade-server.log for embedded tray app), "disabled", "enabled", or custom target file path |
 | `log_max_file_size_mb` | int | 10 | Max active log file size in MB before triggering rotation (steady-state footprint bounded to ~`log_max_file_size_mb * (log_max_files + 1)`) |
 | `log_max_files` | int | 5 | Max number of rotated log backup files to retain (.1 through .N); legacy oversized files are rotated into .1 and pruned over cycles |
-| `global_timeout` | int | 600 | Timeout in seconds for HTTP, inference, and readiness checks |
+| `global_timeout` | int | 600 | Timeout in seconds for HTTP, inference, and readiness checks. Also bounds streaming silence: a streaming request is treated as dead after this many seconds without receiving any bytes |
 | `max_loaded_models` | int | 1 | Max models per type slot. Use -1 for unlimited |
 | `broadcast` | bool | true | Enable or disable UDP broadcasting for server discovery |
 | `extra_models_dir` | string | "" | Secondary directory recursively scanned for GGUF model files. Empty disables extra discovery; existing paths must be readable by `lemond`. Top-level `chat`, `embeddings`, and `reranking` directories select how models run, see [Model Management](../../embeddable/models.md) |

--- a/src/cpp/include/lemon/utils/http_client.h
+++ b/src/cpp/include/lemon/utils/http_client.h
@@ -156,8 +156,9 @@ public:
     //
     // timeout_seconds=0 uses default_timeout_seconds_. A total timeout would
     // cut off a long but healthy generation, so this bounds upstream silence
-    // instead: the transfer is aborted only after kStreamStallSeconds with no
-    // progress, which a streaming response cannot legitimately exceed.
+    // instead: the transfer is aborted only after the configured default
+    // timeout (global_timeout) passes with no progress. It imposes no
+    // total-duration bound on the stream itself.
     static HttpResponse post_stream(
         const std::string& url,
         const std::string& body,

--- a/src/cpp/server/utils/http_client.cpp
+++ b/src/cpp/server/utils/http_client.cpp
@@ -39,10 +39,6 @@ namespace {
 // full request timeout.
 constexpr long kConnectTimeoutSeconds = 30;
 
-// How long a stream may deliver nothing before it is treated as dead. Well
-// above any inter-token gap, well below "never".
-constexpr long kStreamStallSeconds = 120;
-
 // Resolves the 0-means-default convention shared by every request method.
 // Without this, curl reads 0 as "no timeout" and a silent upstream parks the
 // calling httplib worker permanently.
@@ -776,9 +772,12 @@ HttpResponse HttpClient::post_stream(const std::string& url,
     }
     // A total timeout would kill a long but healthy generation, so an
     // unqualified request is bounded by upstream silence instead of duration.
+    // The silence bound follows global_timeout (get_default_timeout), so the
+    // configured value — not a hardcoded constant — decides how long a
+    // prefill or reasoning gap may last before the stream is treated as dead.
     if (timeout_seconds == 0) {
         curl_easy_setopt(curl, CURLOPT_LOW_SPEED_LIMIT, 1L);
-        curl_easy_setopt(curl, CURLOPT_LOW_SPEED_TIME, kStreamStallSeconds);
+        curl_easy_setopt(curl, CURLOPT_LOW_SPEED_TIME, HttpClient::get_default_timeout());
     } else {
         curl_easy_setopt(curl, CURLOPT_TIMEOUT, effective_timeout(timeout_seconds));
     }

--- a/test/cpp/test_http_client_timeout.cpp
+++ b/test/cpp/test_http_client_timeout.cpp
@@ -97,6 +97,18 @@ int main() {
             });
     });
 
+    // Sleeps briefly before streaming a small payload, standing in for a
+    // slow prefill that looks "silent" to the stall detector.
+    svr.Post("/slow-start", [](const httplib::Request&, httplib::Response& res) {
+        res.set_chunked_content_provider(
+            "text/event-stream", [](size_t, httplib::DataSink& sink) {
+                std::this_thread::sleep_for(std::chrono::seconds(3));
+                sink.write("data: hello\n\n", 13);
+                sink.done();
+                return true;
+            });
+    });
+
     std::thread server_thread([&svr]() { svr.listen_after_bind(); });
     svr.wait_until_ready();
 
@@ -151,6 +163,48 @@ int main() {
                         {}, 2, nullptr, policy);
                 }),
                 "post_stream: explicit timeout abandons a silent upstream");
+    }
+
+    // Regression for the streaming stall bound: timeout_seconds=0 used to
+    // apply a hardcoded 120s stall constant regardless of global_timeout.
+    // The silence bound must instead follow the configured default, so a 2s
+    // default has to give up well inside the ceiling (the old constant blew
+    // past it).
+    {
+        const long saved = HttpClient::get_default_timeout();
+        HttpClient::set_default_timeout(2);
+        const bool returned = returns_within_ceiling([&] {
+            HttpClient::post_stream(
+                base + "/silent", "{}",
+                [](const char*, size_t) { return true; },
+                {}, 0, nullptr, policy);
+        });
+        HttpClient::set_default_timeout(saved);
+        r.check(returned,
+                "post_stream: timeout 0 bounds silence by the configured default, not a hardcoded stall constant");
+    }
+
+    // The silence window tracks the configured default without being
+    // needlessly tight: an upstream that starts producing after a short
+    // silent spell is not cut off.
+    {
+        const long saved = HttpClient::get_default_timeout();
+        HttpClient::set_default_timeout(30);
+        std::string streamed;
+        bool delivered = false;
+        const bool returned = returns_within_ceiling([&] {
+            auto response = HttpClient::post_stream(
+                base + "/slow-start", "{}",
+                [&streamed](const char* data, size_t len) {
+                    streamed.append(data, len);
+                    return true;
+                },
+                {}, 0, nullptr, policy);
+            delivered = response.curl_code == 0;
+        });
+        HttpClient::set_default_timeout(saved);
+        r.check(returned && delivered && streamed.find("hello") != std::string::npos,
+                "post_stream: slow-start upstream within the default window is delivered intact");
     }
 
     // The sentinel is the only way to ask for an unbounded transfer, so it must


### PR DESCRIPTION
## Summary

`HttpClient::post_stream()` bounded upstream silence with a hardcoded `kStreamStallSeconds = 120` constant, ignoring the user-configured `global_timeout`. This replaces the constant with `HttpClient::get_default_timeout()` so the stall window tracks the documented `global_timeout` setting (default 600s) while still imposing no total-duration bound on a healthy streaming generation.

Fixes #

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_

- `cmake --build --preset default --target test_http_client_timeout` — builds clean.
- `./build/test_http_client_timeout` — 7 passed, 0 failed, including:
  - slow-start upstream within the default window is delivered intact (no false stall abort)
  - `kNoTimeout` remains distinct from the `0`-means-default sentinel

## Documentation

- [x] Documentation is affected and has been updated.

(`docs/guide/configuration/README.md`: `global_timeout` now documented as also bounding streaming stalls.)

## Breaking Changes

- [x] This PR does not introduce breaking changes.

## AI-assisted contribution

Please select one:

- [x] I used AI tools for this PR.
- [ ] I did not use AI tools for this PR.

If AI tools were used:

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.
