### PR TITLE
fix(server): streaming stall window follows global_timeout (#3386)

### DIFF
--- a/src/cpp/include/lemon/utils/http_client.h
+++ b/src/cpp/include/lemon/utils/http_client.h
@@ -154,10 +154,9 @@ public:
     // (names lowercased) before on_status fires, so a caller deciding what to
     // send downstream can see them without waiting for the transfer to finish.
     //
-    // timeout_seconds=0 uses default_timeout_seconds_. A total timeout would
-    // cut off a long but healthy generation, so this bounds upstream silence
-    // instead: the transfer is aborted only after that many seconds with no
-    // progress.
+    // timeout_seconds bounds upstream silence, not total duration: a total
+    // timeout would cut off a long but healthy generation. 0 uses
+    // default_timeout_seconds_, as in get().
     static HttpResponse post_stream(
         const std::string& url,
         const std::string& body,

--- a/src/cpp/include/lemon/utils/http_client.h
+++ b/src/cpp/include/lemon/utils/http_client.h
@@ -156,8 +156,8 @@ public:
     //
     // timeout_seconds=0 uses default_timeout_seconds_. A total timeout would
     // cut off a long but healthy generation, so this bounds upstream silence
-    // instead: the transfer is aborted only after kStreamStallSeconds with no
-    // progress, which a streaming response cannot legitimately exceed.
+    // instead: the transfer is aborted only after that many seconds with no
+    // progress.
     static HttpResponse post_stream(
         const std::string& url,
         const std::string& body,

--- a/src/cpp/server/utils/http_client.cpp
+++ b/src/cpp/server/utils/http_client.cpp
@@ -770,14 +770,10 @@ HttpResponse HttpClient::post_stream(const std::string& url,
         curl_easy_cleanup(curl);
         throw std::runtime_error("Failed to apply HTTP security policy");
     }
-    // A total timeout would kill a long but healthy generation, so an
-    // unqualified request is bounded by upstream silence instead of duration.
-    if (timeout_seconds == 0) {
-        curl_easy_setopt(curl, CURLOPT_LOW_SPEED_LIMIT, 1L);
-        curl_easy_setopt(curl, CURLOPT_LOW_SPEED_TIME, HttpClient::get_default_timeout());
-    } else {
-        curl_easy_setopt(curl, CURLOPT_TIMEOUT, effective_timeout(timeout_seconds));
-    }
+    // A total timeout would kill a long but healthy generation, so the timeout
+    // bounds upstream silence instead of duration.
+    curl_easy_setopt(curl, CURLOPT_LOW_SPEED_LIMIT, 1L);
+    curl_easy_setopt(curl, CURLOPT_LOW_SPEED_TIME, effective_timeout(timeout_seconds));
     curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, kConnectTimeoutSeconds);
     curl_easy_setopt(curl, CURLOPT_USERAGENT, "lemon.cpp/1.0");
 

--- a/src/cpp/server/utils/http_client.cpp
+++ b/src/cpp/server/utils/http_client.cpp
@@ -39,10 +39,6 @@ namespace {
 // full request timeout.
 constexpr long kConnectTimeoutSeconds = 30;
 
-// How long a stream may deliver nothing before it is treated as dead. Well
-// above any inter-token gap, well below "never".
-constexpr long kStreamStallSeconds = 120;
-
 // Resolves the 0-means-default convention shared by every request method.
 // Without this, curl reads 0 as "no timeout" and a silent upstream parks the
 // calling httplib worker permanently.
@@ -778,7 +774,7 @@ HttpResponse HttpClient::post_stream(const std::string& url,
     // unqualified request is bounded by upstream silence instead of duration.
     if (timeout_seconds == 0) {
         curl_easy_setopt(curl, CURLOPT_LOW_SPEED_LIMIT, 1L);
-        curl_easy_setopt(curl, CURLOPT_LOW_SPEED_TIME, kStreamStallSeconds);
+        curl_easy_setopt(curl, CURLOPT_LOW_SPEED_TIME, HttpClient::get_default_timeout());
     } else {
         curl_easy_setopt(curl, CURLOPT_TIMEOUT, effective_timeout(timeout_seconds));
     }

--- a/test/cpp/test_http_client_timeout.cpp
+++ b/test/cpp/test_http_client_timeout.cpp
@@ -153,6 +153,21 @@ int main() {
                 "post_stream: explicit timeout abandons a silent upstream");
     }
 
+    // timeout_seconds=0 bounds silence with the configured default timeout.
+    {
+        const long saved = HttpClient::get_default_timeout();
+        HttpClient::set_default_timeout(2);
+        const bool returned = returns_within_ceiling([&] {
+            HttpClient::post_stream(
+                base + "/silent", "{}",
+                [](const char*, size_t) { return true; },
+                {}, 0, nullptr, policy);
+        });
+        HttpClient::set_default_timeout(saved);
+        r.check(returned,
+                "post_stream: timeout 0 bounds silence with the default timeout");
+    }
+
     // The sentinel is the only way to ask for an unbounded transfer, so it must
     // not be confused with 0.
     r.check(HttpClient::kNoTimeout != 0,


### PR DESCRIPTION
## Summary

v11.8.0 added a liveness check for responses that allowed them exceed the global timeout if they kept replying. However, it set a fixed 120 seconds timeout for that liveness check, meaning large prefills could easily exceed the timeout since llama-server doesn't send any response packets during prefill.

This PR changes this "liveness" timeout to be configured by `global_timeout`, which:
1. Changes the default from 120 to 600 seconds
2. Allows the user to configure the value with `lemonade config set global_timeout=xxx`

Fixes #3386

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_

1. build and run lemond with default settings and verify prefill no longer terminates at 120 seconds

```
2026-09-01 16:00:23.464 [Info] (Process) 1.47.276.300 I slot print_timing: id  0 | task 29 | prompt processing, n_tokens =   2048, progress = 0.12, t =   5.47 s / 374.12 tokens per second
2026-09-01 16:00:31.697 [Info] (Process) 1.55.509.067 I slot print_timing: id  0 | task 29 | prompt processing, n_tokens =   4096, progress = 0.14, t =  13.58 s / 301.63 tokens per second
2026-09-01 16:00:40.454 [Info] (Process) 2.04.266.961 I slot print_timing: id  0 | task 29 | prompt processing, n_tokens =   6144, progress = 0.17, t =  22.18 s / 277.02 tokens per second
2026-09-01 16:00:49.844 [Info] (Process) 2.13.656.115 I slot print_timing: id  0 | task 29 | prompt processing, n_tokens =   8192, progress = 0.20, t =  31.41 s / 260.78 tokens per second
2026-09-01 16:00:59.945 [Info] (Process) 2.23.757.405 I slot print_timing: id  0 | task 29 | prompt processing, n_tokens =  10240, progress = 0.22, t =  41.29 s / 248.00 tokens per second
2026-09-01 16:01:10.959 [Info] (Process) 2.34.771.694 I slot print_timing: id  0 | task 29 | prompt processing, n_tokens =  12288, progress = 0.25, t =  52.02 s / 236.23 tokens per second
2026-09-01 16:01:23.000 [Info] (Process) 2.46.812.345 I slot print_timing: id  0 | task 29 | prompt processing, n_tokens =  14336, progress = 0.27, t =  63.75 s / 224.89 tokens per second
2026-09-01 16:01:35.866 [Info] (Process) 2.59.679.061 I slot print_timing: id  0 | task 29 | prompt processing, n_tokens =  16384, progress = 0.30, t =  76.36 s / 214.55 tokens per second
2026-09-01 16:01:49.738 [Info] (Process) 3.13.550.881 I slot print_timing: id  0 | task 29 | prompt processing, n_tokens =  18432, progress = 0.32, t =  90.02 s / 204.75 tokens per second
2026-09-01 16:02:04.699 [Info] (Process) 3.28.511.963 I slot print_timing: id  0 | task 29 | prompt processing, n_tokens =  20480, progress = 0.35, t = 104.71 s / 195.59 tokens per second
2026-09-01 16:02:20.793 [Info] (Process) 3.44.605.308 I slot print_timing: id  0 | task 29 | prompt processing, n_tokens =  22528, progress = 0.37, t = 120.42 s / 187.08 tokens per second
2026-09-01 16:02:38.255 [Info] (Process) 4.02.067.991 I slot print_timing: id  0 | task 29 | prompt processing, n_tokens =  24576, progress = 0.40, t = 137.38 s / 178.89 tokens per second
2026-09-01 16:02:56.884 [Info] (Process) 4.20.696.457 I slot print_timing: id  0 | task 29 | prompt processing, n_tokens =  26624, progress = 0.42, t = 155.78 s / 170.91 tokens per second
2026-09-01 16:03:16.437 [Info] (Process) 4.40.249.620 I slot print_timing: id  0 | task 29 | prompt processing, n_tokens =  28672, progress = 0.45, t = 175.00 s / 163.84 tokens per second
2026-09-01 16:03:37.325 [Info] (Process) 5.01.137.308 I slot print_timing: id  0 | task 29 | prompt processing, n_tokens =  30720, progress = 0.47, t = 195.59 s / 157.07 tokens per second
2026-09-01 16:03:59.428 [Info] (Process) 5.23.240.968 I slot print_timing: id  0 | task 29 | prompt processing, n_tokens =  32768, progress = 0.50, t = 217.39 s / 150.73 tokens per second
```

More than 200s!

2. set global_timeout to 20 seconds and verify prefill is terminated at 20 seconds

```
026-09-01 16:05:32.581 [Info] (Process) 6.56.393.462 I slot print_timing: id  0 | task 51 | prompt processing, n_tokens =   2048, progress = 0.02, t =   5.38 s / 380.66 tokens per second
2026-09-01 16:05:39.566 [Info] (Process) 7.03.378.191 I slot print_timing: id  0 | task 51 | prompt processing, n_tokens =   4096, progress = 0.04, t =  12.23 s / 335.01 tokens per second
2026-09-01 16:05:46.867 [Info] (Process) 7.10.679.882 I slot print_timing: id  0 | task 51 | prompt processing, n_tokens =   6144, progress = 0.06, t =  19.44 s / 315.98 tokens per second
2026-09-01 16:05:51.470 [Error] (HttpClient) CURL error: Timeout was reached
2026-09-01 16:05:51.471 [Error] (WrappedServer) Streaming request failed: CURL error: Timeout was reached
```

Less than 20s!

## Documentation

- [x] Documentation is not affected by this change.

## Breaking Changes

- [x] This PR does not introduce breaking changes.

## AI-assisted contribution

Please select one:

- [x] I used AI tools for this PR.

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.
