### PR TITLE
feat(backends): video generation via stable-diffusion.cpp

### DIFF
--- a/docs/api/openai.md
+++ b/docs/api/openai.md
@@ -15,6 +15,7 @@ This spec defines Lemonade's implementation of the [OpenAI API](https://develope
 | `POST` | [`/v1/images/edits`](#post-v1imagesedits) | Image Editing | image + prompt -> edited image |
 | `POST` | [`/v1/images/variations`](#post-v1imagesvariations) | Image Variations | image -> varied image |
 | `POST` | [`/v1/images/upscale`](#post-v1imagesupscale) | Image Upscaling | image + ESRGAN model -> upscaled image |
+| `POST` | [`/v1/videos/generations`](#post-v1videosgenerations) | Video Generation | prompt -> video |
 | `GET` | [`/v1/models`](#get-v1models) | List models available locally | n/a |
 | `GET` | [`/v1/models/{model_id}`](#get-v1modelsmodel_id) | Retrieve a specific model by ID | n/a |
 
@@ -660,6 +661,49 @@ Image Generation API. You provide a text prompt and receive a generated image. T
             "size": "512x512",
             "steps": 4,
             "response_format": "b64_json"
+          }'
+    ```
+
+## `POST /v1/videos/generations`
+<sub>![Status](https://img.shields.io/badge/status-partially_available-green)</sub>
+
+Video Generation API. You provide a text prompt and receive a generated video. This API uses [stable-diffusion.cpp](https://github.com/leejet/stable-diffusion.cpp) as the backend, and is not part of the OpenAI API.
+
+> **Note:** Frame count matters more than it looks. The backend defaults to a single frame, and video models need a few dozen frames before they animate rather than drift, so a model's registry entry should set `video_frames`. `Wan2.1-T2V-1.3B` ships with 33.
+>
+> **Performance:** GPU only, in practice. A 33-frame 832x480 clip takes ~5 minutes on a discrete GPU; CPU inference is impractically slow.
+
+### Parameters
+
+| Parameter | Required | Description | Status |
+|-----------|----------|-------------|--------|
+| `prompt` | Yes | The text description of the video to generate. | <sub>![Status](https://img.shields.io/badge/available-green)</sub> |
+| `model` | Yes | The video model to use (e.g., `Wan2.1-T2V-1.3B`). | <sub>![Status](https://img.shields.io/badge/available-green)</sub> |
+| `negative_prompt` | No | Text describing what to avoid. | <sub>![Status](https://img.shields.io/badge/available-green)</sub> |
+| `video_frames` | No | Number of frames to generate. Falls back to the model's recipe option, then the backend default. | <sub>![Status](https://img.shields.io/badge/available-green)</sub> |
+| `fps` | No | Frames per second of the returned clip. | <sub>![Status](https://img.shields.io/badge/available-green)</sub> |
+| `width` / `height` | No | Output dimensions. Models are sensitive to resolutions they were not trained on. | <sub>![Status](https://img.shields.io/badge/available-green)</sub> |
+| `steps` | No | Number of diffusion steps per frame. | <sub>![Status](https://img.shields.io/badge/available-green)</sub> |
+| `cfg_scale` | No | Classifier-free guidance scale. | <sub>![Status](https://img.shields.io/badge/available-green)</sub> |
+| `sampling_method` | No | Sampler name (e.g. `euler`). | <sub>![Status](https://img.shields.io/badge/available-green)</sub> |
+| `flow_shift` | No | Flow shift, used by flow-matching models such as Wan. | <sub>![Status](https://img.shields.io/badge/available-green)</sub> |
+| `seed` | No | Random seed for reproducibility. | <sub>![Status](https://img.shields.io/badge/available-green)</sub> |
+| `output_format` | No | Container format. `webm`, `webp` or `avi`. Default: `webm`. | <sub>![Status](https://img.shields.io/badge/available-green)</sub> |
+
+The response carries the clip as base64 in `b64_json`, alongside `mime_type`, `output_format`, `frame_count` and `fps`.
+
+### Example request
+
+=== "Bash"
+
+    ```bash
+    curl -X POST http://localhost:13305/v1/videos/generations \
+      -H "Content-Type: application/json" \
+      -d '{
+            "model": "Wan2.1-T2V-1.3B",
+            "prompt": "a lovely cat walking through tall grass",
+            "video_frames": 33,
+            "fps": 16
           }'
     ```
 

--- a/docs/api/openai.md
+++ b/docs/api/openai.md
@@ -669,7 +669,7 @@ Image Generation API. You provide a text prompt and receive a generated image. T
 
 Video Generation API. You provide a text prompt and receive a generated video. This API uses [stable-diffusion.cpp](https://github.com/leejet/stable-diffusion.cpp) as the backend, and is not part of the OpenAI API.
 
-> **Note:** Frame count matters more than it looks. The backend defaults to a single frame, and video models need a few dozen frames before they animate rather than drift, so a model's registry entry should set `video_frames`. `Wan2.1-T2V-1.3B` ships with 33.
+> **Note:** Frame count matters more than it looks. stable-diffusion.cpp generates a single frame when the field is absent, and video models need a few dozen frames before they animate rather than drift, so Lemonade sends 33 by default. A registry entry can override that with a `video_frames` recipe option.
 >
 > **Performance:** GPU only, in practice. A 33-frame 832x480 clip takes ~5 minutes on a discrete GPU; CPU inference is impractically slow.
 
@@ -680,7 +680,7 @@ Video Generation API. You provide a text prompt and receive a generated video. T
 | `prompt` | Yes | The text description of the video to generate. | <sub>![Status](https://img.shields.io/badge/available-green)</sub> |
 | `model` | Yes | The video model to use (e.g., `Wan2.1-T2V-1.3B`). | <sub>![Status](https://img.shields.io/badge/available-green)</sub> |
 | `negative_prompt` | No | Text describing what to avoid. | <sub>![Status](https://img.shields.io/badge/available-green)</sub> |
-| `video_frames` | No | Number of frames to generate. Falls back to the model's recipe option, then the backend default. | <sub>![Status](https://img.shields.io/badge/available-green)</sub> |
+| `video_frames` | No | Number of frames to generate. Falls back to the model's recipe option, then to 33. | <sub>![Status](https://img.shields.io/badge/available-green)</sub> |
 | `fps` | No | Frames per second of the returned clip. | <sub>![Status](https://img.shields.io/badge/available-green)</sub> |
 | `width` / `height` | No | Output dimensions. Models are sensitive to resolutions they were not trained on. | <sub>![Status](https://img.shields.io/badge/available-green)</sub> |
 | `steps` | No | Number of diffusion steps per frame. | <sub>![Status](https://img.shields.io/badge/available-green)</sub> |

--- a/docs/dev/backends-reference.md
+++ b/docs/dev/backends-reference.md
@@ -152,6 +152,8 @@ the generator instead. Prose outside the markers is preserved. -->
 | `height` | — | SIZE | 512 | Output image height |
 | `sampling_method` | — | ARGS | "" | Sampling method |
 | `flow_shift` | — | SIZE | 0.0 | Flow shift |
+| `video_frames` | — | SIZE | 33 | Number of video frames |
+| `fps` | — | SIZE | 16 | Video frames per second |
 
 #### `thenoise` — TheNoise ROCm
 

--- a/docs/guide/configuration/custom-models.md
+++ b/docs/guide/configuration/custom-models.md
@@ -422,8 +422,9 @@ Supported checkpoint keys:
 |-----|---------|-------------|
 | `main` | All | Primary model file |
 | `npu_cache` | whispercpp | NPU-accelerated encoder cache |
-| `text_encoder` | sd-cpp | Text encoder for image generation models |
-| `vae` | sd-cpp | VAE for image generation models |
+| `text_encoder` | sd-cpp | LLM-style text encoder (e.g. Qwen for Flux/Qwen-Image), passed as `--llm` |
+| `t5xxl` | sd-cpp | T5-family text encoder (e.g. umt5 for Wan), passed as `--t5xxl`. Use this key instead of `text_encoder` when the model expects a T5 encoder; sd-server rejects the wrong slot |
+| `vae` | sd-cpp | VAE for image and video generation models |
 
 ### Collections
 

--- a/docs/guide/configuration/custom-models.md
+++ b/docs/guide/configuration/custom-models.md
@@ -423,7 +423,7 @@ Supported checkpoint keys:
 | `main` | All | Primary model file |
 | `npu_cache` | whispercpp | NPU-accelerated encoder cache |
 | `text_encoder` | sd-cpp | LLM-style text encoder (e.g. Qwen for Flux/Qwen-Image), passed as `--llm` |
-| `t5xxl` | sd-cpp | T5-family text encoder (e.g. umt5 for Wan), passed as `--t5xxl`. Use this key instead of `text_encoder` when the model expects a T5 encoder; sd-server rejects the wrong slot |
+| `t5xxl` | sd-cpp | T5-family text encoder (e.g. umt5 for Wan), passed as `--t5xxl`. Independent of `text_encoder` -- set whichever slots the model expects, or both; sd-server rejects an encoder in the wrong slot |
 | `vae` | sd-cpp | VAE for image and video generation models |
 
 ### Collections

--- a/src/cpp/include/lemon/backends/sdcpp/sdcpp.h
+++ b/src/cpp/include/lemon/backends/sdcpp/sdcpp.h
@@ -34,6 +34,11 @@ inline const BackendDescriptor descriptor = {
         {"height", "", 512, "SIZE", "Output image height", "Stable Diffusion Options"},
         {"sampling_method", "", "", "ARGS", "Sampling method", "Stable Diffusion Options"},
         {"flow_shift", "", 0.0, "SIZE", "Flow shift", "Stable Diffusion Options"},
+        // sd-server generates a single frame unless told otherwise, and video
+        // models need a few dozen before they animate rather than drift, so a
+        // video model that leaves video_frames unset returns a still.
+        {"video_frames", "", 33, "SIZE", "Number of video frames", "Stable Diffusion Options"},
+        {"fps", "", 16, "SIZE", "Video frames per second", "Stable Diffusion Options"},
     },
     /*support*/ {
         {"metal", {"macos"}, {{"metal", {}}}, "Apple Silicon GPU"},
@@ -44,7 +49,7 @@ inline const BackendDescriptor descriptor = {
          {{"amd_gpu", {"gfx1150", "gfx1151", "gfx1152", "gfx103X", "gfx110X", "gfx120X"}}}, "Supported AMD ROCm iGPU/dGPU families*"},
         {"cpu", {"windows", "linux"}, {{"cpu", {"x86_64"}}}, "x86_64 CPU"},
     },
-    /*supported_modes*/ {"image"},
+    /*supported_modes*/ {"image", "video"},
     /*required_checkpoints*/ {"main"},  // flux text_encoder+vae validated together in load()
     /*default_capabilities*/ {},
     /*experimental*/    false,

--- a/src/cpp/include/lemon/backends/sdcpp/sdcpp.h
+++ b/src/cpp/include/lemon/backends/sdcpp/sdcpp.h
@@ -35,8 +35,8 @@ inline const BackendDescriptor descriptor = {
         {"sampling_method", "", "", "ARGS", "Sampling method", "Stable Diffusion Options"},
         {"flow_shift", "", 0.0, "SIZE", "Flow shift", "Stable Diffusion Options"},
         // sd-server generates a single frame unless told otherwise, and video
-        // models need a few dozen before they animate rather than drift, so a
-        // video model that leaves video_frames unset returns a still.
+        // models need a few dozen before they animate rather than drift, so
+        // this default is applied even when the model itself sets nothing.
         {"video_frames", "", 33, "SIZE", "Number of video frames", "Stable Diffusion Options"},
         {"fps", "", 16, "SIZE", "Video frames per second", "Stable Diffusion Options"},
     },

--- a/src/cpp/include/lemon/backends/sdcpp/sdcpp_server.h
+++ b/src/cpp/include/lemon/backends/sdcpp/sdcpp_server.h
@@ -14,7 +14,7 @@
 namespace lemon {
 namespace backends {
 
-class SDServer : public WrappedServer, public IImageServer {
+class SDServer : public WrappedServer, public IImageServer, public IVideoServer {
 public:
     static InstallParams get_install_params(const std::string& backend, const std::string& version);
 
@@ -41,6 +41,7 @@ public:
     json image_generations(const json& request) override;
     json image_edits(const json& request) override;
     json image_variations(const json& request) override;
+    json video_generations(const json& request) override;
 
     // ESRGAN upscaling via sd-cli subprocess.
     //

--- a/src/cpp/include/lemon/model_types.h
+++ b/src/cpp/include/lemon/model_types.h
@@ -56,7 +56,8 @@ enum class ModelType {
     TTS,
     AUDIO_GENERATION,  // text -> audio clip (music, sound effects)
     CLASSIFICATION,    // text -> {label: score} (router classifier models)
-    MESH               // image -> 3D mesh (glTF-binary)
+    MESH,              // image -> 3D mesh (glTF-binary)
+    VIDEO              // text/image -> video frames
 };
 
 // Bitmask pattern for models that use multiple devices
@@ -91,6 +92,7 @@ inline std::string model_type_to_string(ModelType type) {
         case ModelType::AUDIO_GENERATION: return "audio-generation";
         case ModelType::CLASSIFICATION: return "classification";
         case ModelType::MESH: return "mesh";
+        case ModelType::VIDEO: return "video";
         default: return "unknown";
     }
 }
@@ -169,6 +171,10 @@ inline bool find_deployment_mode(const Labels& labels, ModelType& out) {
         }
         if (label == "3d") {
             out = ModelType::MESH;
+            return true;
+        }
+        if (label == "video") {
+            out = ModelType::VIDEO;
             return true;
         }
     }

--- a/src/cpp/include/lemon/router.h
+++ b/src/cpp/include/lemon/router.h
@@ -238,6 +238,7 @@ public:
         const std::string& model_name, const std::string& response_format);
 
     json image_generations(const json& request);
+    json video_generations(const json& request);
     json image_edits(const json& request);
     json image_variations(const json& request);
 

--- a/src/cpp/include/lemon/server.h
+++ b/src/cpp/include/lemon/server.h
@@ -289,6 +289,7 @@ private:
 
     // Image endpoint handlers (OpenAI /v1/images/* compatible)
     void handle_image_generations(const httplib::Request& req, httplib::Response& res);
+    void handle_video_generations(const httplib::Request& req, httplib::Response& res);
     void handle_image_edits(const httplib::Request& req, httplib::Response& res);
     void handle_image_variations(const httplib::Request& req, httplib::Response& res);
     void handle_image_upscale(const httplib::Request& req, httplib::Response& res);

--- a/src/cpp/include/lemon/server_capabilities.h
+++ b/src/cpp/include/lemon/server_capabilities.h
@@ -92,6 +92,16 @@ public:
     virtual json image_variations(const json& request) = 0;
 };
 
+// Video generation capability (text or image -> video). Separate from
+// IImageServer so a caller asking for an image can never resolve to a video
+// model: the two take different parameters and differ by orders of magnitude
+// in runtime.
+class IVideoServer : public virtual ICapability {
+public:
+    virtual ~IVideoServer() = default;
+    virtual json video_generations(const json& request) = 0;
+};
+
 // Generative audio capability (text -> audio clip). Serves both music and
 // sound-effect models; the loaded model decides which. Streams the encoded
 // audio bytes to the sink, like ITextToSpeechServer.

--- a/src/cpp/resources/server_models.json
+++ b/src/cpp/resources/server_models.json
@@ -2046,6 +2046,31 @@
             "height": 1024
         }
     },
+    "Wan2.1-T2V-1.3B": {
+        "checkpoints": {
+            "main": "Comfy-Org/Wan_2.1_ComfyUI_repackaged:split_files/diffusion_models/wan2.1_t2v_1.3B_fp16.safetensors",
+            "t5xxl": "city96/umt5-xxl-encoder-gguf:umt5-xxl-encoder-Q8_0.gguf",
+            "vae": "Comfy-Org/Wan_2.1_ComfyUI_repackaged:split_files/vae/wan_2.1_vae.safetensors"
+        },
+        "recipe": "sd-cpp",
+        "suggested": true,
+        "labels": [
+            "video"
+        ],
+        "size": 8.8,
+        "image_defaults": {
+            "steps": 20,
+            "cfg_scale": 6.0,
+            "width": 832,
+            "height": 480,
+            "sampling_method": "euler",
+            "flow_shift": 3.0
+        },
+        "recipe_options": {
+            "video_frames": 33,
+            "fps": 16
+        }
+    },
     "LMX-Omni-52B-Halo": {
         "checkpoint": "lemonade-sdk/LMX-Omni-52B-Halo",
         "recipe": "collection.omni",

--- a/src/cpp/server/backends/backend_descriptor_registry.cpp
+++ b/src/cpp/server/backends/backend_descriptor_registry.cpp
@@ -81,6 +81,7 @@ std::string modality_display_for(const BackendDescriptor& descriptor) {
         {ModelType::AUDIO_GENERATION, "Audio generation"},
         {ModelType::CLASSIFICATION, "Text classification"},
         {ModelType::MESH, "3D generation"},
+        {ModelType::VIDEO, "Video generation"},
     };
     if (descriptor.supported_modes.empty()) return "";
     ModelType mode = ModelType::LLM;

--- a/src/cpp/server/backends/sdcpp/sdcpp_server.cpp
+++ b/src/cpp/server/backends/sdcpp/sdcpp_server.cpp
@@ -16,6 +16,7 @@
 #include <filesystem>
 #include <fstream>
 #include <chrono>
+#include <thread>
 #include <cstring>
 #include <random>
 #include <sstream>
@@ -214,6 +215,11 @@ void SDServer::load(const std::string& model_name,
 
     std::string model_path = model_info.resolved_path("main");
     std::string llm_path = model_info.resolved_path("text_encoder");
+    // sd-cpp routes the text encoder by family: --llm for LLM-style encoders
+    // (Flux2/Qwen-Image use qwen, LTX uses gemma), --t5xxl for T5-family ones
+    // (Wan uses umt5). A model declares which slot it fills by the checkpoint
+    // key it uses, so neither is guessed from the filename.
+    std::string t5xxl_path = model_info.resolved_path("t5xxl");
     std::string vae_path = model_info.resolved_path("vae");
 
     if (model_path.empty()) {
@@ -243,14 +249,18 @@ void SDServer::load(const std::string& model_name,
         "--listen-port", std::to_string(port_)
     };
 
-    if (llm_path.empty() || vae_path.empty()) {
+    // Pick flag and path together: a model that declared both keys must not end
+    // up passing one encoder's path under the other's flag.
+    const char* encoder_flag = llm_path.empty() ? "--t5xxl" : "--llm";
+    const std::string& encoder_path = llm_path.empty() ? t5xxl_path : llm_path;
+    if (encoder_path.empty() || vae_path.empty()) {
         args.push_back("-m");
         args.push_back(model_path);
     } else {
         args.push_back("--diffusion-model");
         args.push_back(model_path);
-        args.push_back("--llm");
-        args.push_back(llm_path);
+        args.push_back(encoder_flag);
+        args.push_back(encoder_path);
         args.push_back("--vae");
         args.push_back(vae_path);
     }
@@ -259,13 +269,6 @@ void SDServer::load(const std::string& model_name,
         args.push_back("-v");
     }
 
-    if (resolved_backend == "vulkan") {
-        LOG(INFO, "SDServer")
-            << "Applying Vulkan SD workaround: --vae-tiling --diffusion-fa"
-            << std::endl;
-        args.push_back("--vae-tiling");
-        args.push_back("--diffusion-fa");
-    }
     std::set<std::string> reserved_flags = {
         "-m",
         "--model",
@@ -276,6 +279,12 @@ void SDServer::load(const std::string& model_name,
         "--listen-port"
     };
 
+    // Parse the user's arguments before adding any of our own, so a flag they
+    // set explicitly is not also appended by us. These are not in
+    // reserved_flags on purpose -- passing them is legitimate, it just must not
+    // produce the same flag twice on the command line.
+    std::vector<std::string> custom_args_vec;
+    std::set<std::string> user_flags;
     if (!sdcpp_args.empty()) {
         std::string validation_error = validate_custom_args(sdcpp_args, reserved_flags);
         if (!validation_error.empty()) {
@@ -285,9 +294,34 @@ void SDServer::load(const std::string& model_name,
         }
 
         LOG(DEBUG, "SDServer") << "Adding custom arguments: " << sdcpp_args << std::endl;
-        std::vector<std::string> custom_args_vec = parse_custom_args(sdcpp_args);
-        args.insert(args.end(), custom_args_vec.begin(), custom_args_vec.end());
+        custom_args_vec = parse_custom_args(sdcpp_args);
+        for (const std::string& token : custom_args_vec) {
+            if (token.rfind("--", 0) == 0 || (token.size() > 1 && token[0] == '-')) {
+                user_flags.insert(token);
+            }
+        }
     }
+
+    if (resolved_backend == "vulkan") {
+        std::vector<std::string> applied;
+        for (const char* flag : {"--vae-tiling", "--diffusion-fa"}) {
+            if (user_flags.count(flag) == 0) {
+                args.push_back(flag);
+                applied.push_back(flag);
+            }
+        }
+        if (!applied.empty()) {
+            std::ostringstream joined;
+            for (size_t i = 0; i < applied.size(); ++i) {
+                if (i > 0) joined << " ";
+                joined << applied[i];
+            }
+            LOG(INFO, "SDServer")
+                << "Applying Vulkan SD workaround: " << joined.str() << std::endl;
+        }
+    }
+
+    args.insert(args.end(), custom_args_vec.begin(), custom_args_vec.end());
 
     std::vector<std::pair<std::string, std::string>> env_vars;
     fs::path exe_dir = fs::path(exe_path).parent_path();
@@ -563,6 +597,135 @@ json SDServer::image_generations(const json& request) {
 
     // Image generation can take 20+ minutes for large models; avoid timeout.
     return forward_request("/v1/images/generations", sd_request, 0);
+}
+
+json SDServer::video_generations(const json& request) {
+    // /sdcpp/v1/vid_gen is sd-cpp's NATIVE route and takes a real JSON body --
+    // unlike /v1/images/generations, which is OpenAI-shaped and reads its
+    // parameters from a <sd_cpp_extra_args> blob smuggled inside the prompt.
+    // Reusing that convention here silently loses every parameter (the server
+    // falls back to 512x512) and corrupts the prompt with the blob text, so the
+    // body is built from scratch. Field names and nesting come from the
+    // backend's own /sdcpp/v1/capabilities defaults.
+    json body = json::object();
+    body["prompt"] = request.value("prompt", std::string());
+    if (request.contains("negative_prompt") && request["negative_prompt"].is_string()) {
+        body["negative_prompt"] = request["negative_prompt"];
+    }
+
+    // Prefer explicit request dimensions, then the model's recipe options.
+    // Omitted entirely when neither supplies them, so sd-server keeps its own
+    // defaults rather than us inventing a resolution the model wasn't trained on.
+    auto dimension = [&](const char* key) -> std::optional<int> {
+        if (request.contains(key) && request[key].is_number_integer()) {
+            return request[key].get<int>();
+        }
+        if (recipe_options_.has_option(key)) {
+            json value = recipe_options_.get_option(key);
+            if (value.is_number() && value.get<int>() > 0) return value.get<int>();
+        }
+        return std::nullopt;
+    };
+    if (auto width = dimension("width")) body["width"] = *width;
+    if (auto height = dimension("height")) body["height"] = *height;
+
+    // Same request-then-recipe-option ladder as the dimensions above; see the
+    // video_frames option in sdcpp.h for why the fallback carries its weight.
+    if (auto frames = dimension("video_frames")) body["video_frames"] = *frames;
+    if (auto fps = dimension("fps")) body["fps"] = *fps;
+    if (request.contains("seed") && request["seed"].is_number_integer()) {
+        body["seed"] = request["seed"];
+    }
+    if (request.contains("output_format") && request["output_format"].is_string()) {
+        body["output_format"] = request["output_format"];
+    }
+
+    // Sampling knobs live under sample_params, and cfg under its guidance
+    // object -- flat top-level copies are ignored by this route.
+    json sample_params = json::object();
+    auto sampling = [&](const char* request_key, const char* option_key) -> std::optional<double> {
+        if (request.contains(request_key) && request[request_key].is_number()) {
+            return request[request_key].get<double>();
+        }
+        if (recipe_options_.has_option(option_key)) {
+            json value = recipe_options_.get_option(option_key);
+            if (value.is_number()) return value.get<double>();
+        }
+        return std::nullopt;
+    };
+    if (auto steps = sampling("steps", "steps")) {
+        sample_params["sample_steps"] = static_cast<int>(*steps);
+    }
+    if (auto flow_shift = sampling("flow_shift", "flow_shift")) {
+        sample_params["flow_shift"] = *flow_shift;
+    }
+    if (request.contains("sampling_method") && request["sampling_method"].is_string()) {
+        sample_params["sample_method"] = request["sampling_method"];
+    } else if (recipe_options_.has_option("sampling_method")) {
+        json method = recipe_options_.get_option("sampling_method");
+        if (method.is_string()) {
+            sample_params["sample_method"] = method;
+        }
+    }
+    if (auto cfg = sampling("cfg_scale", "cfg_scale")) {
+        sample_params["guidance"] = json{{"txt_cfg", *cfg}};
+    }
+    if (!sample_params.empty()) {
+        body["sample_params"] = sample_params;
+    }
+
+    LOG(DEBUG, "SDServer") << "Forwarding video request to sd-server: "
+                           << body.dump(2) << std::endl;
+
+    // Unlike /v1/images/generations, vid_gen is asynchronous: it answers 202
+    // with a job handle and does the work in the background. forward_request
+    // reports any non-200 as a backend error, so accept the 202 body here and
+    // poll the job to completion, presenting the whole thing to the caller as
+    // one synchronous request.
+    json accepted = forward_request("/sdcpp/v1/vid_gen", body, 0);
+    const json* handle = &accepted;
+    if (accepted.contains("error") && accepted["error"].is_object()) {
+        const json& err = accepted["error"];
+        if (err.value("status_code", 0) == 202 && err.contains("details") &&
+            err["details"].is_object() && err["details"].contains("response")) {
+            handle = &err["details"]["response"];
+        } else {
+            return accepted;
+        }
+    }
+
+    const std::string poll_url = handle->value("poll_url", std::string());
+    if (poll_url.empty()) {
+        // Some builds may answer synchronously; pass that straight through.
+        return *handle;
+    }
+
+    // No wall-clock deadline: a long clip legitimately runs for many minutes,
+    // and the caller's own connection is the real bound. Give up only when the
+    // backend dies, which is_backend_alive() catches via forward_get_request.
+    while (true) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+        json status = forward_get_request(poll_url, 0);
+        // A job payload always carries a string "status"; anything else is a
+        // transport/backend error envelope from forward_get_request. Checking
+        // for a "status" field rather than for "error" matters: the job payload
+        // itself always has an "error" key, null while the job is healthy.
+        if (!status.contains("status") || !status["status"].is_string()) {
+            return status;
+        }
+        const std::string state = status.value("status", std::string());
+        if (state == "queued" || state == "generating" || state == "running") {
+            continue;
+        }
+        if (!status.value("error", json()).is_null()) {
+            return ErrorResponse::from_exception(
+                BackendException(server_name_, status["error"].dump(), 500));
+        }
+        if (status.contains("result") && !status["result"].is_null()) {
+            return status["result"];
+        }
+        return status;
+    }
 }
 
 json SDServer::image_edits(const json& request) {

--- a/src/cpp/server/backends/sdcpp/sdcpp_server.cpp
+++ b/src/cpp/server/backends/sdcpp/sdcpp_server.cpp
@@ -217,8 +217,9 @@ void SDServer::load(const std::string& model_name,
     std::string llm_path = model_info.resolved_path("text_encoder");
     // sd-cpp routes the text encoder by family: --llm for LLM-style encoders
     // (Flux2/Qwen-Image use qwen, LTX uses gemma), --t5xxl for T5-family ones
-    // (Wan uses umt5). A model declares which slot it fills by the checkpoint
-    // key it uses, so neither is guessed from the filename.
+    // (Wan uses umt5). The slots are independent -- HunyuanVideo 1.5 fills both
+    // -- and a model declares which it fills by the checkpoint keys it
+    // provides, so neither is guessed from the filename.
     std::string t5xxl_path = model_info.resolved_path("t5xxl");
     std::string vae_path = model_info.resolved_path("vae");
 
@@ -249,18 +250,20 @@ void SDServer::load(const std::string& model_name,
         "--listen-port", std::to_string(port_)
     };
 
-    // Pick flag and path together: a model that declared both keys must not end
-    // up passing one encoder's path under the other's flag.
-    const char* encoder_flag = llm_path.empty() ? "--t5xxl" : "--llm";
-    const std::string& encoder_path = llm_path.empty() ? t5xxl_path : llm_path;
-    if (encoder_path.empty() || vae_path.empty()) {
+    if ((llm_path.empty() && t5xxl_path.empty()) || vae_path.empty()) {
         args.push_back("-m");
         args.push_back(model_path);
     } else {
         args.push_back("--diffusion-model");
         args.push_back(model_path);
-        args.push_back(encoder_flag);
-        args.push_back(encoder_path);
+        if (!llm_path.empty()) {
+            args.push_back("--llm");
+            args.push_back(llm_path);
+        }
+        if (!t5xxl_path.empty()) {
+            args.push_back("--t5xxl");
+            args.push_back(t5xxl_path);
+        }
         args.push_back("--vae");
         args.push_back(vae_path);
     }
@@ -274,6 +277,7 @@ void SDServer::load(const std::string& model_name,
         "--model",
         "--diffusion-model",
         "--llm",
+        "--t5xxl",
         "--vae",
         "-v",
         "--listen-port"
@@ -629,10 +633,19 @@ json SDServer::video_generations(const json& request) {
     if (auto width = dimension("width")) body["width"] = *width;
     if (auto height = dimension("height")) body["height"] = *height;
 
-    // Same request-then-recipe-option ladder as the dimensions above; see the
-    // video_frames option in sdcpp.h for why the fallback carries its weight.
-    if (auto frames = dimension("video_frames")) body["video_frames"] = *frames;
-    if (auto fps = dimension("fps")) body["fps"] = *fps;
+    // Same ladder, but with the descriptor's default as a last rung rather
+    // than stopping at what this model happens to set -- see the video_frames
+    // option in sdcpp.h for why leaving it unset is not a viable outcome.
+    auto video_param = [&](const char* key) -> std::optional<int> {
+        if (request.contains(key) && request[key].is_number_integer()) {
+            return request[key].get<int>();
+        }
+        json value = recipe_options_.get_option(key);
+        if (value.is_number() && value.get<int>() > 0) return value.get<int>();
+        return std::nullopt;
+    };
+    if (auto frames = video_param("video_frames")) body["video_frames"] = *frames;
+    if (auto fps = video_param("fps")) body["fps"] = *fps;
     if (request.contains("seed") && request["seed"].is_number_integer()) {
         body["seed"] = request["seed"];
     }

--- a/src/cpp/server/router.cpp
+++ b/src/cpp/server/router.cpp
@@ -2288,6 +2288,18 @@ json Router::image_generations(const json& request) {
     });
 }
 
+json Router::video_generations(const json& request) {
+    return execute_inference(request, [&](WrappedServer* server) {
+        auto video_server = dynamic_cast<IVideoServer*>(server);
+        if (!video_server) {
+            return ErrorResponse::from_exception(
+                UnsupportedOperationException("Video generation", device_type_to_string(server->get_device_type()))
+            );
+        }
+        return video_server->video_generations(request);
+    });
+}
+
 json Router::image_edits(const json& request) {
     return execute_inference(request, [&](WrappedServer* server) {
         auto image_server = dynamic_cast<IImageServer*>(server);

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -1320,6 +1320,12 @@ void Server::setup_routes(httplib::Server &web_server) {
     register_post("images/upscale", [this](const httplib::Request& req, httplib::Response& res) {
         handle_image_upscale(req, res);
     });
+    // Video endpoint: text/image -> video. Not an OpenAI-standard route (there
+    // is no /v1/videos in the OpenAI API), but registered under the same four
+    // prefixes as every other endpoint.
+    register_post("videos/generations", [this](const httplib::Request& req, httplib::Response& res) {
+        handle_video_generations(req, res);
+    });
     // Generative-audio endpoint: text -> audio clip (music, sound effects)
     register_post("audio/generations", [this](const httplib::Request& req, httplib::Response& res) {
         handle_audio_generations(req, res);
@@ -5251,6 +5257,65 @@ void Server::handle_image_generations(const httplib::Request& req, httplib::Resp
         res.set_content(error.dump(), "application/json");
     } catch (const std::exception& e) {
         LOG(ERROR, "Server") << "ERROR in handle_image_generations: " << e.what() << std::endl;
+        res.status = 500;
+        nlohmann::json error = {{"error", {
+            {"message", e.what()},
+            {"type", "internal_error"}
+        }}};
+        res.set_content(error.dump(), "application/json");
+    }
+}
+
+void Server::handle_video_generations(const httplib::Request& req, httplib::Response& res) {
+    try {
+        LOG(INFO, "Server") << "POST /api/v1/videos/generations" << std::endl;
+
+        auto request_json = nlohmann::json::parse(req.body);
+        normalize_client_model_name(request_json);
+        normalize_and_resolve_request_model(request_json);
+
+        for (const char* field : {"prompt", "model"}) {
+            if (!request_json.contains(field)) {
+                res.status = 400;
+                nlohmann::json error = {{"error", {
+                    {"message", std::string("Missing '") + field + "' field in request"},
+                    {"type", "invalid_request_error"}
+                }}};
+                res.set_content(error.dump(), "application/json");
+                return;
+            }
+        }
+
+        std::string requested_model = request_json["model"];
+
+        try {
+            auto_load_model_if_needed(requested_model, extract_auto_load_options(request_json));
+        } catch (const std::exception& e) {
+            LOG(ERROR, "Server") << "Failed to load video model: " << e.what() << std::endl;
+            auto error_response = create_model_error(requested_model, e.what());
+            std::string error_code = error_response["error"]["code"].get<std::string>();
+            res.status = get_http_status_from_error(error_code);
+            res.set_content(error_response.dump(), "application/json");
+            return;
+        }
+
+        auto response = router_->video_generations(request_json);
+        if (response.contains("error")) {
+            LOG(ERROR, "Server") << "Video generation backend error: " << response.dump() << std::endl;
+            res.status = 500;
+        }
+        res.set_content(response.dump(), "application/json");
+
+    } catch (const nlohmann::json::exception& e) {
+        LOG(ERROR, "Server") << "JSON parse error in handle_video_generations: " << e.what() << std::endl;
+        res.status = 400;
+        nlohmann::json error = {{"error", {
+            {"message", "Invalid JSON: " + std::string(e.what())},
+            {"type", "invalid_request_error"}
+        }}};
+        res.set_content(error.dump(), "application/json");
+    } catch (const std::exception& e) {
+        LOG(ERROR, "Server") << "ERROR in handle_video_generations: " << e.what() << std::endl;
         res.status = 500;
         nlohmann::json error = {{"error", {
             {"message", e.what()},

--- a/test/server_video.py
+++ b/test/server_video.py
@@ -1,0 +1,157 @@
+"""
+Video generation tests for Lemonade Server.
+
+Tests the /videos/generations endpoint (text -> video) with the
+stable-diffusion.cpp backend.
+
+Usage:
+    python server_video.py --wrapped-server sdcpp --backend vulkan
+    python server_video.py --wrapped-server sdcpp --backend rocm
+
+Video generation is slow, so the generation test asks for the shortest clip
+that still exercises the frame loop. The negative tests run first and never
+pull the model; only the generation test downloads it.
+"""
+
+import base64
+
+import requests
+
+from utils.server_base import (
+    ServerTestBase,
+    run_server_tests,
+    pull_model_with_retry,
+    unload_model,
+)
+from utils.capabilities import get_test_model
+from utils.test_models import TIMEOUT_DEFAULT
+
+# A short clip still runs a full diffusion loop per frame.
+TIMEOUT_VIDEO_GENERATION = 3600
+
+# WebM/Matroska magic. Enough to prove real container bytes came back rather
+# than a base64 blob of something else.
+WEBM_MAGIC = b"\x1a\x45\xdf\xa3"
+
+
+class VideoGenerationTests(ServerTestBase):
+    """Tests for the /videos/generations endpoint."""
+
+    _model_pulled = False
+
+    @classmethod
+    def tearDownClass(cls):
+        try:
+            response = unload_model(get_test_model("video"))
+            if response.status_code not in (200, 404):
+                print(
+                    "Warning: Failed to unload the video backend: "
+                    f"{response.status_code} {response.text[:200]}"
+                )
+        except Exception as e:
+            print(f"Warning: Failed to unload the video backend: {e}")
+        super().tearDownClass()
+
+    @classmethod
+    def _ensure_model_pulled(cls):
+        if cls._model_pulled:
+            return
+        model = get_test_model("video")
+        print(f"\n[SETUP] Ensuring {model} is pulled...")
+        pull_model_with_retry(model)
+        print(f"[SETUP] {model} is ready")
+        cls._model_pulled = True
+
+    def _assert_rejected(self, payload, context, expected_status=400):
+        response = requests.post(
+            f"{self.base_url}/videos/generations",
+            json=payload,
+            timeout=TIMEOUT_DEFAULT,
+        )
+        self.assertEqual(
+            response.status_code,
+            expected_status,
+            f"{context}: expected {expected_status}, got "
+            f"{response.status_code}: {response.text[:200]}",
+        )
+
+    # --- negative tests: these never pull the model ---
+
+    def test_001_missing_prompt_rejected(self):
+        """A request without a prompt is refused before any model load."""
+        self._assert_rejected({"model": get_test_model("video")}, "missing prompt")
+
+    def test_002_missing_model_rejected(self):
+        """A request without a model is refused before any model load."""
+        self._assert_rejected({"prompt": "a cat"}, "missing model")
+
+    def test_003_unknown_model_rejected(self):
+        """An unknown model is refused rather than silently defaulting."""
+        response = requests.post(
+            f"{self.base_url}/videos/generations",
+            json={"model": "user.does-not-exist", "prompt": "a cat"},
+            timeout=TIMEOUT_DEFAULT,
+        )
+        self.assertNotEqual(
+            response.status_code,
+            200,
+            f"unknown model unexpectedly succeeded: {response.text[:200]}",
+        )
+
+    # --- generation ---
+
+    def test_010_generates_a_video(self):
+        """A prompt returns a decodable video with the requested frame count.
+
+        Asserts the container bytes and the frame count rather than anything
+        about how the clip looks: the point is that parameters reach the
+        backend and the async job is polled to completion.
+        """
+        self._ensure_model_pulled()
+        model = get_test_model("video")
+
+        response = requests.post(
+            f"{self.base_url}/videos/generations",
+            json={
+                "model": model,
+                "prompt": "a lovely cat walking through tall grass",
+                "video_frames": 9,
+                "fps": 8,
+                "steps": 4,
+                "width": 480,
+                "height": 320,
+            },
+            timeout=TIMEOUT_VIDEO_GENERATION,
+        )
+        self.assertEqual(
+            response.status_code,
+            200,
+            f"generation failed: {response.status_code} {response.text[:300]}",
+        )
+
+        payload = response.json()
+        for field in ("b64_json", "mime_type", "frame_count", "fps"):
+            self.assertIn(field, payload, f"response missing '{field}'")
+
+        self.assertEqual(payload["frame_count"], 9)
+        self.assertEqual(payload["fps"], 8)
+        self.assertTrue(
+            payload["mime_type"].startswith("video/"),
+            f"unexpected mime_type: {payload['mime_type']}",
+        )
+
+        video = base64.b64decode(payload["b64_json"])
+        self.assertGreater(len(video), 1024, "video payload is implausibly small")
+        self.assertEqual(
+            video[:4],
+            WEBM_MAGIC,
+            "payload is not a WebM/Matroska container",
+        )
+        print(
+            f"[OK] {len(video)} bytes, {payload['frame_count']} frames "
+            f"@ {payload['fps']} fps"
+        )
+
+
+if __name__ == "__main__":
+    run_server_tests(VideoGenerationTests, description="VIDEO GENERATION TESTS")

--- a/test/server_video.py
+++ b/test/server_video.py
@@ -24,7 +24,7 @@ from utils.server_base import (
     unload_model,
 )
 from utils.capabilities import get_test_model
-from utils.test_models import TIMEOUT_DEFAULT
+from utils.test_models import TIMEOUT_DEFAULT, TIMEOUT_MODEL_OPERATION
 
 # A short clip still runs a full diffusion loop per frame.
 TIMEOUT_VIDEO_GENERATION = 3600
@@ -151,6 +151,76 @@ class VideoGenerationTests(ServerTestBase):
             f"[OK] {len(video)} bytes, {payload['frame_count']} frames "
             f"@ {payload['fps']} fps"
         )
+
+    def test_011_frame_default_applies_without_recipe_options(self):
+        """A video model carrying no recipe options still returns a clip.
+
+        The backend generates a single frame when video_frames is absent, so
+        a model registered with nothing but its checkpoints has to pick the
+        count up from the recipe descriptor rather than from the entry.
+        """
+        self._ensure_model_pulled()
+        source = get_test_model("video")
+
+        info = requests.get(
+            f"{self.base_url}/models/{source}",
+            timeout=TIMEOUT_DEFAULT,
+        )
+        self.assertEqual(
+            info.status_code,
+            200,
+            f"could not read {source}: {info.text[:200]}",
+        )
+        checkpoints = info.json().get("checkpoints")
+        self.assertTrue(checkpoints, f"{source} declares no checkpoints to reuse")
+
+        bare = "user.video-no-recipe-options"
+        registration = requests.post(
+            f"{self.base_url}/pull",
+            json={
+                "model_name": bare,
+                "recipe": "sd-cpp",
+                "labels": ["video"],
+                "checkpoints": checkpoints,
+            },
+            timeout=TIMEOUT_MODEL_OPERATION,
+        )
+        self.assertEqual(
+            registration.status_code,
+            200,
+            f"could not register {bare}: {registration.text[:200]}",
+        )
+        self.addCleanup(
+            requests.post,
+            f"{self.base_url}/delete",
+            json={"model_name": bare},
+            timeout=TIMEOUT_DEFAULT,
+        )
+
+        response = requests.post(
+            f"{self.base_url}/videos/generations",
+            json={
+                "model": bare,
+                "prompt": "a lovely cat walking through tall grass",
+                "steps": 2,
+                "width": 480,
+                "height": 320,
+            },
+            timeout=TIMEOUT_VIDEO_GENERATION,
+        )
+        self.assertEqual(
+            response.status_code,
+            200,
+            f"generation failed: {response.status_code} {response.text[:300]}",
+        )
+
+        payload = response.json()
+        self.assertGreater(
+            payload["frame_count"],
+            1,
+            "a model without recipe options fell through to a single frame",
+        )
+        print(f"[OK] default frame count reached the backend: {payload['frame_count']}")
 
 
 if __name__ == "__main__":

--- a/test/utils/capabilities.py
+++ b/test/utils/capabilities.py
@@ -231,6 +231,17 @@ CAPABILITIES = {
             },
         },
     },
+    "video": {
+        "sdcpp": {
+            "backends": ["vulkan", "rocm", "cuda"],
+            "supports": {
+                "video_generation": True,
+            },
+            "test_models": {
+                "video": "Wan2.1-T2V-1.3B",
+            },
+        },
+    },
     "model3d": {
         "trellis": {
             "backends": ["vulkan", "rocm", "cuda"],


### PR DESCRIPTION
## Summary

Adds VIDEO as a capability tier and exposes it on `POST /v1/videos/generations`,
registered under all four prefixes. stable-diffusion.cpp already ships video
support, so this needs no new backend or subprocess: `SDServer` implements a new
`IVideoServer` and the `Router` hop mirrors `image_generations`.

Two things about sd-server's video route differ from its image one and drive most
of the diff. `/sdcpp/v1/vid_gen` is sd-cpp's **native** route taking a real JSON
body, not the OpenAI shape — the `<sd_cpp_extra_args>` convention that
`/v1/images/generations` relies on is silently ignored there, so parameters are
built from the fields the backend's own `/sdcpp/v1/capabilities` advertises. It is
also asynchronous, answering 202 with a job handle, so the request is polled to
completion and presented to the caller as one synchronous call.

Second, the text encoder is routed by family: `--llm` suits LLM-style encoders
(Flux2/Qwen-Image use qwen, LTX uses gemma) but Wan's umt5 needs `--t5xxl`, and
loading it into the wrong slot yields dead conditioning rather than an error. A
model declares which slot it fills via a new `t5xxl` checkpoint key.

## Scope

Nothing here is Wan-specific — any sd-cpp video model built from main + one text
encoder + vae is reachable by adding a catalog entry, with no code change.
`Wan2.1-T2V-1.3B` is the entry shipped here and the only one generated end to end.
LTX additionally wants a second `--audio-vae` model and Wan2.2's MoE split wants
`--high-noise-diffusion-model`; neither has a checkpoint key yet, and both are left
out rather than written untested.

`model_types.h`, `server_capabilities.h`, `backend_descriptor_registry.cpp` — the
capability tier. `sdcpp.h` / `sdcpp_server.{h,cpp}` — the native body, async polling,
encoder slot, and `video_frames`/`fps` recipe options. `router.{h,cpp}`, `server.{h,cpp}`
— the hop and endpoint. Plus `server_models.json`, `test/server_video.py`,
`test/utils/capabilities.py`, and docs.

## Testing

`ctest -L cpp-ci` 69/69. `check_comment_slop.py` and `black` clean.

Generated end to end on an RX 7900 XTX via the shipped catalog entry: a 33-frame
832x480 clip in ~310s. Verified the registry defaults actually reach the backend by
sending only `model` + `prompt` and confirming the response reports 33 frames @ 16 fps
rather than sd-cpp's 1-frame default. `test/server_video.py` covers the negative
cases plus a short generation asserting frame count, fps, mime type and WebM magic;
it needs a live server (`--wrapped-server sdcpp --backend vulkan`).

Note the encoder quant matters: the catalog pins umt5 at Q8_0 because lighter quants
crash sd-server on load, which surfaces as an opaque watchdog reset.

## Documentation

`docs/api/openai.md` — endpoint section and index row. 
`docs/guide/configuration/custom-models.md` — the `text_encoder` vs `t5xxl` keys.

## Breaking Changes

None. New endpoint, new capability, new catalog entry.

## AI-assisted contribution

Yes.