### PR TITLE
fix(build): keep curl SecureTransport on the macOS Keychain

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -381,10 +381,40 @@ if(NOT USE_SYSTEM_CURL)
         set(CMAKE_USE_SCHANNEL ON CACHE INTERNAL "")
     elseif(APPLE)
         set(CURL_USE_SECTRANSP ON CACHE INTERNAL "")
+        # SecureTransport consults the Keychain only when no CA bundle is compiled
+        # in. Autodetection would find Apple's static /etc/ssl/cert.pem snapshot,
+        # and any compiled-in bundle makes sectransp pin trust via
+        # SecTrustSetAnchorCertificatesOnly(), ignoring Keychain roots and admin
+        # trust settings. libcurl never reads CURL_CA_BUNDLE from the environment,
+        # so this cannot be corrected at runtime.
+        set(CURL_CA_BUNDLE "none" CACHE INTERNAL "")
+        set(CURL_CA_PATH "none" CACHE INTERNAL "")
     else()
         set(CURL_USE_OPENSSL ON CACHE INTERNAL "")
     endif()
     FetchContent_MakeAvailable(curl)
+
+    if(APPLE)
+        set(_curl_config_h "${curl_BINARY_DIR}/lib/curl_config.h")
+        if(NOT EXISTS "${_curl_config_h}")
+            message(FATAL_ERROR
+                    "Cannot verify the macOS TLS trust store: ${_curl_config_h} is missing.")
+        endif()
+        file(READ "${_curl_config_h}" _curl_config_contents)
+        if(NOT _curl_config_contents MATCHES "#[ \t]*define[ \t]+USE_SECTRANSP[ \t]+1")
+            message(FATAL_ERROR
+                    "curl was not built with SecureTransport, so model downloads would not "
+                    "validate against the macOS Keychain.")
+        endif()
+        if(_curl_config_contents MATCHES "#[ \t]*define[ \t]+CURL_CA_BUNDLE[ \t]"
+           OR _curl_config_contents MATCHES "#[ \t]*define[ \t]+CURL_CA_PATH[ \t]")
+            message(FATAL_ERROR
+                    "curl compiled in a CA bundle/path, which makes SecureTransport bypass the "
+                    "macOS Keychain. Keep CURL_CA_BUNDLE and CURL_CA_PATH set to 'none'.")
+        endif()
+        unset(_curl_config_contents)
+        unset(_curl_config_h)
+    endif()
 endif()
 
 # === zstd ===

--- a/docs/dev/getting-started.md
+++ b/docs/dev/getting-started.md
@@ -730,7 +730,9 @@ All dependencies are automatically fetched by CMake via FetchContent:
 - **libcurl** (8.5.0) - HTTP client for model downloads [curl license]
 - **zstd** (v1.5.7) - Compression library for HTTP [BSD License]
 
-Platform-specific SSL backends are used (Schannel on Windows, SecureTransport on macOS, OpenSSL on Linux).
+Platform-specific SSL backends are used (Schannel on Windows, SecureTransport on macOS, OpenSSL on Linux), so certificate validation follows the OS trust store: the Windows certificate store, the macOS Keychain, and the distribution's CA bundle respectively.
+
+On macOS this requires building curl with `CURL_CA_BUNDLE=none` and `CURL_CA_PATH=none`. Left on `auto`, curl detects Apple's static `/etc/ssl/cert.pem` snapshot and compiles it in, which makes SecureTransport pin trust to that file and ignore Keychain roots — breaking downloads behind TLS-inspecting corporate proxies. The root `CMakeLists.txt` sets both to `none` and then fails the configure step if the resulting `curl_config.h` is not Keychain-backed.
 
 ## Usage
 


### PR DESCRIPTION
## Summary

On macOS, `lemond` and the `lemonade` CLI do not validate TLS against the Keychain, despite being built with SecureTransport. Every model, backend and registry download fails behind a TLS-inspecting corporate proxy, because roots manually installed in the Keychain are ignored.

`CMakeLists.txt` correctly sets `CURL_USE_SECTRANSP ON`, but leaves curl's `CURL_CA_BUNDLE` on `auto`. curl's autodetect list includes `/etc/ssl/cert.pem`, which macOS ships as a static snapshot of Apple's roots, so the build bakes in:

```c
#define CURL_CA_BUNDLE "/etc/ssl/cert.pem"
#define USE_SECTRANSP 1
```

libcurl applies that as the default `CAINFO` for every handle (`lib/url.c:438`). `sectransp.c:1988` then takes the `verify_cert()` path, which calls `SecTrustSetAnchorCertificatesOnly(trust, true)` — pinning trust to that one file and discarding the Keychain, including admin trust settings. Unlike the `curl` tool, libcurl never reads `CURL_CA_BUNDLE` from the environment, so there is no runtime workaround.

This PR pins `CURL_CA_BUNDLE`/`CURL_CA_PATH` to `none` on Apple, and adds a configure-time assertion on the generated `curl_config.h` so a future curl bump cannot silently reintroduce the bypass. That guard matters: SecureTransport was removed in curl 8.15.0, so bumping past the current 8.5.0 pin would otherwise fall back to OpenSSL unnoticed.

Affected call paths are all `HttpSecurityPolicy::ExternalHttpsOnly`: model downloads (`model_manager.cpp:5434`), HF/ModelScope registry queries, GitHub release backend downloads, and `repo.amd.com` ROCm tarballs.

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_

Built and ran on macOS 26.6.2 (arm64, AppleClang).

**Root cause reproduced** by configuring curl 8.5.0 with the pre-fix flags:

```
-- Found CA bundle: /etc/ssl/cert.pem
```

**Runtime proof** — two curl builds, both SecureTransport, differing only in the CA setting:

| Build | `curl -V` | `https://huggingface.co` |
|---|---|---|
| CA bundle autodetected (pre-fix) | SecureTransport | fails — `SSL: peer not verified: RecoverableTrustFailure` |
| `CURL_CA_BUNDLE=none` (post-fix) | SecureTransport | `HTTP=200` |

**Verification is not weakened** — the fixed build still rejects `expired.badssl.com` and `self-signed.badssl.com` with exit 60.

**Post-fix configure** of this repo yields the intended header:

```c
/* #undef CURL_CA_BUNDLE */
/* #undef CURL_CA_PATH */
#define USE_SECTRANSP 1
```

**Guard negative-tested** — removing the two new `set()` lines and re-configuring fails as intended rather than regressing silently:

```
CMake Error: curl compiled in a CA bundle/path, which makes SecureTransport
bypass the macOS Keychain. Keep CURL_CA_BUNDLE and CURL_CA_PATH set to 'none'.
```

**End-to-end** — built `lemond`, `lemonade`, `lemonade-tray` and installed them over an existing v11.8.1 install. The shipped binaries contain the `/etc/ssl/cert.pem` string; the rebuilt ones do not. Downloads then succeed through a corporate HTTPS-inspecting proxy whose CA is installed in the Keychain, which previously failed 100% of the time.

No behaviour change on Windows (Schannel) or Linux (OpenSSL, and distro builds use system libcurl regardless). The new assertion is `if(APPLE)`-scoped and runs automatically in the existing macOS CI job.

## Documentation

- [x] Documentation is affected and has been updated.

`docs/dev/getting-started.md` previously said platform-specific SSL backends were used without noting that macOS needs the CA settings disabled for the Keychain to actually apply.

## Breaking Changes

- [x] This PR does not introduce breaking changes.

## AI-assisted contribution

Please select one:

- [x] I used AI tools for this PR.

If AI tools were used:

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.
