### PR TITLE
models: add K2-Horizon llama.cpp catalog entries

### DIFF
--- a/src/cpp/resources/server_models.json
+++ b/src/cpp/resources/server_models.json
@@ -1228,6 +1228,62 @@
         ],
         "size": 5.16
     },
+    "K2-Horizon-0.9B-GGUF": {
+        "checkpoint": "IFM/K2-Horizon-0.9B-GGUF:K2-Horizon-1B-BF16.gguf",
+        "recipe": "llamacpp",
+        "suggested": true,
+        "labels": [
+            "chat",
+            "reasoning",
+            "tool-calling",
+            "hot"
+        ],
+        "size": 2.16
+    },
+    "K2-Horizon-3.7B-GGUF": {
+        "checkpoint": "IFM/K2-Horizon-3.7B-GGUF:K2-Horizon-4B-BF16.gguf",
+        "recipe": "llamacpp",
+        "suggested": true,
+        "labels": [
+            "chat",
+            "reasoning",
+            "tool-calling"
+        ],
+        "size": 10.13
+    },
+    "K2-Horizon-7B-GGUF": {
+        "checkpoint": "IFM/K2-Horizon-7B-GGUF:K2-Horizon-7B-BF16.gguf",
+        "recipe": "llamacpp",
+        "suggested": true,
+        "labels": [
+            "chat",
+            "reasoning",
+            "tool-calling"
+        ],
+        "size": 18.01
+    },
+    "K2-Horizon-32B-GGUF": {
+        "checkpoint": "IFM/K2-Horizon-32B-GGUF:K2-Horizon-32B-BF16.gguf",
+        "recipe": "llamacpp",
+        "suggested": false,
+        "labels": [
+            "chat",
+            "reasoning",
+            "tool-calling"
+        ],
+        "size": 69.57
+    },
+    "K2-Horizon-MoVA-36B-A4B-GGUF": {
+        "checkpoint": "IFM/K2-Horizon-MoVA-36B-A4B-GGUF:K2-Horizon-36B-BF16.gguf",
+        "recipe": "llamacpp",
+        "suggested": false,
+        "labels": [
+            "chat",
+            "reasoning",
+            "tool-calling"
+        ],
+        "size": 74.92
+    },
     "PromptBridge-0.6b-Alpha-GGUF": {
         "checkpoint": "mradermacher/PromptBridge-0.6b-Alpha-GGUF:PromptBridge-0.6b-Alpha.Q4_K_M.gguf",
         "recipe": "llamacpp",


### PR DESCRIPTION
## Summary

Add IFM K2-Horizon BF16 GGUF models to the llama.cpp catalog.

- [0.9B](https://huggingface.co/IFM/K2-Horizon-0.9B-GGUF)
- [3.7B](https://huggingface.co/IFM/K2-Horizon-3.7B-GGUF)
- [7B](https://huggingface.co/IFM/K2-Horizon-7B-GGUF)
- [32B Stage1](https://huggingface.co/IFM/K2-Horizon-32B-GGUF)
- [MoVA-36B-A4B](https://huggingface.co/IFM/K2-Horizon-MoVA-36B-A4B-GGUF)

See [IFM K2 Horizon](https://ifm.ai/blog/k2/). Draft: merge only after Lemonade-managed llama.cpp supports K2 and returns structured reasoning and tool calls.

## Scope

- [x] One catalog change only.
- [x] No unrelated changes.

## Testing

- [x] `pre-commit run --files src/cpp/resources/server_models.json`
- [x] `ctest --test-dir build -R ^BackendModeContractTest --output-on-failure`

## Documentation

- [x] Documentation is not affected.

## Breaking Changes

- [x] No breaking changes.

## AI-assisted contribution

- [x] AI tools were used and the change was reviewed.