### PR TITLE
fix(server): remove global and streaming timeouts (#3447)

### DIFF
--- a/src/cpp/include/lemon/utils/http_client.h
+++ b/src/cpp/include/lemon/utils/http_client.h
@@ -154,10 +154,8 @@ public:
     // (names lowercased) before on_status fires, so a caller deciding what to
     // send downstream can see them without waiting for the transfer to finish.
     //
-    // timeout_seconds=0 uses default_timeout_seconds_. A total timeout would
-    // cut off a long but healthy generation, so this bounds upstream silence
-    // instead: the transfer is aborted only after kStreamStallSeconds with no
-    // progress, which a streaming response cannot legitimately exceed.
+    // timeout_seconds=0 uses default_timeout_seconds_, as in get(); pass
+    // kNoTimeout to opt out deliberately.
     static HttpResponse post_stream(
         const std::string& url,
         const std::string& body,

--- a/src/cpp/server/utils/http_client.cpp
+++ b/src/cpp/server/utils/http_client.cpp
@@ -39,10 +39,6 @@ namespace {
 // full request timeout.
 constexpr long kConnectTimeoutSeconds = 30;
 
-// How long a stream may deliver nothing before it is treated as dead. Well
-// above any inter-token gap, well below "never".
-constexpr long kStreamStallSeconds = 120;
-
 // Resolves the 0-means-default convention shared by every request method.
 // Without this, curl reads 0 as "no timeout" and a silent upstream parks the
 // calling httplib worker permanently.
@@ -774,14 +770,7 @@ HttpResponse HttpClient::post_stream(const std::string& url,
         curl_easy_cleanup(curl);
         throw std::runtime_error("Failed to apply HTTP security policy");
     }
-    // A total timeout would kill a long but healthy generation, so an
-    // unqualified request is bounded by upstream silence instead of duration.
-    if (timeout_seconds == 0) {
-        curl_easy_setopt(curl, CURLOPT_LOW_SPEED_LIMIT, 1L);
-        curl_easy_setopt(curl, CURLOPT_LOW_SPEED_TIME, kStreamStallSeconds);
-    } else {
-        curl_easy_setopt(curl, CURLOPT_TIMEOUT, effective_timeout(timeout_seconds));
-    }
+    curl_easy_setopt(curl, CURLOPT_TIMEOUT, effective_timeout(timeout_seconds));
     curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, kConnectTimeoutSeconds);
     curl_easy_setopt(curl, CURLOPT_USERAGENT, "lemon.cpp/1.0");
 

--- a/src/cpp/server/utils/http_client.cpp
+++ b/src/cpp/server/utils/http_client.cpp
@@ -46,8 +46,13 @@ long effective_timeout(long timeout_seconds) {
     if (timeout_seconds == HttpClient::kNoTimeout) {
         return 0;
     }
-    return timeout_seconds > 0 ? timeout_seconds
-                               : HttpClient::get_default_timeout();
+    if (timeout_seconds > 0) {
+        return timeout_seconds;
+    }
+    // curl rejects a negative CURLOPT_TIMEOUT, so a non-positive default
+    // means no timeout rather than reaching setopt.
+    const long default_timeout = HttpClient::get_default_timeout();
+    return default_timeout > 0 ? default_timeout : 0;
 }
 
 static std::string trim_copy(const std::string& value) {

--- a/test/cpp/test_http_client_timeout.cpp
+++ b/test/cpp/test_http_client_timeout.cpp
@@ -140,9 +140,6 @@ int main() {
                 "post_multipart: timeout 0 falls back to the default");
     }
 
-    // post_stream bounds silence rather than total duration, so a default-timeout
-    // fallback would wrongly cut off a long healthy generation. An explicit
-    // timeout still applies.
     {
         r.check(returns_within_ceiling([&] {
                     HttpClient::post_stream(
@@ -151,6 +148,20 @@ int main() {
                         {}, 2, nullptr, policy);
                 }),
                 "post_stream: explicit timeout abandons a silent upstream");
+    }
+
+    {
+        const long saved = HttpClient::get_default_timeout();
+        HttpClient::set_default_timeout(2);
+        const bool returned = returns_within_ceiling([&] {
+            HttpClient::post_stream(
+                base + "/silent", "{}",
+                [](const char*, size_t) { return true; },
+                {}, 0, nullptr, policy);
+        });
+        HttpClient::set_default_timeout(saved);
+        r.check(returned,
+                "post_stream: timeout 0 falls back to the default");
     }
 
     // The sentinel is the only way to ask for an unbounded transfer, so it must


### PR DESCRIPTION
## Summary

The hard-coded 120s low-speed stall (`CURLOPT_LOW_SPEED_*`, `kStreamStallSeconds`) introduced by #3223 kills healthy long generations on large models, where prefill/reasoning can legitimately emit no bytes for longer than that (v11.8.0 regression). Before #3223, streams had no timeout at all (the raw `0` reached curl, which reads 0 as "no timeout").

This PR removes the stall path entirely: `post_stream` now sets `CURLOPT_TIMEOUT` via `effective_timeout()` exactly like `get`/`post`/`post_multipart` — one timeout convention across all verbs, governed by one setting.

- **In practice, `global_timeout` (default 600s) is the stream timeout**: every streaming call site passes `timeout_seconds = 0` (the router's chat/completions/responses paths, the cloud backend, the Anthropic upstream relay), which falls back to the configured `global_timeout`. Raising it widens the window for everything uniformly.
- The `timeout_seconds` parameter remains only as a per-request override: OpenMOSS passes a computed deadline remainder; `kNoTimeout` opts out entirely. A non-positive default is clamped before reaching `curl_easy_setopt`, which rejects negative values.
- A new test check guards the `0`-falls-back-to-default stream path (previously it took the deleted stall branch).

Note vs. pre-#3223 behavior: unqualified streams are now bounded at `global_timeout` total duration rather than unbounded; generations longer than that need a raised `global_timeout`.

Fixes #3386

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_ Built with the `default` (Ninja, Release) preset on macOS and ran `test_http_client_timeout`: 6 passed, 0 failed (explicit timeouts, 0-means-default fallbacks for post/post_multipart/post_stream, `kNoTimeout` sentinel).

## Documentation

- [x] Documentation is not affected by this change.

## Breaking Changes

- [x] This PR does not introduce breaking changes.

## AI-assisted contribution

Please select one:

- [x] I used AI tools for this PR.

If AI tools were used:

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.
