### PR TITLE
Use pkgconfig to find libdrm_amdgpu

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1256,10 +1256,18 @@ elseif(UNIX)
     if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
         target_link_libraries(lemonade-server-core PRIVATE
             ${CMAKE_DL_LIBS}
-            drm_amdgpu
         )
 
         if(PkgConfig_FOUND)
+            pkg_check_modules(LIBDRM QUIET libdrm_amdgpu)
+            if(LIBDRM_FOUND)
+                target_include_directories(lemonade-server-core PUBLIC ${LIBDRM_INCLUDE_DIRS})
+                target_link_directories(lemonade-server-core PUBLIC ${LIBDRM_LIBRARY_DIRS})
+                target_link_libraries(lemonade-server-core PUBLIC ${LIBDRM_LIBRARIES})
+                message(STATUS "libdrm_amdgpu found")
+            else()
+                message(FATAL_ERROR "libdrm_amdgpu not found - required for lemonade-server-core!")
+            endif()
             pkg_check_modules(LIBCAP QUIET libcap)
             if(LIBCAP_FOUND)
                 target_include_directories(lemonade-server-core PUBLIC ${LIBCAP_INCLUDE_DIRS})


### PR DESCRIPTION
## Summary

For systems with none standard locations for libdrm, the include/library paths may be different, so set them with pkgconfig.

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_

* Built with PKG_CONFIG_PATH set to non-standard libdrm locations
* Verified build worked, checked binary with `ldd` to ensure linkage
* Built without PKG_CONFIG_PATH set to test error condition
* Tested lemond on target

## Documentation

<!-- Select ONE of the following -->

- [x] Documentation is not affected by this change.
- [ ] Documentation is affected and has been updated.
- [ ] Documentation is affected but will be handled in a separate PR or issue.

## Breaking Changes

- [ ] This PR introduces breaking changes.
- [x] This PR does not introduce breaking changes.

<!-- If breaking changes, describe them and migration path -->

## AI-assisted contribution

Please select one:

- [ ] I used AI tools for this PR.
- [x] I did not use AI tools for this PR.