### PR TITLE
docs(guide): fix allowed origins rendering and structure

### DIFF
--- a/docs/guide/configuration/README.md
+++ b/docs/guide/configuration/README.md
@@ -528,7 +528,7 @@ Set allowed origins as a comma-separated list of complete origins including sche
 
 By default, without configuring `allowed_origins`, Lemonade automatically permits:
 
-- **Loopback & Subdomains**: Loopback addresses (`localhost`, `127.0.0.1`, `[::1]`, `*.localhost`) are permitted automatically.
+- **Loopback Origins**: Loopback addresses (`localhost`, `127.0.0.1`, `[::1]`, and `tauri.localhost`) are permitted automatically.
 - **Native Desktop Apps**: Native desktop application schemes (`lemonade://`, `file://`, `app://.`, `vscode-webview://`, `jan://`, etc.) are permitted for client connections.
 - **Same-Origin LAN & mDNS Web App Access**: Direct browser requests to Lemonade's built-in web interface over active network interfaces (e.g. `http://192.168.1.50:13305/app`, `http://100.100.x.x:13305/app`) and local mDNS hostnames (`http://<hostname>.local:13305/app`) are dynamically permitted without manual configuration because they are same-origin to the server's own interfaces.
 

--- a/docs/guide/configuration/README.md
+++ b/docs/guide/configuration/README.md
@@ -516,7 +516,8 @@ Set allowed origins as a comma-separated list of complete origins including sche
 
 - **Wildcard Ports (`:*`)**: Specify `:*` to match any port on a configured host (e.g. `http://192.168.1.50:*`, `http://*.local:*`, `https://[::1]:*`), useful for homelab setups or frontend development servers running across varying ports.
 - **Wildcard Subdomains (`*.domain`)**: Specify `*.domain` to match subdomains (e.g. `https://*.example.com` or `http://*.local:*`). Subdomain matching strictly enforces a dot boundary so `notexample.com` will not match `*.example.com`.
-- **Universal Wildcards (`*`, `http://*:*`)**: Setting `allowed_origins` to `*` or `http://*:*` allows any origin to connect.
+- **Universal Wildcard (`*`)**: Setting `allowed_origins` to `*` allows any origin across all schemes to connect.
+- **Scheme-Specific Wildcards (`http://*:*`)**: Setting `allowed_origins` to a wildcard pattern with an explicit scheme (such as `http://*:*`) matches any host and port for that scheme, but does not permit other schemes like HTTPS.
 
 > **Warning:** The `LEMONADE_ALLOWED_ORIGINS` environment variable is **deprecated** and will be removed in a future release.
 >
@@ -547,7 +548,7 @@ You must explicitly configure `allowed_origins` for:
 > **Warning:**
 >
 > - **Plain HTTP Origins**: Allowing a non-local plain-HTTP origin (e.g., `http://app.example.com`) is vulnerable to on-path modification (man-in-the-middle) and interception. It is highly recommended to use HTTPS (`https://`) for all remote/non-local allowed origins.
-> - **Wildcard Security Risks**: Using `allowed_origins=*` or `http://*:*` permits any website running in a user's browser to make requests to your local Lemonade server. In particular, if `LEMONADE_API_KEY` is not configured, this exposes the server to unauthenticated remote access and cross-origin attacks from malicious websites. Use wildcards only for development or in secure, isolated environments.
+> - **Wildcard Security Risks**: Using wildcard origins like `*` or `http://*:*` permits matching websites running in a user's browser to make requests to your local Lemonade server. In particular, if `LEMONADE_API_KEY` is not configured, this exposes the server to unauthenticated remote access and cross-origin attacks from malicious websites. Use wildcards only for development or in secure, isolated environments.
 
 ## Model Synchronization & Auto-Updates
 

--- a/docs/guide/configuration/README.md
+++ b/docs/guide/configuration/README.md
@@ -495,37 +495,59 @@ The `LEMONADE_ADMIN_API_KEY` environment variable provides elevated access to bo
 
 The `allowed_origins` setting (in `config.json` or configured via `lemonade config set allowed_origins="..."`) controls which remote web origins are authorized to connect to the server (specifically for CORS headers on HTTP endpoints and origin validation on WebSocket connections).
 
-> [!WARNING]
-> The `LEMONADE_ALLOWED_ORIGINS` environment variable is **deprecated** and will be removed in a future release.
+> Note: `allowed_origins` specifies the **client application/web page's origin** (where the request originates), **not** the target Lemonade server URL. Non-browser HTTP clients (such as CLI tools, cURL, or server-side SDKs) do not send an `Origin` header and are not restricted by origin validation.
+
+#### Configuration
+
+Set allowed origins as a comma-separated list of complete origins including scheme and optional port:
+
+- **Via CLI**:
+  ```bash
+  lemonade config set allowed_origins="https://app.lemonade.dev,http://localhost:3000"
+  ```
+- **In `config.json`**:
+  ```json
+  {
+    "allowed_origins": "https://app.lemonade.dev,http://localhost:3000"
+  }
+  ```
+
+**Wildcard Matching:**
+
+- **Wildcard Ports (`:*`)**: Specify `:*` to match any port on a configured host (e.g. `http://192.168.1.50:*`, `http://*.local:*`, `https://[::1]:*`), useful for homelab setups or frontend development servers running across varying ports.
+- **Wildcard Subdomains (`*.domain`)**: Specify `*.domain` to match subdomains (e.g. `https://*.example.com` or `http://*.local:*`). Subdomain matching strictly enforces a dot boundary so `notexample.com` will not match `*.example.com`.
+- **Universal Wildcards (`*`, `http://*:*`)**: Setting `allowed_origins` to `*` or `http://*:*` allows any origin to connect.
+
+> **Warning:** The `LEMONADE_ALLOWED_ORIGINS` environment variable is **deprecated** and will be removed in a future release.
+>
 > - **Automatic Migration**: If `LEMONADE_ALLOWED_ORIGINS` is set at startup and `allowed_origins` is unset or empty in `config.json`, Lemonade automatically migrates the value into `config.json`.
 > - **Precedence & Conflict Handling**: At startup, `LEMONADE_ALLOWED_ORIGINS` takes interim precedence over `config.json`. If both exist and differ, a warning is logged advising you to unset or remove `LEMONADE_ALLOWED_ORIGINS` to avoid shadowing your configuration file.
 > - **Runtime Updates**: Running `lemonade config set allowed_origins="..."` dynamically applies changes to the active session immediately, overriding any initial environment variable value without restarting the server.
 
-> [!NOTE]
-> `allowed_origins` specifies the **client application/web page's origin** (where the request originates), **not** the target Lemonade server URL. Non-browser HTTP clients (such as CLI tools, cURL, or server-side SDKs) do not send an `Origin` header and are not restricted by origin validation.
+#### Zero-Configuration Defaults
 
-- **Configuration**:
-  - In `config.json`: `"allowed_origins": "https://app.lemonade.dev,http://localhost:3000"`
-  - Via CLI: `lemonade config set allowed_origins="https://app.lemonade.dev,http://localhost:3000"`
-- **Format**: A comma-separated list of complete origins including the scheme and optional port (e.g., `https://app.lemonade.dev,http://localhost:3000`).
-  - **Wildcard Ports**: Specify `:*` to match any port on a configured host (e.g., `http://192.168.1.50:*`, `http://*.local:*`, `https://[::1]:*`), useful for local development and homelab environments where frontend dev servers run across varying ports.
-  - **Wildcard Domains**: Specify `*.domain` to match subdomains (e.g., `http://*.local:*` or `https://*.example.com`). Subdomain matching strictly enforces a dot boundary so `notexample.com` will not match `*.example.com`.
-  > [!WARNING]
-  > Allowing a non-local plain-HTTP origin (e.g., `http://app.example.com`) is vulnerable to on-path modification (man-in-the-middle) and interception. It is highly recommended to use HTTPS (`https://`) for all remote/non-local allowed origins.
-- **Wildcards (`*`, `http://*:*`)**: Setting `allowed_origins` to `*` or using universal wildcards like `http://*:*` allows any origin to connect.
-- **Security Implications of Wildcards**:
-  > [!WARNING]
-  > Using `allowed_origins=*` or `http://*:*` permits any website running in a user's browser to make requests to your local Lemonade server. In particular, if `LEMONADE_API_KEY` is not configured, this exposes the server to unauthenticated remote access and cross-origin attacks from malicious websites. Use wildcards only for development or in secure, isolated environments.
-- **Local/Loopback, Desktop & Same-Origin Access (Zero-Configuration)**:
-  - **Loopback & Subdomains**: Loopback addresses (`localhost`, `127.0.0.1`, `[::1]`, `*.localhost`) are permitted automatically.
-  - **Native Desktop Apps**: Native desktop application schemes (`lemonade://`, `file://`, `app://.`, `vscode-webview://`, `jan://`, etc.) are permitted for client connections.
-  - **Same-Origin LAN & mDNS Web App Access**: Direct browser requests to Lemonade's built-in web interface over active network interfaces (e.g. `http://192.168.1.50:13305/app`, `http://100.100.x.x:13305/app`) and local mDNS hostnames (`http://<hostname>.local:13305/app`) are dynamically permitted without manual configuration because they are same-origin to the server's own interfaces.
-- **When Allowed Origins Must Be Configured**:
-  - **Cross-Origin Web Applications**: Any external or third-party web application hosted on a different domain or port connecting to Lemonade in the browser (e.g. a web UI hosted at `https://app.lemonade.dev` or `http://localhost:3000` calling Lemonade on `http://192.168.1.50:13305`).
-  - **Reverse Proxies & TLS Frontends**: Reverse proxies, tunnels, or frontends terminating TLS (e.g., `https://lemonade.example.com` or Tailscale Serve at `https://mybox.tailnet.ts.net`). Because proxies forward HTTPS requests to an HTTP server and present external hostnames not belonging to local network interfaces, their external origins must be explicitly allowlisted. (By contrast, direct access via a local Tailscale interface IP `http://100.x.y.z:13305` is zero-config).
-  - **Sandboxed Frames**: Opaque `null` origins (e.g. from sandboxed browser iframes) are rejected unless explicitly listed in `allowed_origins` to prevent CSWSH attacks.
-  > [!NOTE]
-  > When an explicit `allowed_origins` list is configured, it is authoritative: zero-configuration fallback for unlisted non-loopback LAN origins is disabled. If you access the server through both a reverse proxy and direct LAN IP in a browser, include both in `allowed_origins`.
+By default, without configuring `allowed_origins`, Lemonade automatically permits:
+
+- **Loopback & Subdomains**: Loopback addresses (`localhost`, `127.0.0.1`, `[::1]`, `*.localhost`) are permitted automatically.
+- **Native Desktop Apps**: Native desktop application schemes (`lemonade://`, `file://`, `app://.`, `vscode-webview://`, `jan://`, etc.) are permitted for client connections.
+- **Same-Origin LAN & mDNS Web App Access**: Direct browser requests to Lemonade's built-in web interface over active network interfaces (e.g. `http://192.168.1.50:13305/app`, `http://100.100.x.x:13305/app`) and local mDNS hostnames (`http://<hostname>.local:13305/app`) are dynamically permitted without manual configuration because they are same-origin to the server's own interfaces.
+
+#### When Configuration Is Required
+
+You must explicitly configure `allowed_origins` for:
+
+- **Cross-Origin Web Applications**: Any external or third-party web application hosted on a different domain or port connecting to Lemonade in the browser (e.g. a web UI hosted at `https://app.lemonade.dev` or `http://localhost:3000` calling Lemonade on `http://192.168.1.50:13305`).
+- **Reverse Proxies & TLS Frontends**: Reverse proxies, tunnels, or frontends terminating TLS (e.g., `https://lemonade.example.com` or Tailscale Serve at `https://mybox.tailnet.ts.net`). Because proxies forward HTTPS requests to an HTTP server and present external hostnames not belonging to local network interfaces, their external origins must be explicitly allowlisted. (By contrast, direct access via a local Tailscale interface IP `http://100.x.y.z:13305` is zero-config).
+- **Sandboxed Frames**: Opaque `null` origins (e.g. from sandboxed browser iframes) are rejected unless explicitly listed in `allowed_origins` to prevent CSWSH attacks.
+
+> Note: When an explicit `allowed_origins` list is configured, it is authoritative: zero-configuration fallback for unlisted non-loopback LAN origins is disabled. If you access the server through both a reverse proxy and direct LAN IP in a browser, include both in `allowed_origins`.
+
+#### Security Considerations
+
+> **Warning:**
+>
+> - **Plain HTTP Origins**: Allowing a non-local plain-HTTP origin (e.g., `http://app.example.com`) is vulnerable to on-path modification (man-in-the-middle) and interception. It is highly recommended to use HTTPS (`https://`) for all remote/non-local allowed origins.
+> - **Wildcard Security Risks**: Using `allowed_origins=*` or `http://*:*` permits any website running in a user's browser to make requests to your local Lemonade server. In particular, if `LEMONADE_API_KEY` is not configured, this exposes the server to unauthenticated remote access and cross-origin attacks from malicious websites. Use wildcards only for development or in secure, isolated environments.
 
 ## Model Synchronization & Auto-Updates
 


### PR DESCRIPTION
## Spec Driven Development

This PR:
- [x] fixes something and does not need a WG/RFC.
- [ ] is within the scope of WG:
- [ ] has approved RFC #

## Summary

Fixes the "Allowed Origins" configuration section on the documentation website:
- Replaces unsupported GitHub-style `> [!WARNING]` and `> [!NOTE]` markers with standard Markdown callouts (`> **Warning:**` and `> Note:`) that Zensical renders properly without unresolved link warnings.
- Organizes the dense bullet list into structured `####` subsections (`Configuration`, `Zero-Configuration Defaults`, `When Configuration Is Required`, `Security Considerations`), providing a clean reading experience and enabling right-hand sidebar navigation.
- Converts inline configuration snippets into copyable `bash` and `json` code blocks.
- Refines origin matching accuracy: clarifies loopback origins (`tauri.localhost` rather than generic `*.localhost`) and wildcard matching semantics (`http://*:*` for any HTTP origin on any host/port vs `*` for universal matching).

## Visual Verification

<details>
<summary>Before and After Screenshots</summary>

### Before
<img width="1400" height="2000" alt="image" src="https://github.com/user-attachments/assets/9cf08a59-eedb-40d9-aace-4949b1c9ecf6" />

### After
<img width="1400" height="2000" alt="image" src="https://github.com/user-attachments/assets/12137869-b3e8-480a-9714-9714cd871fac" />

</details>

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] The code change has been locally tested.

_Testing details:_
Built the documentation locally using `.venv/bin/zensical build --clean`, confirming zero unresolved link warnings in `docs/guide/configuration/README.md`. Rendered the page in headless Chrome to verify that all callouts, code fences, and navigation links display cleanly.

## Documentation

- [ ] Documentation is not affected by this change.
- [x] Documentation is affected and has been updated.

## Breaking Changes

- [ ] This PR introduces breaking changes.
- [x] This PR does not introduce breaking changes.