### PR TITLE
feat(router): reject previous_response_id on a router collection

### DIFF
--- a/docs/api/openai.md
+++ b/docs/api/openai.md
@@ -356,6 +356,15 @@ Embeddings API. You provide input text and receive vector representations (embed
 
 Responses API. You provide an input and receive a response. This API will also load the model if it is not already loaded.
 
+> **Limitations:** `previous_response_id` is not implemented — a response chain is
+> state held inside the backend that created it. Addressing a
+> [`collection.router`](../dev/router-policy.md) collection *and* sending a non-empty
+> `previous_response_id` is rejected with a `400` and
+> `error.code = "router_response_chain_unsupported"`, because the router may select a
+> different candidate for this turn than served the last one, and that candidate knows
+> nothing about the id. Resend the full `input`, or address a concrete model instead of
+> the collection.
+
 ### Parameters
 
 | Parameter | Required | Description | Status |

--- a/src/cpp/include/lemon/error_types.h
+++ b/src/cpp/include/lemon/error_types.h
@@ -22,6 +22,8 @@ namespace ErrorType {
     constexpr const char* INTERNAL_ERROR = "internal_error";
     constexpr const char* SLOTS_PINNED = "slots_pinned_error";
     constexpr const char* ROUTER_RESIDENCY_CONFLICT = "router_residency_conflict";
+    constexpr const char* ROUTER_RESPONSE_CHAIN_UNSUPPORTED =
+        "router_response_chain_unsupported";
 }
 
 // Base exception class for all Lemon errors

--- a/src/cpp/include/lemon/server.h
+++ b/src/cpp/include/lemon/server.h
@@ -156,6 +156,12 @@ private:
     std::optional<RouterDispatchResult> route_collection_request(
         const nlohmann::json& request_json,
         const ModelInfo& collection_info);
+    // The one place that answers "does this request address a router
+    // collection?". Dispatch and the responses-chain guard must agree on that,
+    // so neither derives it independently. Propagates registry exceptions:
+    // a failed lookup means something different at each call site.
+    std::optional<ModelInfo> router_collection_info(const nlohmann::json& request_json);
+
     // If request_json addresses a collection.router model, rewrite its "model"
     // field in place to the engine-selected candidate and return the Decision.
     // No-op otherwise.

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -143,7 +143,8 @@ int get_error_status_code(const json& response, int default_status_code = 500) {
 
         if (type == ErrorType::INVALID_REQUEST ||
             type == "invalid_request_error" ||
-            type == ErrorType::UNSUPPORTED_OPERATION) {
+            type == ErrorType::UNSUPPORTED_OPERATION ||
+            type == ErrorType::ROUTER_RESPONSE_CHAIN_UNSUPPORTED) {
             return 400;
         }
 
@@ -171,6 +172,24 @@ void set_router_residency_conflict_response(
             {"type", ErrorType::ROUTER_RESIDENCY_CONFLICT},
             {"param", "model"},
             {"code", ErrorType::ROUTER_RESIDENCY_CONFLICT},
+        }},
+    };
+    res.set_content(response.dump(), "application/json");
+}
+
+void set_router_response_chain_unsupported_response(const std::string& requested_model,
+                                                    httplib::Response& res) {
+    res.status = 400;
+    const json response = {
+        {"error", {
+            {"message",
+             "'previous_response_id' refers to state held by whichever backend served "
+             "the earlier turn, and router collection '" + requested_model +
+             "' may select a different candidate for this one. Resend the full 'input', "
+             "or address a concrete model instead of the collection."},
+            {"type", ErrorType::ROUTER_RESPONSE_CHAIN_UNSUPPORTED},
+            {"param", "previous_response_id"},
+            {"code", ErrorType::ROUTER_RESPONSE_CHAIN_UNSUPPORTED},
         }},
     };
     res.set_content(response.dump(), "application/json");
@@ -3829,6 +3848,21 @@ void Server::handle_routing_validate(const httplib::Request& req, httplib::Respo
     }
 }
 
+std::optional<ModelInfo> Server::router_collection_info(const nlohmann::json& request_json) {
+    if (!request_json.contains("model") || !request_json["model"].is_string()) {
+        return std::nullopt;
+    }
+    const std::string requested_model = request_json["model"].get<std::string>();
+    if (!model_manager_->model_exists(requested_model)) {
+        return std::nullopt;
+    }
+    ModelInfo info = model_manager_->get_model_info(requested_model);
+    if (!is_router_collection_recipe(info.recipe)) {
+        return std::nullopt;
+    }
+    return info;
+}
+
 std::optional<RouterDispatchResult> Server::apply_router_collection_dispatch(
     nlohmann::json& request_json) {
     if (!request_json.contains("model") || !request_json["model"].is_string()) {
@@ -3836,14 +3870,11 @@ std::optional<RouterDispatchResult> Server::apply_router_collection_dispatch(
     }
     const std::string requested_model = request_json["model"].get<std::string>();
     try {
-        if (!model_manager_->model_exists(requested_model)) {
+        std::optional<ModelInfo> info = router_collection_info(request_json);
+        if (!info) {
             return std::nullopt;
         }
-        ModelInfo info = model_manager_->get_model_info(requested_model);
-        if (!is_router_collection_recipe(info.recipe)) {
-            return std::nullopt;
-        }
-        auto dispatch = route_collection_request(request_json, info);
+        auto dispatch = route_collection_request(request_json, *info);
         if (!dispatch) {
             return std::nullopt;
         }
@@ -5642,6 +5673,32 @@ void Server::handle_responses(const httplib::Request& req, httplib::Response& re
         auto request_json = nlohmann::json::parse(req.body);
         normalize_client_model_name(request_json);
         normalize_and_resolve_request_model(request_json);
+
+        // A response chain lives entirely inside the backend that created it, so
+        // it cannot survive this turn routing to a different candidate than the
+        // last one. Reject before dispatch and before any model load: the
+        // alternative is a new candidate silently answering without the chain's
+        // context, which is the upstream behavior this deliberately doesn't copy.
+        if (request_json.contains("previous_response_id") &&
+            request_json["previous_response_id"].is_string() &&
+            !request_json["previous_response_id"].get<std::string>().empty()) {
+            std::optional<ModelInfo> collection;
+            try {
+                collection = router_collection_info(request_json);
+            } catch (const std::exception&) {
+                // Registry lookup failed, so we cannot tell it is a collection.
+                // Fall through and let the normal path report what is actually
+                // wrong with the model rather than blaming previous_response_id.
+            }
+            if (collection) {
+                const std::string requested_model = request_json["model"].get<std::string>();
+                LOG(WARNING, "Server")
+                    << "Rejected /responses with previous_response_id on router collection '"
+                    << requested_model << "'" << std::endl;
+                set_router_response_chain_unsupported_response(requested_model, res);
+                return;
+            }
+        }
 
         // A collection.router model flips this endpoint into engine mode: pick a
         // candidate and rewrite the model before the usual load/forward logic.

--- a/test/server_router.py
+++ b/test/server_router.py
@@ -1242,6 +1242,70 @@ class RouterTests(ServerTestBase):
         finally:
             self._delete_collection(collection)
 
+    def test_640_responses_rejects_previous_response_id(self):
+        """A response chain cannot cross routing candidates (#2957).
+
+        Rejected before dispatch and before any model load, so this asserts on
+        the error shape only -- no inference runs.
+        """
+        resp = requests.post(
+            f"{self.base_url}/responses",
+            json={
+                "model": COLLECTION_NAME,
+                "input": "continue where we left off",
+                "previous_response_id": "resp_abc123",
+                "max_output_tokens": 8,
+            },
+            timeout=TIMEOUT_DEFAULT,
+        )
+        self.assertEqual(
+            resp.status_code, 400, f"status {resp.status_code}: {resp.text}"
+        )
+        error = resp.json().get("error", {})
+        self.assertEqual(error.get("code"), "router_response_chain_unsupported")
+        self.assertEqual(error.get("param"), "previous_response_id")
+        self.assertIn(COLLECTION_NAME, error.get("message", ""))
+        print("[OK] previous_response_id on a router collection -> 400")
+
+    def test_641_responses_allows_previous_response_id_on_plain_model(self):
+        """Negative control: the guard is scoped to router collections, so a
+        concrete model still reaches the backend. Whatever the backend makes of
+        an unknown chain id, it must not be our routing rejection."""
+        resp = requests.post(
+            f"{self.base_url}/responses",
+            json={
+                "model": DEFAULT_MODEL,
+                "input": "say hi",
+                "previous_response_id": "resp_abc123",
+                "max_output_tokens": 8,
+            },
+            timeout=600,
+        )
+        body = resp.text
+        self.assertNotIn("router_response_chain_unsupported", body)
+        print(
+            f"[OK] plain model with previous_response_id not rejected by the "
+            f"router guard (status {resp.status_code})"
+        )
+
+    def test_642_responses_ignores_empty_previous_response_id(self):
+        """An empty string is not a chain reference, so it must not trip the
+        guard -- clients that always send the field shouldn't be locked out."""
+        resp = requests.post(
+            f"{self.base_url}/responses",
+            json={
+                "model": COLLECTION_NAME,
+                "input": "say hi",
+                "previous_response_id": "",
+                "max_output_tokens": 8,
+            },
+            timeout=600,
+        )
+        self.assertNotIn("router_response_chain_unsupported", resp.text)
+        print(
+            f"[OK] empty previous_response_id not rejected (status {resp.status_code})"
+        )
+
 
 if __name__ == "__main__":
     run_server_tests(RouterTests, description="ROUTER TESTS")


### PR DESCRIPTION
## Summary

Reject `previous_response_id` on a router collection. `/v1/responses` now
returns 400 with `router_response_chain_unsupported` when the addressed model
is a `collection.router`, before dispatch and before any model load. A response
chain is state held inside the backend that created it, so it cannot survive a
turn routing to a different candidate than served the last one; previously the
field was ignored everywhere in `src/` and the selected candidate silently
answered without the chain's context.

Part of #2957 (Guard 2 of 3), not `Fixes`. Guard 1 needs a `route_policy`
schema key, which would conflict on `schema-lock.json` with #3169 and #3339
while both are open; Guard 3 belongs on top of the candidate-filter framework
#3339 introduces. Please leave #2957 open on merge.

## Scope

`src/cpp/server/server.cpp` — the guard at the top of `handle_responses`, a
response shaper mirroring `set_router_residency_conflict_response`, and
`router_collection_info()` extracted from `apply_router_collection_dispatch` so
the guard and dispatch cannot disagree about what counts as a router
collection. `error_types.h` / `server.h` — the error code and the helper's
declaration. Plus `docs/api/openai.md` and `test/server_router.py`.

## Testing

C++ build + full `cpp-ci` CTest suite (69/69). Three new cases in
`server_router.py` covering the 400's shape, a concrete-model control, and an
empty-string control.

Also checked end-to-end against a live `lemond`, using a collection whose
components point at nonexistent checkpoints so the loader always fails: only
the collection with a non-empty `previous_response_id` short-circuits with the
400, while an empty string, an absent field, a concrete model, and
`/chat/completions` on the same collection all reach the loader instead.

## Documentation

`docs/api/openai.md` — Limitations note on `POST /v1/responses`.

## Breaking Changes

Narrow: that one request shape previously returned 200 and now returns 400. The
old success answered without the chain's context, and the error names both
alternatives — resend the full `input`, or address a concrete model.

## AI-assisted contribution

Yes.