### PR TITLE
fix(models): persist cost metadata through user-model registration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2847,6 +2847,23 @@ if(BUILD_TESTING AND EXISTS "${_MODEL_MANAGER_COLLECTION_VALIDATION_TEST_SRC}")
     add_cpp_ci_test(ModelManagerCollectionValidationTest CI ON COMMAND test_model_manager_collection_validation)
 endif()
 
+# Cost/latency hints must survive user-model registration: they travel in
+# ModelInfo::extras, so a key missing from USER_DEFINED_MODEL_PROPS is dropped
+# silently and the router prices the model as free.
+set(_MODEL_MANAGER_COST_PROPS_TEST_SRC
+    "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_model_manager_cost_props.cpp"
+)
+if(BUILD_TESTING AND EXISTS "${_MODEL_MANAGER_COST_PROPS_TEST_SRC}")
+    add_executable(test_model_manager_cost_props
+        test/cpp/test_model_manager_cost_props.cpp
+    )
+    target_link_libraries(test_model_manager_cost_props PRIVATE lemonade-server-core)
+    add_dependencies(test_model_manager_cost_props copy_resources)
+
+    include(CTest)
+    add_cpp_ci_test(ModelManagerCostPropsTest CI ON COMMAND test_model_manager_cost_props)
+endif()
+
 set(_EXTRA_MODEL_DISCOVERY_TEST_SRC
     "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_extra_model_discovery.cpp"
 )

--- a/docs/guide/configuration/custom-models.md
+++ b/docs/guide/configuration/custom-models.md
@@ -386,6 +386,10 @@ This file contains a JSON object where each key is a model name and each value d
 | `size` | No | Number | Model size in GB. Informational only — displayed in the UI and used for RAM filtering. |
 | `mmproj` | No | String | Filename of the multimodal projector file for llamacpp vision models (must be in the same registry repo as the checkpoint). This is a **top-level field**, not inside `checkpoints`. |
 | `image_defaults` | No | Object | Default image generation parameters for `sd-cpp` models. See [Image defaults](#image-defaults). |
+| `cost_tier` | No | String | Coarse price band for cost-aware routing: `free`, `low`, `medium` or `high`. Any other value is ignored when a routing decision is resolved. See [Cost metadata](#cost-metadata). |
+| `cost_input_per_million` | No | Number | Price per million input tokens. Negative values are ignored. |
+| `cost_output_per_million` | No | Number | Price per million output tokens. Negative values are ignored. |
+| `latency_ms_hint` | No | Number | Expected time-to-first-token in milliseconds, for policies that weigh latency. Negative values are ignored. |
 
 \* Either `checkpoint` or `checkpoints` is required, but not both.
 \*\* Required only when `recipe: "collection.omni"`. Collections do not use `checkpoint`/`checkpoints`.
@@ -461,6 +465,34 @@ For `sd-cpp` recipe models, you can specify default image generation parameters:
     }
 }
 ```
+
+### Cost metadata
+
+A `collection.router` policy can route on price — see the `cost` classifier and
+the `cost_select` routing mode in the [API reference](../../api/openai.md). Those
+read four optional fields off each candidate model:
+
+```json
+{
+  "user.Qwen3-8B-GGUF": {
+    "checkpoint": "unsloth/Qwen3-8B-GGUF:Q4_K_M",
+    "recipe": "llamacpp",
+    "cost_tier": "free",
+    "cost_input_per_million": 0.0,
+    "cost_output_per_million": 0.0,
+    "latency_ms_hint": 90
+  }
+}
+```
+
+Local models are usually free to run, so the useful case is mixing local and
+cloud candidates in one policy: give the local models `cost_tier: "free"` and
+let the cloud provider's discovered prices stand, so a cost-aware rule can
+prefer local until a request genuinely needs the stronger remote model.
+
+Cloud models get their prices from provider discovery and need none of this.
+Values that cannot be used — an unrecognized `cost_tier`, a negative price — are
+ignored when the decision is resolved rather than rejected at registration.
 
 ### Model naming
 

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -118,7 +118,12 @@ static const std::vector<std::string> USER_DEFINED_MODEL_PROPS = std::vector<std
     "checkpoints", "checkpoint", "recipe", "mmproj", "size",
     "image_defaults", "audio_defaults", "components", "recipe_options",
     "routing", "system_prompt", "version", "source", "registry_source",
-    "auto_update"
+    "auto_update",
+    // Cost and latency hints reach the router through ModelInfo::extras rather
+    // than a typed field, so they are deliberately absent from parse_extras'
+    // known-key set and must be listed here to survive registration.
+    "cost_tier", "cost_input_per_million", "cost_output_per_million",
+    "latency_ms_hint"
 };
 
 static std::string visible_extra_variant_name(const lemon::GgufVariant& variant) {

--- a/test/cpp/test_model_manager_cost_props.cpp
+++ b/test/cpp/test_model_manager_cost_props.cpp
@@ -1,0 +1,134 @@
+// Cost and latency hints must survive user-model registration. They reach the
+// router through ModelInfo::extras rather than a typed field, so a key missing
+// from USER_DEFINED_MODEL_PROPS is dropped silently at registration and
+// cost_select then ranks the model as having no price at all.
+
+#include "lemon/model_manager.h"
+#include "lemon/routing_classifier_services.h"
+#include "lemon/utils/path_utils.h"
+
+#include <chrono>
+#include <cstdio>
+#include <filesystem>
+#include <string>
+
+namespace fs = std::filesystem;
+using lemon::ModelManager;
+using lemon::json;
+
+static int g_failures = 0;
+
+static void check(const char* name, bool ok) {
+    std::printf("[%s] %s\n", ok ? "PASS" : "FAIL", name);
+    if (!ok) ++g_failures;
+}
+
+static bool near(double a, double b) {
+    return a > b - 1e-9 && a < b + 1e-9;
+}
+
+static fs::path make_temp_dir() {
+    fs::path dir = fs::temp_directory_path();
+    dir /= "model_manager_cost_props_" +
+           std::to_string(std::chrono::steady_clock::now().time_since_epoch().count());
+    fs::create_directories(dir);
+    return dir;
+}
+
+static json priced_model(const std::string& name) {
+    return json{
+        {"model_name", name},
+        {"recipe", "llamacpp"},
+        {"checkpoint", "example/" + name + ":Q4_K_M"},
+        {"cost_tier", "low"},
+        {"cost_input_per_million", 0.25},
+        {"cost_output_per_million", 1.5},
+        {"latency_ms_hint", 120.0},
+    };
+}
+
+static void test_registration_preserves_cost_props(ModelManager& manager) {
+    json doc = priced_model("user.PricedModel");
+    manager.register_user_model("user.PricedModel", doc, "test");
+
+    lemon::ModelInfo info = manager.get_model_info_unfiltered("user.PricedModel");
+    const auto& e = info.extras;
+
+    check("cost_tier survives registration",
+          e.count("cost_tier") && e.at("cost_tier") == "low");
+    check("cost_input_per_million survives registration",
+          e.count("cost_input_per_million") &&
+          near(e.at("cost_input_per_million").get<double>(), 0.25));
+    check("cost_output_per_million survives registration",
+          e.count("cost_output_per_million") &&
+          near(e.at("cost_output_per_million").get<double>(), 1.5));
+    check("latency_ms_hint survives registration",
+          e.count("latency_ms_hint") &&
+          near(e.at("latency_ms_hint").get<double>(), 120.0));
+}
+
+// The whole point of persisting the keys: the router has to be able to read a
+// price back out of a model the user registered through the API.
+static void test_router_resolves_registered_cost(ModelManager& manager) {
+    lemon::ModelInfo info = manager.get_model_info_unfiltered("user.PricedModel");
+    lemon::CostInfo cost = lemon::resolve_cost_info(
+        info.cost_input_per_million >= 0.0
+            ? std::optional<double>{info.cost_input_per_million}
+            : std::nullopt,
+        info.cost_output_per_million >= 0.0
+            ? std::optional<double>{info.cost_output_per_million}
+            : std::nullopt,
+        info.extras);
+
+    check("router resolves a registered model's cost tier",
+          cost.cost_tier.has_value() && *cost.cost_tier == "low");
+    check("router resolves a registered model's input price",
+          cost.cost_input_per_million.has_value() &&
+          near(*cost.cost_input_per_million, 0.25));
+    check("router resolves a registered model's output price",
+          cost.cost_output_per_million.has_value() &&
+          near(*cost.cost_output_per_million, 1.5));
+    check("router resolves a registered model's latency hint",
+          cost.latency_ms_hint.has_value() && near(*cost.latency_ms_hint, 120.0));
+}
+
+// Values the read side already refuses are still persisted verbatim; they are
+// filtered when resolved, not at registration. Pinning that so a future change
+// to either side is a deliberate one.
+static void test_unusable_values_are_dropped_on_read(ModelManager& manager) {
+    json doc = priced_model("user.BadlyPricedModel");
+    doc["cost_tier"] = "cheapish";
+    doc["cost_input_per_million"] = -3.0;
+    manager.register_user_model("user.BadlyPricedModel", doc, "test");
+
+    lemon::ModelInfo info = manager.get_model_info_unfiltered("user.BadlyPricedModel");
+    lemon::CostInfo cost =
+        lemon::resolve_cost_info(std::nullopt, std::nullopt, info.extras);
+
+    check("an unrecognized cost_tier resolves to no tier",
+          !cost.cost_tier.has_value());
+    check("a negative input price resolves to no price",
+          !cost.cost_input_per_million.has_value());
+    check("a valid sibling price still resolves",
+          cost.cost_output_per_million.has_value() &&
+          near(*cost.cost_output_per_million, 1.5));
+}
+
+int main() {
+    fs::path temp = make_temp_dir();
+    lemon::utils::set_cache_dir(temp.string());
+
+    ModelManager manager;
+    test_registration_preserves_cost_props(manager);
+    test_router_resolves_registered_cost(manager);
+    test_unusable_values_are_dropped_on_read(manager);
+
+    fs::remove_all(temp);
+
+    if (g_failures == 0) {
+        std::printf("All model manager cost prop tests passed.\n");
+    } else {
+        std::printf("%d model manager cost prop test(s) failed.\n", g_failures);
+    }
+    return g_failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

`resolve_cost_info` reads `cost_tier`, `cost_input_per_million`,
`cost_output_per_million` and `latency_ms_hint` out of `ModelInfo::extras`, and
`parse_extras` routes any model-JSON key outside `kKnownKeys` there. So all four
already work for a model shipped in `server_models.json`, or hand-written into
`user_models.json`.

They do not work through the API. `USER_DEFINED_MODEL_PROPS`
(`model_manager.cpp:117`) is the allowlist for what `POST /pull` persists and
named none of them, so they were dropped without a diagnostic and `cost_select`
ranked the model as having no price at all. Cost reporting (#2763) and
`cost_select` (#3100) both exist, but there was no supported way to give a
locally registered model the prices they rank on.

Adding the four keys to that allowlist is the whole fix. It is sufficient
because the user-model branch of `build_cache` runs `parse_extras` over the
persisted entry, so they reach `extras` on load exactly as a built-in model's
do — no new plumbing, and the read side is untouched.

`latency_ms_hint` is included because it travels the same path and had the
identical gap; fixing only the three cost keys would have left it broken.

## Scope

Four keys and a comment in `model_manager.cpp`, one new test, its CMake wiring,
and docs.

Values the router cannot use — an unrecognized `cost_tier`, a negative price —
are still filtered when the decision is resolved rather than refused at
registration. That keeps user models on the same footing as the
`server_models.json` entries taking the same code path; making registration
stricter than the built-in catalog seemed like a separate decision, so it is
left out and pinned by a test instead.

## Testing

`ctest -L cpp-ci` 65/67 on Windows/MSVC. The two failures — `RecipeHidingTest`
and `LogRotationTest` — are pre-existing and host-specific, confirmed by
stashing this change and re-running them on unmodified `main`. `RecipeHidingTest`
reports `max model size: 17179869184.0 GB` on this box, so no recipe reaches the
memory heuristic it asserts on.

`test_model_manager_cost_props` covers registration survival for all four keys,
the end-to-end path through `resolve_cost_info`, and the two negative cases.
With the allowlist change reverted it fails 9 of 11, so it does catch the bug
rather than passing either way.

`check_comment_slop.py`, whitespace and `gen_backend_boilerplate.py --check`
clean.

## Documentation

`docs/guide/configuration/custom-models.md` — four rows in the Fields table plus
a **Cost metadata** section. It previously mentioned cost nowhere. The section
notes the case that motivates the fields at all: local models are free to run,
so the useful configuration is mixing local and cloud candidates in one policy —
mark the local ones `cost_tier: "free"` and let provider discovery price the
cloud ones, so a rule can prefer local until a request needs the remote model.

## Breaking Changes

None. Four additions to an allowlist; previously these keys were silently
discarded, so nothing depended on that.

## AI-assisted contribution

Yes.