### PR TITLE
llamacpp:sycl — first-class Intel GPU backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -948,6 +948,7 @@ include_directories(
 set(SOURCES_CORE
     src/cpp/server/server.cpp
     src/cpp/server/collection_orchestrator.cpp
+    src/cpp/server/image_multipart.cpp
     src/cpp/server/jobs/job_ops.cpp
     src/cpp/server/jobs/job_manager.cpp
     src/cpp/server/router.cpp
@@ -1180,6 +1181,35 @@ if(BUILD_TESTING AND EXISTS "${LLAMACPP_REQUEST_TEST_SOURCE}")
     )
     target_link_libraries(test_llamacpp_request PRIVATE nlohmann_json::nlohmann_json)
     add_cpp_ci_test(llamacpp_request CI OFF COMMAND test_llamacpp_request)
+endif()
+
+set(IMAGE_MULTIPART_TEST_SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_image_multipart.cpp")
+if(BUILD_TESTING AND EXISTS "${IMAGE_MULTIPART_TEST_SOURCE}")
+    add_executable(test_image_multipart
+        ${IMAGE_MULTIPART_TEST_SOURCE}
+        src/cpp/server/image_multipart.cpp
+        src/cpp/server/utils/json_utils.cpp
+        src/cpp/server/utils/path_utils.cpp
+    )
+    target_include_directories(test_image_multipart PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/server
+    )
+    target_link_libraries(test_image_multipart PRIVATE
+        lemonade-httplib
+        nlohmann_json::nlohmann_json
+    )
+    if(WIN32)
+        target_sources(test_image_multipart PRIVATE
+            src/cpp/server/utils/platform/path_windows.cpp)
+    elseif(APPLE)
+        target_sources(test_image_multipart PRIVATE
+            src/cpp/server/utils/platform/path_macos.cpp)
+    else()
+        target_sources(test_image_multipart PRIVATE
+            src/cpp/server/utils/platform/path_linux.cpp)
+    endif()
+    add_cpp_ci_test(ImageMultipartTest CI ON COMMAND test_image_multipart)
 endif()
 
 set(MCP_CLIENT_CONFIG_TEST_SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_mcp_client_config.cpp")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3122,6 +3122,18 @@ if(BUILD_TESTING AND CMAKE_SYSTEM_NAME STREQUAL "Linux" AND EXISTS "${_LLAMACPP_
     add_cpp_ci_test(LlamaCppSystemBackendTest CI ON COMMAND test_llamacpp_system_backend)
 endif()
 
+set(_LLAMACPP_SYCL_DEFAULT_BACKEND_TEST_SRC
+    "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_llamacpp_sycl_default_backend.cpp"
+)
+if(BUILD_TESTING AND CMAKE_SYSTEM_NAME STREQUAL "Linux" AND EXISTS "${_LLAMACPP_SYCL_DEFAULT_BACKEND_TEST_SRC}")
+    add_executable(test_llamacpp_sycl_default_backend
+        test/cpp/test_llamacpp_sycl_default_backend.cpp
+    )
+    target_link_libraries(test_llamacpp_sycl_default_backend PRIVATE lemonade-server-core)
+    add_dependencies(test_llamacpp_sycl_default_backend copy_resources)
+    add_cpp_ci_test(LlamaCppSyclDefaultBackendTest CI ON COMMAND test_llamacpp_sycl_default_backend)
+endif()
+
 set(_DLL_VERSION_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_backend_utils_dll_version.cpp")
 if(BUILD_TESTING AND EXISTS "${_DLL_VERSION_TEST_SRC}")
     add_executable(test_backend_utils_dll_version test/cpp/test_backend_utils_dll_version.cpp)

--- a/README.md
+++ b/README.md
@@ -147,8 +147,8 @@ Lemonade supports multiple inference engines for LLM, speech, TTS, and image gen
   </thead>
   <tbody>
     <tr>
-      <td rowspan="11"><strong>Text generation</strong></td>
-      <td rowspan="6"><code>llamacpp</code></td>
+      <td rowspan="12"><strong>Text generation</strong></td>
+      <td rowspan="7"><code>llamacpp</code></td>
       <td><code>system</code></td>
       <td><code>x86_64</code>/ARM64 CPU, GPU</td>
       <td>Linux</td>
@@ -162,6 +162,11 @@ Lemonade supports multiple inference engines for LLM, speech, TTS, and image gen
       <td><code>cuda</code></td>
       <td>NVIDIA GPUs (Turing or newer)**</td>
       <td>Windows, Linux</td>
+    </tr>
+    <tr>
+      <td><code>sycl</code></td>
+      <td>Intel Arc / Xe GPUs (oneAPI SYCL)</td>
+      <td>Linux</td>
     </tr>
     <tr>
       <td><code>vulkan</code></td>

--- a/docs/dev/backends-reference.md
+++ b/docs/dev/backends-reference.md
@@ -13,7 +13,7 @@ the generator instead. Prose outside the markers is preserved. -->
 | `ds4` | DwarfStar4 (experimental) | no | yes | rocm |
 | `flm` | FastFlowLM NPU | no | yes | npu |
 | `kokoro` | Kokoro | no | no | cpu, metal |
-| `llamacpp` | Llama.cpp GPU | yes | yes | cpu, cuda, metal, rocm, system, vulkan |
+| `llamacpp` | Llama.cpp GPU | yes | yes | cpu, cuda, metal, rocm, sycl, system, vulkan |
 | `llamacpp-hrx` | HRX GPU (experimental) | no | yes | hrx |
 | `moonshine` | Moonshine | no | no | cpu |
 | `onnxruntime` | ONNX Runtime | no | no | cpu |
@@ -42,6 +42,7 @@ the generator instead. Prose outside the markers is preserved. -->
 | `llamacpp` | system | linux | cpu (arm64, x86_64) |
 | `llamacpp` | metal | macos | metal |
 | `llamacpp` | cuda | linux, windows | nvidia_gpu (sm_100, sm_120, sm_121, sm_75, sm_80, sm_86, sm_89, sm_90) |
+| `llamacpp` | sycl | linux | intel_gpu |
 | `llamacpp` | vulkan | linux, windows | amd_gpu; cpu (arm64, x86_64) |
 | `llamacpp` | rocm | linux, windows | amd_gpu (gfx103X, gfx110X, gfx1150, gfx1151, gfx1152, gfx120X, gfx908, gfx90a, gfx942, gfx950) |
 | `llamacpp` | cpu | linux, windows | cpu (arm64, x86_64) |

--- a/docs/guide/configuration/README.md
+++ b/docs/guide/configuration/README.md
@@ -82,6 +82,8 @@ When `lemond` starts, effective configuration is resolved by deep-merging settin
     "prefer_system": true,
     "rocm_args": "",
     "rocm_bin": "builtin",
+    "sycl_args": "",
+    "sycl_bin": "builtin",
     "vulkan_args": "",
     "vulkan_bin": "builtin"
   },

--- a/docs/guide/configuration/llamacpp.md
+++ b/docs/guide/configuration/llamacpp.md
@@ -233,7 +233,7 @@ lemonade config set llamacpp.rocm_bin=b1260
 ## Platform Specifics
 
 ### Linux
-- All backends supported (CPU, Vulkan, ROCm, CUDA, System)
+- All backends supported (CPU, Vulkan, ROCm, CUDA, SYCL, System)
 - CPU and Vulkan backends support both x86_64 and ARM64 (aarch64) systems; on ARM64, Vulkan is the default
 - ROCm requires compatible AMD GPU (see above)
 - CUDA requires compatible NVIDIA GPU (see above)

--- a/docs/guide/configuration/llamacpp.md
+++ b/docs/guide/configuration/llamacpp.md
@@ -43,6 +43,16 @@ Lemonade uses [llama.cpp](https://github.com/ggerganov/llama.cpp) as its primary
 - **Runtime**: Bundled CUDA runtime libraries (no system-wide CUDA toolkit installation required)
 - **Notes**: On Windows, .7z extraction requires the bsdtar bundled with Windows 11 22H2+. On Linux, the build is shipped as .tar.xz and extracts with the system `tar`.
 
+### SYCL
+- **Platform**: Linux
+- **Hardware**: Intel Arc discrete GPUs and Intel Xe iGPUs (Level Zero)
+- **Use Case**: Intel GPU-optimized llama.cpp
+- **Performance**: Prefer SYCL over Vulkan on Intel Arc
+- **Installation**: Set `llamacpp.sycl_bin` to a directory containing an Intel
+  oneAPI `llama-server` (Lemonade does not download a Linux SYCL zip). Example:
+  `lemonade config set llamacpp.backend=sycl llamacpp.sycl_bin=/opt/llama/bin`
+- **Device**: `--device SYCL0` by default; override with `llamacpp.device`
+
 ### Metal
 - **Platform**: macOS only
 - **Hardware**: Apple Silicon (M1/M2/M3/M4) and Intel Macs with Metal support
@@ -197,7 +207,8 @@ lemonade config set llamacpp.rocm_bin=b1260
      - Use **Vulkan** (ROCm not supported)
 
 3. **Do you have an Intel GPU or older NVIDIA GPU?**
-   - Use **Vulkan**
+   - Intel GPU → **SYCL** if `sycl_bin` is set, else **Vulkan**
+   - Older NVIDIA GPU → **Vulkan**
 
 4. **Are you using macOS?**
    - Use **Metal**

--- a/src/cpp/include/lemon/backends/backend_ops.h
+++ b/src/cpp/include/lemon/backends/backend_ops.h
@@ -142,7 +142,7 @@ public:
     // The /system-info state for a backend variant that is supported but not
     // currently available (install probe failed).
     struct UnavailableState {
-        std::string state;    // "installable" | "update_required" | "action_required"
+        std::string state;    // "installable" | "not_installed" | "update_required" | "action_required"
         std::string message;  // shown to the user
         std::string action;   // remediation (a URL or an install command)
         bool attach_installed_version = false;  // surface the installed version too

--- a/src/cpp/include/lemon/backends/backend_utils.h
+++ b/src/cpp/include/lemon/backends/backend_utils.h
@@ -253,6 +253,15 @@ namespace lemon::backends {
             bool skip_visible_devices = false);
 
         /**
+         * Adds default SYCL runtime variables without overriding host settings.
+         * The default oneAPI device selector is omitted when the caller supplied
+         * an explicit llama.cpp device.
+         */
+        static void apply_sycl_env_vars(
+            std::vector<std::pair<std::string, std::string>>& env_vars,
+            bool has_explicit_device);
+
+        /**
          * Validates that the device selection string prefix matches the selected backend.
          * Throws std::invalid_argument if a device prefix contradicts the backend choice
          * (e.g. passing target_device "ROCm2" to a "vulkan" or "cuda" backend).

--- a/src/cpp/include/lemon/backends/llamacpp/llamacpp.h
+++ b/src/cpp/include/lemon/backends/llamacpp/llamacpp.h
@@ -35,6 +35,7 @@ inline const BackendDescriptor descriptor = {
         {"metal", {"macos"}, {{"metal", {}}}, "Apple Silicon GPU"},
         {"cuda", {"windows", "linux"},
          {{"nvidia_gpu", {"sm_75", "sm_80", "sm_86", "sm_89", "sm_90", "sm_100", "sm_120", "sm_121"}}}, "NVIDIA GPUs (Turing or newer)**"},
+        {"sycl", {"linux"}, {{"intel_gpu", {}}}, "Intel Arc / Xe GPUs (oneAPI SYCL)"},
         {"vulkan", {"windows", "linux"}, {{"cpu", {"x86_64", "arm64"}}, {"amd_gpu", {}}}, "x86_64 CPU, AMD iGPU, AMD dGPU; ARM64 CPU/GPU (Linux)"},
         {"rocm", {"windows", "linux"},
          {{"amd_gpu", {"gfx103X", "gfx110X", "gfx1150", "gfx1151", "gfx1152", "gfx120X", "gfx908", "gfx90a", "gfx942", "gfx950"}}}, "AMD GPUs supported by ROCm",
@@ -57,8 +58,8 @@ inline const BackendDescriptor descriptor = {
     /*version_policy*/  VersionPolicy::Exact,
     /*self_manages_downloads*/ false,
     /*takes_args*/      true,
-    /*arg_variants*/    {"rocm", "vulkan", "cpu"},
-    /*bin_variants*/    {"rocm", "vulkan", "cuda", "cpu"},
+    /*arg_variants*/    {"rocm", "vulkan", "cpu", "sycl"},
+    /*bin_variants*/    {"rocm", "vulkan", "cuda", "cpu", "sycl"},
     /*config_extra*/    {{"prefer_system", true}},
 };
 

--- a/src/cpp/include/lemon/system_info.h
+++ b/src/cpp/include/lemon/system_info.h
@@ -32,6 +32,9 @@ struct GPUInfo : DeviceInfo {
     std::string compute_capability;  // NVIDIA only: "MAJOR.MINOR" from nvidia-smi (e.g. "8.6")
     double vram_gb = 0.0;
     double virtual_gb = 0.0;
+    std::string pci_addr;
+    std::string pci_device_id;
+    bool integrated = false;
 };
 
 struct NPUInfo : DeviceInfo {
@@ -68,6 +71,7 @@ public:
     virtual GPUInfo get_amd_igpu_device() = 0;
     virtual std::vector<GPUInfo> get_amd_dgpu_devices() = 0;
     virtual std::vector<GPUInfo> get_nvidia_gpu_devices() = 0;
+    virtual std::vector<GPUInfo> get_intel_gpu_devices() { return {}; }
     virtual NPUInfo get_npu_device() = 0;
 
     // Apple Silicon unified-memory GPU. Only meaningful on macOS; the base
@@ -220,6 +224,7 @@ public:
     GPUInfo get_amd_igpu_device() override;
     std::vector<GPUInfo> get_amd_dgpu_devices() override;
     std::vector<GPUInfo> get_nvidia_gpu_devices() override;
+    std::vector<GPUInfo> get_intel_gpu_devices() override;
     NPUInfo get_npu_device() override;
 
     // Override to add Linux-specific fields

--- a/src/cpp/resources/backend_versions.json
+++ b/src/cpp/resources/backend_versions.json
@@ -57,6 +57,7 @@
   },
   "llamacpp": {
     "vulkan": "b10723",
+    "sycl": "b10723",
     "rocm-stable": "b10711",
     "rocm-nightly": "b1319",
     "cuda": "b10711",

--- a/src/cpp/resources/defaults.json
+++ b/src/cpp/resources/defaults.json
@@ -44,6 +44,8 @@
     "prefer_system": true,
     "rocm_args": "",
     "rocm_bin": "builtin",
+    "sycl_args": "",
+    "sycl_bin": "builtin",
     "vulkan_args": "",
     "vulkan_bin": "builtin"
   },

--- a/src/cpp/server/backend_manager.cpp
+++ b/src/cpp/server/backend_manager.cpp
@@ -557,9 +557,24 @@ BackendManager::InstallParams BackendManager::get_install_params(const std::stri
     // Two-pass: first call gets the repo for resolve_user_version (filename
     // discarded); second call templates the resolved tag into the real filename.
     auto pinned_params = spec->install_params_fn(resolved_backend, pinned);
+    if (pinned_params.repo.empty()) {
+        if (recipe == "llamacpp" && resolved_backend == "sycl") {
+            throw std::runtime_error(
+                "llamacpp:sycl is user-managed; set llamacpp.sycl_bin to a "
+                "llama-server directory or install oneAPI");
+        }
+        throw std::runtime_error(
+            "Backend " + recipe + ":" + resolved_backend +
+            " does not provide automatic install parameters");
+    }
     std::string resolved_version = resolve_user_version(
         recipe, resolved_backend, pinned, pinned_params.repo);
     auto final_params = spec->install_params_fn(resolved_backend, resolved_version);
+    if (final_params.repo.empty() || final_params.filename.empty()) {
+        throw std::runtime_error(
+            "Backend " + recipe + ":" + resolved_backend +
+            " returned incomplete automatic install parameters");
+    }
     // Allow backends to override the release tag (e.g. per-GPU-target releases)
     std::string release_version = final_params.version_override.empty()
                                       ? resolved_version
@@ -586,6 +601,12 @@ void BackendManager::install_backend(const std::string& recipe, const std::strin
     const std::string existing_backend_binary =
         installed_backend_binary_path(*spec, resolved_backend);
     const bool has_existing_backend = !existing_backend_binary.empty();
+
+    if (recipe == "llamacpp" && resolved_backend == "sycl" &&
+        has_existing_backend) {
+        report_backend_ready(recipe, resolved_backend, progress_cb);
+        return;
+    }
 
     if (auto* cfg = RuntimeConfig::global()) {
         const bool offline = cfg->offline();

--- a/src/cpp/server/backends/backend_utils.cpp
+++ b/src/cpp/server/backends/backend_utils.cpp
@@ -384,6 +384,16 @@ namespace lemon::backends {
         std::string exe_path = find_external_backend_binary(spec.recipe, resolved_backend);
 
         if (!exe_path.empty()) {
+            std::error_code ec;
+            if (fs::is_directory(fs::path(exe_path), ec)) {
+                const std::string external_executable =
+                    find_executable_in_install_dir(exe_path, spec.binary);
+                if (!external_executable.empty()) {
+                    return external_executable;
+                }
+                throw std::runtime_error(
+                    spec.binary + " not found in configured directory: " + exe_path);
+            }
             return exe_path;
         }
 

--- a/src/cpp/server/backends/backend_utils.cpp
+++ b/src/cpp/server/backends/backend_utils.cpp
@@ -2091,16 +2091,20 @@ namespace lemon::backends {
         const bool is_rocm_device = (lower_device.rfind("rocm", 0) == 0);
         const bool is_cuda_device = (lower_device.rfind("cuda", 0) == 0);
         const bool is_vulkan_device = (lower_device.rfind("vulkan", 0) == 0);
+        const bool is_sycl_device = (lower_device.rfind("sycl", 0) == 0);
 
         const bool is_rocm_backend = (lower_backend.rfind("rocm", 0) == 0);
         const bool is_cuda_backend = (lower_backend.rfind("cuda", 0) == 0);
         const bool is_vulkan_backend = (lower_backend.rfind("vulkan", 0) == 0);
+        const bool is_sycl_backend = (lower_backend == "sycl");
 
         if (is_rocm_device && !is_rocm_backend) {
             throw std::invalid_argument(
                 "Device selection '" + target_device + "' contradicts backend choice '" + backend +
                 "'. Expected a " + backend + " device identifier (e.g. " +
-                (is_vulkan_backend ? "Vulkan0" : is_cuda_backend ? "CUDA0" : "a matching device") + ").");
+                (is_vulkan_backend ? "Vulkan0" :
+                 is_cuda_backend ? "CUDA0" :
+                 is_sycl_backend ? "SYCL0" : "a matching device") + ").");
         }
         if (is_cuda_device && !is_cuda_backend) {
             throw std::invalid_argument(
@@ -2108,6 +2112,11 @@ namespace lemon::backends {
                 "'. Expected a " + backend + " device identifier.");
         }
         if (is_vulkan_device && !is_vulkan_backend) {
+            throw std::invalid_argument(
+                "Device selection '" + target_device + "' contradicts backend choice '" + backend +
+                "'. Expected a " + backend + " device identifier.");
+        }
+        if (is_sycl_device && !is_sycl_backend) {
             throw std::invalid_argument(
                 "Device selection '" + target_device + "' contradicts backend choice '" + backend +
                 "'. Expected a " + backend + " device identifier.");

--- a/src/cpp/server/backends/backend_utils.cpp
+++ b/src/cpp/server/backends/backend_utils.cpp
@@ -2081,6 +2081,23 @@ namespace lemon::backends {
 #endif
     }
 
+    void BackendUtils::apply_sycl_env_vars(
+            std::vector<std::pair<std::string, std::string>>& env_vars,
+            bool has_explicit_device) {
+        auto inherit_or_set = [&env_vars](const char* key, const char* value) {
+            const char* existing = std::getenv(key);
+            if (!existing || existing[0] == '\0') {
+                env_vars.push_back({key, value});
+            }
+        };
+
+        if (!has_explicit_device) {
+            inherit_or_set("ONEAPI_DEVICE_SELECTOR", "level_zero:0");
+        }
+        inherit_or_set("ZES_ENABLE_SYSMAN", "1");
+        inherit_or_set("GGML_SYCL_F16", "1");
+    }
+
     void BackendUtils::validate_device_backend_match(
             const std::string& backend,
             const std::string& target_device) {

--- a/src/cpp/server/backends/llamacpp/llamacpp_server.cpp
+++ b/src/cpp/server/backends/llamacpp/llamacpp_server.cpp
@@ -101,6 +101,10 @@ static bool is_llamacpp_cuda_backend(const std::string& backend) {
     return backend == "cuda";
 }
 
+static bool is_llamacpp_sycl_backend(const std::string& backend) {
+    return backend == "sycl";
+}
+
 static bool is_dflash_draft_checkpoint(std::string checkpoint) {
     std::transform(checkpoint.begin(), checkpoint.end(), checkpoint.begin(),
                    [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
@@ -531,6 +535,30 @@ void LlamaCppServer::load(const std::string& model_name,
             skip_visible_devices = true;
         }
         BackendUtils::apply_cuda_env_vars(env_vars, "LlamaCpp", skip_visible_devices);
+    }
+
+    if (is_llamacpp_sycl_backend(llamacpp_backend)) {
+        auto inherit_or_set = [&](const char* key, const char* value) {
+            const char* existing = std::getenv(key);
+            if (!existing || existing[0] == '\0') {
+                env_vars.push_back({key, value});
+            }
+        };
+        inherit_or_set("ONEAPI_DEVICE_SELECTOR", "level_zero:0");
+        inherit_or_set("ZES_ENABLE_SYSMAN", "1");
+        inherit_or_set("GGML_SYCL_F16", "1");
+#ifndef _WIN32
+        fs::path exe_dir = fs::path(executable).parent_path();
+        std::string lib_path = exe_dir.string();
+        const char* existing_ld_path = std::getenv("LD_LIBRARY_PATH");
+        if (existing_ld_path && existing_ld_path[0] != '\0') {
+            lib_path = lib_path + ":" + std::string(existing_ld_path);
+        }
+        env_vars.push_back({"LD_LIBRARY_PATH", lib_path});
+#endif
+        if (llamacpp_device.empty()) {
+            push_arg(args, reserved_flags, "--device", "SYCL0");
+        }
     }
 
 #ifdef __APPLE__

--- a/src/cpp/server/backends/llamacpp/llamacpp_server.cpp
+++ b/src/cpp/server/backends/llamacpp/llamacpp_server.cpp
@@ -245,6 +245,10 @@ InstallParams LlamaCppServer::get_install_params(const std::string& backend, con
 #else
         throw std::runtime_error("CPU llamacpp not supported on this platform");
 #endif
+    } else if (resolved_backend == "sycl") {
+        // Linux SYCL builds need the oneAPI runtime. Do not download a Vulkan
+        // zip. Users set llamacpp.sycl_bin (or LEMONADE_LLAMACPP_SYCL_BIN).
+        return params;
     } else {  // vulkan
         params.repo = "ggml-org/llama.cpp";
 #ifdef _WIN32

--- a/src/cpp/server/backends/llamacpp/llamacpp_server.cpp
+++ b/src/cpp/server/backends/llamacpp/llamacpp_server.cpp
@@ -538,15 +538,8 @@ void LlamaCppServer::load(const std::string& model_name,
     }
 
     if (is_llamacpp_sycl_backend(llamacpp_backend)) {
-        auto inherit_or_set = [&](const char* key, const char* value) {
-            const char* existing = std::getenv(key);
-            if (!existing || existing[0] == '\0') {
-                env_vars.push_back({key, value});
-            }
-        };
-        inherit_or_set("ONEAPI_DEVICE_SELECTOR", "level_zero:0");
-        inherit_or_set("ZES_ENABLE_SYSMAN", "1");
-        inherit_or_set("GGML_SYCL_F16", "1");
+        BackendUtils::apply_sycl_env_vars(
+            env_vars, /*has_explicit_device=*/!llamacpp_device.empty());
 #ifndef _WIN32
         fs::path exe_dir = fs::path(executable).parent_path();
         std::string lib_path = exe_dir.string();
@@ -916,6 +909,13 @@ public:
     }
 
     InstallCheck check_install(const std::string& backend, bool binary_found) const override {
+        if (backend == "sycl" && !binary_found) {
+            return {
+                false,
+                "Set llamacpp.sycl_bin to a llama-server directory or install oneAPI"
+            };
+        }
+
         // The system llama-server also needs the ggml HIP plugin for ROCm GPU
         // acceleration when an AMD GPU (KFD) is present.
         if (binary_found && backend == "system") {
@@ -926,6 +926,24 @@ public:
 #endif
         }
         return {binary_found, ""};
+    }
+
+    std::optional<UnavailableState> classify_unavailable(
+        const std::string& backend,
+        const std::string& install_error,
+        const std::string& default_install_command) const override {
+        (void)default_install_command;
+        if (backend != "sycl") {
+            return std::nullopt;
+        }
+        return UnavailableState{
+            "not_installed",
+            install_error.empty()
+                ? "Set llamacpp.sycl_bin to a llama-server directory or install oneAPI"
+                : install_error,
+            "",
+            false
+        };
     }
 };
 }  // namespace

--- a/src/cpp/server/image_multipart.cpp
+++ b/src/cpp/server/image_multipart.cpp
@@ -1,0 +1,41 @@
+#include "image_multipart.h"
+
+#include "lemon/utils/json_utils.h"
+
+#include <string>
+#include <utility>
+
+namespace lemon {
+
+bool populate_image_request(const httplib::FormFiles& files,
+                            nlohmann::json& request) {
+    bool has_primary = false;
+    nlohmann::json references = nlohmann::json::array();
+
+    for (const auto& file_pair : files) {
+        const std::string& field_name = file_pair.first;
+        const auto& file = file_pair.second;
+        const bool is_primary_field =
+            field_name == "image" || field_name == "image[]";
+
+        if (!has_primary && is_primary_field) {
+            request["image_data"] =
+                utils::JsonUtils::base64_encode(file.content);
+            request["image_filename"] = file.filename;
+            has_primary = true;
+            continue;
+        }
+
+        if (field_name.compare(0, 5, "image") == 0) {
+            references.push_back(
+                utils::JsonUtils::base64_encode(file.content));
+        }
+    }
+
+    if (!references.empty()) {
+        request["references"] = std::move(references);
+    }
+    return has_primary;
+}
+
+}  // namespace lemon

--- a/src/cpp/server/image_multipart.h
+++ b/src/cpp/server/image_multipart.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <httplib.h>
+#include <nlohmann/json.hpp>
+
+namespace lemon {
+
+bool populate_image_request(const httplib::FormFiles& files,
+                            nlohmann::json& request);
+
+}  // namespace lemon

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -1,3 +1,5 @@
+#include "image_multipart.h"
+
 #include "lemon/server.h"
 #include "lemon/audio_types.h"
 #include "lemon/auto_tune.h"
@@ -5293,15 +5295,10 @@ bool Server::parse_n_from_form(const httplib::Request& req, httplib::Response& r
 }
 
 bool Server::extract_image_from_form(const httplib::Request& req, httplib::Response& res, nlohmann::json& out) {
-    for (const auto& file_pair : req.form.files) {
-        if (file_pair.first == "image" || file_pair.first == "image[]") {
-            const auto& file = file_pair.second;
-            out["image_data"] = utils::JsonUtils::base64_encode(file.content);
-            out["image_filename"] = file.filename;
-            LOG(INFO, "Server") << "Image file: " << file.filename
-                      << " (" << file.content.size() << " bytes)" << std::endl;
-            return true;
-        }
+    if (populate_image_request(req.form.files, out)) {
+        LOG(INFO, "Server") << "Image file: " << out["image_filename"].get<std::string>()
+                            << std::endl;
+        return true;
     }
     res.status = 400;
     nlohmann::json error = {{"error", {

--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -4315,6 +4315,39 @@ double SystemInfo::get_global_vram_usage_pct() {
             }
         }
     } catch (...) {}
+
+    try {
+        auto intel = lemon::system_info_detail::intel_pci_devices_from_sysfs(
+            "/sys/bus/pci/devices");
+        for (const auto& d : intel) {
+            const fs::path mm =
+                fs::path("/sys/kernel/debug/dri") / d.pci_addr / "vram0_mm";
+            std::ifstream in(mm);
+            if (in) {
+                std::ostringstream oss;
+                oss << in.rdbuf();
+                const double r =
+                    lemon::system_info_detail::xe_vram_usage_ratio_from_mm(oss.str());
+                if (r >= 0.0) {
+                    highest_ratio = std::max(highest_ratio, r);
+                }
+            }
+        }
+        if (highest_ratio < 0.0 &&
+            !find_executable_in_path("xpu-smi").empty()) {
+            std::string output;
+            const int rc = lemon::utils::ProcessManager::run_command(
+                "xpu-smi stats -d 0", output, 5);
+            if (rc == 0) {
+                const double r =
+                    lemon::system_info_detail::xpu_smi_vram_usage_ratio(output);
+                if (r >= 0.0) {
+                    highest_ratio = std::max(highest_ratio, r);
+                }
+            }
+        }
+    } catch (...) {
+    }
 #endif
 
 #ifdef _WIN32

--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -522,6 +522,7 @@ static const std::map<std::string, std::string> DEVICE_TYPE_NAMES = {
     {"amd_gpu", "AMD GPU"},
     {"amd_npu", "AMD NPU"},
     {"nvidia_gpu", "NVIDIA GPU"},
+    {"intel_gpu", "Intel GPU"},
     {"metal", "MacOS Metal GPU"}
 };
 
@@ -990,6 +991,34 @@ json SystemInfo::get_device_dict() {
         devices["nvidia_gpu_error"] = std::string("Detection exception: ") + e.what();
     }
 
+    try {
+        devices["intel_gpu"] = json::array();
+        for (const auto& gpu : get_intel_gpu_devices()) {
+            json gpu_json = {
+                {"name", gpu.name},
+                {"available", gpu.available},
+                {"integrated", gpu.integrated},
+                {"family", gpu.integrated ? "i915" : "xe"}
+            };
+            if (!gpu.pci_addr.empty()) {
+                gpu_json["pci"] = gpu.pci_addr;
+            }
+            if (!gpu.pci_device_id.empty()) {
+                gpu_json["device_id"] = gpu.pci_device_id;
+            }
+            if (gpu.vram_gb > 0) {
+                gpu_json["vram_gb"] = gpu.vram_gb;
+            }
+            if (!gpu.error.empty()) {
+                gpu_json["error"] = gpu.error;
+            }
+            devices["intel_gpu"].push_back(gpu_json);
+        }
+    } catch (const std::exception& e) {
+        devices["intel_gpu"] = json::array();
+        devices["intel_gpu_error"] = std::string("Detection exception: ") + e.what();
+    }
+
     // Get NPU info - with fault tolerance
     // Use CPU processor name as the NPU device name (e.g., "AMD Ryzen AI 9 HX 375")
     try {
@@ -1138,6 +1167,23 @@ json SystemInfo::build_recipes_info(const json& devices) {
                 if (!name.empty()) {
                     detected_devices.push_back({
                         "nvidia_gpu",
+                        name,
+                        family,
+                        true
+                    });
+                }
+            }
+        }
+    }
+
+    if (devices.contains("intel_gpu") && devices["intel_gpu"].is_array()) {
+        for (const auto& gpu : devices["intel_gpu"]) {
+            if (gpu.value("available", false)) {
+                std::string name = gpu.value("name", "");
+                std::string family = gpu.value("family", "");
+                if (!name.empty()) {
+                    detected_devices.push_back({
+                        "intel_gpu",
                         name,
                         family,
                         true
@@ -3135,6 +3181,34 @@ GPUInfo LinuxSystemInfo::get_amd_igpu_device() {
 
 std::vector<GPUInfo> LinuxSystemInfo::get_amd_dgpu_devices() {
     return detect_amd_gpus("discrete");
+}
+
+std::vector<GPUInfo> LinuxSystemInfo::get_intel_gpu_devices() {
+    std::vector<GPUInfo> gpus;
+    auto devices = system_info_detail::intel_pci_devices_from_sysfs(
+        "/sys/bus/pci/devices");
+    int index = 0;
+    for (const auto& device : devices) {
+        GPUInfo gpu;
+        gpu.index = index++;
+        gpu.pci_addr = device.pci_addr;
+        gpu.pci_device_id = device.device_id;
+        gpu.available = device.driver == "xe" || device.driver == "i915";
+        gpu.integrated = device.driver == "i915";
+        gpu.name = gpu.integrated ? "Intel integrated GPU" : "Intel discrete GPU";
+        if (device.device_id == "0xe223") {
+            gpu.name = "Intel Arc Pro B70";
+        }
+        gpu.driver_version = device.driver;
+        gpu.uuid = device.pci_addr;
+        gpus.push_back(gpu);
+    }
+    std::stable_sort(gpus.begin(), gpus.end(),
+                     [](const GPUInfo& a, const GPUInfo& b) {
+                         return static_cast<int>(a.integrated) <
+                                static_cast<int>(b.integrated);
+                     });
+    return gpus;
 }
 
 std::vector<GPUInfo> LinuxSystemInfo::get_nvidia_gpu_devices() {

--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -1641,6 +1641,9 @@ json SystemInfo::build_recipes_info(const json& devices) {
         if (supported && !skip_as_default) {
             const std::string effective_state =
                 recipes[def.recipe]["backends"][def.backend].value("state", "unsupported");
+            if (!system_info_detail::backend_state_can_be_default(effective_state)) {
+                continue;
+            }
             const bool locally_installed = effective_state == "installed"
                 || effective_state == "update_available"
                 || effective_state == "update_required";
@@ -4318,24 +4321,7 @@ double SystemInfo::get_global_vram_usage_pct() {
 
     try {
         double intel_ratio = -1.0;
-        auto intel = lemon::system_info_detail::intel_pci_devices_from_sysfs(
-            "/sys/bus/pci/devices");
-        for (const auto& d : intel) {
-            const fs::path mm =
-                fs::path("/sys/kernel/debug/dri") / d.pci_addr / "vram0_mm";
-            std::ifstream in(mm);
-            if (in) {
-                std::ostringstream oss;
-                oss << in.rdbuf();
-                const double r =
-                    lemon::system_info_detail::xe_vram_usage_ratio_from_mm(oss.str());
-                if (r >= 0.0) {
-                    intel_ratio = std::max(intel_ratio, r);
-                }
-            }
-        }
-        if (intel_ratio < 0.0 &&
-            !find_executable_in_path("xpu-smi").empty()) {
+        if (!find_executable_in_path("xpu-smi").empty()) {
             std::string output;
             const int rc = lemon::utils::ProcessManager::run_command(
                 "xpu-smi stats -d 0", output, 5);
@@ -4344,6 +4330,26 @@ double SystemInfo::get_global_vram_usage_pct() {
                     lemon::system_info_detail::xpu_smi_vram_usage_ratio(output);
                 if (r >= 0.0) {
                     intel_ratio = std::max(intel_ratio, r);
+                }
+            }
+        }
+
+        if (intel_ratio < 0.0) {
+            auto intel = lemon::system_info_detail::intel_pci_devices_from_sysfs(
+                "/sys/bus/pci/devices");
+            for (const auto& d : intel) {
+                const fs::path mm =
+                    fs::path("/sys/kernel/debug/dri") / d.pci_addr / "vram0_mm";
+                std::ifstream in(mm);
+                if (in) {
+                    std::ostringstream oss;
+                    oss << in.rdbuf();
+                    const double r =
+                        lemon::system_info_detail::xe_vram_usage_ratio_from_mm(
+                            oss.str());
+                    if (r >= 0.0) {
+                        intel_ratio = std::max(intel_ratio, r);
+                    }
                 }
             }
         }

--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -1288,6 +1288,8 @@ json SystemInfo::build_recipes_info(const json& devices) {
 
     std::map<std::pair<std::string, std::string>, int> backend_status_priority;
     std::set<std::string> default_backend_installed;
+    std::map<std::string, bool> configured_default_resolved;
+    std::map<std::string, bool> configured_default_applied;
 
     auto set_backend_status = [&recipes, &backend_status_priority](
                                 const std::string& recipe,
@@ -1631,10 +1633,23 @@ json SystemInfo::build_recipes_info(const json& devices) {
 
         auto configured_default = configured_default_backends.find(def.recipe);
         if (configured_default != configured_default_backends.end()) {
-            if (def.backend == configured_default->second) {
-                recipes[def.recipe]["default_backend"] = def.backend;
+            const std::string& configured_backend = configured_default->second;
+            if (def.backend == configured_backend) {
+                configured_default_resolved[def.recipe] = true;
+                const std::string effective_state =
+                    recipes[def.recipe]["backends"][def.backend].value("state", "unsupported");
+                if (system_info_detail::backend_state_can_be_default(effective_state)) {
+                    recipes[def.recipe]["default_backend"] = def.backend;
+                    configured_default_applied[def.recipe] = true;
+                }
+                continue;
             }
-            continue;
+            if (!configured_default_resolved.count(def.recipe)) {
+                continue;
+            }
+            if (configured_default_applied.count(def.recipe)) {
+                continue;
+            }
         }
 
         bool skip_as_default = (def.backend == "system" && !prefer_llamacpp_system);
@@ -1734,7 +1749,7 @@ SystemInfo::SupportedBackendsResult SystemInfo::get_supported_backends(const std
         if (recipe_info["backends"].contains(default_backend)) {
             const auto& backend = recipe_info["backends"][default_backend];
             std::string state = backend.value("state", "unsupported");
-            if (state != "unsupported") {
+            if (system_info_detail::backend_state_is_supported(state)) {
                 result.backends.push_back(default_backend);
             }
         }
@@ -1751,7 +1766,7 @@ SystemInfo::SupportedBackendsResult SystemInfo::get_supported_backends(const std
             if (recipe_info["backends"].contains(def.backend)) {
                 const auto& backend = recipe_info["backends"][def.backend];
                 std::string state = backend.value("state", "unsupported");
-                if (state != "unsupported") {
+                if (system_info_detail::backend_state_is_supported(state)) {
                     result.backends.push_back(def.backend);
                 } else if (result.not_supported_error.empty() && backend.contains("message")) {
                     // Capture first error encountered (in preference order)

--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -4317,6 +4317,7 @@ double SystemInfo::get_global_vram_usage_pct() {
     } catch (...) {}
 
     try {
+        double intel_ratio = -1.0;
         auto intel = lemon::system_info_detail::intel_pci_devices_from_sysfs(
             "/sys/bus/pci/devices");
         for (const auto& d : intel) {
@@ -4329,11 +4330,11 @@ double SystemInfo::get_global_vram_usage_pct() {
                 const double r =
                     lemon::system_info_detail::xe_vram_usage_ratio_from_mm(oss.str());
                 if (r >= 0.0) {
-                    highest_ratio = std::max(highest_ratio, r);
+                    intel_ratio = std::max(intel_ratio, r);
                 }
             }
         }
-        if (highest_ratio < 0.0 &&
+        if (intel_ratio < 0.0 &&
             !find_executable_in_path("xpu-smi").empty()) {
             std::string output;
             const int rc = lemon::utils::ProcessManager::run_command(
@@ -4342,9 +4343,12 @@ double SystemInfo::get_global_vram_usage_pct() {
                 const double r =
                     lemon::system_info_detail::xpu_smi_vram_usage_ratio(output);
                 if (r >= 0.0) {
-                    highest_ratio = std::max(highest_ratio, r);
+                    intel_ratio = std::max(intel_ratio, r);
                 }
             }
+        }
+        if (intel_ratio >= 0.0) {
+            highest_ratio = std::max(highest_ratio, intel_ratio);
         }
     } catch (...) {
     }

--- a/src/cpp/server/system_info_utils.h
+++ b/src/cpp/server/system_info_utils.h
@@ -19,6 +19,10 @@
 
 namespace lemon::system_info_detail {
 
+inline bool backend_state_can_be_default(const std::string& state) {
+    return state != "not_installed";
+}
+
 inline const std::set<std::string>& cuda_supported_archs() {
     static const std::set<std::string> archs = {
         "sm_75",   // Turing       (RTX 20, GTX 16, T4, Quadro RTX)
@@ -412,13 +416,13 @@ inline double xpu_smi_vram_usage_ratio(const std::string& stats_text) {
             total = metric_value(line, "GPU Memory Total (MiB)");
         }
     }
+    if (std::isfinite(used) && std::isfinite(total) && used >= 0.0 && total > 0.0) {
+        return std::min(1.0, used / total);
+    }
     if (utilization_pct >= 0.0 && utilization_pct <= 100.0) {
         return utilization_pct / 100.0;
     }
-    if (!std::isfinite(used) || !std::isfinite(total) || used < 0.0 || total <= 0.0) {
-        return -1.0;
-    }
-    return std::min(1.0, used / total);
+    return -1.0;
 }
 
 }  // namespace lemon::system_info_detail

--- a/src/cpp/server/system_info_utils.h
+++ b/src/cpp/server/system_info_utils.h
@@ -2,6 +2,8 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cerrno>
+#include <cmath>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
@@ -343,17 +345,28 @@ inline double xe_vram_usage_ratio_from_mm(const std::string& vram0_mm_text) {
         };
         key = trim(key);
         val = trim(val);
-        if (key == "size") {
+        auto parse_u64 = [](const std::string& s, uint64_t& out) -> bool {
+            if (s.empty() || s[0] == '-') {
+                return false;
+            }
             char* end = nullptr;
-            const unsigned long long parsed = std::strtoull(val.c_str(), &end, 10);
-            if (end != val.c_str() && *end == '\0' && parsed > 0) {
+            errno = 0;
+            const unsigned long long parsed = std::strtoull(s.c_str(), &end, 10);
+            if (end == s.c_str() || *end != '\0' || errno == ERANGE) {
+                return false;
+            }
+            out = parsed;
+            return true;
+        };
+        if (key == "size") {
+            uint64_t parsed = 0;
+            if (parse_u64(val, parsed) && parsed > 0) {
                 size = parsed;
                 have_size = true;
             }
         } else if (key == "usage") {
-            char* end = nullptr;
-            const unsigned long long parsed = std::strtoull(val.c_str(), &end, 10);
-            if (end != val.c_str() && *end == '\0') {
+            uint64_t parsed = 0;
+            if (parse_u64(val, parsed)) {
                 usage = parsed;
                 have_usage = true;
             }
@@ -385,7 +398,7 @@ inline double xpu_smi_vram_usage_ratio(const std::string& stats_text) {
             }
             char* end = nullptr;
             const double v = std::strtod(last.c_str(), &end);
-            if (end == last.c_str() || *end != '\0') {
+            if (end == last.c_str() || *end != '\0' || !std::isfinite(v)) {
                 return -1.0;
             }
             return v;
@@ -396,7 +409,7 @@ inline double xpu_smi_vram_usage_ratio(const std::string& stats_text) {
             total = last_num(line);
         }
     }
-    if (used < 0.0 || total <= 0.0) {
+    if (!std::isfinite(used) || !std::isfinite(total) || used < 0.0 || total <= 0.0) {
         return -1.0;
     }
     return std::min(1.0, used / total);

--- a/src/cpp/server/system_info_utils.h
+++ b/src/cpp/server/system_info_utils.h
@@ -19,8 +19,12 @@
 
 namespace lemon::system_info_detail {
 
+inline bool backend_state_is_supported(const std::string& state) {
+    return state != "unsupported" && state != "not_installed";
+}
+
 inline bool backend_state_can_be_default(const std::string& state) {
-    return state != "not_installed";
+    return backend_state_is_supported(state);
 }
 
 inline const std::set<std::string>& cuda_supported_archs() {

--- a/src/cpp/server/system_info_utils.h
+++ b/src/cpp/server/system_info_utils.h
@@ -4,12 +4,14 @@
 #include <cctype>
 #include <cstdint>
 #include <cstdio>
+#include <cstdlib>
 #include <exception>
 #include <filesystem>
 #include <fstream>
 #include <set>
-#include <system_error>
+#include <sstream>
 #include <string>
+#include <system_error>
 #include <utility>
 #include <vector>
 
@@ -239,6 +241,150 @@ inline bool rocm_device_memory_from_sysfs(const std::filesystem::path& kfd_nodes
     free_bytes = total - used;
     total_bytes = total;
     return true;
+}
+
+struct IntelPciDevice {
+    std::string pci_addr;
+    std::string vendor;
+    std::string device_id;
+    std::string pci_class;
+    std::string driver;
+    bool is_display = false;
+};
+
+inline std::string read_sysfs_trimmed(const std::filesystem::path& path) {
+    std::ifstream in(path);
+    std::string line;
+    if (!in || !std::getline(in, line)) {
+        return "";
+    }
+    while (!line.empty() && (line.back() == '\n' || line.back() == '\r' ||
+                             line.back() == ' ' || line.back() == '\t')) {
+        line.pop_back();
+    }
+    return line;
+}
+
+inline bool intel_pci_is_display(const std::string& pci_class_hex) {
+    std::string c = pci_class_hex;
+    for (char& ch : c) {
+        ch = static_cast<char>(std::tolower(static_cast<unsigned char>(ch)));
+    }
+    return c == "0x030000" || c == "0x038000";
+}
+
+inline std::string intel_driver_name(const std::filesystem::path& device_dir) {
+    std::error_code ec;
+    const std::filesystem::path drv = device_dir / "driver";
+    if (!std::filesystem::is_symlink(drv, ec) && !std::filesystem::exists(drv, ec)) {
+        return "";
+    }
+    auto target = std::filesystem::read_symlink(drv, ec);
+    if (ec) {
+        target = std::filesystem::canonical(drv, ec);
+    }
+    if (ec) {
+        return "";
+    }
+    return target.filename().string();
+}
+
+inline std::vector<IntelPciDevice> intel_pci_devices_from_sysfs(
+    const std::filesystem::path& pci_devices_root) {
+    std::vector<IntelPciDevice> out;
+    std::error_code ec;
+    if (!std::filesystem::is_directory(pci_devices_root, ec)) {
+        return out;
+    }
+    for (const auto& entry : std::filesystem::directory_iterator(pci_devices_root, ec)) {
+        if (!entry.is_directory(ec)) {
+            continue;
+        }
+        const auto dir = entry.path();
+        const std::string vendor = read_sysfs_trimmed(dir / "vendor");
+        if (vendor != "0x8086") {
+            continue;
+        }
+        IntelPciDevice d;
+        d.pci_addr = dir.filename().string();
+        d.vendor = vendor;
+        d.device_id = read_sysfs_trimmed(dir / "device");
+        d.pci_class = read_sysfs_trimmed(dir / "class");
+        d.driver = intel_driver_name(dir);
+        d.is_display = intel_pci_is_display(d.pci_class);
+        if (d.is_display) {
+            out.push_back(d);
+        }
+    }
+    return out;
+}
+
+inline double xe_vram_usage_ratio_from_mm(const std::string& vram0_mm_text) {
+    uint64_t size = 0;
+    uint64_t usage = 0;
+    bool have_size = false;
+    bool have_usage = false;
+    std::istringstream iss(vram0_mm_text);
+    std::string line;
+    while (std::getline(iss, line)) {
+        auto colon = line.find(':');
+        if (colon == std::string::npos) {
+            continue;
+        }
+        std::string key = line.substr(0, colon);
+        std::string val = line.substr(colon + 1);
+        auto trim = [](std::string s) {
+            size_t b = s.find_first_not_of(" \t");
+            size_t e = s.find_last_not_of(" \t\r");
+            if (b == std::string::npos) {
+                return std::string();
+            }
+            return s.substr(b, e - b + 1);
+        };
+        key = trim(key);
+        val = trim(val);
+        if (key == "size") {
+            size = std::strtoull(val.c_str(), nullptr, 10);
+            have_size = size > 0;
+        } else if (key == "usage") {
+            usage = std::strtoull(val.c_str(), nullptr, 10);
+            have_usage = true;
+        }
+    }
+    if (!have_size) {
+        return -1.0;
+    }
+    (void)have_usage;
+    return std::min(1.0, static_cast<double>(usage) / static_cast<double>(size));
+}
+
+inline double xpu_smi_vram_usage_ratio(const std::string& stats_text) {
+    double used = -1.0;
+    double total = -1.0;
+    std::istringstream iss(stats_text);
+    std::string line;
+    while (std::getline(iss, line)) {
+        auto used_pos = line.find("GPU Memory Used (MiB)");
+        auto total_pos = line.find("GPU Memory Total (MiB)");
+        auto last_num = [&](const std::string& s) {
+            std::istringstream ls(s);
+            std::string tok;
+            std::string last;
+            while (ls >> tok) {
+                last = tok;
+            }
+            return last.empty() ? -1.0 : std::stod(last);
+        };
+        if (used_pos != std::string::npos) {
+            used = last_num(line);
+        } else if (total_pos != std::string::npos) {
+            total = last_num(line);
+        }
+    }
+    if (used < 0.0 || total <= 0.0) {
+        return -1.0;
+    }
+    return std::min(1.0, used / total);
 }
 
 }  // namespace lemon::system_info_detail

--- a/src/cpp/server/system_info_utils.h
+++ b/src/cpp/server/system_info_utils.h
@@ -344,17 +344,24 @@ inline double xe_vram_usage_ratio_from_mm(const std::string& vram0_mm_text) {
         key = trim(key);
         val = trim(val);
         if (key == "size") {
-            size = std::strtoull(val.c_str(), nullptr, 10);
-            have_size = size > 0;
+            char* end = nullptr;
+            const unsigned long long parsed = std::strtoull(val.c_str(), &end, 10);
+            if (end != val.c_str() && *end == '\0' && parsed > 0) {
+                size = parsed;
+                have_size = true;
+            }
         } else if (key == "usage") {
-            usage = std::strtoull(val.c_str(), nullptr, 10);
-            have_usage = true;
+            char* end = nullptr;
+            const unsigned long long parsed = std::strtoull(val.c_str(), &end, 10);
+            if (end != val.c_str() && *end == '\0') {
+                usage = parsed;
+                have_usage = true;
+            }
         }
     }
-    if (!have_size) {
+    if (!have_size || !have_usage) {
         return -1.0;
     }
-    (void)have_usage;
     return std::min(1.0, static_cast<double>(usage) / static_cast<double>(size));
 }
 
@@ -373,7 +380,15 @@ inline double xpu_smi_vram_usage_ratio(const std::string& stats_text) {
             while (ls >> tok) {
                 last = tok;
             }
-            return last.empty() ? -1.0 : std::stod(last);
+            if (last.empty()) {
+                return -1.0;
+            }
+            char* end = nullptr;
+            const double v = std::strtod(last.c_str(), &end);
+            if (end == last.c_str() || *end != '\0') {
+                return -1.0;
+            }
+            return v;
         };
         if (used_pos != std::string::npos) {
             used = last_num(line);

--- a/src/cpp/server/system_info_utils.h
+++ b/src/cpp/server/system_info_utils.h
@@ -381,33 +381,39 @@ inline double xe_vram_usage_ratio_from_mm(const std::string& vram0_mm_text) {
 inline double xpu_smi_vram_usage_ratio(const std::string& stats_text) {
     double used = -1.0;
     double total = -1.0;
+    double utilization_pct = -1.0;
+    auto metric_value = [](const std::string& line,
+                           const std::string& metric) {
+        const size_t metric_pos = line.find(metric);
+        if (metric_pos == std::string::npos) {
+            return -1.0;
+        }
+        std::string remainder = line.substr(metric_pos + metric.size());
+        std::replace(remainder.begin(), remainder.end(), '|', ' ');
+        std::istringstream values(remainder);
+        std::string token;
+        while (values >> token) {
+            char* end = nullptr;
+            const double value = std::strtod(token.c_str(), &end);
+            if (end != token.c_str() && *end == '\0' && std::isfinite(value)) {
+                return value;
+            }
+        }
+        return -1.0;
+    };
     std::istringstream iss(stats_text);
     std::string line;
     while (std::getline(iss, line)) {
-        auto used_pos = line.find("GPU Memory Used (MiB)");
-        auto total_pos = line.find("GPU Memory Total (MiB)");
-        auto last_num = [&](const std::string& s) {
-            std::istringstream ls(s);
-            std::string tok;
-            std::string last;
-            while (ls >> tok) {
-                last = tok;
-            }
-            if (last.empty()) {
-                return -1.0;
-            }
-            char* end = nullptr;
-            const double v = std::strtod(last.c_str(), &end);
-            if (end == last.c_str() || *end != '\0' || !std::isfinite(v)) {
-                return -1.0;
-            }
-            return v;
-        };
-        if (used_pos != std::string::npos) {
-            used = last_num(line);
-        } else if (total_pos != std::string::npos) {
-            total = last_num(line);
+        if (line.find("GPU Memory Util (%)") != std::string::npos) {
+            utilization_pct = metric_value(line, "GPU Memory Util (%)");
+        } else if (line.find("GPU Memory Used (MiB)") != std::string::npos) {
+            used = metric_value(line, "GPU Memory Used (MiB)");
+        } else if (line.find("GPU Memory Total (MiB)") != std::string::npos) {
+            total = metric_value(line, "GPU Memory Total (MiB)");
         }
+    }
+    if (utilization_pct >= 0.0 && utilization_pct <= 100.0) {
+        return utilization_pct / 100.0;
     }
     if (!std::isfinite(used) || !std::isfinite(total) || used < 0.0 || total <= 0.0) {
         return -1.0;

--- a/test/cpp/test_backend_utils_gpu_env.cpp
+++ b/test/cpp/test_backend_utils_gpu_env.cpp
@@ -6,6 +6,7 @@
 
 #include <cstdlib>
 #include <filesystem>
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <utility>
@@ -185,6 +186,41 @@ int main() {
         check(BackendUtils::find_external_backend_binary("llamacpp", "rocm-stable").empty(),
               "builtin remains reserved after clearing the environment");
         lemon::RuntimeConfig::set_global(nullptr);
+    }
+
+    {
+        const std::filesystem::path bin_dir =
+            std::filesystem::temp_directory_path() /
+            ("lemonade_sycl_bin_" + std::to_string(
+#ifdef _WIN32
+                _getpid()
+#else
+                getpid()
+#endif
+            ));
+        std::filesystem::create_directories(bin_dir);
+#ifdef _WIN32
+        const std::filesystem::path executable = bin_dir / "llama-server.exe";
+#else
+        const std::filesystem::path executable = bin_dir / "llama-server";
+#endif
+        std::ofstream(executable) << "stub";
+        std::filesystem::permissions(
+            executable,
+            std::filesystem::perms::owner_exec |
+                std::filesystem::perms::group_exec |
+                std::filesystem::perms::others_exec,
+            std::filesystem::perm_options::add);
+
+        lemon::RuntimeConfig config(
+            lemon::json{{"llamacpp", {{"sycl_bin", bin_dir.string()}}}});
+        lemon::RuntimeConfig::set_global(&config);
+        const lemon::backends::BackendSpec spec("llamacpp", "llama-server");
+        check(BackendUtils::get_backend_binary_path(spec, "sycl") ==
+                  executable.string(),
+              "SYCL directory override resolves its llama-server executable");
+        lemon::RuntimeConfig::set_global(nullptr);
+        std::filesystem::remove_all(bin_dir);
     }
 
     if (g_failures > 0) {

--- a/test/cpp/test_backend_utils_gpu_env.cpp
+++ b/test/cpp/test_backend_utils_gpu_env.cpp
@@ -113,6 +113,33 @@ int main() {
         }
         check(no_throw_matching,
               "validate_device_backend_match accepts matching pairs and system/auto backends gracefully");
+
+        bool threw_sycl_vulkan = false;
+        try {
+            BackendUtils::validate_device_backend_match("sycl", "Vulkan0");
+        } catch (const std::invalid_argument&) {
+            threw_sycl_vulkan = true;
+        }
+        check(threw_sycl_vulkan,
+              "validate_device_backend_match throws for Vulkan device on sycl backend");
+
+        bool threw_vulkan_sycl = false;
+        try {
+            BackendUtils::validate_device_backend_match("vulkan", "SYCL0");
+        } catch (const std::invalid_argument&) {
+            threw_vulkan_sycl = true;
+        }
+        check(threw_vulkan_sycl,
+              "validate_device_backend_match throws for SYCL device on vulkan backend");
+
+        bool sycl_ok = true;
+        try {
+            BackendUtils::validate_device_backend_match("sycl", "SYCL0");
+            BackendUtils::validate_device_backend_match("sycl", "SYCL1");
+        } catch (...) {
+            sycl_ok = false;
+        }
+        check(sycl_ok, "validate_device_backend_match accepts SYCL0 on sycl backend");
     }
 
     // Test 3: a custom backend binary environment variable takes precedence

--- a/test/cpp/test_backend_utils_gpu_env.cpp
+++ b/test/cpp/test_backend_utils_gpu_env.cpp
@@ -12,7 +12,10 @@
 #include <utility>
 #include <vector>
 
+#include <lemon/backend_manager.h>
+#include <lemon/backends/backend_registry.h>
 #include <lemon/backends/backend_utils.h>
+#include <lemon/backends/llamacpp/llamacpp_server.h>
 #include <lemon/runtime_config.h>
 
 #ifdef _WIN32
@@ -69,6 +72,9 @@ int main() {
     clear_env_var("HIP_VISIBLE_DEVICES");
     clear_env_var("ROCR_VISIBLE_DEVICES");
     clear_env_var("CUDA_VISIBLE_DEVICES");
+    clear_env_var("GGML_SYCL_F16");
+    clear_env_var("ONEAPI_DEVICE_SELECTOR");
+    clear_env_var("ZES_ENABLE_SYSMAN");
 
     // Test 1: apply_cuda_env_vars respects pre-existing CUDA_VISIBLE_DEVICES in host environment
     {
@@ -221,6 +227,49 @@ int main() {
               "SYCL directory override resolves its llama-server executable");
         lemon::RuntimeConfig::set_global(nullptr);
         std::filesystem::remove_all(bin_dir);
+    }
+
+    {
+        const auto params =
+            lemon::backends::LlamaCppServer::get_install_params("sycl", "test");
+        check(params.repo.empty() && params.filename.empty(),
+              "SYCL remains a user-managed backend without GitHub install parameters");
+
+        const auto unavailable = lemon::backends::ops_for("llamacpp")
+                                     ->classify_unavailable(
+                                         "sycl", "", "lemonade backends install llamacpp:sycl");
+        check(unavailable.has_value() && unavailable->state == "not_installed",
+              "missing SYCL binary is not marked installable");
+        check(unavailable.has_value() &&
+                  unavailable->message.find("llamacpp.sycl_bin") != std::string::npos &&
+                  unavailable->action.empty(),
+              "missing SYCL binary reports configuration guidance without install action");
+
+        bool rejected_empty_install = false;
+        try {
+            lemon::BackendManager manager;
+            (void)manager.get_install_params("llamacpp", "sycl");
+        } catch (const std::runtime_error& error) {
+            rejected_empty_install =
+                std::string(error.what()).find("llamacpp.sycl_bin") != std::string::npos;
+        }
+        check(rejected_empty_install,
+              "backend manager rejects SYCL before attempting an empty GitHub install");
+    }
+
+    {
+        std::vector<std::pair<std::string, std::string>> env_vars;
+        BackendUtils::apply_sycl_env_vars(env_vars, /*has_explicit_device=*/true);
+        check(!has_key(env_vars, "ONEAPI_DEVICE_SELECTOR"),
+              "explicit SYCL device suppresses the default oneAPI selector");
+        check(has_key(env_vars, "ZES_ENABLE_SYSMAN") &&
+                  has_key(env_vars, "GGML_SYCL_F16"),
+              "explicit SYCL device retains non-selection runtime defaults");
+
+        env_vars.clear();
+        BackendUtils::apply_sycl_env_vars(env_vars, /*has_explicit_device=*/false);
+        check(has_key(env_vars, "ONEAPI_DEVICE_SELECTOR"),
+              "automatic SYCL device selection adds the default oneAPI selector");
     }
 
     if (g_failures > 0) {

--- a/test/cpp/test_image_multipart.cpp
+++ b/test/cpp/test_image_multipart.cpp
@@ -1,0 +1,65 @@
+#include "image_multipart.h"
+
+#include <cstdio>
+#include <httplib.h>
+#include <nlohmann/json.hpp>
+#include <string>
+
+namespace {
+
+int failures = 0;
+
+void check(bool condition, const char* message) {
+    if (!condition) {
+        std::fprintf(stderr, "FAIL: %s\n", message);
+        ++failures;
+    }
+}
+
+httplib::FormData file(const std::string& content,
+                       const std::string& filename) {
+    httplib::FormData value;
+    value.content = content;
+    value.filename = filename;
+    value.content_type = "image/png";
+    return value;
+}
+
+}  // namespace
+
+int main() {
+    httplib::FormFiles files;
+    files.emplace("image", file("primary", "primary.png"));
+    files.emplace("image1", file("first-reference", "reference-1.png"));
+    files.emplace("image2", file("second-reference", "reference-2.png"));
+    files.emplace("mask", file("mask", "mask.png"));
+
+    nlohmann::json request = nlohmann::json::object();
+    check(lemon::populate_image_request(files, request),
+          "finds the primary image");
+    check(request.value("image_data", "") == "cHJpbWFyeQ==",
+          "encodes the primary image");
+    check(request.value("image_filename", "") == "primary.png",
+          "preserves the primary filename");
+    check(request.contains("references") && request["references"].is_array(),
+          "creates a references array");
+    check(request["references"] ==
+              nlohmann::json::array({"Zmlyc3QtcmVmZXJlbmNl",
+                                     "c2Vjb25kLXJlZmVyZW5jZQ=="}),
+          "encodes image-prefixed extras in order");
+
+    httplib::FormFiles array_files;
+    array_files.emplace("image[]", file("primary", "primary.png"));
+    array_files.emplace("image[]", file("reference", "reference.png"));
+    request = nlohmann::json::object();
+    check(lemon::populate_image_request(array_files, request),
+          "finds an image array primary");
+    check(request["references"] ==
+              nlohmann::json::array({"cmVmZXJlbmNl"}),
+          "preserves extra image array files");
+
+    if (failures == 0) {
+        std::printf("All image multipart tests passed\n");
+    }
+    return failures == 0 ? 0 : 1;
+}

--- a/test/cpp/test_llamacpp_sycl_default_backend.cpp
+++ b/test/cpp/test_llamacpp_sycl_default_backend.cpp
@@ -1,0 +1,143 @@
+// Regression coverage for llamacpp SYCL default-backend selection when the
+// configured backend has no user-provided binary.
+
+#include <algorithm>
+#include <chrono>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <utility>
+
+#include <lemon/config_file.h>
+#include <lemon/runtime_config.h>
+#include <lemon/system_info.h>
+
+namespace fs = std::filesystem;
+using lemon::json;
+
+namespace {
+
+int failures = 0;
+
+void check(bool condition, const std::string& message) {
+    if (condition) {
+        std::cout << "[ok] " << message << std::endl;
+    } else {
+        std::cerr << "[FAIL] " << message << std::endl;
+        ++failures;
+    }
+}
+
+#ifdef __linux__
+
+class ScopedRuntimeConfig {
+public:
+    explicit ScopedRuntimeConfig(lemon::RuntimeConfig* config)
+        : previous_(lemon::RuntimeConfig::global()) {
+        lemon::RuntimeConfig::set_global(config);
+    }
+
+    ~ScopedRuntimeConfig() {
+        lemon::RuntimeConfig::set_global(previous_);
+    }
+
+private:
+    lemon::RuntimeConfig* previous_;
+};
+
+class TestSystemInfo final : public lemon::SystemInfo {
+public:
+    lemon::CPUInfo get_cpu_device() override { return {}; }
+    lemon::GPUInfo get_amd_igpu_device() override { return {}; }
+    std::vector<lemon::GPUInfo> get_amd_dgpu_devices() override { return {}; }
+    std::vector<lemon::GPUInfo> get_nvidia_gpu_devices() override { return {}; }
+    lemon::NPUInfo get_npu_device() override { return {}; }
+};
+
+std::string test_cpu_family() {
+#if defined(__aarch64__)
+    return "arm64";
+#else
+    return "x86_64";
+#endif
+}
+
+json test_devices_with_intel_gpu() {
+    return {
+        {"cpu",
+         {
+             {"name", "Test CPU"},
+             {"available", true},
+             {"family", test_cpu_family()},
+         }},
+        {"intel_gpu",
+         json::array({
+             {
+                 {"name", "Intel Arc Pro B70"},
+                 {"available", true},
+                 {"family", "xe"},
+                 {"device_id", "0xe223"},
+                 {"pci", "0000:03:00.0"},
+             },
+         })},
+    };
+}
+
+json build_recipes(TestSystemInfo& system_info, const std::string& configured_backend) {
+    json config_json = lemon::ConfigFile::base_defaults();
+    config_json["llamacpp"]["backend"] = configured_backend;
+    lemon::RuntimeConfig config(config_json);
+    ScopedRuntimeConfig config_scope(&config);
+    return system_info.build_recipes_info(test_devices_with_intel_gpu());
+}
+
+#endif  // __linux__
+
+}  // namespace
+
+int main() {
+#ifndef __linux__
+    std::cout << "llamacpp SYCL default-backend tests are Linux-only; skipped."
+              << std::endl;
+    return 0;
+#else
+    TestSystemInfo system_info;
+    const json recipes = build_recipes(system_info, "sycl");
+
+    check(recipes.contains("llamacpp"), "llamacpp recipe exists");
+    if (!recipes.contains("llamacpp")) {
+        return failures == 0 ? 0 : 1;
+    }
+
+    const auto& backends = recipes["llamacpp"]["backends"];
+    check(backends.contains("sycl"), "sycl backend is surfaced");
+    if (backends.contains("sycl")) {
+        check(backends["sycl"].value("state", "") == "not_installed",
+              "missing SYCL binary reports not_installed");
+    }
+
+    const std::string default_backend =
+        recipes["llamacpp"].value("default_backend", "");
+    check(default_backend != "sycl",
+          "configured sycl without binary does not become default_backend");
+    check(!default_backend.empty(),
+          "default_backend falls back when configured sycl is unavailable");
+
+    const auto supported = lemon::SystemInfo::get_supported_backends("llamacpp");
+    const bool sycl_listed =
+        std::find(supported.backends.begin(), supported.backends.end(), "sycl")
+        != supported.backends.end();
+    check(!sycl_listed,
+          "get_supported_backends omits not_installed sycl");
+
+    if (failures != 0) {
+        std::cerr << "Total failures: " << failures << std::endl;
+        return 1;
+    }
+
+    std::cout << "All llamacpp SYCL default-backend tests passed!" << std::endl;
+    return 0;
+#endif
+}

--- a/test/cpp/test_system_info_helpers.cpp
+++ b/test/cpp/test_system_info_helpers.cpp
@@ -133,6 +133,14 @@ static bool expect_device_memory(const char* name,
 
 static bool test_intel_pci_and_vram() {
     bool pass = true;
+    pass &= expect_bool(
+        "not-installed backend is excluded from automatic defaults",
+        lemon::system_info_detail::backend_state_can_be_default("not_installed"),
+        false);
+    pass &= expect_bool(
+        "installable backend remains eligible for automatic defaults",
+        lemon::system_info_detail::backend_state_can_be_default("installable"),
+        true);
     pass &= expect_bool("display class 0x030000",
         lemon::system_info_detail::intel_pci_is_display("0x030000"), true);
     pass &= expect_bool("3d class 0x038000",
@@ -234,6 +242,17 @@ static bool test_intel_pci_and_vram() {
     pass &= expect_bool(
         "xpu-smi ratio 0.25",
         std::abs(lemon::system_info_detail::xpu_smi_vram_usage_ratio(smi) - 0.25) < 1e-9,
+        true);
+    const char* smi_with_rounded_utilization =
+        "GPU Memory Util (%)   33\n"
+        "GPU Memory Used (MiB) 8192\n"
+        "GPU Memory Total (MiB) 32768\n";
+    pass &= expect_bool(
+        "xpu-smi used and total override rounded utilization",
+        std::abs(lemon::system_info_detail::xpu_smi_vram_usage_ratio(
+                     smi_with_rounded_utilization) -
+                 0.25) <
+            1e-9,
         true);
     const char* smi_b70 =
         "+-----------------------------+--------------------------------------------------------------------+\n"

--- a/test/cpp/test_system_info_helpers.cpp
+++ b/test/cpp/test_system_info_helpers.cpp
@@ -200,6 +200,14 @@ static bool test_intel_pci_and_vram() {
         "empty mm is -1",
         lemon::system_info_detail::xe_vram_usage_ratio_from_mm("") < 0.0,
         true);
+    const char* mm_no_usage =
+        "         vram0_mm:\n"
+        "                 name: vram0\n"
+        "                 size: 34359738368\n";
+    pass &= expect_bool(
+        "mm without usage is -1",
+        lemon::system_info_detail::xe_vram_usage_ratio_from_mm(mm_no_usage) < 0.0,
+        true);
 
     const char* smi =
         "GPU Utilization (%)    12\n"
@@ -208,6 +216,13 @@ static bool test_intel_pci_and_vram() {
     pass &= expect_bool(
         "xpu-smi ratio 0.25",
         std::abs(lemon::system_info_detail::xpu_smi_vram_usage_ratio(smi) - 0.25) < 1e-9,
+        true);
+    const char* smi_nonnumeric =
+        "GPU Memory Used (MiB)  n/a\n"
+        "GPU Memory Total (MiB) unknown\n";
+    pass &= expect_bool(
+        "xpu-smi nonnumeric memory is -1",
+        lemon::system_info_detail::xpu_smi_vram_usage_ratio(smi_nonnumeric) < 0.0,
         true);
     return pass;
 }

--- a/test/cpp/test_system_info_helpers.cpp
+++ b/test/cpp/test_system_info_helpers.cpp
@@ -12,6 +12,7 @@
 #include <filesystem>
 #include <fstream>
 #include <set>
+#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>
@@ -128,6 +129,87 @@ static bool expect_device_memory(const char* name,
                     static_cast<unsigned long long>(expected_total));
     }
     return ok;
+}
+
+static bool test_intel_pci_and_vram() {
+    bool pass = true;
+    pass &= expect_bool("display class 0x030000",
+        lemon::system_info_detail::intel_pci_is_display("0x030000"), true);
+    pass &= expect_bool("3d class 0x038000",
+        lemon::system_info_detail::intel_pci_is_display("0x038000"), true);
+    pass &= expect_bool("non-display class 0x020000",
+        lemon::system_info_detail::intel_pci_is_display("0x020000"), false);
+
+    fs::path root = fs::temp_directory_path() / "lemonade_intel_pci";
+    fs::remove_all(root);
+    fs::path b70 = root / "0000:03:00.0";
+    fs::create_directories(b70);
+    {
+        std::ofstream(b70 / "vendor") << "0x8086\n";
+        std::ofstream(b70 / "device") << "0xe223\n";
+        std::ofstream(b70 / "class") << "0x038000\n";
+        std::ofstream(b70 / "uevent") << "DRIVER=xe\n";
+        fs::create_symlink("../../../bus/pci/drivers/xe", b70 / "driver");
+    }
+    fs::path igpu = root / "0000:00:02.0";
+    fs::create_directories(igpu);
+    {
+        std::ofstream(igpu / "vendor") << "0x8086\n";
+        std::ofstream(igpu / "device") << "0x4680\n";
+        std::ofstream(igpu / "class") << "0x030000\n";
+        std::ofstream(igpu / "uevent") << "DRIVER=i915\n";
+        fs::create_symlink("../../../bus/pci/drivers/i915", igpu / "driver");
+    }
+    fs::path nic = root / "0000:04:00.0";
+    fs::create_directories(nic);
+    {
+        std::ofstream(nic / "vendor") << "0x8086\n";
+        std::ofstream(nic / "device") << "0x15f2\n";
+        std::ofstream(nic / "class") << "0x020000\n";
+    }
+    fs::path nvidia = root / "0000:01:00.0";
+    fs::create_directories(nvidia);
+    {
+        std::ofstream(nvidia / "vendor") << "0x10de\n";
+        std::ofstream(nvidia / "device") << "0x2204\n";
+        std::ofstream(nvidia / "class") << "0x030000\n";
+    }
+
+    auto gpus = lemon::system_info_detail::intel_pci_devices_from_sysfs(root);
+    pass &= expect_bool("two intel display functions", gpus.size() == 2, true);
+    bool saw_b70 = false;
+    bool saw_igpu = false;
+    for (const auto& d : gpus) {
+        if (d.device_id == "0xe223" && d.driver == "xe") saw_b70 = true;
+        if (d.device_id == "0x4680" && d.driver == "i915") saw_igpu = true;
+    }
+    pass &= expect_bool("found B70 xe", saw_b70, true);
+    pass &= expect_bool("found iGPU i915", saw_igpu, true);
+    fs::remove_all(root);
+
+    const char* mm =
+        "         vram0_mm:\n"
+        "                 name: vram0\n"
+        "                 size: 34359738368\n"
+        "                usage: 8589934592\n";
+    pass &= expect_bool(
+        "vram0_mm ratio 0.25",
+        std::abs(lemon::system_info_detail::xe_vram_usage_ratio_from_mm(mm) - 0.25) < 1e-9,
+        true);
+    pass &= expect_bool(
+        "empty mm is -1",
+        lemon::system_info_detail::xe_vram_usage_ratio_from_mm("") < 0.0,
+        true);
+
+    const char* smi =
+        "GPU Utilization (%)    12\n"
+        "GPU Memory Used (MiB)  8192\n"
+        "GPU Memory Total (MiB) 32768\n";
+    pass &= expect_bool(
+        "xpu-smi ratio 0.25",
+        std::abs(lemon::system_info_detail::xpu_smi_vram_usage_ratio(smi) - 0.25) < 1e-9,
+        true);
+    return pass;
 }
 
 int main() {
@@ -338,6 +420,8 @@ int main() {
             "an empty topology goes unreported",
             sysfs, "gfx1151", false);
     }
+
+    failures += !test_intel_pci_and_vram();
 
     std::printf("\n%d failures\n", failures);
     return failures == 0 ? 0 : 1;

--- a/test/cpp/test_system_info_helpers.cpp
+++ b/test/cpp/test_system_info_helpers.cpp
@@ -138,6 +138,18 @@ static bool test_intel_pci_and_vram() {
         lemon::system_info_detail::backend_state_can_be_default("not_installed"),
         false);
     pass &= expect_bool(
+        "unsupported backend is excluded from automatic defaults",
+        lemon::system_info_detail::backend_state_can_be_default("unsupported"),
+        false);
+    pass &= expect_bool(
+        "not-installed backend is excluded from supported backends",
+        lemon::system_info_detail::backend_state_is_supported("not_installed"),
+        false);
+    pass &= expect_bool(
+        "installable backend is supported for selection",
+        lemon::system_info_detail::backend_state_is_supported("installable"),
+        true);
+    pass &= expect_bool(
         "installable backend remains eligible for automatic defaults",
         lemon::system_info_detail::backend_state_can_be_default("installable"),
         true);

--- a/test/cpp/test_system_info_helpers.cpp
+++ b/test/cpp/test_system_info_helpers.cpp
@@ -235,6 +235,15 @@ static bool test_intel_pci_and_vram() {
         "xpu-smi ratio 0.25",
         std::abs(lemon::system_info_detail::xpu_smi_vram_usage_ratio(smi) - 0.25) < 1e-9,
         true);
+    const char* smi_b70 =
+        "+-----------------------------+--------------------------------------------------------------------+\n"
+        "| GPU Memory Used (MiB)       | 0                                                                  |\n"
+        "| GPU Memory Util (%)         | 0                                                                  |\n"
+        "+-----------------------------+--------------------------------------------------------------------+\n";
+    pass &= expect_bool(
+        "xpu-smi B70 utilization ratio 0",
+        std::abs(lemon::system_info_detail::xpu_smi_vram_usage_ratio(smi_b70)) < 1e-9,
+        true);
     const char* smi_nonnumeric =
         "GPU Memory Used (MiB)  n/a\n"
         "GPU Memory Total (MiB) unknown\n";

--- a/test/cpp/test_system_info_helpers.cpp
+++ b/test/cpp/test_system_info_helpers.cpp
@@ -208,6 +208,24 @@ static bool test_intel_pci_and_vram() {
         "mm without usage is -1",
         lemon::system_info_detail::xe_vram_usage_ratio_from_mm(mm_no_usage) < 0.0,
         true);
+    const char* mm_negative_usage =
+        "         vram0_mm:\n"
+        "                 name: vram0\n"
+        "                 size: 34359738368\n"
+        "                usage: -1\n";
+    pass &= expect_bool(
+        "mm negative usage is -1",
+        lemon::system_info_detail::xe_vram_usage_ratio_from_mm(mm_negative_usage) < 0.0,
+        true);
+    const char* mm_nonnumeric_usage =
+        "         vram0_mm:\n"
+        "                 name: vram0\n"
+        "                 size: 34359738368\n"
+        "                usage: n/a\n";
+    pass &= expect_bool(
+        "mm nonnumeric usage is -1",
+        lemon::system_info_detail::xe_vram_usage_ratio_from_mm(mm_nonnumeric_usage) < 0.0,
+        true);
 
     const char* smi =
         "GPU Utilization (%)    12\n"
@@ -223,6 +241,20 @@ static bool test_intel_pci_and_vram() {
     pass &= expect_bool(
         "xpu-smi nonnumeric memory is -1",
         lemon::system_info_detail::xpu_smi_vram_usage_ratio(smi_nonnumeric) < 0.0,
+        true);
+    const char* smi_nan =
+        "GPU Memory Used (MiB)  nan\n"
+        "GPU Memory Total (MiB) 32768\n";
+    pass &= expect_bool(
+        "xpu-smi nan memory used is -1",
+        lemon::system_info_detail::xpu_smi_vram_usage_ratio(smi_nan) < 0.0,
+        true);
+    const char* smi_inf =
+        "GPU Memory Used (MiB)  inf\n"
+        "GPU Memory Total (MiB) 32768\n";
+    pass &= expect_bool(
+        "xpu-smi inf memory used is -1",
+        lemon::system_info_detail::xpu_smi_vram_usage_ratio(smi_inf) < 0.0,
         true);
     return pass;
 }


### PR DESCRIPTION
## Summary

Add a first-class `llamacpp:sycl` backend so Intel Arc is detected as `intel_gpu`, llama.cpp can BYO a SYCL `llama-server` via `llamacpp.sycl_bin`, and `auto_evict` can see Arc VRAM.

Fixes #3508

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_

- CTest `SystemInfoHelpersTest` and `BackendUtilsGpuEnvTest` passed on the feature branch.
- `python docs/tools/gen_backend_boilerplate.py --check` is clean.
- Hardware smoke on Intel Arc Pro B70 (Linux `xe`, throwaway `lemond` on port 8765, production left up): `/system-info` listed discrete `intel_gpu` `0xe223`; `recipes.llamacpp.backends.sycl` was `installed`; load of an existing GGUF used `--device SYCL0` and `ONEAPI_DEVICE_SELECTOR=level_zero:0`; streaming chat returned tokens; `get_global_vram_usage_pct()` returned `0` (non-negative, not `-1`). Optional `test/server_llm.py --backend sycl` was not run (Python test deps not installed on the LXC).

## Documentation

- [ ] Documentation is not affected by this change.
- [x] Documentation is affected and has been updated.
- [ ] Documentation is affected but will be handled in a separate PR or issue.

## Breaking Changes

- [ ] This PR introduces breaking changes.
- [x] This PR does not introduce breaking changes.

Linux SYCL is BYO (`sycl_bin`); lemonade does not download a Vulkan zip as a fake SYCL build.

## AI-assisted contribution

- [x] I used AI tools for this PR.
- [ ] I did not use AI tools for this PR.

If AI tools were used:

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.