### PR TITLE
feat(server): support wildcard port and host matching in allowed origins

### DIFF
--- a/docs/guide/configuration/README.md
+++ b/docs/guide/configuration/README.md
@@ -502,12 +502,14 @@ The `allowed_origins` setting (in `config.json` or configured via `lemonade conf
   - In `config.json`: `"allowed_origins": "https://app.lemonade.dev,http://localhost:3000"`
   - Via CLI: `lemonade config set allowed_origins="https://app.lemonade.dev,http://localhost:3000"`
 - **Format**: A comma-separated list of complete origins including the scheme and optional port (e.g., `https://app.lemonade.dev,http://localhost:3000`).
+  - **Wildcard Ports**: Specify `:*` to match any port on a configured host (e.g., `http://192.168.1.50:*`, `http://*.local:*`, `https://[::1]:*`), useful for local development and homelab environments where frontend dev servers run across varying ports.
+  - **Wildcard Domains**: Specify `*.domain` to match subdomains (e.g., `http://*.local:*` or `https://*.example.com`). Subdomain matching strictly enforces a dot boundary so `notexample.com` will not match `*.example.com`.
   > [!WARNING]
   > Allowing a non-local plain-HTTP origin (e.g., `http://app.example.com`) is vulnerable to on-path modification (man-in-the-middle) and interception. It is highly recommended to use HTTPS (`https://`) for all remote/non-local allowed origins.
-- **Wildcard (`*`)**: Setting `allowed_origins` to `*` allows any origin to connect.
-- **Security Implications of `*`**:
+- **Wildcards (`*`, `http://*:*`)**: Setting `allowed_origins` to `*` or using universal wildcards like `http://*:*` allows any origin to connect.
+- **Security Implications of Wildcards**:
   > [!WARNING]
-  > Using `allowed_origins=*` permits any website running in a user's browser to make requests to your local Lemonade server. In particular, if `LEMONADE_API_KEY` is not configured, this exposes the server to unauthenticated remote access and cross-origin attacks from malicious websites. Use wildcards only for development or in secure, isolated environments.
+  > Using `allowed_origins=*` or `http://*:*` permits any website running in a user's browser to make requests to your local Lemonade server. In particular, if `LEMONADE_API_KEY` is not configured, this exposes the server to unauthenticated remote access and cross-origin attacks from malicious websites. Use wildcards only for development or in secure, isolated environments.
 - **Local/Loopback, Desktop & Same-Origin Access (Zero-Configuration)**:
   - **Loopback & Subdomains**: Loopback addresses (`localhost`, `127.0.0.1`, `[::1]`, `*.localhost`) are permitted automatically.
   - **Native Desktop Apps**: Native desktop application schemes (`lemonade://`, `file://`, `app://.`, `vscode-webview://`, `jan://`, etc.) are permitted for client connections.

--- a/src/cpp/include/lemon/utils/origin_utils.h
+++ b/src/cpp/include/lemon/utils/origin_utils.h
@@ -6,6 +6,7 @@
 #include <cctype>
 #include <chrono>
 #include <mutex>
+#include <regex>
 #include <sstream>
 #include <string>
 #include <unordered_set>
@@ -33,6 +34,7 @@ struct Origin {
     std::string scheme;
     std::string host;
     int port = -1;
+    bool wildcard_port = false;
 
     bool is_valid() const {
         return !host.empty();
@@ -56,31 +58,62 @@ struct Origin {
             return false;
         }
 
-        if (host != pattern.host) {
+        static const std::regex wildcard_domain_regex(R"(^\*\.(.+)$)");
+        std::smatch match;
+
+        if (pattern.host == "*") {
+            // Universal host wildcard
+        } else if (std::regex_match(pattern.host, match, wildcard_domain_regex)) {
+            std::string suffix = "." + match[1].str();
+            if (host.size() <= suffix.size() || host.compare(host.size() - suffix.size(), suffix.size(), suffix) != 0) {
+                return false;
+            }
+        } else if (host != pattern.host) {
             return false;
         }
 
-        if (get_effective_port() != pattern.get_effective_port()) {
-            return false;
-        }
-
-        return true;
+        return pattern.wildcard_port || get_effective_port() == pattern.get_effective_port();
     }
 };
+
+inline std::string trim(std::string s) {
+    s.erase(0, s.find_first_not_of(" \t\r\n"));
+    if (!s.empty()) {
+        s.erase(s.find_last_not_of(" \t\r\n") + 1);
+    }
+    return s;
+}
 
 inline std::string to_lower(std::string s) {
     std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c) { return std::tolower(c); });
     return s;
 }
 
+inline bool parse_port(const std::string& port_str, Origin& out) {
+    static const std::regex port_regex(R"(^(\*|[0-9]{1,5})$)");
+    std::smatch match;
+    if (!std::regex_match(port_str, match, port_regex)) {
+        return false;
+    }
+    if (match[1] == "*") {
+        out.wildcard_port = true;
+        return true;
+    }
+    try {
+        long long p = std::stoll(match[1].str());
+        if (p < 0 || p > 65535) {
+            return false;
+        }
+        out.port = static_cast<int>(p);
+        return true;
+    } catch (...) {
+        return false;
+    }
+}
+
 inline Origin parse_origin(const std::string& origin_str) {
     Origin out;
-    std::string str = origin_str;
-
-    str.erase(0, str.find_first_not_of(" \t\r\n"));
-    if (!str.empty()) {
-        str.erase(str.find_last_not_of(" \t\r\n") + 1);
-    }
+    std::string str = trim(origin_str);
 
     if (str.empty()) {
         return out;
@@ -132,47 +165,17 @@ inline Origin parse_origin(const std::string& origin_str) {
         out.host = "[" + to_lower(raw_ipv6) + "]";
         std::string rest = host_and_port.substr(bracket_end + 1);
         if (!rest.empty()) {
-            if (rest[0] == ':') {
-                std::string port_str = rest.substr(1);
-                if (port_str.empty() || !std::all_of(port_str.begin(), port_str.end(), [](unsigned char c) { return std::isdigit(c); })) {
-                    return Origin{};
-                }
-                try {
-                    size_t idx = 0;
-                    long long p = std::stoll(port_str, &idx);
-                    if (idx != port_str.size() || p < 0 || p > 65535) {
-                        return Origin{};
-                    }
-                    out.port = static_cast<int>(p);
-                } catch (...) {
-                    return Origin{};
-                }
-            } else {
+            if (rest[0] != ':' || !parse_port(rest.substr(1), out)) {
                 return Origin{};
             }
         }
     } else {
         size_t first_colon = host_and_port.find(':');
         size_t last_colon = host_and_port.find_last_of(':');
-        if (last_colon != std::string::npos) {
-            if (first_colon == last_colon) {
-                out.host = to_lower(host_and_port.substr(0, last_colon));
-                std::string port_str = host_and_port.substr(last_colon + 1);
-                if (port_str.empty() || !std::all_of(port_str.begin(), port_str.end(), [](unsigned char c) { return std::isdigit(c); })) {
-                    return Origin{};
-                }
-                try {
-                    size_t idx = 0;
-                    long long p = std::stoll(port_str, &idx);
-                    if (idx != port_str.size() || p < 0 || p > 65535) {
-                        return Origin{};
-                    }
-                    out.port = static_cast<int>(p);
-                } catch (...) {
-                    return Origin{};
-                }
-            } else {
-                out.host = to_lower(host_and_port);
+        if (last_colon != std::string::npos && first_colon == last_colon) {
+            out.host = to_lower(host_and_port.substr(0, last_colon));
+            if (!parse_port(host_and_port.substr(last_colon + 1), out)) {
+                return Origin{};
             }
         } else {
             out.host = to_lower(host_and_port);
@@ -402,9 +405,9 @@ inline bool is_origin_allowed(
         std::stringstream ss(allowed_origins);
         std::string item;
         while (std::getline(ss, item, ',')) {
-            item.erase(0, item.find_first_not_of(" \t\r\n"));
-            if (!item.empty()) {
-                item.erase(item.find_last_not_of(" \t\r\n") + 1);
+            item = trim(item);
+            if (item.empty()) {
+                continue;
             }
             const bool is_opaque_null = request_origin.scheme.empty() && request_origin.host == "null" && request_origin.port == -1;
             if (to_lower(item) == "null" && is_opaque_null) {

--- a/test/cpp/test_origin_utils.cpp
+++ b/test/cpp/test_origin_utils.cpp
@@ -17,220 +17,243 @@ struct TestResult {
         printf("[FAIL] %s\n", name.c_str());
         ++failed;
     }
+
+    void expect(bool condition, const std::string& name) {
+        if (condition) {
+            ok(name);
+        } else {
+            fail(name);
+        }
+    }
 };
 
 static void test_parse_origin(TestResult& r) {
     using namespace lemon::utils;
 
+    // --- Positive Parsing Cases ---
     {
         Origin o = parse_origin("http://localhost:3000");
-        if (o.scheme == "http" && o.host == "localhost" && o.port == 3000) {
-            r.ok("parse http://localhost:3000");
-        } else {
-            r.fail("parse http://localhost:3000");
-        }
+        r.expect(o.scheme == "http" && o.host == "localhost" && o.port == 3000, "parse http://localhost:3000");
     }
     {
         Origin o = parse_origin("https://app.lemonade.dev");
-        if (o.scheme == "https" && o.host == "app.lemonade.dev" && o.port == -1) {
-            r.ok("parse https://app.lemonade.dev");
-        } else {
-            r.fail("parse https://app.lemonade.dev");
-        }
+        r.expect(o.scheme == "https" && o.host == "app.lemonade.dev" && o.port == -1, "parse https://app.lemonade.dev");
     }
     {
         Origin o = parse_origin("HTTP://LocalHost:8080");
-        if (o.scheme == "http" && o.host == "localhost" && o.port == 8080) {
-            r.ok("parse HTTP://LocalHost:8080 (normalization)");
-        } else {
-            r.fail("parse HTTP://LocalHost:8080 (normalization)");
-        }
+        r.expect(o.scheme == "http" && o.host == "localhost" && o.port == 8080, "parse HTTP://LocalHost:8080 (normalization)");
     }
     {
         Origin o = parse_origin("http://[::1]:8080");
-        if (o.scheme == "http" && o.host == "[::1]" && o.port == 8080) {
-            r.ok("parse http://[::1]:8080");
-        } else {
-            r.fail("parse http://[::1]:8080");
-        }
+        r.expect(o.scheme == "http" && o.host == "[::1]" && o.port == 8080, "parse http://[::1]:8080");
     }
     {
         Origin o = parse_origin("https://[2001:db8::1]:8443");
-        if (o.scheme == "https" && o.host == "[2001:db8::1]" && o.port == 8443) {
-            r.ok("parse https://[2001:db8::1]:8443");
-        } else {
-            r.fail("parse https://[2001:db8::1]:8443");
-        }
+        r.expect(o.scheme == "https" && o.host == "[2001:db8::1]" && o.port == 8443, "parse https://[2001:db8::1]:8443");
     }
     {
         Origin o = parse_origin("http://[fe80::1%25eth0]:8080");
-        if (o.scheme == "http" && o.host == "[fe80::1]" && o.port == 8080) {
-            r.ok("parse http://[fe80::1%25eth0]:8080 (IPv6 zone ID %25eth0 stripping)");
-        } else {
-            r.fail("parse http://[fe80::1%25eth0]:8080 (IPv6 zone ID %25eth0 stripping)");
-        }
+        r.expect(o.scheme == "http" && o.host == "[fe80::1]" && o.port == 8080, "parse http://[fe80::1%25eth0]:8080 (IPv6 zone ID %25eth0 stripping)");
     }
     {
         Origin o = parse_origin("http://[fe80::1%1]:8080");
-        if (o.scheme == "http" && o.host == "[fe80::1]" && o.port == 8080) {
-            r.ok("parse http://[fe80::1%1]:8080 (IPv6 zone ID %1 stripping)");
-        } else {
-            r.fail("parse http://[fe80::1%1]:8080 (IPv6 zone ID %1 stripping)");
-        }
-    }
-    {
-        Origin o = parse_origin("https://example.com/some/path");
-        if (!o.is_valid()) {
-            r.ok("reject origin containing path https://example.com/some/path");
-        } else {
-            r.fail("reject origin containing path https://example.com/some/path");
-        }
+        r.expect(o.scheme == "http" && o.host == "[fe80::1]" && o.port == 8080, "parse http://[fe80::1%1]:8080 (IPv6 zone ID %1 stripping)");
     }
     {
         Origin o = parse_origin("https://example.com/");
-        if (o.scheme == "https" && o.host == "example.com" && o.port == -1) {
-            r.ok("allow origin with trailing slash https://example.com/");
-        } else {
-            r.fail("allow origin with trailing slash https://example.com/");
-        }
-    }
-    {
-        Origin o = parse_origin("https://example.com?query=1");
-        if (!o.is_valid()) {
-            r.ok("reject origin containing query https://example.com?query=1");
-        } else {
-            r.fail("reject origin containing query https://example.com?query=1");
-        }
-    }
-    {
-        Origin o = parse_origin("https://example.com#fragment");
-        if (!o.is_valid()) {
-            r.ok("reject origin containing fragment https://example.com#fragment");
-        } else {
-            r.fail("reject origin containing fragment https://example.com#fragment");
-        }
-    }
-    {
-        Origin o = parse_origin("https://user:pass@example.com");
-        if (!o.is_valid()) {
-            r.ok("reject origin containing userinfo https://user:pass@example.com");
-        } else {
-            r.fail("reject origin containing userinfo https://user:pass@example.com");
-        }
+        r.expect(o.scheme == "https" && o.host == "example.com" && o.port == -1, "allow origin with trailing slash https://example.com/");
     }
     {
         Origin o = parse_origin("app.lemonade.dev");
-        if (o.scheme.empty() && o.host == "app.lemonade.dev" && o.port == -1) {
-            r.ok("parse app.lemonade.dev (no scheme)");
-        } else {
-            r.fail("parse app.lemonade.dev (no scheme)");
-        }
+        r.expect(o.scheme.empty() && o.host == "app.lemonade.dev" && o.port == -1, "parse app.lemonade.dev (no scheme)");
     }
     {
         Origin o = parse_origin("app.lemonade.dev:8080");
-        if (o.scheme.empty() && o.host == "app.lemonade.dev" && o.port == 8080) {
-            r.ok("parse app.lemonade.dev:8080 (no scheme)");
-        } else {
-            r.fail("parse app.lemonade.dev:8080 (no scheme)");
-        }
+        r.expect(o.scheme.empty() && o.host == "app.lemonade.dev" && o.port == 8080, "parse app.lemonade.dev:8080 (no scheme)");
     }
     {
         Origin o = parse_origin("2001:db8::1");
-        if (o.scheme.empty() && o.host == "2001:db8::1" && o.port == -1) {
-            r.ok("parse bare IPv6 address without port");
-        } else {
-            r.fail("parse bare IPv6 address without port");
-        }
+        r.expect(o.scheme.empty() && o.host == "2001:db8::1" && o.port == -1, "parse bare IPv6 address without port");
+    }
+    {
+        Origin o = parse_origin("http://192.168.1.50:*");
+        r.expect(o.is_valid() && o.scheme == "http" && o.host == "192.168.1.50" && o.wildcard_port, "parse wildcard port http://192.168.1.50:*");
+    }
+    {
+        Origin o = parse_origin("http://*.local:*");
+        r.expect(o.is_valid() && o.scheme == "http" && o.host == "*.local" && o.wildcard_port, "parse wildcard host and port http://*.local:*");
+    }
+    {
+        Origin o = parse_origin("https://[::1]:*");
+        r.expect(o.is_valid() && o.scheme == "https" && o.host == "[::1]" && o.wildcard_port, "parse bracketed IPv6 wildcard port https://[::1]:*");
+    }
+    {
+        Origin o = parse_origin("https://[2001:db8::1]:*");
+        r.expect(o.is_valid() && o.scheme == "https" && o.host == "[2001:db8::1]" && o.wildcard_port, "parse bracketed IPv6 full address wildcard port https://[2001:db8::1]:*");
+    }
+    {
+        Origin o = parse_origin("http://[fe80::1%25eth0]:*");
+        r.expect(o.is_valid() && o.scheme == "http" && o.host == "[fe80::1]" && o.wildcard_port, "parse bracketed IPv6 zone ID with wildcard port http://[fe80::1%25eth0]:*");
+    }
+    {
+        Origin o = parse_origin("http://localhost:65535");
+        r.expect(o.is_valid() && o.port == 65535, "parse boundary port 65535");
+    }
+    {
+        Origin o = parse_origin("http://localhost:0");
+        r.expect(o.is_valid() && o.port == 0, "parse boundary port 0");
+    }
+    {
+        Origin o = parse_origin("http://*:*");
+        r.expect(o.is_valid() && o.scheme == "http" && o.host == "*" && o.wildcard_port, "parse universal wildcard http://*:*");
+    }
+
+    // --- Negative / Malformed Parsing Cases ---
+    {
+        Origin o = parse_origin("https://example.com/some/path");
+        r.expect(!o.is_valid(), "reject origin containing path https://example.com/some/path");
+    }
+    {
+        Origin o = parse_origin("https://example.com?query=1");
+        r.expect(!o.is_valid(), "reject origin containing query https://example.com?query=1");
+    }
+    {
+        Origin o = parse_origin("https://example.com#fragment");
+        r.expect(!o.is_valid(), "reject origin containing fragment https://example.com#fragment");
+    }
+    {
+        Origin o = parse_origin("https://user:pass@example.com");
+        r.expect(!o.is_valid(), "reject origin containing userinfo https://user:pass@example.com");
     }
     {
         Origin o = parse_origin("https://app.example.com:999999999999999");
-        if (!o.is_valid()) {
-            r.ok("reject port overflow https://app.example.com:999999999999999");
-        } else {
-            r.fail("reject port overflow https://app.example.com:999999999999999");
-        }
+        r.expect(!o.is_valid(), "reject port overflow https://app.example.com:999999999999999");
     }
     {
         Origin o = parse_origin("https://[2001:db8::1]:443junk");
-        if (!o.is_valid()) {
-            r.ok("reject trailing port characters after IPv6 bracket");
-        } else {
-            r.fail("reject trailing port characters after IPv6 bracket");
-        }
+        r.expect(!o.is_valid(), "reject trailing port characters after IPv6 bracket");
     }
     {
         Origin o = parse_origin("https://[2001:db8::1]junk");
-        if (!o.is_valid()) {
-            r.ok("reject trailing junk after IPv6 bracket");
-        } else {
-            r.fail("reject trailing junk after IPv6 bracket");
-        }
+        r.expect(!o.is_valid(), "reject trailing junk after IPv6 bracket");
     }
     {
         Origin o = parse_origin("https://[2001:db8::1");
-        if (!o.is_valid()) {
-            r.ok("reject malformed bracketed IPv6 (missing closing bracket)");
-        } else {
-            r.fail("reject malformed bracketed IPv6 (missing closing bracket)");
-        }
+        r.expect(!o.is_valid(), "reject malformed bracketed IPv6 (missing closing bracket)");
     }
     {
         Origin o = parse_origin("https://app.example.com:65536");
-        if (!o.is_valid()) {
-            r.ok("reject out of range port 65536");
-        } else {
-            r.fail("reject out of range port 65536");
-        }
+        r.expect(!o.is_valid(), "reject out of range port 65536");
+    }
+    {
+        Origin o = parse_origin("http://localhost:*80");
+        r.expect(!o.is_valid(), "reject invalid wildcard port http://localhost:*80");
+    }
+    {
+        Origin o = parse_origin("http://localhost:*junk");
+        r.expect(!o.is_valid(), "reject invalid wildcard port with trailing junk http://localhost:*junk");
+    }
+    {
+        Origin o = parse_origin("http://localhost:**");
+        r.expect(!o.is_valid(), "reject invalid double wildcard port http://localhost:**");
+    }
+    {
+        Origin o = parse_origin("http://localhost:");
+        r.expect(!o.is_valid(), "reject empty port http://localhost:");
     }
 }
 
 static void test_origin_matching(TestResult& r) {
     using namespace lemon::utils;
 
+    // --- Positive Matching Cases ---
     {
         Origin req = parse_origin("https://app.lemonade.dev");
         Origin pat = parse_origin("https://app.lemonade.dev");
-        if (req.matches(pat)) {
-            r.ok("match exact https://app.lemonade.dev");
-        } else {
-            r.fail("match exact https://app.lemonade.dev");
-        }
-    }
-    {
-        Origin req = parse_origin("https://app.lemonade.dev:8443");
-        Origin pat = parse_origin("https://app.lemonade.dev");
-        if (!req.matches(pat)) {
-            r.ok("reject port mismatch https://app.lemonade.dev:8443 vs https://app.lemonade.dev");
-        } else {
-            r.fail("reject port mismatch https://app.lemonade.dev:8443 vs https://app.lemonade.dev");
-        }
-    }
-    {
-        Origin req = parse_origin("http://app.lemonade.dev");
-        Origin pat = parse_origin("https://app.lemonade.dev");
-        if (!req.matches(pat)) {
-            r.ok("reject scheme mismatch http vs https");
-        } else {
-            r.fail("reject scheme mismatch http vs https");
-        }
-    }
-    {
-        Origin req = parse_origin("https://app.lemonade.dev");
-        Origin pat = parse_origin("app.lemonade.dev");
-        if (!req.matches(pat)) {
-            r.ok("reject no-scheme pattern https://app.lemonade.dev vs app.lemonade.dev");
-        } else {
-            r.fail("reject no-scheme pattern https://app.lemonade.dev vs app.lemonade.dev");
-        }
+        r.expect(req.matches(pat), "match exact https://app.lemonade.dev");
     }
     {
         Origin req = parse_origin("https://app.lemonade.dev:443");
         Origin pat = parse_origin("https://app.lemonade.dev");
-        if (req.matches(pat)) {
-            r.ok("match default ports https://app.lemonade.dev:443 vs https://app.lemonade.dev");
-        } else {
-            r.fail("match default ports https://app.lemonade.dev:443 vs https://app.lemonade.dev");
-        }
+        r.expect(req.matches(pat), "match default ports https://app.lemonade.dev:443 vs https://app.lemonade.dev");
+    }
+    {
+        Origin pat = parse_origin("http://192.168.1.50:*");
+        Origin req1 = parse_origin("http://192.168.1.50:3000");
+        Origin req2 = parse_origin("http://192.168.1.50:8080");
+        Origin req3 = parse_origin("http://192.168.1.50:5173");
+        Origin req4 = parse_origin("http://192.168.1.50");
+        Origin req5 = parse_origin("http://192.168.1.50:80");
+        r.expect(req1.matches(pat) && req2.matches(pat) && req3.matches(pat) && req4.matches(pat) && req5.matches(pat), "wildcard port matches varying ports (3000, 8080, 5173, default 80)");
+    }
+    {
+        Origin pat = parse_origin("http://*.example.com:*");
+        Origin req_sub = parse_origin("http://sub.example.com:3000");
+        Origin req_nested = parse_origin("http://a.b.example.com:8080");
+        Origin req_deep = parse_origin("http://x.y.z.example.com:5173");
+        r.expect(req_sub.matches(pat) && req_nested.matches(pat) && req_deep.matches(pat), "subdomain wildcard matches subdomains of example.com (including deep nested)");
+    }
+    {
+        Origin pat = parse_origin("http://*.local:*");
+        Origin req_dev = parse_origin("http://dev.local:5173");
+        Origin req_dashboard = parse_origin("http://dashboard.local:3000");
+        r.expect(req_dev.matches(pat) && req_dashboard.matches(pat), "wildcard host matches *.local mDNS hosts");
+    }
+    {
+        Origin pat_all = parse_origin("http://*:*");
+        Origin req1 = parse_origin("http://anyhost.org:8080");
+        Origin req2 = parse_origin("http://otherhost.net:3000");
+        r.expect(req1.matches(pat_all) && req2.matches(pat_all), "universal wildcard http://*:* matches any host and port for http");
+    }
+    {
+        Origin pat_port = parse_origin("http://*:8080");
+        Origin req1 = parse_origin("http://anyhost.org:8080");
+        r.expect(req1.matches(pat_port), "universal host with specific port http://*:8080 matches port 8080 only");
+    }
+
+    // --- Negative / Mismatch Cases ---
+    {
+        Origin req = parse_origin("https://app.lemonade.dev:8443");
+        Origin pat = parse_origin("https://app.lemonade.dev");
+        r.expect(!req.matches(pat), "reject port mismatch https://app.lemonade.dev:8443 vs https://app.lemonade.dev");
+    }
+    {
+        Origin req = parse_origin("http://app.lemonade.dev");
+        Origin pat = parse_origin("https://app.lemonade.dev");
+        r.expect(!req.matches(pat), "reject scheme mismatch http vs https");
+    }
+    {
+        Origin req = parse_origin("https://app.lemonade.dev");
+        Origin pat = parse_origin("app.lemonade.dev");
+        r.expect(!req.matches(pat), "reject no-scheme pattern https://app.lemonade.dev vs app.lemonade.dev");
+    }
+    {
+        Origin pat = parse_origin("http://192.168.1.50:*");
+        Origin req_mismatch_scheme = parse_origin("https://192.168.1.50:3000");
+        Origin req_mismatch_host = parse_origin("http://192.168.1.51:3000");
+        r.expect(!req_mismatch_scheme.matches(pat), "wildcard port rejects scheme mismatch https vs http");
+        r.expect(!req_mismatch_host.matches(pat), "wildcard port rejects host mismatch 192.168.1.51 vs 192.168.1.50");
+    }
+    {
+        Origin pat = parse_origin("http://*.example.com:*");
+        Origin req_notexample = parse_origin("http://notexample.com:3000");
+        Origin req_badexample = parse_origin("http://badexample.com:3000");
+        Origin req_suffix_attacker = parse_origin("http://example.com.attacker.com:3000");
+        Origin req_prefix_attacker = parse_origin("http://attacker-example.com:3000");
+        Origin req_apex = parse_origin("http://example.com:3000");
+        r.expect(!req_notexample.matches(pat) && !req_badexample.matches(pat) && !req_suffix_attacker.matches(pat) && !req_prefix_attacker.matches(pat), "subdomain wildcard enforces dot boundary rejecting notexample.com, badexample.com, and attacker domains");
+        r.expect(!req_apex.matches(pat), "subdomain wildcard rejects apex domain example.com");
+    }
+    {
+        Origin pat = parse_origin("http://*.local:*");
+        Origin req_notlocal = parse_origin("http://notlocal.com:5173");
+        Origin req_apex_local = parse_origin("http://local:5173");
+        r.expect(!req_notlocal.matches(pat) && !req_apex_local.matches(pat), "wildcard host rejects notlocal.com and apex local");
+    }
+    {
+        Origin pat_port = parse_origin("http://*:8080");
+        Origin req2 = parse_origin("http://otherhost.net:3000");
+        r.expect(!req2.matches(pat_port), "reject universal host port mismatch");
     }
 }
 
@@ -238,20 +261,13 @@ static void test_server_self_set(TestResult& r) {
     using namespace lemon::utils;
 
     auto self_set = get_server_self_set("192.168.1.17");
-    if (self_set.find("localhost") != self_set.end() &&
-        self_set.find("127.0.0.1") != self_set.end() &&
-        self_set.find("::1") != self_set.end() &&
-        self_set.find("[::1]") != self_set.end()) {
-        r.ok("server_self_set contains loopback entries");
-    } else {
-        r.fail("server_self_set contains loopback entries");
-    }
+    r.expect(self_set.find("localhost") != self_set.end() &&
+             self_set.find("127.0.0.1") != self_set.end() &&
+             self_set.find("::1") != self_set.end() &&
+             self_set.find("[::1]") != self_set.end(),
+             "server_self_set contains loopback entries");
 
-    if (self_set.find("192.168.1.17") != self_set.end()) {
-        r.ok("server_self_set contains bound host");
-    } else {
-        r.fail("server_self_set contains bound host");
-    }
+    r.expect(self_set.find("192.168.1.17") != self_set.end(), "server_self_set contains bound host");
 
     bool has_hostname = false;
     for (const auto& entry : self_set) {
@@ -260,11 +276,7 @@ static void test_server_self_set(TestResult& r) {
             break;
         }
     }
-    if (has_hostname || !self_set.empty()) {
-        r.ok("server_self_set contains OS hostname or mDNS entry");
-    } else {
-        r.fail("server_self_set contains OS hostname or mDNS entry");
-    }
+    r.expect(has_hostname || !self_set.empty(), "server_self_set contains OS hostname or mDNS entry");
 }
 
 static void test_is_origin_allowed(TestResult& r) {
@@ -272,179 +284,55 @@ static void test_is_origin_allowed(TestResult& r) {
 
     std::unordered_set<std::string> mock_self = {"192.168.1.17", "192.168.1.50", "lemonade.lan", "[fe80::1]", "mybox.local"};
 
-    // Non-browser client empty-Origin regression test
-    if (is_origin_allowed("", "", "192.168.1.17:13305", "http", mock_self)) {
-        r.ok("acceptance: allow non-browser empty-Origin request");
-    } else {
-        r.fail("acceptance: allow non-browser empty-Origin request");
-    }
+    // --- Positive / Allowed Cases ---
+    r.expect(is_origin_allowed("", "", "192.168.1.17:13305", "http", mock_self), "acceptance: allow non-browser empty-Origin request");
+    r.expect(is_origin_allowed("http://localhost:3000", ""), "allow loopback localhost");
+    r.expect(is_origin_allowed("http://127.0.0.1:8080", ""), "allow loopback 127.0.0.1");
+    r.expect(is_origin_allowed("http://[::1]:3000", ""), "allow loopback [::1]");
+    r.expect(is_origin_allowed("http://tauri.localhost", ""), "allow loopback tauri.localhost");
+    r.expect(is_origin_allowed("lemonade://app", "") && is_origin_allowed("lemonade://ui", ""), "allow lemonade:// desktop app scheme");
+    r.expect(is_origin_allowed("file://", "") && is_origin_allowed("app://.", "") && is_origin_allowed("jan://app", "") && is_origin_allowed("vscode-webview://", ""), "allow standard desktop app schemes (file, app, jan, vscode-webview)");
 
-    if (is_origin_allowed("http://localhost:3000", "")) {
-        r.ok("allow loopback localhost");
-    } else {
-        r.fail("allow loopback localhost");
-    }
-    if (is_origin_allowed("http://127.0.0.1:8080", "")) {
-        r.ok("allow loopback 127.0.0.1");
-    } else {
-        r.fail("allow loopback 127.0.0.1");
-    }
-    if (is_origin_allowed("http://[::1]:3000", "")) {
-        r.ok("allow loopback [::1]");
-    } else {
-        r.fail("allow loopback [::1]");
-    }
-    if (is_origin_allowed("http://tauri.localhost", "")) {
-        r.ok("allow loopback tauri.localhost");
-    } else {
-        r.fail("allow loopback tauri.localhost");
-    }
-    if (!is_origin_allowed("http://evil.localhost", "")) {
-        r.ok("reject unlisted *.localhost host");
-    } else {
-        r.fail("reject unlisted *.localhost host");
-    }
-    if (is_origin_allowed("lemonade://app", "") && is_origin_allowed("lemonade://ui", "")) {
-        r.ok("allow lemonade:// desktop app scheme");
-    } else {
-        r.fail("allow lemonade:// desktop app scheme");
-    }
-    if (is_origin_allowed("file://", "") && is_origin_allowed("app://.", "") && is_origin_allowed("jan://app", "") && is_origin_allowed("vscode-webview://", "")) {
-        r.ok("allow standard desktop app schemes (file, app, jan, vscode-webview)");
-    } else {
-        r.fail("allow standard desktop app schemes (file, app, jan, vscode-webview)");
-    }
+    // Explicit allowlist positive matches
+    r.expect(is_origin_allowed("https://app.lemonade.dev", "*") && is_origin_allowed("http://any-random-site.com", "*"), "allow wildcard * for any origin");
+    r.expect(is_origin_allowed("https://app.lemonade.dev", "https://app.lemonade.dev"), "allow specific matching origin");
+    r.expect(is_origin_allowed("https://app.lemonade.dev", "http://localhost:3000,  https://app.lemonade.dev, http://another.com"), "allow multiple origins with whitespace");
+    r.expect(is_origin_allowed("http://localhost:3000", "https://app.lemonade.dev"), "allow loopback origin even when explicit remote allowlist configured");
+    r.expect(is_origin_allowed("lemonade://app", "https://app.lemonade.dev"), "allow desktop scheme even when explicit remote allowlist configured");
+    r.expect(is_origin_allowed("http://192.168.1.17:13305", "https://app.lemonade.dev,http://192.168.1.17:13305", "192.168.1.17:13305", "http", mock_self), "allow LAN IP when explicitly listed in allowlist");
+    r.expect(is_origin_allowed("http://192.168.1.50:5173", "http://192.168.1.50:*"), "allow wildcard port in allowed origins config");
+    r.expect(is_origin_allowed("http://192.168.1.50:5173", "https://app.lemonade.dev, http://192.168.1.50:*, http://*.local:*"), "allow wildcard port in comma-separated list");
+    r.expect(is_origin_allowed("http://dashboard.local:3000", "http://*.local:*"), "allow wildcard domain in allowed origins config");
 
-    // Rule 1: Explicit allowlist authoritative first
-    if (is_origin_allowed("https://app.lemonade.dev", "*") && is_origin_allowed("http://any-random-site.com", "*")) {
-        r.ok("allow wildcard * for any origin");
-    } else {
-        r.fail("allow wildcard * for any origin");
-    }
-    if (is_origin_allowed("https://app.lemonade.dev", "https://app.lemonade.dev")) {
-        r.ok("allow specific matching origin");
-    } else {
-        r.fail("allow specific matching origin");
-    }
-    if (!is_origin_allowed("http://app.lemonade.dev", "https://app.lemonade.dev")) {
-        r.ok("reject specific origin scheme mismatch");
-    } else {
-        r.fail("reject specific origin scheme mismatch");
-    }
-    if (is_origin_allowed("https://app.lemonade.dev", "http://localhost:3000,  https://app.lemonade.dev, http://another.com")) {
-        r.ok("allow multiple origins with whitespace");
-    } else {
-        r.fail("allow multiple origins with whitespace");
-    }
-    if (is_origin_allowed("http://localhost:3000", "https://app.lemonade.dev")) {
-        r.ok("allow loopback origin even when explicit remote allowlist configured");
-    } else {
-        r.fail("allow loopback origin even when explicit remote allowlist configured");
-    }
-    if (is_origin_allowed("lemonade://app", "https://app.lemonade.dev")) {
-        r.ok("allow desktop scheme even when explicit remote allowlist configured");
-    } else {
-        r.fail("allow desktop scheme even when explicit remote allowlist configured");
-    }
-    if (!is_origin_allowed("http://192.168.1.17:13305", "https://app.lemonade.dev", "192.168.1.17:13305", "http", mock_self)) {
-        r.ok("reject unlisted same-origin LAN IP when explicit allowlist configured (no fallthrough)");
-    } else {
-        r.fail("reject unlisted same-origin LAN IP when explicit allowlist configured (no fallthrough)");
-    }
-    if (is_origin_allowed("http://192.168.1.17:13305", "https://app.lemonade.dev,http://192.168.1.17:13305", "192.168.1.17:13305", "http", mock_self)) {
-        r.ok("allow LAN IP when explicitly listed in allowlist");
-    } else {
-        r.fail("allow LAN IP when explicitly listed in allowlist");
-    }
+    // Same-origin LAN and mDNS positive matches
+    r.expect(is_origin_allowed("http://192.168.1.17:13305", "", "192.168.1.17:13305", "http", mock_self), "acceptance: allow same-origin LAN IP 192.168.1.17:13305 in server_self_set");
+    r.expect(is_origin_allowed("http://mybox.local:13305", "", "mybox.local:13305", "http", mock_self), "acceptance: allow same-origin mDNS mybox.local:13305 in server_self_set");
+    r.expect(is_origin_allowed("http://MYBOX.LOCAL:13305", "", "mybox.local:13305", "http", mock_self), "acceptance: allow case-insensitive hostname MYBOX.LOCAL");
+    r.expect(is_origin_allowed("http://mybox.local.:13305", "", "mybox.local:13305", "http", mock_self), "acceptance: allow trailing-dot hostname mybox.local.");
+    r.expect(is_origin_allowed("http://192.168.1.17", "", "192.168.1.17:80", "http", mock_self), "acceptance: allow default port 80 normalization with bare origin");
+    r.expect(is_origin_allowed("http://192.168.1.50:13305", "", "192.168.1.50:13305", "http", mock_self), "allow same-origin LAN IP and port");
+    r.expect(is_origin_allowed("http://192.168.1.50:13305", "", "192.168.1.50:13305", "", mock_self), "allow same-origin LAN IP with default http scheme");
+    r.expect(is_origin_allowed("https://lemonade.lan:8443", "", "lemonade.lan:8443", "https", mock_self), "allow same-origin HTTPS domain and port in server_self_set");
+    r.expect(is_origin_allowed("http://[fe80::1]:13305", "", "[fe80::1]:13305", "http", mock_self), "allow same-origin IPv6 address and port in server_self_set");
+    r.expect(is_origin_allowed("null", "null", "192.168.1.50:13305", "http", mock_self), "allow opaque null origin with explicit allowlist");
 
-    // Rule 3: Zero-config LAN and mDNS acceptance tests
-    if (is_origin_allowed("http://192.168.1.17:13305", "", "192.168.1.17:13305", "http", mock_self)) {
-        r.ok("acceptance: allow same-origin LAN IP 192.168.1.17:13305 in server_self_set");
-    } else {
-        r.fail("acceptance: allow same-origin LAN IP 192.168.1.17:13305 in server_self_set");
-    }
-    if (is_origin_allowed("http://mybox.local:13305", "", "mybox.local:13305", "http", mock_self)) {
-        r.ok("acceptance: allow same-origin mDNS mybox.local:13305 in server_self_set");
-    } else {
-        r.fail("acceptance: allow same-origin mDNS mybox.local:13305 in server_self_set");
-    }
-    if (is_origin_allowed("http://MYBOX.LOCAL:13305", "", "mybox.local:13305", "http", mock_self)) {
-        r.ok("acceptance: allow case-insensitive hostname MYBOX.LOCAL");
-    } else {
-        r.fail("acceptance: allow case-insensitive hostname MYBOX.LOCAL");
-    }
-    if (is_origin_allowed("http://mybox.local.:13305", "", "mybox.local:13305", "http", mock_self)) {
-        r.ok("acceptance: allow trailing-dot hostname mybox.local.");
-    } else {
-        r.fail("acceptance: allow trailing-dot hostname mybox.local.");
-    }
-    if (is_origin_allowed("http://192.168.1.17", "", "192.168.1.17:80", "http", mock_self)) {
-        r.ok("acceptance: allow default port 80 normalization with bare origin");
-    } else {
-        r.fail("acceptance: allow default port 80 normalization with bare origin");
-    }
-    if (!is_origin_allowed("http://evil.com:13305", "", "evil.com:13305", "http", mock_self)) {
-        r.ok("acceptance: reject DNS rebind evil.com:13305 matching host but not in server_self_set");
-    } else {
-        r.fail("acceptance: reject DNS rebind evil.com:13305 matching host but not in server_self_set");
-    }
-
-    if (is_origin_allowed("http://192.168.1.50:13305", "", "192.168.1.50:13305", "http", mock_self)) {
-        r.ok("allow same-origin LAN IP and port");
-    } else {
-        r.fail("allow same-origin LAN IP and port");
-    }
-    if (is_origin_allowed("http://192.168.1.50:13305", "", "192.168.1.50:13305", "", mock_self)) {
-        r.ok("allow same-origin LAN IP with default http scheme");
-    } else {
-        r.fail("allow same-origin LAN IP with default http scheme");
-    }
-    if (!is_origin_allowed("http://192.168.1.50:13305", "", "192.168.1.50:8000", "http", mock_self)) {
-        r.ok("reject same-origin port mismatch");
-    } else {
-        r.fail("reject same-origin port mismatch");
-    }
-    if (!is_origin_allowed("http://evil.com", "", "192.168.1.50:13305", "http", mock_self)) {
-        r.ok("reject cross-origin host mismatch without allowlist");
-    } else {
-        r.fail("reject cross-origin host mismatch without allowlist");
-    }
-    if (!is_origin_allowed("https://192.168.1.50:13305", "", "192.168.1.50:13305", "http", mock_self)) {
-        r.ok("reject same-origin scheme mismatch https vs http");
-    } else {
-        r.fail("reject same-origin scheme mismatch https vs http");
-    }
-    if (!is_origin_allowed("https://mybox.local:13305", "", "mybox.local:13305", "http", mock_self)) {
-        r.ok("reject mDNS HTTPS origin against HTTP host scheme mismatch");
-    } else {
-        r.fail("reject mDNS HTTPS origin against HTTP host scheme mismatch");
-    }
-    if (is_origin_allowed("https://lemonade.lan:8443", "", "lemonade.lan:8443", "https", mock_self)) {
-        r.ok("allow same-origin HTTPS domain and port in server_self_set");
-    } else {
-        r.fail("allow same-origin HTTPS domain and port in server_self_set");
-    }
-    if (is_origin_allowed("http://[fe80::1]:13305", "", "[fe80::1]:13305", "http", mock_self)) {
-        r.ok("allow same-origin IPv6 address and port in server_self_set");
-    } else {
-        r.fail("allow same-origin IPv6 address and port in server_self_set");
-    }
-    if (!is_origin_allowed("null", "", "192.168.1.50:13305", "http", mock_self)) {
-        r.ok("reject opaque null origin against host without allowlist");
-    } else {
-        r.fail("reject opaque null origin against host without allowlist");
-    }
-    if (is_origin_allowed("null", "null", "192.168.1.50:13305", "http", mock_self)) {
-        r.ok("allow opaque null origin with explicit allowlist");
-    } else {
-        r.fail("allow opaque null origin with explicit allowlist");
-    }
+    // --- Negative / Rejected Cases ---
+    r.expect(!is_origin_allowed("http://evil.localhost", ""), "reject unlisted *.localhost host");
+    r.expect(!is_origin_allowed("http://app.lemonade.dev", "https://app.lemonade.dev"), "reject specific origin scheme mismatch");
+    r.expect(!is_origin_allowed("http://192.168.1.17:13305", "https://app.lemonade.dev", "192.168.1.17:13305", "http", mock_self), "reject unlisted same-origin LAN IP when explicit allowlist configured (no fallthrough)");
+    r.expect(!is_origin_allowed("http://notlocal.com:3000", "http://*.local:*"), "reject non-matching domain against wildcard domain config");
+    r.expect(!is_origin_allowed("http://evil.com:13305", "", "evil.com:13305", "http", mock_self), "acceptance: reject DNS rebind evil.com:13305 matching host but not in server_self_set");
+    r.expect(!is_origin_allowed("http://192.168.1.50:13305", "", "192.168.1.50:8000", "http", mock_self), "reject same-origin port mismatch");
+    r.expect(!is_origin_allowed("http://evil.com", "", "192.168.1.50:13305", "http", mock_self), "reject cross-origin host mismatch without allowlist");
+    r.expect(!is_origin_allowed("https://192.168.1.50:13305", "", "192.168.1.50:13305", "http", mock_self), "reject same-origin scheme mismatch https vs http");
+    r.expect(!is_origin_allowed("https://mybox.local:13305", "", "mybox.local:13305", "http", mock_self), "reject mDNS HTTPS origin against HTTP host scheme mismatch");
+    r.expect(!is_origin_allowed("null", "", "192.168.1.50:13305", "http", mock_self), "reject opaque null origin against host without allowlist");
 }
 
 static void test_resolve_allowed_origins(TestResult& r) {
     using namespace lemon::utils;
     std::string origins = resolve_allowed_origins();
-    r.ok("resolve_allowed_origins callable without error");
+    r.expect(!origins.empty() || origins.empty(), "resolve_allowed_origins callable without error");
 }
 
 static void test_is_same_origin(TestResult& r) {
@@ -452,56 +340,19 @@ static void test_is_same_origin(TestResult& r) {
 
     std::unordered_set<std::string> mock_self = {"192.168.1.17", "192.168.1.50", "example.com", "mybox.local"};
 
-    if (is_same_origin("http://192.168.1.50:13305", "192.168.1.50:13305", "http", mock_self)) {
-        r.ok("same origin match exact http://192.168.1.50:13305");
-    } else {
-        r.fail("same origin match exact http://192.168.1.50:13305");
-    }
-    if (is_same_origin("http://example.com", "example.com", "http", mock_self)) {
-        r.ok("same origin match default port 80 http://example.com");
-    } else {
-        r.fail("same origin match default port 80 http://example.com");
-    }
-    if (is_same_origin("http://example.com:80", "example.com", "http", mock_self)) {
-        r.ok("same origin match explicit port 80 with default Host port");
-    } else {
-        r.fail("same origin match explicit port 80 with default Host port");
-    }
-    if (is_same_origin("https://example.com:443", "example.com", "https", mock_self)) {
-        r.ok("same origin match explicit port 443 with default HTTPS Host");
-    } else {
-        r.fail("same origin match explicit port 443 with default HTTPS Host");
-    }
-    if (!is_same_origin("http://example.com:8080", "example.com:9090", "http", mock_self)) {
-        r.ok("same origin reject port mismatch");
-    } else {
-        r.fail("same origin reject port mismatch");
-    }
-    if (!is_same_origin("http://attacker.com", "192.168.1.50:13305", "http", mock_self)) {
-        r.ok("same origin reject hostname mismatch");
-    } else {
-        r.fail("same origin reject hostname mismatch");
-    }
-    if (!is_same_origin("http://evil.com:13305", "evil.com:13305", "http", mock_self)) {
-        r.ok("same origin reject host not in server_self_set (DNS rebind)");
-    } else {
-        r.fail("same origin reject host not in server_self_set (DNS rebind)");
-    }
-    if (!is_same_origin("http://192.168.1.50:13305", "", "http", mock_self)) {
-        r.ok("same origin reject empty host header");
-    } else {
-        r.fail("same origin reject empty host header");
-    }
-    if (!is_same_origin("", "192.168.1.50:13305", "http", mock_self)) {
-        r.ok("same origin reject empty origin");
-    } else {
-        r.fail("same origin reject empty origin");
-    }
-    if (!is_same_origin("null", "192.168.1.50:13305", "http", mock_self)) {
-        r.ok("same origin reject null origin");
-    } else {
-        r.fail("same origin reject null origin");
-    }
+    // --- Positive Same-Origin Matches ---
+    r.expect(is_same_origin("http://192.168.1.50:13305", "192.168.1.50:13305", "http", mock_self), "same origin match exact http://192.168.1.50:13305");
+    r.expect(is_same_origin("http://example.com", "example.com", "http", mock_self), "same origin match default port 80 http://example.com");
+    r.expect(is_same_origin("http://example.com:80", "example.com", "http", mock_self), "same origin match explicit port 80 with default Host port");
+    r.expect(is_same_origin("https://example.com:443", "example.com", "https", mock_self), "same origin match explicit port 443 with default HTTPS Host");
+
+    // --- Negative Same-Origin Mismatches & Security Checks ---
+    r.expect(!is_same_origin("http://example.com:8080", "example.com:9090", "http", mock_self), "same origin reject port mismatch");
+    r.expect(!is_same_origin("http://attacker.com", "192.168.1.50:13305", "http", mock_self), "same origin reject hostname mismatch");
+    r.expect(!is_same_origin("http://evil.com:13305", "evil.com:13305", "http", mock_self), "same origin reject host not in server_self_set (DNS rebind)");
+    r.expect(!is_same_origin("http://192.168.1.50:13305", "", "http", mock_self), "same origin reject empty host header");
+    r.expect(!is_same_origin("", "192.168.1.50:13305", "http", mock_self), "same origin reject empty origin");
+    r.expect(!is_same_origin("null", "192.168.1.50:13305", "http", mock_self), "same origin reject null origin");
 }
 
 static void test_is_websocket_origin_allowed(TestResult& r) {
@@ -509,52 +360,21 @@ static void test_is_websocket_origin_allowed(TestResult& r) {
 
     std::unordered_set<std::string> mock_self = {"192.168.1.17", "192.168.1.50", "mybox.local"};
 
-    // WS zero-config LAN and mDNS acceptance tests
-    if (is_websocket_origin_allowed("http://192.168.1.17:13305", "", "192.168.1.17:13305", "http", mock_self)) {
-        r.ok("acceptance: websocket allow same-origin LAN IP 192.168.1.17:13305 in server_self_set");
-    } else {
-        r.fail("acceptance: websocket allow same-origin LAN IP 192.168.1.17:13305 in server_self_set");
-    }
-    if (is_websocket_origin_allowed("http://mybox.local:13305", "", "mybox.local:13305", "http", mock_self)) {
-        r.ok("acceptance: websocket allow same-origin mDNS mybox.local:13305 in server_self_set");
-    } else {
-        r.fail("acceptance: websocket allow same-origin mDNS mybox.local:13305 in server_self_set");
-    }
-    if (!is_websocket_origin_allowed("http://evil.com:13305", "", "evil.com:13305", "http", mock_self)) {
-        r.ok("acceptance: websocket reject DNS rebind evil.com:13305 not in server_self_set");
-    } else {
-        r.fail("acceptance: websocket reject DNS rebind evil.com:13305 not in server_self_set");
-    }
+    // --- Positive / Allowed WebSocket Cases ---
+    r.expect(is_websocket_origin_allowed("http://192.168.1.17:13305", "", "192.168.1.17:13305", "http", mock_self), "acceptance: websocket allow same-origin LAN IP 192.168.1.17:13305 in server_self_set");
+    r.expect(is_websocket_origin_allowed("http://mybox.local:13305", "", "mybox.local:13305", "http", mock_self), "acceptance: websocket allow same-origin mDNS mybox.local:13305 in server_self_set");
+    r.expect(is_websocket_origin_allowed("http://localhost:3000", ""), "websocket allow loopback origin");
+    r.expect(is_websocket_origin_allowed("lemonade://app", ""), "websocket allow lemonade:// desktop app origin");
+    r.expect(is_origin_allowed("file://", "") && is_origin_allowed("app://.", "") && is_origin_allowed("jan://app", ""), "allow desktop app origins (file, app, jan)");
+    r.expect(is_websocket_origin_allowed("http://custom-client.com:3000", "http://custom-client.com:3000"), "websocket allow cross origin if in explicit allowlist");
+    r.expect(is_websocket_origin_allowed("http://192.168.1.50:5173", "http://192.168.1.50:*"), "websocket allow wildcard port if in allowlist");
+    r.expect(is_websocket_origin_allowed("http://dashboard.local:3000", "http://*.local:*"), "websocket allow wildcard host if in allowlist");
 
-    if (is_websocket_origin_allowed("http://localhost:3000", "")) {
-        r.ok("websocket allow loopback origin");
-    } else {
-        r.fail("websocket allow loopback origin");
-    }
-
-    if (is_websocket_origin_allowed("lemonade://app", "")) {
-        r.ok("websocket allow lemonade:// desktop app origin");
-    } else {
-        r.fail("websocket allow lemonade:// desktop app origin");
-    }
-
-    if (!is_websocket_origin_allowed("http://unconfigured.com:3000", "")) {
-        r.ok("websocket reject unconfigured remote origin without allowlist");
-    } else {
-        r.fail("websocket reject unconfigured remote origin without allowlist");
-    }
-
-    if (is_websocket_origin_allowed("http://custom-client.com:3000", "http://custom-client.com:3000")) {
-        r.ok("websocket allow cross origin if in explicit allowlist");
-    } else {
-        r.fail("websocket allow cross origin if in explicit allowlist");
-    }
-
-    if (!is_websocket_origin_allowed("http://null", "null")) {
-        r.ok("websocket reject standard http null host origins from matching null allowlist");
-    } else {
-        r.fail("websocket reject standard http null host origins from matching null allowlist");
-    }
+    // --- Negative / Rejected WebSocket Cases ---
+    r.expect(!is_websocket_origin_allowed("http://evil.com:13305", "", "evil.com:13305", "http", mock_self), "acceptance: websocket reject DNS rebind evil.com:13305 not in server_self_set");
+    r.expect(!is_websocket_origin_allowed("http://unconfigured.com:3000", ""), "websocket reject unconfigured remote origin without allowlist");
+    r.expect(!is_websocket_origin_allowed("http://notlocal.com:3000", "http://*.local:*"), "websocket reject non-matching domain against wildcard host allowlist");
+    r.expect(!is_websocket_origin_allowed("http://null", "null"), "websocket reject standard http null host origins from matching null allowlist");
 }
 
 int main() {


### PR DESCRIPTION
Approved RFC:  #3427

## Summary

I have added wildcard port matching (`:*`) and subdomain pattern matching (`*.domain:*`, `*.domain`) to origin validation in `origin_utils.h`. This allows web dashboards and frontend development servers running on varying ports (such as `http://192.168.1.50:3000`, `:8080`, `:5173`) or local mDNS domains (`http://*.local:*`) to connect to Lemonade without needing to reconfigure allowed origins whenever a dev server switches ports.

### Key Features

* **Wildcard Port Matching (`:*`)**: Added `:*` support across IPv4 addresses, hostnames, and bracketed IPv6 addresses (`https://[::1]:*`, `https://[2001:db8::1]:*`), matching any port on that host while enforcing strict scheme checks (`http` vs `https`).
* **Subdomain Wildcard Matching (`*.domain`)**: Added subdomain pattern matching with dot-boundary enforcement. `*.example.com` matches `sub.example.com` and `a.b.example.com`, but strictly rejects `notexample.com`, `badexample.com`, and apex `example.com`.
* **Universal Wildcard Support & Safety Warnings**: Supported `allowed_origins=*` and `http://*:*` for development environments, with explicit documentation warnings explaining the security risks of broad wildcards.
* **Malformed Input Rejection**: Strict validation rejects malformed port syntax (e.g. `:*80`, `:*junk`, `:**`, empty `:`).
* **DRY Helper Consolidation**: Extracted `parse_port` and `trim` helpers in `origin_utils.h`, removing duplicated parsing logic between bracketed IPv6 and standard hostname paths.
* **Centralized Configuration Integration**: Integrates directly with `allowed_origins` in `config.json` and CLI (`lemonade config set allowed_origins="..."`), covering both HTTP CORS and WebSocket streams.

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_
* **Unit Tests**: Ran `test_origin_utils` with 106/106 tests passing, including tests for wildcard ports, bracketed IPv6, subdomain dot-boundary checks, malformed port rejections, and integration in comma-separated allowlists.
* **CTest Suite**: Ran `ctest -R OriginUtilsTest` with 100% passing.
* **Integration Tests**: Ran `test/server_websocket_auth.py` with 14/14 tests passing.
* **Boilerplate Sync**: Ran `python3 docs/tools/gen_backend_boilerplate.py --check --lemond build/lemond` with zero drift.

## Documentation

- [ ] Documentation is not affected by this change.
- [x] Documentation is affected and has been updated.
- [ ] Documentation is affected but will be handled in a separate PR or issue.

Updated `docs/guide/configuration/README.md` to document wildcard port (`:*`) and wildcard domain (`*.domain`) configuration syntax and security warnings for universal wildcards.

## Breaking Changes

- [ ] This PR introduces breaking changes.
- [x] This PR does not introduce breaking changes.

## AI-assisted contribution

- [x] I used AI tools for this PR.
- [ ] I did not use AI tools for this PR.

If AI tools were used:
- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.