### PR TITLE
fix(rocm): fall back to the tarball when the wheel path is too deep

### DIFF
--- a/src/cpp/include/lemon/backends/backend_utils.h
+++ b/src/cpp/include/lemon/backends/backend_utils.h
@@ -192,8 +192,9 @@ namespace lemon::backends {
          *  get_therock_lib_paths). Returns "" for empty input. */
         static std::string join_runtime_dirs(const std::vector<std::string>& dirs);
 
-        /** Stage TheRock's amdhip64_7.dll next to a ROCm backend exe, unless
-         *  System32 already ships a newer runtime. No-op off Windows. */
+        /** Stage TheRock's HIP runtime set (the amdhip64 and amd_comgr DLLs)
+         *  next to a ROCm backend exe, so the loader cannot mix it with the
+         *  display driver's copies in System32. No-op off Windows. */
         static bool stage_therock_hip_runtime(const std::string& rocm_arch,
                                               const fs::path& target_dir);
 

--- a/src/cpp/include/lemon/backends/backend_utils.h
+++ b/src/cpp/include/lemon/backends/backend_utils.h
@@ -153,6 +153,12 @@ namespace lemon::backends {
         /** Directory holding the lemonade-managed ROCm wheel venv for arch/version. */
         static std::string get_therock_wheel_dir(const std::string& arch, const std::string& version);
 
+        /** True when a wheel install would place rocBLAS's files past the depth
+         *  it can load from (measured: 174 chars works, 175 faults). Always
+         *  false off Windows. */
+        static bool therock_wheel_path_too_long(const std::string& arch,
+                                                const std::string& version);
+
         /** True when the pip-wheel runtime for arch/version is still usable. See impl for liveness check vs tarball fallback. */
         static bool therock_wheel_runtime_alive(const std::string& arch,
                                                 const std::string& version);

--- a/src/cpp/server/backends/backend_utils.cpp
+++ b/src/cpp/server/backends/backend_utils.cpp
@@ -1953,6 +1953,22 @@ namespace lemon::backends {
     }
 #endif
 
+    namespace {
+#ifdef _WIN32
+    // The HIP runtime and the code-object manager it loads are versioned as a
+    // set. Everything else TheRock ships (OpenCL.dll in particular) is left to
+    // the system so we do not downgrade unrelated subsystems.
+    bool is_hip_runtime_dll(const std::string& name) {
+        std::string lower = name;
+        std::transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
+        if (lower.size() < 4 || lower.compare(lower.size() - 4, 4, ".dll") != 0) {
+            return false;
+        }
+        return lower.rfind("amdhip64", 0) == 0 || lower.rfind("amd_comgr", 0) == 0;
+    }
+#endif
+    } // namespace
+
     bool BackendUtils::stage_therock_hip_runtime(const std::string& rocm_arch,
                                                  const fs::path& target_dir) {
 #ifndef _WIN32
@@ -1968,74 +1984,62 @@ namespace lemon::backends {
         if (therock_dirs.empty()) {
             return false;
         }
-
-        const fs::path therock_dll = utils::path_from_utf8(therock_dirs.front()) / "amdhip64_7.dll";
-        if (!fs::exists(therock_dll)) {
-            return false;
-        }
-
-        const fs::path target_dll = target_dir / "amdhip64_7.dll";
+        const fs::path therock_bin = utils::path_from_utf8(therock_dirs.front());
 
         wchar_t sysdir[MAX_PATH] = {};
         if (GetSystemDirectoryW(sysdir, MAX_PATH) == 0) {
             return false;
         }
-        const fs::path system_dll = fs::path(sysdir) / "amdhip64_7.dll";
+        const fs::path system_dir(sysdir);
 
-        const uint64_t therock_ver = read_dll_version(therock_dll);
-
-        // A previously staged copy may be locked by a running backend process
-        // (Windows blocks overwriting a loaded DLL), so leave it untouched when
-        // it is already at least as new as TheRock's.
-        const uint64_t staged_ver = read_dll_version(target_dll);
-        if (staged_ver != 0 && staged_ver >= therock_ver) {
-            LOG(INFO, "BackendUtils")
-                << "Existing amdhip64_7.dll at " << utils::path_to_utf8(target_dll)
-                << " is at least as new as TheRock's; leaving it in place" << std::endl;
-            return false;
-        }
-
-        // Windows loads DLLs from the exe dir before System32, so the staged
-        // copy wins over System32. Stage System32's runtime first (a plain
-        // path, where GetFileVersionInfoW is reliable) and only overwrite it
-        // with TheRock's when TheRock is newer.
-        std::error_code ec;
-        if (fs::exists(system_dll)) {
-            fs::copy_file(system_dll, target_dll, fs::copy_options::overwrite_existing, ec);
-            if (!ec) {
-                const uint64_t system_ver = read_dll_version(target_dll);
-                if (system_ver != 0 && system_ver >= therock_ver) {
-                    LOG(INFO, "BackendUtils")
-                        << "System32 amdhip64_7.dll is at least as new as TheRock's; staged it at "
-                        << utils::path_to_utf8(target_dll) << std::endl;
-                    return false;
-                }
-                fs::copy_file(therock_dll, target_dll, fs::copy_options::overwrite_existing, ec);
-                if (!ec) {
-                    LOG(INFO, "BackendUtils")
-                        << "TheRock's amdhip64_7.dll is newer than System32's; staged it at "
-                        << utils::path_to_utf8(target_dll) << std::endl;
-                    return true;
-                }
-                LOG(ERROR, "BackendUtils")
-                    << "Failed to copy amdhip64_7.dll from TheRock: " << ec.message() << std::endl;
-                return false;
+        // amdhip64 loads amd_comgr through the ordinary loader search, which
+        // reaches System32 before PATH. Staging one without the other pairs
+        // TheRock's HIP with the display driver's comgr (or the reverse), and a
+        // mixed pair fails device discovery outright: hipGetDeviceCount()
+        // returns 0 and callers report "no ROCm-capable device is detected".
+        // Stage every member of the set that System32 would otherwise supply so
+        // the exe directory holds one internally consistent runtime.
+        bool staged_any = false;
+        std::error_code iter_ec;
+        for (const auto& entry : fs::directory_iterator(therock_bin, iter_ec)) {
+            if (!entry.is_regular_file()) {
+                continue;
             }
-            LOG(WARNING, "BackendUtils")
-                << "Failed to stage System32 amdhip64_7.dll: " << ec.message() << std::endl;
+            const fs::path name = entry.path().filename();
+            if (!is_hip_runtime_dll(utils::path_to_utf8(name))) {
+                continue;
+            }
+            if (!fs::exists(system_dir / name)) {
+                continue;
+            }
+
+            const fs::path target = target_dir / name;
+            // A staged copy already matching TheRock's is both correct and
+            // possibly locked by a running backend, which Windows refuses to
+            // overwrite.
+            if (fs::exists(target) &&
+                read_dll_version(target) == read_dll_version(entry.path())) {
+                continue;
+            }
+
+            std::error_code copy_ec;
+            fs::copy_file(entry.path(), target, fs::copy_options::overwrite_existing, copy_ec);
+            if (copy_ec) {
+                LOG(WARNING, "BackendUtils")
+                    << "Failed to stage " << utils::path_to_utf8(name) << " from TheRock: "
+                    << copy_ec.message() << std::endl;
+                continue;
+            }
+            staged_any = true;
+            LOG(INFO, "BackendUtils")
+                << "Staged TheRock " << utils::path_to_utf8(name) << " at "
+                << utils::path_to_utf8(target) << std::endl;
         }
 
-        fs::copy_file(therock_dll, target_dll, fs::copy_options::overwrite_existing, ec);
-        if (!ec) {
-            LOG(INFO, "BackendUtils")
-                << "Copied amdhip64_7.dll from TheRock to " << utils::path_to_utf8(target_dll)
-                << std::endl;
-            return true;
-        }
-        LOG(ERROR, "BackendUtils") << "Failed to copy amdhip64_7.dll: " << ec.message() << std::endl;
-        return false;
+        return staged_any;
 #endif
     }
+
     void BackendUtils::apply_cuda_env_vars(
             std::vector<std::pair<std::string, std::string>>& env_vars,
             const std::string& log_tag,

--- a/src/cpp/server/backends/backend_utils.cpp
+++ b/src/cpp/server/backends/backend_utils.cpp
@@ -1039,6 +1039,24 @@ namespace lemon::backends {
         return (therock_base / (arch + "-" + version)).string();
     }
 
+    bool BackendUtils::therock_wheel_path_too_long(const std::string& arch,
+                                                   const std::string& version) {
+#ifndef _WIN32
+        (void)arch;
+        (void)version;
+        return false;
+#else
+        // Deepest path rocBLAS resolves relative to its own directory. The
+        // kernel pack is named after the architecture, so derive it rather than
+        // pinning the one this was measured on.
+        static constexpr size_t kMaxWorkingLength = 174;
+        const std::string deepest = get_therock_wheel_dir(arch, version) +
+            "\\venv\\Lib\\site-packages\\_rocm_sdk_libraries\\.kpack\\blas_lib_" +
+            arch + ".kpack";
+        return deepest.size() > kMaxWorkingLength;
+#endif
+    }
+
     std::string BackendUtils::get_therock_wheel_dir(const std::string& arch, const std::string& version) {
         fs::path base = fs::path(utils::get_downloaded_bin_dir()) / "therock-wheels";
         return (base / (arch + "-" + version)).string();
@@ -1232,6 +1250,22 @@ namespace lemon::backends {
         if (auto* cfg = RuntimeConfig::global()) {
             method = cfg->rocm_install_method();
         }
+
+#ifdef _WIN32
+        // rocBLAS crashes (access violation inside Tensile) when its files sit
+        // deeper than ~174 characters, measured on gfx1151: a runtime installed
+        // at 174 loads, one at 175 faults, identically across four hosts. The
+        // wheel layout buries the runtime under venv/Lib/site-packages, which
+        // costs ~45 characters more than the tarball, so a deep enough cache
+        // directory pushes it over. Prefer the tarball there rather than
+        // installing something that cannot work.
+        if (method == "auto" && therock_wheel_path_too_long(arch, version)) {
+            LOG(INFO, "BackendUtils")
+                << "Wheel runtime would install past the ROCm path-length limit; "
+                << "using the TheRock tarball instead" << std::endl;
+            method = "tarball";
+        }
+#endif
 
         reset_therock_wheels_cancelled();
 

--- a/src/cpp/server/backends/sdcpp/sdcpp_server.cpp
+++ b/src/cpp/server/backends/sdcpp/sdcpp_server.cpp
@@ -333,19 +333,7 @@ void SDServer::load(const std::string& model_name,
                         new_path = *it + ";" + new_path;
                     }
 
-                    fs::path therock_dll = fs::path(therock_bin) / "amdhip64_7.dll";
-                    fs::path target_dll = exe_dir / "amdhip64_7.dll";
-                    if (fs::exists(therock_dll)) {
-                        std::error_code ec;
-                        fs::copy_file(therock_dll, target_dll, fs::copy_options::overwrite_existing, ec);
-                        if (!ec) {
-                            LOG(INFO, "SDServer") << "Copied amdhip64_7.dll from TheRock to " << path_to_utf8(target_dll) << std::endl;
-                        } else {
-                            LOG(ERROR, "SDServer") << "Failed to copy amdhip64_7.dll: " << ec.message() << std::endl;
-                        }
-                    } else {
-                        LOG(DEBUG, "SDServer") << "amdhip64_7.dll not found in TheRock at " << path_to_utf8(therock_dll) << std::endl;
-                    }
+                    BackendUtils::stage_therock_hip_runtime(rocm_arch, exe_dir);
                 }
             }
         }


### PR DESCRIPTION
## Summary

rocBLAS faults inside Tensile when its files sit deeper than **174 characters**. Measured on gfx1151 across four otherwise-identical hosts: a runtime installed at 174 loads and generates images; one at 175 dies with an access violation (`0xC0000005`) before allocating a single buffer. The wheel layout costs ~45 characters more than the tarball because it nests the runtime under `venv/Lib/site-packages/_rocm_sdk_libraries`, so a deep enough lemonade home dir pushes the wheel over the limit while the tarball still fits.

When `rocm_install_method` is `auto`, this now measures the path the wheel *would* produce and installs the tarball instead of something that cannot work. Explicit `wheel` is untouched, so anyone who has opted in still gets what they asked for.

This is why the sd-cpp `rocm-stable` CI leg has been failing on three of four Halo rigs while passing on the fourth: the passing rig's CI agent lives at `C:\actions-runner` and the others at `C:\Users\user\actions-runner`, an 11-character difference that lands on either side of the limit. Nothing about the drivers, Adrenalin version, GPU, caches, or the wheel binaries differed — all were verified identical.

Stacked on #3462, which fixes the separate DLL-mixing bug; without it the tarball path fails too.

Fixes #

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_

Path length was swept directly on the rigs by installing the runtime into padded directories, holding everything else constant:

| kernel-data path length | 120 | 164 | 166 | 168 | 170 | 172 | 174 | 175 | 200 |
|---|---|---|---|---|---|---|---|---|---|
| result | ok | ok | ok | ok | ok | ok | ok | **crash** | **crash** |

Identical on `sjlab-stx-halo-06/07/08/09`. Ruled out beforehand, each by measurement rather than inference: driver and Adrenalin version, GPU model and VRAM, System32 `amdhip64`/`amd_comgr`/`OpenCL`, machine-level AMD caches (wiping changed nothing either way), install method, cache-directory reuse, wheel vs tarball `rocblas.dll` (swapping the binaries changed nothing), and `.kpack` placement.

Linux builds clean; the Windows-only branch is compile-checked by CI.

## Documentation

- [x] Documentation is not affected by this change.

## Breaking Changes

- [x] This PR does not introduce breaking changes.

## AI-assisted contribution

- [x] I used AI tools for this PR.

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011QSgagaAkHY863teRf64Hi
