### PR TITLE
fix: name the gpt-oss-120b checkpoint instead of globbing

### DIFF
--- a/src/cpp/resources/server_models.json
+++ b/src/cpp/resources/server_models.json
@@ -1671,7 +1671,7 @@
         "size": 11.6
     },
     "gpt-oss-120b-mxfp-GGUF": {
-        "checkpoint": "ggml-org/gpt-oss-120b-GGUF:*",
+        "checkpoint": "ggml-org/gpt-oss-120b-GGUF:gpt-oss-120b-MXFP4.gguf",
         "recipe": "llamacpp",
         "suggested": true,
         "labels": [


### PR DESCRIPTION
Fixes #3495.

`lemonade load gpt-oss-120b-mxfp-GGUF` currently fails with `llama-server failed to start`.

The entry is registered with a wildcard checkpoint, `"ggml-org/gpt-oss-120b-GGUF:*"`. That was unambiguous when written, but `ggml-org/gpt-oss-120b-GGUF` has since gained EAGLE3 speculative-decoding drafts, so the repo now holds three GGUFs and the glob resolves to `eagle3-gpt-oss-120b-BF16.gguf` (1.5 GB) instead of `gpt-oss-120b-MXFP4.gguf` (63.4 GB). `GET /api/v1/models` shows the mismatch directly — the entry reports `"size": 1.48` where the registry declares `63.4`.

An EAGLE3 draft head cannot be loaded standalone, so llama-server exits:

```
E llama_init_from_model: failed to initialize the context: eagle3 requires ctx_other to be set
E srv    load_model: failed to create_context with model .../eagle3-gpt-oss-120b-BF16.gguf
E srv  llama_server: exiting due to model loading error
```

This names the file, as the other 227 registry entries do. It is the only `:*` entry in `server_models.json`.

Verified on a Strix Halo (gfx1151) host, llamacpp vulkan backend b0.2.0: with this checkpoint the model loads the correct 59 GiB file and generates normally (`finish_reason: "stop"`, ~55 tok/s). No re-download is needed for anyone who already has the repo — the MXFP4 file was being fetched by the glob all along, just not selected.

Deliberately minimal. As noted in #3495, those EAGLE3 files could instead be wired up as a real `checkpoints.draft` (the mechanism `Gemma-4-*-MTP-GGUF` already uses), but that would also need an eagle3 branch in `resolve_llamacpp_runtime_args` — it only emits `--spec-type` for `dflash`/`mtp` today, and llama.cpp defaults `--spec-type` to `none`. I have not measured that path, so it seems better as a separate change with numbers behind it.