### PR TITLE
fix(gui): restore Effective Settings

### DIFF
--- a/src/app/package.json
+++ b/src/app/package.json
@@ -30,6 +30,7 @@
     "test:default-chat-model": "node tests/default-chat-model.runtime.cjs",
     "test:storage": "node tests/storage.runtime.cjs",
     "test:configuration-consistency": "node tests/configuration-consistency.runtime.cjs",
+    "test:effective-settings": "node tests/effective-settings.runtime.cjs",
     "test:sampler-args": "node tests/sampler-args.runtime.cjs",
     "test:directory-settings": "node tests/directory-settings.runtime.cjs",
     "test:model-list-backends": "node tests/model-list-backend-layout.runtime.cjs",

--- a/src/app/src/api.ts
+++ b/src/app/src/api.ts
@@ -120,6 +120,9 @@ function normalizeLoadedModel(model: unknown): LoadedModel | null {
   if (!isObject(model)) return null;
   const modelName = String(model.model_name || model.name || '').trim();
   if (!modelName) return null;
+  const launchCommand = Array.isArray(model.launch_command)
+    ? model.launch_command.filter((value): value is string => typeof value === 'string')
+    : [];
   return {
     model_name: modelName,
     checkpoint: String(model.checkpoint || ''),
@@ -134,6 +137,7 @@ function normalizeLoadedModel(model: unknown): LoadedModel | null {
     input_modalities: Array.isArray(model.input_modalities) ? model.input_modalities.filter((value): value is string => typeof value === 'string') : undefined,
     output_modalities: Array.isArray(model.output_modalities) ? model.output_modalities.filter((value): value is string => typeof value === 'string') : undefined,
     recipe_options: isObject(model.recipe_options) ? model.recipe_options : undefined,
+    launch_command: launchCommand.length > 0 ? launchCommand : undefined,
     pinned: typeof model.pinned === 'boolean' ? model.pinned : undefined,
   };
 }
@@ -227,6 +231,7 @@ export interface LoadedModel {
   input_modalities?: string[];
   output_modalities?: string[];
   recipe_options?: Record<string, unknown>;
+  launch_command?: string[];
   pinned?: boolean;
 }
 
@@ -239,15 +244,6 @@ export interface ModelOptions {
   defaults: Record<string, unknown>;
   resolved_ctx_size: number;
   load_command: string;
-}
-
-export interface EffectiveLoadCommand {
-  model_name: string;
-  recipe: string;
-  backend: string;
-  options: Record<string, unknown>;
-  args: string[];
-  ctx_size_auto_resolved?: boolean;
 }
 
 export interface ModelInfo {
@@ -1432,13 +1428,6 @@ class LemonadeAPI {
     const result = await this._json('/api/v1/load', { method: 'POST', body });
     this._notifyModelsChanged();
     return result;
-  }
-
-  async effectiveLoadCommand(modelName: string, recipeOptions?: Record<string, unknown>, modelInfo?: ModelInfo | null): Promise<EffectiveLoadCommand> {
-    void modelName;
-    void recipeOptions;
-    void modelInfo;
-    throw new Error('Effective Settings is temporarily unavailable while GUI3 is synchronized with the current server API.');
   }
 
   async unloadModel(modelName?: string): Promise<unknown> {

--- a/src/app/src/components/ChatView.tsx
+++ b/src/app/src/components/ChatView.tsx
@@ -1199,6 +1199,10 @@ const ChatView: React.FC<ChatViewProps> = ({
     return loadedSnapshot || snapshotFromName(currentModel, loadedModels);
   }, [currentLoadedModel, currentCustomModelInfo, currentKnownModelInfo, currentModel, loadedModels]);
   const currentCapability = currentModelSnapshot?.capability || 'unknown';
+  const currentEffectiveSettingsModelInfo = currentKnownModelInfo || currentCustomModelInfo;
+  const canShowEffectiveSettings = !!currentModel
+    && currentCapability !== 'image'
+    && !isCollectionModel(currentEffectiveSettingsModelInfo);
   // A collection deploys as chat; its Omni surface comes from the recipe.
   const currentIsOmniCollection = snapshotIdentity(currentModelSnapshot) === 'omni';
   const currentDefaultModel = lemonadeDefaultModel(currentModel);
@@ -3754,7 +3758,7 @@ ${finalText}`
               )}
             </div>
           )}
-          {currentModel && currentCapability !== 'image' && (
+          {canShowEffectiveSettings && (
             <button
               type="button"
               className="composer__tools-toggle composer__effective-settings"
@@ -3774,19 +3778,18 @@ ${finalText}`
             <Icon name="logs" size={13} /> Logs
           </button>
         </div>
-        {currentModel && effectiveSettingsOpen && (
+        {canShowEffectiveSettings && effectiveSettingsOpen && (
           <Suspense fallback={null}>
             <EffectiveSettingsModal
               open={effectiveSettingsOpen}
               onClose={() => setEffectiveSettingsOpen(false)}
               modelName={currentModel}
-              modelInfo={currentKnownModelInfo || currentCustomModelInfo || null}
+              modelInfo={currentEffectiveSettingsModelInfo || null}
               recipe={currentRecipe}
               mcpEnabled={useMcp}
               mcpServerIds={selectedMcpServerIds}
               fallbackCtxSize={serverDefaultCtxSize}
               loadedModel={currentLoadedModel}
-              isModelLoaded={!!currentLoadedModel}
               onReload={async () => {
                 const api = await getApiClient();
                 await api.reloadModel(currentModel, undefined, currentKnownModelInfo || currentCustomModelInfo || null);

--- a/src/app/src/components/ChatView.tsx
+++ b/src/app/src/components/ChatView.tsx
@@ -11,6 +11,7 @@ import { scheduleIdleWork } from '../startupScheduler';
 
 const Model3DResult = lazy(() => import(/* webpackChunkName: "chat-model3d" */ './Model3DResult'));
 const LogViewer = lazy(() => import(/* webpackChunkName: "chat-logs" */ './LogViewer'));
+const EffectiveSettingsModal = lazy(() => import(/* webpackChunkName: "chat-effective-settings" */ './EffectiveSettingsModal'));
 const LazyMarkdownMessage = lazy(() => import(/* webpackChunkName: "markdown-renderer" */ './MarkdownMessage'));
 const MarkdownMessage: React.FC<React.ComponentProps<typeof LazyMarkdownMessage>> = props => (
   <Suspense fallback={<div className="message__content message__content--loading" aria-busy="true" />}>
@@ -957,6 +958,7 @@ const ChatView: React.FC<ChatViewProps> = ({
   const [downloadItems, setDownloadItems] = useState<DownloadListItem[]>([]);
   const downloadAvailabilityKeyRef = useRef(chatBlockingDownloadsKey(downloadItems));
   const [unloadAnnouncement, setUnloadAnnouncement] = useState('');
+  const [effectiveSettingsOpen, setEffectiveSettingsOpen] = useState(false);
   const [serverDefaultCtxSize, setServerDefaultCtxSize] = useState(DEFAULT_CONTEXT_SIZE);
   const [currentModelRecipeOptions, setCurrentModelRecipeOptions] = useState<Record<string, unknown> | null>(null);
   const chatRootRef = useRef<HTMLDivElement>(null);
@@ -3752,6 +3754,17 @@ ${finalText}`
               )}
             </div>
           )}
+          {currentModel && currentCapability !== 'image' && (
+            <button
+              type="button"
+              className="composer__tools-toggle composer__effective-settings"
+              onClick={() => setEffectiveSettingsOpen(true)}
+              title="Effective settings"
+              aria-label="Effective settings"
+            >
+              <Icon name="sliders-horizontal" size={13} />
+            </button>
+          )}
           <button
             className={`composer__tools-toggle ${showInlineLogs ? 'composer__tools-toggle--active' : ''}`}
             onClick={handleToggleInlineLogs}
@@ -3761,6 +3774,32 @@ ${finalText}`
             <Icon name="logs" size={13} /> Logs
           </button>
         </div>
+        {currentModel && effectiveSettingsOpen && (
+          <Suspense fallback={null}>
+            <EffectiveSettingsModal
+              open={effectiveSettingsOpen}
+              onClose={() => setEffectiveSettingsOpen(false)}
+              modelName={currentModel}
+              modelInfo={currentKnownModelInfo || currentCustomModelInfo || null}
+              recipe={currentRecipe}
+              mcpEnabled={useMcp}
+              mcpServerIds={selectedMcpServerIds}
+              fallbackCtxSize={serverDefaultCtxSize}
+              loadedModel={currentLoadedModel}
+              isModelLoaded={!!currentLoadedModel}
+              onReload={async () => {
+                const api = await getApiClient();
+                await api.reloadModel(currentModel, undefined, currentKnownModelInfo || currentCustomModelInfo || null);
+                await Promise.resolve(onRefresh());
+              }}
+              onLoad={async () => {
+                const api = await getApiClient();
+                await api.loadModel(currentModel, undefined, currentKnownModelInfo || currentCustomModelInfo || null);
+                await Promise.resolve(onRefresh());
+              }}
+            />
+          </Suspense>
+        )}
         {streamingToolStatus && (
           <div className="composer__tool-status">
             <span className="composer__tool-status-dot" />

--- a/src/app/src/components/EffectiveSettingsModal.tsx
+++ b/src/app/src/components/EffectiveSettingsModal.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
-import api, { type ModelInfo, type ModelOptions, type EffectiveLoadCommand, type LoadedModel, friendlyErrorMessage } from '../api';
+import api, { type ModelInfo, type ModelOptions, type LoadedModel, friendlyErrorMessage } from '../api';
 import {
   type RecipeOptions,
   type SamplingParams,
@@ -91,9 +91,8 @@ function shellQuote(token: string): string {
   return `'${token.replace(/'/g, `'\\''`)}'`;
 }
 
-function formatCommand(modelName: string, args: string[]): string {
-  const parts = ['lemonade', 'load', shellQuote(modelName), ...args.map(shellQuote)];
-  return parts.join(' ');
+function formatCommand(command: string[]): string {
+  return command.map(shellQuote).join(' ');
 }
 
 interface SourceRow {
@@ -124,15 +123,14 @@ const EffectiveSettingsModal: React.FC<EffectiveSettingsModalProps> = ({
   const argsField = backendArgsFieldForRecipe(recipe);
   const canEditArgs = backendSupportsArgs(recipe) && !!argsField;
 
-  const [effective, setEffective] = useState<EffectiveLoadCommand | null>(null);
   const [serverModelOptions, setServerModelOptions] = useState<ModelOptions | null>(null);
+  const [runtimeModel, setRuntimeModel] = useState<LoadedModel | null>(loadedModel || null);
+  const [launchCommand, setLaunchCommand] = useState<string[] | null>(loadedModel?.launch_command || null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const [unlocked, setUnlocked] = useState(false);
   const [draft, setDraft] = useState('');
-  const [preview, setPreview] = useState<EffectiveLoadCommand | null>(null);
-  const [previewError, setPreviewError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [notice, setNotice] = useState<string | null>(null);
   const [samplingDraft, setSamplingDraft] = useState<Record<keyof SamplingParams, string>>({
@@ -160,33 +158,46 @@ const EffectiveSettingsModal: React.FC<EffectiveSettingsModalProps> = ({
     if (!modelName) return;
     setLoading(true);
     setError(null);
-    try {
-      const result = await api.effectiveLoadCommand(modelName, undefined, modelInfo);
-      setEffective(result);
-      const committed = argsField ? result.options[argsField] : undefined;
+    const [healthResult, optionsResult] = await Promise.allSettled([
+      api.health(),
+      api.getModelOptions(modelName),
+    ]);
+
+    if (optionsResult.status === 'fulfilled') {
+      setServerModelOptions(optionsResult.value);
+      const committed = argsField ? optionsResult.value.effective?.[argsField] : undefined;
       setDraft(typeof committed === 'string' ? committed : '');
-      try {
-        setServerModelOptions(await api.getModelOptions(modelName));
-      } catch {
-        // The effective load command remains useful even if the auxiliary
-        // saved/default source breakdown cannot be fetched.
-        setServerModelOptions(null);
-      }
-    } catch (err) {
-      setError(friendlyErrorMessage(err));
-      setEffective(null);
+    } else {
       setServerModelOptions(null);
-    } finally {
-      setLoading(false);
+      const committed = argsField ? loadedModel?.recipe_options?.[argsField] : undefined;
+      setDraft(typeof committed === 'string' ? committed : '');
     }
-  }, [modelName, modelInfo, argsField]);
+
+    if (healthResult.status === 'rejected') {
+      setRuntimeModel(null);
+      setLaunchCommand(null);
+      setError(friendlyErrorMessage(healthResult.reason));
+    } else {
+      const target = modelName.trim().toLowerCase();
+      const running = healthResult.value.all_models_loaded.find(
+        model => model.model_name.trim().toLowerCase() === target,
+      ) || null;
+      setRuntimeModel(running);
+      setLaunchCommand(running?.launch_command || null);
+      if (!running) {
+        setError('Launch command unavailable because this model is not currently loaded.');
+      } else if (!running.launch_command?.length) {
+        setError('The server did not report a launch command for this loaded model.');
+      }
+    }
+
+    setLoading(false);
+  }, [modelName, argsField, loadedModel]);
 
   useEffect(() => {
     if (!open) return;
     setUnlocked(false);
     setNotice(null);
-    setPreview(null);
-    setPreviewError(null);
     loadEffective();
     const savedSampling = loadModelTuning(modelName)?.sampling || {};
     setSamplingDraft({
@@ -225,21 +236,6 @@ const EffectiveSettingsModal: React.FC<EffectiveSettingsModalProps> = ({
       window.clearTimeout(timeout);
     };
   }, [open, loadedModel]);
-
-  useEffect(() => {
-    if (!open || !unlocked || !argsField) { setPreview(null); return; }
-    let cancelled = false;
-    const handle = setTimeout(async () => {
-      setPreviewError(null);
-      try {
-        const result = await api.effectiveLoadCommand(modelName, { [argsField]: draft, merge_args: false }, modelInfo);
-        if (!cancelled) setPreview(result);
-      } catch (err) {
-        if (!cancelled) { setPreview(null); setPreviewError(friendlyErrorMessage(err)); }
-      }
-    }, 350);
-    return () => { cancelled = true; clearTimeout(handle); };
-  }, [open, unlocked, draft, argsField, modelName, modelInfo]);
 
   const closeRef = useRef<HTMLButtonElement>(null);
   useEffect(() => {
@@ -305,7 +301,7 @@ const EffectiveSettingsModal: React.FC<EffectiveSettingsModalProps> = ({
     }
   }, [modelName, isModelLoaded, onReload, loadEffective]);
 
-  const serverContextRaw = serverModelOptions?.effective?.ctx_size ?? effective?.options?.ctx_size;
+  const serverContextRaw = serverModelOptions?.effective?.ctx_size;
   const resolvedContextRaw = serverContextRaw ?? resolved?.tuning.recipe_options?.ctx_size;
   const autoContextSizeEnabled = isAutoContextSize(serverContextRaw);
 
@@ -323,7 +319,7 @@ const EffectiveSettingsModal: React.FC<EffectiveSettingsModalProps> = ({
       return { value: runtimeContext.toLocaleString(), source: 'Runtime' };
     }
 
-    const effectiveContext = positiveContextSize(effective?.options?.ctx_size);
+    const effectiveContext = positiveContextSize(serverModelOptions?.resolved_ctx_size);
     if (effectiveContext !== null) {
       return { value: effectiveContext.toLocaleString(), source: 'Effective load' };
     }
@@ -338,7 +334,7 @@ const EffectiveSettingsModal: React.FC<EffectiveSettingsModalProps> = ({
 
     if (loadedModel && resolvingContextSize) return { value: 'Resolving…', source: 'Runtime' };
     return { value: 'Unavailable', source: 'Configuration' };
-  }, [autoContextSizeEnabled, effective, loadedContextSize, loadedModel, resolved, resolvedContextRaw, resolvingContextSize]);
+  }, [autoContextSizeEnabled, loadedContextSize, loadedModel, resolved, resolvedContextRaw, resolvingContextSize, serverModelOptions]);
 
   const sourceRows = useMemo<SourceRow[]>(() => {
     if (!resolved && !serverModelOptions) return [];
@@ -394,8 +390,11 @@ const EffectiveSettingsModal: React.FC<EffectiveSettingsModalProps> = ({
 
   if (!open) return null;
 
-  const previewArgs = preview?.args ?? effective?.args ?? [];
-  const backendLabel = effective?.backend || '—';
+  const backend = serverModelOptions?.effective?.[`${recipe}_backend`];
+  const backendLabel = (typeof backend === 'string' && backend)
+    || runtimeModel?.recipe
+    || recipe
+    || '—';
 
   const body = (
     <div className="inspect-modal-overlay effective-settings-overlay" onClick={onClose}>
@@ -431,7 +430,7 @@ const EffectiveSettingsModal: React.FC<EffectiveSettingsModalProps> = ({
             <h5 className="effective-settings__section-title">Settings by source</h5>
             <p className="effective-settings__note">
               <Icon name="info" size={12} />
-              <span className="effective-settings__note-copy">These rows show known sources for individual settings. The <strong>Effective load command</strong> below is authoritative. It includes architecture and global defaults applied by the server that may not appear here.</span>
+              <span className="effective-settings__note-copy">These rows show known sources for individual settings. The <strong>Effective load command</strong> below is the authoritative command reported by the running server.</span>
             </p>
             <div className="effective-settings__rows">
               <div className="effective-settings__row">
@@ -520,11 +519,11 @@ const EffectiveSettingsModal: React.FC<EffectiveSettingsModalProps> = ({
             <h5 className="effective-settings__section-title"><Icon name="terminal-square" size={14} /> Effective load command</h5>
             {loading && <p className="effective-settings__empty">Resolving…</p>}
             {error && <p className="effective-settings__error">{error}</p>}
-            {!loading && !error && (
+            {!loading && !error && launchCommand && (
               <>
-                <pre className="effective-settings__command"><code>{formatCommand(modelName, previewArgs)}</code></pre>
+                <pre className="effective-settings__command"><code>{formatCommand(launchCommand)}</code></pre>
                 <p className="effective-settings__note">
-                  <Icon name="info" size={12} /> Fixed launch flags (model path, port, chat template, metrics) are added by the server at load time and are not shown here.
+                  <Icon name="info" size={12} /> This is the exact command used to start the current backend process. Argument changes appear here after the model reloads.
                 </p>
               </>
             )}
@@ -549,7 +548,6 @@ const EffectiveSettingsModal: React.FC<EffectiveSettingsModalProps> = ({
                   <p className="effective-settings__hint">
                     These raw backend arguments replace the resolved ones for the next load of this model. Session-only - nothing is written to disk, and it resets when you reload the app.
                   </p>
-                  {previewError && <p className="effective-settings__error">{previewError}</p>}
                   <div className="effective-settings__actions">
                     <WorkspaceActionButton appearance="primary" size="small" onClick={applyOverride} disabled={busy}>
                       {busy ? 'Applying…' : (isModelLoaded ? 'Apply & reload' : 'Apply for next load')}

--- a/src/app/src/components/EffectiveSettingsModal.tsx
+++ b/src/app/src/components/EffectiveSettingsModal.tsx
@@ -112,21 +112,22 @@ interface EffectiveSettingsModalProps {
   mcpServerIds: string[];
   fallbackCtxSize?: number;
   loadedModel?: LoadedModel | null;
-  isModelLoaded: boolean;
   onReload: () => Promise<void>;
   onLoad: () => Promise<void>;
 }
 
 const EffectiveSettingsModal: React.FC<EffectiveSettingsModalProps> = ({
-  open, onClose, modelName, modelInfo, recipe, mcpEnabled, mcpServerIds, fallbackCtxSize, loadedModel, isModelLoaded, onReload, onLoad,
+  open, onClose, modelName, modelInfo, recipe, mcpEnabled, mcpServerIds, fallbackCtxSize, loadedModel, onReload, onLoad,
 }) => {
   const argsField = backendArgsFieldForRecipe(recipe);
   const canEditArgs = backendSupportsArgs(recipe) && !!argsField;
 
   const [serverModelOptions, setServerModelOptions] = useState<ModelOptions | null>(null);
   const [runtimeModel, setRuntimeModel] = useState<LoadedModel | null>(loadedModel || null);
+  const [runtimeStateModelName, setRuntimeStateModelName] = useState<string | null>(null);
   const [launchCommand, setLaunchCommand] = useState<string[] | null>(loadedModel?.launch_command || null);
-  const [loading, setLoading] = useState(false);
+  const [configurationLoading, setConfigurationLoading] = useState(false);
+  const [runtimeLoading, setRuntimeLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const [unlocked, setUnlocked] = useState(false);
@@ -142,8 +143,24 @@ const EffectiveSettingsModal: React.FC<EffectiveSettingsModalProps> = ({
   });
   const [loadedContextSize, setLoadedContextSize] = useState<number | null>(null);
   const [resolvingContextSize, setResolvingContextSize] = useState(false);
+  const configurationRequestRef = useRef(0);
+  const runtimeRequestRef = useRef(0);
+  const draftRevisionRef = useRef(0);
+  const loadedModelRef = useRef<LoadedModel | null>(loadedModel || null);
+  const healthFailedRef = useRef(false);
 
   const hasOverride = !!getSessionArgsOverride(modelName);
+  const runtimeStatePending = runtimeLoading || runtimeStateModelName !== modelName;
+  const isRuntimeModelLoaded = !runtimeStatePending && !!runtimeModel;
+  const loading = configurationLoading || runtimeStatePending;
+
+  useEffect(() => {
+    loadedModelRef.current = loadedModel || null;
+    if (healthFailedRef.current) {
+      setRuntimeModel(loadedModel || null);
+      setLaunchCommand(loadedModel?.launch_command || null);
+    }
+  }, [loadedModel]);
 
   const resolved = useMemo(() => {
     if (!modelInfo || !open) return null;
@@ -154,34 +171,48 @@ const EffectiveSettingsModal: React.FC<EffectiveSettingsModalProps> = ({
     }
   }, [modelName, modelInfo, fallbackCtxSize, open]);
 
-  const loadEffective = useCallback(async () => {
+  const loadConfiguration = useCallback(async (replaceDraft: boolean) => {
     if (!modelName) return;
-    setLoading(true);
-    setError(null);
-    const [healthResult, optionsResult] = await Promise.allSettled([
-      api.health(),
-      api.getModelOptions(modelName),
-    ]);
-
-    if (optionsResult.status === 'fulfilled') {
-      setServerModelOptions(optionsResult.value);
-      const committed = argsField ? optionsResult.value.effective?.[argsField] : undefined;
-      setDraft(typeof committed === 'string' ? committed : '');
-    } else {
+    const request = ++configurationRequestRef.current;
+    const draftRevision = draftRevisionRef.current;
+    setConfigurationLoading(true);
+    try {
+      const options = await api.getModelOptions(modelName);
+      if (request !== configurationRequestRef.current) return;
+      setServerModelOptions(options);
+      if (replaceDraft && draftRevision === draftRevisionRef.current) {
+        const sessionArgs = getSessionArgsOverride(modelName)?.args;
+        const committed = sessionArgs ?? (argsField ? options.effective?.[argsField] : undefined);
+        setDraft(typeof committed === 'string' ? committed : '');
+      }
+    } catch {
+      if (request !== configurationRequestRef.current) return;
       setServerModelOptions(null);
-      const committed = argsField ? loadedModel?.recipe_options?.[argsField] : undefined;
-      setDraft(typeof committed === 'string' ? committed : '');
+      if (replaceDraft && draftRevision === draftRevisionRef.current) {
+        const sessionArgs = getSessionArgsOverride(modelName)?.args;
+        const committed = sessionArgs ?? (argsField ? loadedModelRef.current?.recipe_options?.[argsField] : undefined);
+        setDraft(typeof committed === 'string' ? committed : '');
+      }
+    } finally {
+      if (request === configurationRequestRef.current) setConfigurationLoading(false);
     }
+  }, [modelName, argsField]);
 
-    if (healthResult.status === 'rejected') {
-      setRuntimeModel(null);
-      setLaunchCommand(null);
-      setError(friendlyErrorMessage(healthResult.reason));
-    } else {
+  const refreshRuntime = useCallback(async () => {
+    if (!modelName) return;
+    const request = ++runtimeRequestRef.current;
+    setRuntimeLoading(true);
+    setRuntimeStateModelName(null);
+    setError(null);
+    try {
+      const health = await api.health();
+      if (request !== runtimeRequestRef.current) return;
       const target = modelName.trim().toLowerCase();
-      const running = healthResult.value.all_models_loaded.find(
+      const running = health.all_models_loaded.find(
         model => model.model_name.trim().toLowerCase() === target,
       ) || null;
+      healthFailedRef.current = false;
+      setRuntimeStateModelName(modelName);
       setRuntimeModel(running);
       setLaunchCommand(running?.launch_command || null);
       if (!running) {
@@ -189,16 +220,28 @@ const EffectiveSettingsModal: React.FC<EffectiveSettingsModalProps> = ({
       } else if (!running.launch_command?.length) {
         setError('The server did not report a launch command for this loaded model.');
       }
+    } catch (healthError) {
+      if (request !== runtimeRequestRef.current) return;
+      healthFailedRef.current = true;
+      const fallbackModel = loadedModelRef.current;
+      setRuntimeStateModelName(modelName);
+      setRuntimeModel(fallbackModel);
+      setLaunchCommand(fallbackModel?.launch_command || null);
+      setError(friendlyErrorMessage(healthError));
+    } finally {
+      if (request === runtimeRequestRef.current) setRuntimeLoading(false);
     }
-
-    setLoading(false);
-  }, [modelName, argsField, loadedModel]);
+  }, [modelName]);
 
   useEffect(() => {
-    if (!open) return;
+    if (!open) {
+      configurationRequestRef.current += 1;
+      return;
+    }
+    draftRevisionRef.current = 0;
     setUnlocked(false);
     setNotice(null);
-    loadEffective();
+    void loadConfiguration(true);
     const savedSampling = loadModelTuning(modelName)?.sampling || {};
     setSamplingDraft({
       temperature: savedSampling.temperature === undefined ? '' : String(savedSampling.temperature),
@@ -207,10 +250,18 @@ const EffectiveSettingsModal: React.FC<EffectiveSettingsModalProps> = ({
       min_p: savedSampling.min_p === undefined ? '' : String(savedSampling.min_p),
       repeat_penalty: savedSampling.repeat_penalty === undefined ? '' : String(savedSampling.repeat_penalty),
     });
-  }, [open, loadEffective]);
+  }, [open, modelName, loadConfiguration]);
 
   useEffect(() => {
-    if (!open || !loadedModel) {
+    if (!open) {
+      runtimeRequestRef.current += 1;
+      return;
+    }
+    void refreshRuntime();
+  }, [open, modelName, refreshRuntime]);
+
+  useEffect(() => {
+    if (!open || !runtimeModel) {
       setLoadedContextSize(null);
       setResolvingContextSize(false);
       return;
@@ -224,7 +275,7 @@ const EffectiveSettingsModal: React.FC<EffectiveSettingsModalProps> = ({
       settled = true;
       setResolvingContextSize(false);
     }, 5000);
-    void api.loadedModelContextSize(loadedModel).then(contextSize => {
+    void api.loadedModelContextSize(runtimeModel).then(contextSize => {
       if (cancelled || settled) return;
       settled = true;
       window.clearTimeout(timeout);
@@ -235,7 +286,7 @@ const EffectiveSettingsModal: React.FC<EffectiveSettingsModalProps> = ({
       cancelled = true;
       window.clearTimeout(timeout);
     };
-  }, [open, loadedModel]);
+  }, [open, runtimeModel]);
 
   const closeRef = useRef<HTMLButtonElement>(null);
   useEffect(() => {
@@ -260,7 +311,7 @@ const EffectiveSettingsModal: React.FC<EffectiveSettingsModalProps> = ({
     };
     try {
       setSessionArgsOverride(modelName, recipe, draft.trim());
-      if (isModelLoaded) {
+      if (isRuntimeModelLoaded) {
         try {
           await onReload();
         } catch (reloadErr) {
@@ -276,30 +327,36 @@ const EffectiveSettingsModal: React.FC<EffectiveSettingsModalProps> = ({
     } catch (err) {
       setNotice(friendlyErrorMessage(err));
     } finally {
-      await loadEffective();
+      await Promise.all([
+        loadConfiguration(true),
+        refreshRuntime(),
+      ]);
       setBusy(false);
     }
-  }, [argsField, modelName, recipe, draft, isModelLoaded, onReload, onLoad, loadEffective]);
+  }, [argsField, modelName, recipe, draft, isRuntimeModelLoaded, onReload, onLoad, loadConfiguration, refreshRuntime]);
 
   const resetOverride = useCallback(async () => {
     setBusy(true);
     setNotice(null);
     try {
       clearSessionArgsOverride(modelName);
-      if (isModelLoaded) {
+      if (isRuntimeModelLoaded) {
         await onReload();
         setNotice('Cleared the session override and reloaded with resolved settings.');
       } else {
         setNotice('Cleared the session override.');
       }
-      await loadEffective();
+      await Promise.all([
+        loadConfiguration(true),
+        refreshRuntime(),
+      ]);
       setUnlocked(false);
     } catch (err) {
       setNotice(friendlyErrorMessage(err));
     } finally {
       setBusy(false);
     }
-  }, [modelName, isModelLoaded, onReload, loadEffective]);
+  }, [modelName, isRuntimeModelLoaded, onReload, loadConfiguration, refreshRuntime]);
 
   const serverContextRaw = serverModelOptions?.effective?.ctx_size;
   const resolvedContextRaw = serverContextRaw ?? resolved?.tuning.recipe_options?.ctx_size;
@@ -311,7 +368,7 @@ const EffectiveSettingsModal: React.FC<EffectiveSettingsModalProps> = ({
       if (runtimeContext !== null) {
         return { value: `${runtimeContext.toLocaleString()} (auto)`, source: 'Runtime' };
       }
-      if (loadedModel && resolvingContextSize) return { value: 'Resolving…', source: 'Runtime' };
+      if (runtimeModel && resolvingContextSize) return { value: 'Resolving…', source: 'Runtime' };
       return { value: 'Auto', source: 'Configuration' };
     }
 
@@ -332,9 +389,9 @@ const EffectiveSettingsModal: React.FC<EffectiveSettingsModalProps> = ({
       };
     }
 
-    if (loadedModel && resolvingContextSize) return { value: 'Resolving…', source: 'Runtime' };
+    if (runtimeModel && resolvingContextSize) return { value: 'Resolving…', source: 'Runtime' };
     return { value: 'Unavailable', source: 'Configuration' };
-  }, [autoContextSizeEnabled, loadedContextSize, loadedModel, resolved, resolvedContextRaw, resolvingContextSize, serverModelOptions]);
+  }, [autoContextSizeEnabled, loadedContextSize, runtimeModel, resolved, resolvedContextRaw, resolvingContextSize, serverModelOptions]);
 
   const sourceRows = useMemo<SourceRow[]>(() => {
     if (!resolved && !serverModelOptions) return [];
@@ -540,20 +597,24 @@ const EffectiveSettingsModal: React.FC<EffectiveSettingsModalProps> = ({
                   <textarea
                     className="textarea effective-settings__textarea"
                     value={draft}
+                    disabled={busy}
                     spellCheck={false}
                     placeholder="--threads 8 --flash-attn on"
-                    onChange={e => setDraft(e.target.value)}
+                    onChange={e => {
+                      draftRevisionRef.current += 1;
+                      setDraft(e.target.value);
+                    }}
                     rows={3}
                   />
                   <p className="effective-settings__hint">
                     These raw backend arguments replace the resolved ones for the next load of this model. Session-only - nothing is written to disk, and it resets when you reload the app.
                   </p>
                   <div className="effective-settings__actions">
-                    <WorkspaceActionButton appearance="primary" size="small" onClick={applyOverride} disabled={busy}>
-                      {busy ? 'Applying…' : (isModelLoaded ? 'Apply & reload' : 'Apply for next load')}
+                    <WorkspaceActionButton appearance="primary" size="small" onClick={applyOverride} disabled={busy || runtimeStatePending}>
+                      {busy ? 'Applying…' : (runtimeStatePending ? 'Resolving…' : (isRuntimeModelLoaded ? 'Apply & reload' : 'Apply for next load'))}
                     </WorkspaceActionButton>
                     {hasOverride && (
-                      <WorkspaceActionButton appearance="secondary" size="small" icon="rotate-ccw" onClick={resetOverride} disabled={busy}>
+                      <WorkspaceActionButton appearance="secondary" size="small" icon="rotate-ccw" onClick={resetOverride} disabled={busy || runtimeStatePending}>
                         Reset override
                       </WorkspaceActionButton>
                     )}
@@ -563,7 +624,7 @@ const EffectiveSettingsModal: React.FC<EffectiveSettingsModalProps> = ({
               {!unlocked && hasOverride && (
                 <div className="effective-settings__actions">
                   <span className="effective-settings__override-flag"><Icon name="alert" size={12} /> A session override is active.</span>
-                  <WorkspaceActionButton appearance="secondary" size="small" icon="rotate-ccw" onClick={resetOverride} disabled={busy}>
+                  <WorkspaceActionButton appearance="secondary" size="small" icon="rotate-ccw" onClick={resetOverride} disabled={busy || runtimeStatePending}>
                     Reset override
                   </WorkspaceActionButton>
                 </div>

--- a/src/app/src/components/EffectiveSettingsModal.tsx
+++ b/src/app/src/components/EffectiveSettingsModal.tsx
@@ -119,9 +119,7 @@ interface EffectiveSettingsModalProps {
 const EffectiveSettingsModal: React.FC<EffectiveSettingsModalProps> = ({
   open, onClose, modelName, modelInfo, recipe, mcpEnabled, mcpServerIds, fallbackCtxSize, loadedModel, onReload, onLoad,
 }) => {
-  const argsField = backendArgsFieldForRecipe(recipe);
-  const canEditArgs = backendSupportsArgs(recipe) && !!argsField;
-
+  const [systemInfo, setSystemInfo] = useState<Record<string, unknown> | null>(() => api.systemInfoData);
   const [serverModelOptions, setServerModelOptions] = useState<ModelOptions | null>(null);
   const [runtimeModel, setRuntimeModel] = useState<LoadedModel | null>(loadedModel || null);
   const [runtimeStateModelName, setRuntimeStateModelName] = useState<string | null>(null);
@@ -149,6 +147,8 @@ const EffectiveSettingsModal: React.FC<EffectiveSettingsModalProps> = ({
   const loadedModelRef = useRef<LoadedModel | null>(loadedModel || null);
   const healthFailedRef = useRef(false);
 
+  const argsField = backendArgsFieldForRecipe(recipe, systemInfo);
+  const canEditArgs = backendSupportsArgs(recipe, systemInfo) && !!argsField;
   const hasOverride = !!getSessionArgsOverride(modelName);
   const runtimeStatePending = runtimeLoading || runtimeStateModelName !== modelName;
   const isRuntimeModelLoaded = !runtimeStatePending && !!runtimeModel;
@@ -170,6 +170,21 @@ const EffectiveSettingsModal: React.FC<EffectiveSettingsModalProps> = ({
       return null;
     }
   }, [modelName, modelInfo, fallbackCtxSize, open]);
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    void api.systemInfo()
+      .then(info => {
+        if (!cancelled) setSystemInfo(info);
+      })
+      .catch(() => {
+        if (!cancelled) setSystemInfo(api.systemInfoData);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open]);
 
   const loadConfiguration = useCallback(async (replaceDraft: boolean) => {
     if (!modelName) return;

--- a/src/app/tests/a11y.spec.ts
+++ b/src/app/tests/a11y.spec.ts
@@ -2997,6 +2997,7 @@ test.describe('Chat toolbar accessibility', () => {
               labels: ['chat'],
               capabilities: ['chat'],
               input_modalities: inputModalities,
+              launch_command: ['llama-server', '--threads', '8'],
             },
           ],
         }),
@@ -3031,7 +3032,7 @@ test.describe('Chat toolbar accessibility', () => {
     await expect(page.getByRole('button', { name: /Add files, photos, or tools/i })).toBeVisible();
     // Logs toggle
     await expect(page.getByRole('button', { name: /Logs/i })).toBeVisible();
-    await expect(page.getByRole('button', { name: 'Effective settings' })).toHaveCount(0);
+    await expect(page.getByRole('button', { name: 'Effective settings' })).toBeVisible();
   });
 
   test('A187 — add menu exposes one unified tools entry and is keyboard-operable', async ({ page }) => {
@@ -3231,12 +3232,11 @@ test.describe('Chat toolbar accessibility', () => {
 //
 //   - Built-in tuning source badge is renamed to "Recipe default".
 //   - Local direct-config badge renamed to "Direct configuration".
-//   - An authority note near Settings by source explains that the load command
-//     includes server-applied defaults not shown in the rows table.
-// Range: A188–A192.
+//   - An authority note identifies the running server as the command source.
+// Range: A188–A193.
 
-test.describe.skip('Effective Settings modal accessibility', () => {
-  async function openEffectiveSettings(page: Page): Promise<void> {
+test.describe('Effective Settings modal accessibility', () => {
+  async function openEffectiveSettings(page: Page, includeLaunchCommand = true): Promise<void> {
     await page.route('**/api/v1/health**', async route =>
       route.fulfill({
         contentType: 'application/json',
@@ -3255,24 +3255,37 @@ test.describe.skip('Effective Settings modal accessibility', () => {
               last_use: Date.now(),
               labels: ['chat'],
               capabilities: ['chat'],
+              ...(includeLaunchCommand ? { launch_command: ['llama-server', '--threads', '8'] } : {}),
             },
           ],
         }),
       }),
     );
-    await page.route('**/api/v1/models**', async route =>
-      route.fulfill({
+    await page.route('**/api/v1/models**', async route => {
+      if (route.request().url().includes('/options')) {
+        await route.fulfill({
+          contentType: 'application/json',
+          body: JSON.stringify({
+            model_name: 'Llama-3.1-8B-Instruct',
+            recipe: 'llamacpp',
+            saved: {},
+            effective: { llamacpp_backend: 'cpu' },
+            defaults: {},
+            resolved_ctx_size: 4096,
+            load_command: '',
+          }),
+        });
+        return;
+      }
+      await route.fulfill({
         contentType: 'application/json',
         body: JSON.stringify({
           data: [
             { id: 'Llama-3.1-8B-Instruct', name: 'Llama-3.1-8B-Instruct', labels: ['chat'], recipe: 'llamacpp', downloaded: true },
           ],
         }),
-      }),
-    );
-    await page.route('**/api/v1/load**', async route =>
-      route.fulfill({ contentType: 'application/json', body: JSON.stringify({ args: ['--threads', '8'], options: {}, backend: 'llamacpp' }) }),
-    );
+      });
+    });
     await page.goto('/');
     await page.waitForSelector('.chat');
     await page.waitForTimeout(300);
@@ -3290,6 +3303,7 @@ test.describe.skip('Effective Settings modal accessibility', () => {
     const copy = note.locator('.effective-settings__note-copy');
     await expect(copy).toHaveCount(1);
     await expect(copy.locator('strong')).toHaveText('Effective load command');
+    await expect(page.locator('.effective-settings__command')).toHaveText('llama-server --threads 8');
   });
 
   test('A192 — modal passes a WCAG 2.1 AA axe-core scan with no critical/serious violations', async ({ page }) => {
@@ -3302,5 +3316,13 @@ test.describe.skip('Effective Settings modal accessibility', () => {
       v => v.impact === 'critical' || v.impact === 'serious',
     );
     expect(critical, formatViolations(critical)).toHaveLength(0);
+  });
+
+  test('A193 — missing runtime launch command is explained explicitly', async ({ page }) => {
+    await openEffectiveSettings(page, false);
+    await expect(page.locator('.effective-settings__error')).toHaveText(
+      'The server did not report a launch command for this loaded model.',
+    );
+    await expect(page.locator('.effective-settings__command')).toHaveCount(0);
   });
 });

--- a/src/app/tests/configuration-consistency.runtime.cjs
+++ b/src/app/tests/configuration-consistency.runtime.cjs
@@ -77,13 +77,13 @@ assert.doesNotMatch(styles, /\.titlebar--chat\s+\.titlebar__nav/);
 assert.match(chatSource, /api\.getDefaultContextSize\(\)/);
 assert.match(chatSource, /fallbackCtxSize=\{serverDefaultCtxSize\}/);
 assert.match(effectiveSource, /positiveContextSize\(loadedContextSize\)/);
-assert.match(effectiveSource, /positiveContextSize\(effective\?\.options\?\.ctx_size\)/);
+assert.match(effectiveSource, /positiveContextSize\(serverModelOptions\?\.resolved_ctx_size\)/);
 assert.match(effectiveSource, /positiveContextSize\(resolvedContextRaw\)/);
 assert.match(effectiveSource, /\{contextSetting\.value\}/);
 assert.doesNotMatch(effectiveSource, /'Not loaded'/);
 
 const runtimePosition = effectiveSource.indexOf('positiveContextSize(loadedContextSize)');
-const serverPosition = effectiveSource.indexOf('positiveContextSize(effective?.options?.ctx_size)');
+const serverPosition = effectiveSource.indexOf('positiveContextSize(serverModelOptions?.resolved_ctx_size)');
 const localPosition = effectiveSource.indexOf('positiveContextSize(resolvedContextRaw)');
 assert.ok(runtimePosition >= 0 && runtimePosition < serverPosition && serverPosition < localPosition,
   'context resolution priority must remain runtime, server-effective, then local configuration');

--- a/src/app/tests/effective-settings.runtime.cjs
+++ b/src/app/tests/effective-settings.runtime.cjs
@@ -23,6 +23,12 @@ assert.doesNotMatch(chatSource, /isModelLoaded=\{!!currentLoadedModel\}/,
 
 assert.match(effectiveSource, /health\.all_models_loaded\.find/,
   'effective settings must resolve the running model from health');
+assert.match(effectiveSource, /api\.systemInfo\(\)/,
+  'effective settings must load server recipe metadata');
+assert.match(effectiveSource, /backendArgsFieldForRecipe\(recipe, systemInfo\)/,
+  'backend args must resolve their option name from server recipe metadata');
+assert.match(effectiveSource, /backendSupportsArgs\(recipe, systemInfo\)/,
+  'backend args support must use server recipe metadata');
 assert.match(effectiveSource, /formatCommand\(launchCommand\)/,
   'effective settings must render the server-reported launch command');
 assert.match(effectiveSource, /Launch command unavailable because this model is not currently loaded\./,

--- a/src/app/tests/effective-settings.runtime.cjs
+++ b/src/app/tests/effective-settings.runtime.cjs
@@ -1,0 +1,27 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const root = path.resolve(__dirname, '..');
+const apiSource = fs.readFileSync(path.join(root, 'src/api.ts'), 'utf8');
+const chatSource = fs.readFileSync(path.join(root, 'src/components/ChatView.tsx'), 'utf8');
+const effectiveSource = fs.readFileSync(path.join(root, 'src/components/EffectiveSettingsModal.tsx'), 'utf8');
+
+assert.match(apiSource, /launch_command: launchCommand\.length > 0 \? launchCommand : undefined/,
+  'health normalization must retain the server-reported launch command');
+assert.doesNotMatch(apiSource, /effectiveLoadCommand/,
+  'the retired command-preview API must not be restored');
+
+assert.match(chatSource, /aria-label="Effective settings"/,
+  'the chat toolbar must expose Effective Settings');
+assert.match(chatSource, /<EffectiveSettingsModal/,
+  'the chat view must render the Effective Settings modal');
+
+assert.match(effectiveSource, /healthResult\.value\.all_models_loaded\.find/,
+  'effective settings must resolve the running model from health');
+assert.match(effectiveSource, /formatCommand\(launchCommand\)/,
+  'effective settings must render the server-reported launch command');
+assert.match(effectiveSource, /Launch command unavailable because this model is not currently loaded\./,
+  'effective settings must explain when no runtime command is available');
+
+console.log('Effective Settings runtime contract checks passed.');

--- a/src/app/tests/effective-settings.runtime.cjs
+++ b/src/app/tests/effective-settings.runtime.cjs
@@ -16,12 +16,37 @@ assert.match(chatSource, /aria-label="Effective settings"/,
   'the chat toolbar must expose Effective Settings');
 assert.match(chatSource, /<EffectiveSettingsModal/,
   'the chat view must render the Effective Settings modal');
+assert.match(chatSource, /!isCollectionModel\(currentEffectiveSettingsModelInfo\)/,
+  'virtual collection models must not expose Effective Settings without a concrete runtime');
+assert.doesNotMatch(chatSource, /isModelLoaded=\{!!currentLoadedModel\}/,
+  'the modal action state must not be fixed to a parent health snapshot');
 
-assert.match(effectiveSource, /healthResult\.value\.all_models_loaded\.find/,
+assert.match(effectiveSource, /health\.all_models_loaded\.find/,
   'effective settings must resolve the running model from health');
 assert.match(effectiveSource, /formatCommand\(launchCommand\)/,
   'effective settings must render the server-reported launch command');
 assert.match(effectiveSource, /Launch command unavailable because this model is not currently loaded\./,
   'effective settings must explain when no runtime command is available');
+assert.match(effectiveSource, /const sessionArgs = getSessionArgsOverride\(modelName\)\?\.args;[\s\S]*?sessionArgs \?\? \(argsField \? options\.effective\?\.\[argsField\]/,
+  'session overrides must initialize the draft before server effective values');
+assert.match(effectiveSource, /const runtimeStatePending = runtimeLoading \|\| runtimeStateModelName !== modelName;[\s\S]*?const isRuntimeModelLoaded = !runtimeStatePending && !!runtimeModel;/,
+  'load and reload actions must use the fresh runtime snapshot');
+assert.match(effectiveSource, /catch \(healthError\)[\s\S]*?const fallbackModel = loadedModelRef\.current;[\s\S]*?setRuntimeModel\(fallbackModel\);/,
+  'parent runtime props may only be used when the health request fails');
+assert.match(effectiveSource, /const configurationRequestRef = useRef\(0\);/);
+assert.match(effectiveSource, /const runtimeRequestRef = useRef\(0\);/);
+assert.match(effectiveSource, /const draftRevisionRef = useRef\(0\);/);
+assert.match(effectiveSource, /draftRevision === draftRevisionRef\.current/,
+  'stale configuration requests must not overwrite an edited draft');
+assert.match(effectiveSource, /\}, \[open, modelName, loadConfiguration\]\);/,
+  'configuration initialization must not rerun for parent runtime object refreshes');
+assert.match(effectiveSource, /\}, \[open, modelName, refreshRuntime\]\);/,
+  'runtime refreshes must be scoped to opening or changing models');
+assert.match(effectiveSource, /if \(healthFailedRef\.current\)[\s\S]*?setRuntimeModel\(loadedModel \|\| null\);/,
+  'parent runtime snapshots must remain fallback-only after health failures');
+assert.match(effectiveSource, /value=\{draft\}[\s\S]*?disabled=\{busy\}/,
+  'the draft must not remain editable while a submitted value is being refreshed');
+assert.match(effectiveSource, /onClick=\{resetOverride\} disabled=\{busy \|\| runtimeStatePending\}/,
+  'reset must wait for fresh runtime state before choosing reload behavior');
 
 console.log('Effective Settings runtime contract checks passed.');

--- a/src/app/tests/router-load-regression.runtime.cjs
+++ b/src/app/tests/router-load-regression.runtime.cjs
@@ -79,7 +79,7 @@ try {
   assert.doesNotMatch(registrationSource, /\/api\/v1\/pull/, 'definition registration must never fall back to /pull');
 
   const loadStart = apiSource.indexOf('async loadModel(');
-  const loadEnd = apiSource.indexOf('async effectiveLoadCommand', loadStart);
+  const loadEnd = apiSource.indexOf('async unloadModel', loadStart);
   assert.ok(loadStart >= 0 && loadEnd > loadStart, 'loadModel source must be inspectable');
   const loadSource = apiSource.slice(loadStart, loadEnd);
   assert.doesNotMatch(loadSource, /registerModelDefinition/, 'Router load must never write a cached Router definition back to the server');


### PR DESCRIPTION
## Summary

Restores GUI3 Effective Settings using each loaded model's `launch_command` from `/api/v1/health`. The modal preserves settings, sampling, and session override behavior while explicitly explaining when no runtime command is available.

Fixes: N/A

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_ `npm run typecheck`; `npm run build:renderer`; `npm run test:effective-settings`; `npx playwright test --project=a11y --grep "A186|A191|A192|A193"` (4 passed).

## Documentation

- [x] Documentation is not affected by this change.
- [ ] Documentation is affected and has been updated.
- [ ] Documentation is affected but will be handled in a separate PR or issue.

## Breaking Changes

- [ ] This PR introduces breaking changes.
- [x] This PR does not introduce breaking changes.

N/A

## AI-assisted contribution

Please select one:

- [x] I used AI tools for this PR.
- [ ] I did not use AI tools for this PR.

If AI tools were used:

- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.