### PR TITLE
docs: clarify Fedora FLM beta setup

### DIFF
--- a/docs/guide/install/fedora.md
+++ b/docs/guide/install/fedora.md
@@ -33,3 +33,38 @@ sudo systemctl --no-pager status lemond
 ```
 
 Once the service is running, open [http://localhost:13305](http://localhost:13305) in your browser.
+
+
+## Linux FLM/NPU beta notes
+
+The Linux FLM/NPU backend is currently beta. Before starting `lemond`, make sure the runtime libraries and model configuration are visible to the service.
+
+For an interactive test, export the variables in the shell that launches the server:
+
+```bash
+export LEMONADE_FLM_LINUX_BETA=1
+export LD_LIBRARY_PATH=/path/to/fastflowlm/lib:/path/to/xrt/lib
+export FLM_CONFIG_PATH=/path/to/model_list.json
+lemond
+```
+
+For a systemd installation, put the same settings in an override instead of relying on a shell profile:
+
+```ini
+# sudo systemctl edit lemond
+[Service]
+Environment=LEMONADE_FLM_LINUX_BETA=1
+Environment=LD_LIBRARY_PATH=/path/to/fastflowlm/lib:/path/to/xrt/lib
+Environment=FLM_CONFIG_PATH=/path/to/model_list.json
+LimitMEMLOCK=infinity
+```
+
+Apply the override and inspect the service log:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl restart lemond
+sudo journalctl -u lemond -n 100 --no-pager
+```
+
+The beta path and its environment names may change as support matures. If startup fails, verify the library paths, model-list path, device/runtime versions, and the `journalctl` output when reporting the issue.


### PR DESCRIPTION
This keeps the Fedora installation guide focused while documenting the Linux FLM/NPU beta boundary, the environment needed by interactive and systemd launches, and basic service-log validation. It addresses the setup gap described in #1315.