### PR TITLE
Make --force actually bypass CUDA/ROCm hardware filtering

### DIFF
--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -623,10 +623,12 @@ lemonade backends uninstall SPEC
 | `lemonade backends install SPEC` | Install a backend. Format: `recipe:backend` (e.g., `llamacpp:vulkan`) |
 | `lemonade backends uninstall SPEC` | Uninstall a backend. Format: `recipe:backend` (e.g., `llamacpp:cpu`) |
 | `lemonade backends install SPEC --force` | Bypass hardware filtering and attempt the install anyway |
+| `lemonade backends install SPEC --force --arch ARCH` | Force-install a specific GPU target (e.g. `sm_89`, `gfx1151`) when no matching device is present |
 
 **Notes:**
 - Supported backends depend on your system and the recipe
 - Use `lemonade backends --all` to list all available recipes and backends
+- GPU-specific backends (CUDA, ROCm) publish per-architecture binaries. If `--force` alone can't detect a target GPU, pass `--arch` to select one explicitly (useful when preparing an install for a different machine)
 
 **Examples:**
 

--- a/src/cpp/cli/lemonade_client.cpp
+++ b/src/cpp/cli/lemonade_client.cpp
@@ -1390,13 +1390,17 @@ int LemonadeClient::list_recipes(bool show_all) const {
     }
 }
 
-int LemonadeClient::install_backend(const std::string& recipe, const std::string& backend, bool force) {
+int LemonadeClient::install_backend(const std::string& recipe, const std::string& backend, bool force,
+                                    const std::string& arch) {
     std::cout << "Installing backend: " << recipe << ":" << backend << std::endl;
 
     try {
         json request_body = {{"recipe", recipe}, {"backend", backend}};
         request_body["stream"] = true;
         request_body["force"] = force;
+        if (!arch.empty()) {
+            request_body["arch"] = arch;
+        }
         std::string body = request_body.dump();
 
         StreamingRequestState state;

--- a/src/cpp/cli/main.cpp
+++ b/src/cpp/cli/main.cpp
@@ -164,6 +164,7 @@ struct CliConfig {
     std::string backend_spec;  // Format: "recipe:backend"
     bool backends_showall = false;
     bool force = false;
+    std::string backend_arch;  // Optional target arch (e.g. sm_89, gfx1151) for --force installs
     std::string output_file;
     bool downloaded = false;
     bool dry_run = false;
@@ -592,7 +593,7 @@ static int handle_backends_command(lemonade::LemonadeClient& client,
         int result = 0;
         handle_backend_operation(config.backend_spec, "Install",
             [&client, &config, &result](const std::string& recipe, const std::string& backend) {
-                result = client.install_backend(recipe, backend, config.force);
+                result = client.install_backend(recipe, backend, config.force, config.backend_arch);
                 return result;
             });
         return result;
@@ -1316,6 +1317,10 @@ int main(int argc, char* argv[]) {
     // Backend management options
     backends_install_cmd->add_option("spec", config.backend_spec, "Backend spec (recipe:backend)")->required()->type_name("SPEC");
     backends_install_cmd->add_flag("--force", config.force, "Bypass hardware filtering when installing a backend");
+    backends_install_cmd->add_option("--arch", config.backend_arch,
+        "Target architecture to install for when no compatible device is present "
+        "(e.g. sm_89 for CUDA, gfx1151 for ROCm). Requires --force.")
+        ->type_name("ARCH");
     backends_uninstall_cmd->add_option("spec", config.backend_spec, "Backend spec (recipe:backend)")->required()->type_name("SPEC");
 
     // Cloud provider commands. `cloud` is a subcommand group with install /

--- a/src/cpp/include/lemon/system_info.h
+++ b/src/cpp/include/lemon/system_info.h
@@ -134,6 +134,12 @@ public:
     // affect concurrent requests.
     static void set_rocm_arch_override(const std::string& arch);
 
+    // Same as set_rocm_arch_override(), but for get_cuda_arch(). Lets
+    // `--force --arch sm_XX` installs pick a specific CUDA target when no
+    // NVIDIA GPU is present (e.g. building a backend image on a GPU-less host
+    // for later deployment on a different machine).
+    static void set_cuda_arch_override(const std::string& arch);
+
     // True if (recipe, backend) is published for the given ROCm family/ISA, per
     // the backend support matrix. Lets callers tell "this arch should have an
     // asset" from "this arch is intentionally not built" without duplicating the

--- a/src/cpp/include/lemon_cli/lemonade_client.h
+++ b/src/cpp/include/lemon_cli/lemonade_client.h
@@ -113,7 +113,8 @@ public:
 
     // Recipe/backend commands
     int list_recipes(bool show_all = false) const;
-    int install_backend(const std::string& recipe, const std::string& backend, bool force = false);
+    int install_backend(const std::string& recipe, const std::string& backend, bool force = false,
+                        const std::string& arch = "");
     int uninstall_backend(const std::string& recipe, const std::string& backend);
 
     // Cloud provider commands. Each maps to one /v1/cloud/* or /v1/{install,

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -7389,6 +7389,30 @@ namespace {
 
 constexpr auto DOWNLOAD_TERMINAL_VISIBILITY = std::chrono::seconds(30);
 
+// Sets both the ROCm and CUDA per-thread arch overrides for the lifetime of
+// this guard, so `--force --arch <target>` installs resolve asset URLs for a
+// specific target even when no matching GPU is present. Clears both
+// overrides on destruction (including on exception) so they cannot leak into
+// later work on this thread.
+struct ScopedArchOverride {
+    explicit ScopedArchOverride(const std::string& arch) : active(!arch.empty()) {
+        if (active) {
+            SystemInfo::set_rocm_arch_override(arch);
+            SystemInfo::set_cuda_arch_override(arch);
+        }
+    }
+    ~ScopedArchOverride() {
+        if (active) {
+            SystemInfo::set_rocm_arch_override("");
+            SystemInfo::set_cuda_arch_override("");
+        }
+    }
+    ScopedArchOverride(const ScopedArchOverride&) = delete;
+    ScopedArchOverride& operator=(const ScopedArchOverride&) = delete;
+
+    bool active;
+};
+
 } // namespace
 
 nlohmann::json Server::download_progress_to_json(const DownloadProgress& p) {
@@ -7994,6 +8018,7 @@ void Server::handle_install(const httplib::Request& req, httplib::Response& res)
         bool stream = request_json.value("stream", false);
         bool subscribe = request_json.value("subscribe", true);
         bool force = request_json.value("force", false);
+        std::string arch = request_json.value("arch", "");
 
         if (recipe.empty() || backend.empty()) {
             res.status = 400;
@@ -8045,7 +8070,8 @@ void Server::handle_install(const httplib::Request& req, httplib::Response& res)
         }
 
         if (stream) {
-            auto operation = [this, recipe, backend, force](DownloadProgressCallback progress_cb) {
+            auto operation = [this, recipe, backend, force, arch](DownloadProgressCallback progress_cb) {
+                ScopedArchOverride arch_override(arch);
                 backend_manager_->install_backend(recipe, backend, force, progress_cb);
                 SystemInfoCache::invalidate_recipes();
                 model_manager_->invalidate_models_cache();
@@ -8067,6 +8093,7 @@ void Server::handle_install(const httplib::Request& req, httplib::Response& res)
 
             stream_download_operation(res, operation);
         } else {
+            ScopedArchOverride arch_override(arch);
             backend_manager_->install_backend(recipe, backend, force);
             SystemInfoCache::invalidate_recipes();
             model_manager_->invalidate_models_cache();

--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -564,6 +564,9 @@ std::string SystemInfo::get_unsupported_backend_error(const std::string& recipe,
                 }
             }
             error += ".";
+            error += " To install for a specific target when no compatible device is "
+                     "present, pass --force --arch <target> (e.g. --force --arch sm_89 "
+                     "for CUDA, --force --arch gfx1151 for ROCm).";
             break;
         }
     }
@@ -2060,10 +2063,16 @@ std::string identify_npu_arch() {
 namespace {
     // Per-thread arch override consumed by get_rocm_arch(). Empty = probe hardware.
     thread_local std::string g_rocm_arch_override;
+    // Per-thread arch override consumed by get_cuda_arch(). Empty = probe hardware.
+    thread_local std::string g_cuda_arch_override;
 }
 
 void SystemInfo::set_rocm_arch_override(const std::string& arch) {
     g_rocm_arch_override = arch;
+}
+
+void SystemInfo::set_cuda_arch_override(const std::string& arch) {
+    g_cuda_arch_override = arch;
 }
 
 std::string SystemInfo::rocm_asset_family(const std::string& arch) {
@@ -2196,6 +2205,9 @@ std::string SystemInfo::get_cuda_arch() {
     // On multi-GPU systems, selects the GPU with the highest supported compute
     // capability. Uses the cached family field (populated from nvidia-smi during
     // device detection), falling back to marketing-name inference for older drivers.
+    if (!g_cuda_arch_override.empty()) {
+        return g_cuda_arch_override;
+    }
     try {
         json system_info = SystemInfoCache::get_system_info_with_cache();
 


### PR DESCRIPTION
## Summary

`--force` was meant to bypass hardware filtering when installing a backend, but for GPU-architecture-specific backends (llamacpp `cuda`/`rocm-nightly`, `vllm` rocm, `whispercpp` rocm, `sd-cpp` cuda/rocm) the release asset filename is resolved per detected GPU arch, so install still threw "No compatible device detected..." even with `--force`, since there was no GPU to detect an arch from.

Adds `--arch` (paired with `--force`) so a target architecture (e.g. `sm_89`, `gfx1151`) can be specified explicitly, letting `--force` truly bypass hardware filtering for the reported use case (building a backend install on a GPU-less host for deployment elsewhere). Extends the existing per-thread ROCm arch override mechanism to CUDA and wires it into the real `/install` endpoint (previously only available on the debug `/install/dry-run` endpoint).

Fixes #3460

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [ ] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_
- `cmake --build --preset default` — builds clean.
- `ctest -L cpp-ci` — 68/68 tests pass.
- Author (agent) ran a manual smoke test against a locally running `lemond` with no NVIDIA GPU present (`--force llamacpp:cuda` now errors with a clear `--arch` hint; `--force --arch sm_89 llamacpp:cuda` successfully installs). PR author (@kenvandine) still needs to independently verify on real hardware before merge.

## Documentation

- [x] Documentation is affected and has been updated.

Updated `docs/guide/cli.md` backend install table/notes to document `--arch`.

## Breaking Changes

- [x] This PR does not introduce breaking changes.

## AI-assisted contribution

- [x] I used AI tools for this PR.

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.
