### PR TITLE
fix(mcp): resolve model aliases in gateway tool calls

### DIFF
--- a/src/cpp/include/lemon/mcp_server.h
+++ b/src/cpp/include/lemon/mcp_server.h
@@ -22,8 +22,15 @@ using json = nlohmann::json;
 class McpServer : public std::enable_shared_from_this<McpServer> {
 public:
     using EnsureLoadedFn = std::function<void(const std::string&)>;
+    // Aliases live in Server's AliasManager, which the gateway does not own.
+    // Injected rather than reached for, so a tool argument resolves the same
+    // way it does on the REST endpoints.
+    using ResolveAliasFn = std::function<std::string(const std::string&)>;
 
-    McpServer(Router* router, ModelManager* model_manager, EnsureLoadedFn ensure_loaded);
+    McpServer(Router* router,
+              ModelManager* model_manager,
+              EnsureLoadedFn ensure_loaded,
+              ResolveAliasFn resolve_alias = {});
     ~McpServer();
 
     // Must be called on a shared_ptr instance — handlers capture shared_from_this().
@@ -73,9 +80,12 @@ private:
                                          const std::string& name_hint);
     static json tools_descriptor();
 
+    std::string resolve_alias(const std::string& model_name) const;
+
     Router* router_;
     ModelManager* model_manager_;
     EnsureLoadedFn ensure_loaded_;
+    ResolveAliasFn resolve_alias_;
 };
 
 }  // namespace lemon

--- a/src/cpp/server/mcp_server.cpp
+++ b/src/cpp/server/mcp_server.cpp
@@ -215,10 +215,18 @@ std::string unique_token() {
 
 }  // namespace
 
-McpServer::McpServer(Router* router, ModelManager* model_manager, EnsureLoadedFn ensure_loaded)
+McpServer::McpServer(Router* router,
+                     ModelManager* model_manager,
+                     EnsureLoadedFn ensure_loaded,
+                     ResolveAliasFn resolve_alias)
     : router_(router),
       model_manager_(model_manager),
-      ensure_loaded_(std::move(ensure_loaded)) {}
+      ensure_loaded_(std::move(ensure_loaded)),
+      resolve_alias_(std::move(resolve_alias)) {}
+
+std::string McpServer::resolve_alias(const std::string& model_name) const {
+    return resolve_alias_ ? resolve_alias_(model_name) : model_name;
+}
 
 McpServer::~McpServer() = default;
 
@@ -449,7 +457,7 @@ std::variant<std::string, json> McpServer::resolve_model_for_tool(
     // 1. Explicit model argument always wins.
     if (arguments.contains("model") && arguments["model"].is_string() &&
         !arguments["model"].get<std::string>().empty()) {
-        return arguments["model"].get<std::string>();
+        return resolve_alias(arguments["model"].get<std::string>());
     }
 
     // 2. Reuse a model of the right type that's already loaded \u2014 zero cost.
@@ -815,7 +823,7 @@ json McpServer::tool_omni(const json& arguments) {
     std::string model;
     if (arguments.contains("model") && arguments["model"].is_string() &&
         !arguments["model"].get<std::string>().empty()) {
-        model = arguments["model"].get<std::string>();
+        model = resolve_alias(arguments["model"].get<std::string>());
     } else {
         for (const auto& [name, info] : model_manager_->get_downloaded_models()) {
             if (is_omni_collection_recipe(info.recipe)) {

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -1500,7 +1500,8 @@ void Server::setup_routes(httplib::Server &web_server) {
     auto mcp_server = std::make_shared<McpServer>(
         router_.get(),
         model_manager_.get(),
-        [this](const std::string& m) { auto_load_model_if_needed(m); });
+        [this](const std::string& m) { auto_load_model_if_needed(m); },
+        [this](const std::string& m) { return resolve_alias_target(m); });
     mcp_server->register_routes(web_server);
 
     // Setup static file serving for web UI

--- a/test/server_mcp.py
+++ b/test/server_mcp.py
@@ -421,6 +421,54 @@ class McpGatewayTests(ServerTestBase):
         # Some tiny test models emit empty strings — just assert the shape.
         self.assertIsInstance(content[0]["text"], str)
 
+    def test_031_chat_tool_resolves_a_model_alias(self):
+        """An alias must work as the `model` argument, as it does on the REST endpoints."""
+        alias = f"mcp-alias-{uuid.uuid4().hex[:8]}"
+        base = f"http://localhost:{PORT}"
+
+        registered = requests.post(
+            f"{base}/internal/aliases",
+            json={"alias": alias, "target": ENDPOINT_TEST_MODEL},
+            headers=_auth_headers(),
+            timeout=TIMEOUT_DEFAULT,
+        )
+        self.assertEqual(
+            registered.status_code,
+            200,
+            msg=f"could not register alias: {registered.text[:200]}",
+        )
+        self.addCleanup(
+            requests.delete,
+            f"{base}/internal/aliases/{alias}",
+            headers=_auth_headers(),
+            timeout=TIMEOUT_DEFAULT,
+        )
+
+        response = _post(
+            {
+                "jsonrpc": "2.0",
+                "id": 11,
+                "method": "tools/call",
+                "params": {
+                    "name": "lemonade_chat",
+                    "arguments": {
+                        "model": alias,
+                        "messages": [
+                            {"role": "user", "content": "Say hello in 3 words."},
+                        ],
+                        "max_tokens": 16,
+                    },
+                },
+            },
+            timeout=TIMEOUT_MODEL_OPERATION,
+        )
+        body = response.json()
+        self.assertNotIn("error", body, msg=str(body))
+        self.assertFalse(
+            body["result"]["isError"],
+            msg=f"alias was not resolved: {body['result']}",
+        )
+
 
 if __name__ == "__main__":
     run_server_tests(McpGatewayTests, description="MCP GATEWAY TESTS")


### PR DESCRIPTION
## Summary

An alias passed as the `model` argument of an MCP tool fails with "Model not
found", while the same alias works on `/v1/chat/completions` against the same
running server.

`normalize_client_model_name` and `normalize_and_resolve_request_model` run at
eleven sites in `server.cpp`, once per core endpoint, but never in
`mcp_server.cpp`. The name therefore reached the gateway unresolved and was
looked up verbatim.

Aliases live in Server's `AliasManager`, which the gateway does not own, so the
resolver is injected as a callback in the same shape as the existing
`EnsureLoadedFn` rather than reaching across for the manager. It defaults to
empty and passes the name through when unset, so the parameter is optional and
no other caller changes.

Applied in two places. `resolve_model_for_tool` covers `lemonade_chat`,
`lemonade_transcribe_audio` and `lemonade_generate_image`; `tool_omni` repeats
the same precedence inline instead of calling that helper, so fixing only the
shared path would have left `lemonade_omni` broken.

Only the explicit-argument branch resolves. The remaining branches return names
taken from the router or the registry, which are already concrete.

Fixes #3434.

## Scope

A callback and a one-line helper in `mcp_server.{h,cpp}`, two call sites, the
wiring at the single construction site in `server.cpp`, and one test.

The Anthropic half of the same report — #3433, filed by the same reporter — is
deliberately not fixed here. `handle_messages` skips router-collection dispatch
as well as alias resolution, which is #3087 and assigned elsewhere; the two
belong in one change rather than being half-fixed from two directions.

## Testing

Ran the repro from #3434 against a live server, on the same build with and
without the change:

without fix:  isError: true   "Error: Model not found: ALIAS"
with fix:     isError: false  "Hi there! How are you doing today"



The same alias returns 200 on `/api/v1/chat/completions` in both builds, so the
alias itself was never the problem.

`test_031_chat_tool_resolves_a_model_alias` in `test/server_mcp.py` registers an
alias, calls `lemonade_chat` with it, and removes the alias on cleanup.

`ctest -L cpp-ci` 65/67 on Windows/MSVC. The two failures — `RecipeHidingTest`
and `LogRotationTest` — are pre-existing and host-specific, confirmed by
stashing this change and re-running them on unmodified `main`.

`check_comment_slop.py`, whitespace and `black` clean.

## Documentation

Not affected. `docs/guide/configuration/custom-models.md` already states that an
alias resolves in any API request, with no surface qualification — the reporter
quoted that line in the issue. This makes the documented behaviour true for MCP
rather than changing what is documented.

## Breaking Changes

None. The new constructor parameter is optional and defaults to empty, and the
gateway behaves exactly as before when it is not supplied.

## AI-assisted contribution

Yes.