### PR TITLE
fix(server): give auto-tune real VRAM usage on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2967,6 +2967,19 @@ if(BUILD_TESTING AND EXISTS "${_AUTO_TUNE_TEST_SRC}")
     add_cpp_ci_test(AutoTuneTest CI OFF COMMAND test_auto_tune)
 endif()
 
+set(_GPU_ADAPTER_MEMORY_TEST_SRC
+    "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_gpu_adapter_memory.cpp"
+)
+if(BUILD_TESTING AND EXISTS "${_GPU_ADAPTER_MEMORY_TEST_SRC}")
+    add_executable(test_gpu_adapter_memory test/cpp/test_gpu_adapter_memory.cpp)
+    target_include_directories(test_gpu_adapter_memory PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/include
+    )
+
+    include(CTest)
+    add_cpp_ci_test(GpuAdapterMemoryTest CI ON COMMAND test_gpu_adapter_memory)
+endif()
+
 set(_TELEMETRY_HELPERS_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_telemetry_helpers.cpp")
 if(BUILD_TESTING AND EXISTS "${_TELEMETRY_HELPERS_TEST_SRC}")
     add_executable(test_telemetry_helpers test/cpp/test_telemetry_helpers.cpp)

--- a/src/cpp/include/lemon/gpu_adapter_memory.h
+++ b/src/cpp/include/lemon/gpu_adapter_memory.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <vector>
+
+namespace lemon {
+
+struct GpuAdapterMemory {
+    uint64_t dedicated_bytes = 0;
+};
+
+// Windows reports one row per adapter LUID: a single card's usage is the largest
+// row, not the sum, and rows cannot be attributed once a second card is present.
+inline double single_physical_gpu_dedicated_gb(size_t physical_gpu_count,
+                                               const std::vector<GpuAdapterMemory>& adapters) {
+    if (physical_gpu_count != 1 || adapters.empty()) return -1.0;
+
+    uint64_t dedicated_bytes = 0;
+    for (const auto& adapter : adapters) {
+        dedicated_bytes = (std::max)(dedicated_bytes, adapter.dedicated_bytes);
+    }
+    return static_cast<double>(dedicated_bytes) / (1024.0 * 1024.0 * 1024.0);
+}
+
+} // namespace lemon

--- a/src/cpp/server/platform/metrics_windows.cpp
+++ b/src/cpp/server/platform/metrics_windows.cpp
@@ -1,3 +1,5 @@
+#include "../utils/wmi_helper.h"
+#include <lemon/gpu_adapter_memory.h>
 #include <lemon/system_metrics_platform.h>
 #include <windows.h>
 #include <cmath>
@@ -66,8 +68,11 @@ public:
     }
 
     double get_vram_usage_gb() override {
-        // VRAM monitoring not implemented for Windows
-        return -1.0;
+        wmi::WMIConnection conn;
+        if (!conn.is_valid()) return -1.0;
+
+        return single_physical_gpu_dedicated_gb(wmi::get_physical_gpu_count(conn),
+                                                wmi::get_gpu_adapter_memory(conn));
     }
 
     double get_npu_utilization() override {

--- a/src/cpp/server/utils/wmi_helper.cpp
+++ b/src/cpp/server/utils/wmi_helper.cpp
@@ -248,6 +248,25 @@ uint64_t get_property_uint64(IWbemClassObject* pObj, const std::wstring& prop_na
     return result;
 }
 
+size_t get_physical_gpu_count(WMIConnection& conn) {
+    size_t count = 0;
+    conn.query(L"SELECT Name FROM Win32_VideoController",
+               [&count](IWbemClassObject*) { ++count; });
+    return count;
+}
+
+std::vector<GpuAdapterMemory> get_gpu_adapter_memory(WMIConnection& conn) {
+    std::vector<GpuAdapterMemory> adapters;
+    conn.query(L"SELECT DedicatedUsage FROM "
+               L"Win32_PerfFormattedData_GPUPerformanceCounters_GPUAdapterMemory",
+               [&adapters](IWbemClassObject* pObj) {
+                   GpuAdapterMemory adapter;
+                   adapter.dedicated_bytes = get_property_uint64(pObj, L"DedicatedUsage");
+                   adapters.push_back(adapter);
+               });
+    return adapters;
+}
+
 std::string get_driver_version_setupapi(const std::string& device_name_substr) {
     // Convert search string to lowercase for case-insensitive matching
     std::string needle = device_name_substr;

--- a/src/cpp/server/utils/wmi_helper.h
+++ b/src/cpp/server/utils/wmi_helper.h
@@ -2,6 +2,8 @@
 
 #ifdef _WIN32
 
+#include <lemon/gpu_adapter_memory.h>
+
 #include <string>
 #include <vector>
 #include <functional>
@@ -56,6 +58,9 @@ std::string acp_to_utf8(const std::string& acp_str);
 std::string get_property_string(IWbemClassObject* pObj, const std::wstring& prop_name);
 int get_property_int(IWbemClassObject* pObj, const std::wstring& prop_name);
 uint64_t get_property_uint64(IWbemClassObject* pObj, const std::wstring& prop_name);
+
+size_t get_physical_gpu_count(WMIConnection& conn);
+std::vector<GpuAdapterMemory> get_gpu_adapter_memory(WMIConnection& conn);
 
 // SetupAPI-based driver version lookup.
 // Enumerates all present devices via SetupAPI and returns the driver version

--- a/test/cpp/test_gpu_adapter_memory.cpp
+++ b/test/cpp/test_gpu_adapter_memory.cpp
@@ -1,0 +1,76 @@
+// Standalone test for single-physical-GPU dedicated VRAM attribution.
+//
+// Compile: g++ -std=c++17 -I src/cpp/include test/cpp/test_gpu_adapter_memory.cpp -o test_gpu_adapter_memory
+
+#include "lemon/gpu_adapter_memory.h"
+#include <cmath>
+#include <cstdio>
+#include <vector>
+
+using lemon::GpuAdapterMemory;
+using lemon::single_physical_gpu_dedicated_gb;
+
+static int g_failures = 0;
+
+static void check(const char* name, bool ok) {
+    std::printf("[%s] %s\n", ok ? "PASS" : "FAIL", name);
+    if (!ok) ++g_failures;
+}
+
+static bool approx_eq(double a, double b, double tol = 0.001) {
+    return std::fabs(a - b) < tol;
+}
+
+static constexpr uint64_t GIB = 1024ull * 1024ull * 1024ull;
+
+static void test_single_adapter() {
+    std::vector<GpuAdapterMemory> adapters{{2 * GIB}};
+    check("single adapter reports its dedicated usage",
+          approx_eq(single_physical_gpu_dedicated_gb(1, adapters), 2.0));
+}
+
+static void test_software_adapter_is_ignored() {
+    std::vector<GpuAdapterMemory> adapters{{0}, {1126723584}};
+    check("largest row wins over an idle software adapter",
+          approx_eq(single_physical_gpu_dedicated_gb(1, adapters), 1.049, 0.001));
+}
+
+static void test_rows_are_not_summed() {
+    std::vector<GpuAdapterMemory> adapters{{3 * GIB}, {1 * GIB}};
+    check("rows are not summed",
+          approx_eq(single_physical_gpu_dedicated_gb(1, adapters), 3.0));
+}
+
+static void test_multi_gpu_is_unattributable() {
+    std::vector<GpuAdapterMemory> adapters{{2 * GIB}, {4 * GIB}};
+    check("two physical GPUs report no usage",
+          single_physical_gpu_dedicated_gb(2, adapters) < 0.0);
+}
+
+static void test_no_adapters() {
+    std::vector<GpuAdapterMemory> adapters;
+    check("no adapter rows report no usage",
+          single_physical_gpu_dedicated_gb(1, adapters) < 0.0);
+}
+
+static void test_idle_gpu_reports_zero() {
+    std::vector<GpuAdapterMemory> adapters{{0}};
+    check("an idle GPU reports zero, not unavailable",
+          approx_eq(single_physical_gpu_dedicated_gb(1, adapters), 0.0));
+}
+
+int main() {
+    test_single_adapter();
+    test_software_adapter_is_ignored();
+    test_rows_are_not_summed();
+    test_multi_gpu_is_unattributable();
+    test_no_adapters();
+    test_idle_gpu_reports_zero();
+
+    if (g_failures == 0) {
+        std::printf("\nAll gpu_adapter_memory tests passed\n");
+        return 0;
+    }
+    std::printf("\n%d gpu_adapter_memory test(s) FAILED\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary

Fixes #3461.

When Lemonade loads a model, auto-tune uses the available GPU memory to choose its context size. On Windows, it mistakenly used system RAM usage instead of VRAM usage. In testing, this made an 8 GB graphics card appear to have 0.00 GB free, so auto-tune selected the minimum context size of 4,096 tokens.

Technically, `get_vram_usage_gb()` returned `-1.0`, causing auto-tune to fall back to `get_memory_usage_gb()`. Windows now reads the actual dedicated-memory usage from its GPU performance counters.

Measured on an 8 GB RX 5700 XT with `Llama-3.2-1B-Instruct-GGUF` and automatic `ctx_size`:

| | Before | After |
|---|---:|---:|
| Reported in use | 11.30 GB (system RAM) | 1.19 GB (VRAM) |
| Available VRAM | 0.00 GB | 6.81 GB |
| Context size chosen | 4,096 | 131,072 (the model's own limit) |

## Implementation notes

The fix reads current VRAM usage from Windows and only returns a value when it can be safely attributed to a single GPU.

- Windows can return multiple memory-counter rows, including zero-use software adapters, so the implementation selects the largest value instead of adding them together.
- Windows does not reliably identify which physical GPU owns each row. If more than one GPU is detected, the existing fallback behavior is preserved.
- The result is not cached because auto-tune must observe VRAM released when another model is unloaded.

## Testing details

- Built `lemond` on Windows 11 with MSVC in Release mode, with no new warnings.
- Tested end to end on an 8 GB AMD Radeon RX 5700 XT by loading `Llama-3.2-1B-Instruct-GGUF` with automatic `ctx_size`. Available VRAM increased from 0.00 GB to 6.81 GB, and the selected context increased from 4,096 to the model's 131,072-token limit.
- Added `test_gpu_adapter_memory` coverage for valid single-GPU readings and fallback cases. The test passes under MSVC and g++ with `-Wall -Wextra`.

---

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed above.

## Documentation

- [x] Documentation is not affected by this change.

## Breaking Changes

- [x] This PR does not introduce breaking changes.

On supported Windows systems, `vram_gb` in `/system-stats` and `/metrics` now reports a value where it previously returned `null`.

## AI-assisted contribution

- [x] I used AI tools for this PR.
- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.
