### PR TITLE
docs: Add missing macOS user install config path

### DIFF
--- a/docs/guide/configuration/README.md
+++ b/docs/guide/configuration/README.md
@@ -14,7 +14,7 @@ If you used an installer from the Lemonade release your `config.json` will be at
   > Note: The systemd service runs as the `lemonade` user. Persistent config lives in `/var/lib/lemonade` (systemd StateDirectory), downloaded backends go to `/var/cache/lemonade` (CacheDirectory), and models are cached under `/var/lib/lemonade/.cache/huggingface`. For Debian/Ubuntu, upgrading the package automatically migrates data from the old `/opt/var/lib/lemonade` path to `/var/lib/lemonade`.
 
 - **Windows:** `%USERPROFILE%\.config\lemonade\config.json`
-- **macOS:** `/Library/Application Support/lemonade/.config/config.json`
+- **macOS:** `~/.config/lemonade/config.json` (user install) or `/Library/Application Support/lemonade/.config/config.json` (system install)
 
 If you are using a standalone `lemond` executable, the default location is `~/.config/lemonade/config.json`.
 

--- a/docs/guide/configuration/custom-models.md
+++ b/docs/guide/configuration/custom-models.md
@@ -255,7 +255,8 @@ If you used an installer from a Lemonade release, the config directory is typica
 |----|------------------|
 | Linux systemd install | `/var/lib/lemonade` |
 | Windows | `%USERPROFILE%\.config\lemonade` |
-| macOS system install | `/Library/Application Support/lemonade/.config` |
+| macOS (user install) | `~/.config/lemonade` |
+| macOS (system install) | `/Library/Application Support/lemonade/.config` |
 
 For a standalone `lemond` executable, the default config directory is `~/.config/lemonade`. Pass an explicit `config_dir` positional argument if you want persistent JSON files somewhere else; `cache_dir` only controls downloaded/runtime data.
 


### PR DESCRIPTION
## Summary

The documentation only showed the macOS system install path (`/Library/Application Support/lemonade/.config`) which is used when running as root. Normal macOS users (non-root) use `~/.config/lemonade` according to `src/cpp/server/utils/platform/path_macos.cpp` line 93.

Updated both configuration documentation files to show both paths:
- **User install (most common):** `~/.config/lemonade`  
- **System install (root):** `/Library/Application Support/lemonade/.config`

Fixes #3465 (related - found during comprehensive path audit)

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_
- Pre-commit hooks pass (trailing whitespace, end-of-file fixer)
- Documentation-only changes, no code modified
- Verified paths against `src/cpp/server/utils/platform/path_macos.cpp`:
  - Line 93: Normal users get `$HOME/.config/lemonade`
  - Line 101: Root gets `/Library/Application Support/lemonade/.config`

## Documentation

- [x] Documentation is affected and has been updated.

## Breaking Changes

- [x] This PR does not introduce breaking changes.

## AI-assisted contribution

- [x] I used AI tools for this PR.
- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.