### PR TITLE
feat(telemetry): emit the routing decision as span attributes

### DIFF
--- a/src/cpp/server/router.cpp
+++ b/src/cpp/server/router.cpp
@@ -1781,6 +1781,7 @@ json Router::chat_completion(const json& request, std::atomic<bool>* cancel) {
                 if (request.contains("top_p")) span->set_attribute("llm.config.top_p", request["top_p"]);
                 if (request.contains("max_tokens")) span->set_attribute("llm.config.max_tokens", request["max_tokens"]);
                 if (request.contains("max_completion_tokens")) span->set_attribute("llm.config.max_completion_tokens", request["max_completion_tokens"]);
+                telemetry::apply_route_attributes(*span);
             }
             return server->chat_completion(request);
         });
@@ -1899,6 +1900,7 @@ json Router::completion(const json& request) {
                 if (request.contains("temperature")) span->set_attribute("llm.config.temperature", request["temperature"]);
                 if (request.contains("top_p")) span->set_attribute("llm.config.top_p", request["top_p"]);
                 if (request.contains("max_tokens")) span->set_attribute("llm.config.max_tokens", request["max_tokens"]);
+                telemetry::apply_route_attributes(*span);
             }
             return server->completion(request);
         });
@@ -2641,6 +2643,7 @@ void Router::chat_completion_stream(const std::string& request_body, httplib::Da
                 if (request_json.contains("top_p")) span->set_attribute("llm.config.top_p", request_json["top_p"]);
                 if (request_json.contains("max_tokens")) span->set_attribute("llm.config.max_tokens", request_json["max_tokens"]);
                 if (request_json.contains("max_completion_tokens")) span->set_attribute("llm.config.max_completion_tokens", request_json["max_completion_tokens"]);
+                telemetry::apply_route_attributes(*span);
             }
 
             server->forward_streaming_request("/v1/chat/completions", request_body, telemetry_sink, true, 0,
@@ -2765,6 +2768,7 @@ void Router::completion_stream(const std::string& request_body, httplib::DataSin
                 if (request_json.contains("temperature")) span->set_attribute("llm.config.temperature", request_json["temperature"]);
                 if (request_json.contains("top_p")) span->set_attribute("llm.config.top_p", request_json["top_p"]);
                 if (request_json.contains("max_tokens")) span->set_attribute("llm.config.max_tokens", request_json["max_tokens"]);
+                telemetry::apply_route_attributes(*span);
             }
 
             server->forward_streaming_request("/v1/completions", request_body, telemetry_sink, true, 0,
@@ -2875,6 +2879,7 @@ void Router::responses_stream(const std::string& request_body, httplib::DataSink
                 if (request_json.contains("temperature")) span->set_attribute("llm.config.temperature", request_json["temperature"]);
                 if (request_json.contains("top_p")) span->set_attribute("llm.config.top_p", request_json["top_p"]);
                 if (request_json.contains("max_tokens")) span->set_attribute("llm.config.max_tokens", request_json["max_tokens"]);
+                telemetry::apply_route_attributes(*span);
             }
 
             server->forward_streaming_request("/v1/responses", request_body, telemetry_sink, true, 0,

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -937,6 +937,7 @@ httplib::Server::HandlerResponse Server::authenticate_request(const httplib::Req
         }
     }
 
+    telemetry::g_current_route_decision.clear();
     telemetry::g_incoming_client_id.clear();
     telemetry::g_incoming_session_id.clear();
 
@@ -3713,6 +3714,32 @@ std::optional<RouterDispatchResult> Server::route_collection_request(
     result.decision = std::move(decision);
     router_->note_route_decision(utils::conversation_fingerprint(request_json),
                                  result.selected_model);
+
+    // Every dispatch path reaches this one function, so publishing here covers
+    // chat, completions and responses without three call sites drifting apart.
+    // estimated_cost is flattened because a span attribute should be a scalar,
+    // and each field is optional, so an absent one simply is not emitted.
+    json route_attrs = {
+        {"collection", result.requested_model},
+        {"to", result.selected_model},
+        {"matched_rule", result.decision.matched_rule},
+        {"default_used", result.decision.default_used},
+    };
+    const auto cost_it = result.decision.outputs.find("estimated_cost");
+    if (cost_it != result.decision.outputs.end() && cost_it->is_object()) {
+        for (const auto& [key, value] : cost_it->items()) {
+            // A policy author may set outputs["estimated_cost"] themselves, so
+            // its keys are arbitrary and must not shadow the decision's own.
+            if (route_attrs.contains(key)) {
+                continue;
+            }
+            if (value.is_string() || value.is_number() || value.is_boolean()) {
+                route_attrs[key] = value;
+            }
+        }
+    }
+    telemetry::g_current_route_decision = route_attrs.dump();
+
     return result;
 }
 

--- a/src/cpp/server/telemetry.cpp
+++ b/src/cpp/server/telemetry.cpp
@@ -1502,5 +1502,31 @@ thread_local std::string g_incoming_trace_id;
 thread_local std::string g_incoming_parent_span_id;
 thread_local std::string g_incoming_client_id;
 thread_local std::string g_incoming_session_id;
+thread_local std::string g_current_route_decision;
+
+std::map<std::string, nlohmann::json> route_span_attributes(const std::string& payload) {
+    std::map<std::string, nlohmann::json> attributes;
+    if (payload.empty()) {
+        return attributes;
+    }
+    nlohmann::json route = nlohmann::json::parse(payload, nullptr, /*allow_exceptions=*/false);
+    if (!route.is_object()) {
+        // Telemetry is observational: a malformed payload yields no attributes
+        // rather than disturbing the request it is describing.
+        return attributes;
+    }
+    for (const auto& [key, value] : route.items()) {
+        if (value.is_string() || value.is_number() || value.is_boolean()) {
+            attributes.emplace("llm.route." + key, value);
+        }
+    }
+    return attributes;
+}
+
+void apply_route_attributes(InferenceSpan& span) {
+    for (const auto& [key, value] : route_span_attributes(g_current_route_decision)) {
+        span.set_attribute(key, value);
+    }
+}
 
 } // namespace lemon::telemetry

--- a/src/cpp/server/telemetry.h
+++ b/src/cpp/server/telemetry.h
@@ -85,4 +85,24 @@ extern thread_local std::string g_incoming_parent_span_id;
 extern thread_local std::string g_incoming_client_id;
 extern thread_local std::string g_incoming_session_id;
 
+// The routing decision for the current request, as a compact JSON object
+// ({collection, to, matched_rule, default_used} plus the flattened
+// estimated_cost fields). Empty when the request did not go through a
+// collection.router. A thread-local because the inference span is created deep
+// in Router, where the Decision is no longer in scope; cleared per request like
+// the trace-context fields above so it cannot leak across a reused worker.
+extern thread_local std::string g_current_route_decision;
+
+// Map a g_current_route_decision payload to its span attributes, under the
+// existing llm.* namespace. Split out from apply_route_attributes so the
+// mapping is unit-testable without constructing a span. An empty, malformed,
+// or non-object payload yields no attributes, and a non-scalar member is
+// skipped rather than stringified -- a span attribute is a scalar.
+std::map<std::string, nlohmann::json> route_span_attributes(const std::string& payload);
+
+// Mirror the current request's routing decision onto its inference span, so a
+// trace shows which candidate a collection.router picked and what that
+// candidate was reported to cost. No-op when the request was not routed.
+void apply_route_attributes(InferenceSpan& span);
+
 } // namespace lemon::telemetry

--- a/test/cpp/test_telemetry_helpers.cpp
+++ b/test/cpp/test_telemetry_helpers.cpp
@@ -65,11 +65,58 @@ static void check_map_empty(const char* name, const std::map<std::string, nlohma
 }
 
 
+// The routing decision reaches span creation through a thread-local, so the
+// mapping from that payload to span attributes is where the interesting
+// behavior lives: what is emitted, and what is deliberately not.
+static void test_route_span_attributes() {
+    using lemon::telemetry::route_span_attributes;
+
+    check_bool("route attributes: empty payload emits nothing",
+               route_span_attributes("").empty(), true);
+    check_bool("route attributes: malformed JSON emits nothing",
+               route_span_attributes("{not json").empty(), true);
+    check_bool("route attributes: non-object payload emits nothing",
+               route_span_attributes("[1,2,3]").empty(), true);
+
+    auto attrs = route_span_attributes(
+        R"({"collection":"user.RouterKit","to":"Qwen3-8B-GGUF",)"
+        R"("matched_rule":"code-remote","default_used":false,)"
+        R"("cost_tier":"free","cost_input_per_million":0.15})");
+
+    check_eq("route attributes: collection is namespaced under llm.route",
+             attrs.count("llm.route.collection") ? attrs.at("llm.route.collection").get<std::string>() : "<missing>",
+             "user.RouterKit");
+    check_eq("route attributes: selected candidate",
+             attrs.count("llm.route.to") ? attrs.at("llm.route.to").get<std::string>() : "<missing>",
+             "Qwen3-8B-GGUF");
+    check_eq("route attributes: matched rule",
+             attrs.count("llm.route.matched_rule") ? attrs.at("llm.route.matched_rule").get<std::string>() : "<missing>",
+             "code-remote");
+    check_bool("route attributes: default_used survives as a bool",
+               attrs.count("llm.route.default_used") && attrs.at("llm.route.default_used").is_boolean(), true);
+    check_eq("route attributes: flattened cost_tier",
+             attrs.count("llm.route.cost_tier") ? attrs.at("llm.route.cost_tier").get<std::string>() : "<missing>",
+             "free");
+    check_bool("route attributes: flattened per-million price stays numeric",
+               attrs.count("llm.route.cost_input_per_million") &&
+                   attrs.at("llm.route.cost_input_per_million").is_number(), true);
+
+    // A span attribute is a scalar, so a nested member is skipped rather than
+    // stringified into something no backend can filter on.
+    auto nested = route_span_attributes(R"({"to":"m","trace":[{"rule":"r"}],"outputs":{"a":1}})");
+    check_bool("route attributes: nested array is skipped", nested.count("llm.route.trace") == 0, true);
+    check_bool("route attributes: nested object is skipped", nested.count("llm.route.outputs") == 0, true);
+    check_bool("route attributes: scalars alongside nested members still emit",
+               nested.count("llm.route.to") == 1, true);
+}
+
 int main() {
     using lemon::telemetry::hex_to_bytes;
     using lemon::telemetry::standardize_thinking;
 
     std::printf("=== RUNNING TELEMETRY HELPERS C++ TESTS ===\n");
+
+    test_route_span_attributes();
 
     // --- hex_to_bytes tests ---
     check_eq("hex_to_bytes: empty string", hex_to_bytes(""), "");


### PR DESCRIPTION
## Summary

Mirror a `collection.router` decision onto the request's inference span. Spans
now carry `llm.route.{collection,to,matched_rule,default_used}` under the
existing `llm.*` namespace, plus the decision's `estimated_cost` (from #2763)
flattened into `llm.route.cost_*`. Previously the decision was visible only to
the client on `x_lemonade_route`, so a trace showed which model ran but not that
a policy picked it, or why.

The span is created inside `Router`, where the `Decision` is out of scope, so
the decision travels on a thread-local published by `Server` — the same pattern
as the existing trace-context fields, including the per-request clear that stops
a stale value leaking onto a later request on a reused worker. It is published
from `route_collection_request`, the one function every dispatch path already
goes through, so chat, completions and responses cannot drift apart.

Distinct from the routing telemetry in #2968, which counts decisions and
switches server-wide; this is per-request detail on the span itself.

Note the cost half stays empty for local models today: nothing populates cost
metadata for them, since `USER_DEFINED_MODEL_PROPS` drops `cost_tier` /
`cost_input_per_million` / `cost_output_per_million` on registration. The
routing fields are unaffected.

## Scope

`telemetry.h` / `telemetry.cpp` — the thread-local, plus `route_span_attributes`
(payload -> attributes, a pure function) and `apply_route_attributes`.
`server.cpp` — per-request clear, and publishing the decision at the dispatch
choke point. `router.cpp` — one call in each of the five span sites (chat,
completions and responses, streaming and not). `test_telemetry_helpers.cpp`.

## Testing

C++ build + full `cpp-ci` CTest suite, 69/69. Twelve new cases cover the
mapping: an empty, malformed or non-object payload emits nothing, a nested
member is skipped rather than stringified, and author-set `estimated_cost` keys
cannot shadow the decision's own.

Also confirmed on a live server rather than only in unit tests. Registered a
router collection over two local GGUF candidates, connected to the spans
WebSocket, and captured the emitted span for a routed request:

```
SPAN name=chat.completions
llm.backend            = llamacpp
gen_ai.request.model   = Qwen3-1.7B-GGUF
llm.route.collection   = user.Router-Demo
llm.route.matched_rule = code-to-bigger
llm.route.to           = Qwen3-1.7B-GGUF
llm.route.default_used = False
```


## Documentation

No docs change.

## Breaking Changes

None. Purely additive attributes on an existing span; a request that is not
routed emits nothing new.

## AI-assisted contribution

Yes.