### PR TITLE
ci(hrx): bump hrx + add llama-3.1 8b ci coverage

### DIFF
--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -1303,6 +1303,11 @@ jobs:
             extra_args: "--wrapped-server llamacpp"
             backends: "vulkan rocm"
             runner: [Linux, vulkan, rocm, lemon-prod]
+          - name: llamacpp-hrx
+            script: server_llm.py
+            extra_args: "--wrapped-server llamacpp-hrx"
+            backends: "hrx"
+            runner: [Linux, rocm, stx-halo, lemon-prod]
           - name: omni
             script: server_omni.py
             extra_args: "--wrapped-server llamacpp"

--- a/src/cpp/resources/backend_versions.json
+++ b/src/cpp/resources/backend_versions.json
@@ -49,8 +49,8 @@
         }
       },
       "ROCm/ggml-staging-automation": {
-        "hrx-b59": {
-          "llama-hrx-b59-bin-manylinux-hrx-x64.tar.gz": "sha256:d2fe01432c372ae4382678cb80542a0c5c80a8e3862c52b3d94e77e81062f1b7"
+        "hrx-b69": {
+          "llama-hrx-b69-bin-manylinux-hrx-x64.tar.gz": "sha256:e82b6bc6ec896afcf32dfa99e75ecaffa9b0470ac35c3ae8939f05c5cfb8a87c"
         }
       }
     }
@@ -64,7 +64,7 @@
     "cpu": "b10723"
   },
   "llamacpp-hrx": {
-    "hrx": "hrx-b59"
+    "hrx": "hrx-b69"
   },
   "whispercpp": {
     "cpu": "v1.8.4",

--- a/src/cpp/resources/server_models.json
+++ b/src/cpp/resources/server_models.json
@@ -976,6 +976,15 @@
         ],
         "size": 18.6
     },
+    "Meta-Llama-3.1-8B-Instruct-HRX": {
+        "checkpoint": "bartowski/Meta-Llama-3.1-8B-Instruct-GGUF:Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf",
+        "recipe": "llamacpp-hrx",
+        "suggested": true,
+        "labels": [
+            "chat"
+        ],
+        "size": 4.92
+    },
     "Qwen3-Coder-30B-A3B-Instruct-GGUF": {
         "checkpoint": "unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF:Qwen3-Coder-30B-A3B-Instruct-Q4_K_M.gguf",
         "recipe": "llamacpp",

--- a/test/cpp/test_hrx_contract.cpp
+++ b/test/cpp/test_hrx_contract.cpp
@@ -18,7 +18,7 @@ namespace {
 namespace hrx = lemon::backends::hrx;
 using lemon::backends::HrxServer;
 
-constexpr const char* kReleaseVersion = "hrx-b59";
+constexpr const char* kReleaseVersion = "hrx-b69";
 
 int failures = 0;
 
@@ -118,7 +118,7 @@ void check_installer_contract() {
           params.repo == "ROCm/ggml-staging-automation");
     check("HRX installer maps the version to the exact release asset",
           params.filename ==
-              "llama-hrx-b59-bin-manylinux-hrx-x64.tar.gz");
+              "llama-hrx-b69-bin-manylinux-hrx-x64.tar.gz");
 #else
     const bool unsupported_host_rejected = throws_exception([] {
         (void)HrxServer::get_install_params("hrx", kReleaseVersion);

--- a/test/utils/capabilities.py
+++ b/test/utils/capabilities.py
@@ -75,6 +75,13 @@ CAPABILITIES = {
                 "reranking": "jina-reranker-v1-tiny-en-GGUF",
             },
         },
+        "llamacpp-hrx": {
+            "backends": ["hrx"],
+            "supports": {"chat_completions": True},
+            "test_models": {
+                "llm": "Meta-Llama-3.1-8B-Instruct-HRX",
+            },
+        },
         "ryzenai": {
             "backends": ["cpu", "hybrid", "npu"],
             "supports": {


### PR DESCRIPTION
llama-3.1 8b is a small model suitable for use in CI.

## Summary

This PR:
- Bumps hrx
- Adds llama-3.1 8b as an hrx qualified model
- As llama-3.1 8b is a small model suitable for use in CI, adds CI coverage for hrx

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

```
    test/server_llm.py \
    --wrapped-server llamacpp-hrx \
    --backend hrx \
    --cli-binary ./build/lemonade
```

## Documentation

- [x] Documentation is not affected by this change.
- [ ] Documentation is affected and has been updated.
- [ ] Documentation is affected but will be handled in a separate PR or issue.

## Breaking Changes

- [ ] This PR introduces breaking changes.
- [x] This PR does not introduce breaking changes.

## AI-assisted contribution

Please select one:

- [x] I used AI tools for this PR.
- [ ] I did not use AI tools for this PR.

If AI tools were used:

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.
