### PR TITLE
Add Junie (JetBrains) as a supported launch agent

### DIFF
--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -660,7 +660,7 @@ lemonade launch [AGENT] [--model MODEL_NAME] [options]
 
 | Option/Argument | Description | Required |
 |-----------------|-------------|----------|
-| `AGENT` | Agent name to launch. Supported agents: `claude`, `codex`, `opencode`, `pi`. If omitted, you will be prompted to select one. | No |
+| `AGENT` | Agent name to launch. Supported agents: `claude`, `codex`, `opencode`, `pi`, `junie`. If omitted, you will be prompted to select one. | No |
 | `--model MODEL_NAME` | Model name to launch with. If omitted, you will be prompted to select one. | No |
 | `--directory DIR` | Remote recipes directory used only if you choose recipe import at prompt | No |
 | `--recipe-file FILE` | Remote recipe JSON filename used only if you choose recipe import at prompt | No |
@@ -682,10 +682,11 @@ Codex-only option:
 - `--provider` is accepted only by `lemonade launch codex` and is passed directly to Codex as `model_provider`; provider resolution/errors are handled by Codex.
 - To customize recipe options (e.g. context size) for the launched model, configure them ahead of time with `lemonade load <model> ... --save-options`, or with `lemonade config set`.
 - `--agent-args` is parsed and appended to the launched agent command.
-- Supported agents: `claude`, `codex`, `opencode`, `pi`
+- Supported agents: `claude`, `codex`, `opencode`, `pi`, `junie`
 - `opencode` uses an auto-managed config file at `~/.config/opencode/opencode.json`.
 - `pi` uses auto-managed config files at `~/.pi/agent/models.json` and `~/.pi/agent/settings.json`.
-- When no `--api-key` is provided, the generated `opencode` and `pi` providers use a default `apiKey` value of `lemonade`.
+- `junie` uses an auto-managed custom model profile at `~/.junie/models/lemonade.json` (honors `JUNIE_HOME`) and is launched with `--model custom:lemonade`.
+- When no `--api-key` is provided, the generated `opencode`, `pi`, and `junie` providers use a default `apiKey` value of `lemonade`.
 
 **Examples:**
 

--- a/docs/integrations/junie.md
+++ b/docs/integrations/junie.md
@@ -1,0 +1,78 @@
+# Junie
+
+Junie is JetBrains' coding agent CLI. With Lemonade, you can run Junie against local models through Lemonade's OpenAI-compatible API.
+
+This guide focuses on the most common launch flows.
+
+## Prerequisites
+
+1. Install Junie:
+
+    ```bash
+    curl -fsSL https://junie.jetbrains.com/install.sh | bash
+    ```
+
+    See [https://junie.jetbrains.com/](https://junie.jetbrains.com/) for details and other platforms.
+
+2. Make sure Lemonade Server is running (`lemond`).
+
+## Launch Junie with Lemonade
+
+Use:
+
+```bash
+lemonade launch junie [options]
+```
+
+Lemonade automatically writes a custom model profile at `~/.junie/models/lemonade.json` pointing Junie at your local server, and starts Junie with `--model custom:lemonade`. If `JUNIE_HOME` is set, the profile is written under that directory instead.
+
+## Use Case 1: First-time user (discover + import + launch)
+
+If you are not sure which model to use yet, start with:
+
+```bash
+lemonade launch junie
+```
+
+You will get an interactive menu where you can:
+
+- Select a recipe to import and launch.
+- Browse downloaded models.
+- Browse recommended llama.cpp models (download may be required), then launch.
+
+All remote recipes in this flow are sourced from:
+`https://github.com/lemonade-sdk/recipes`
+
+## Use Case 2: You already know the model
+
+If you already downloaded a model or already imported the recipe, skip the interactive flow:
+
+```bash
+lemonade launch junie -m Qwen3.5-35B-A3B-GGUF
+```
+
+Equivalent long form:
+
+```bash
+lemonade launch junie --model Qwen3.5-35B-A3B-GGUF
+```
+
+When `--model` is provided, launch goes straight to starting the agent and loading that model. The selected model name is stored as the `id` inside `~/.junie/models/lemonade.json`.
+
+## Passing Junie arguments with `--agent-args`
+
+You can pass any extra Junie CLI flags through Lemonade:
+
+```bash
+lemonade launch junie --model Qwen3.5-35B-A3B-GGUF --agent-args "--brave"
+```
+
+If Junie supports a flag, you can pass it through `--agent-args`.
+
+## Related CLI Docs
+
+For more launch examples and full option details, see:
+`docs/lemonade-cli.md`
+
+For Junie product details, see JetBrains' docs:
+https://junie.jetbrains.com/

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -103,6 +103,7 @@ nav:
     - CodeGPT: integrations/codeGPT.md
     - Continue: integrations/continue.md
     - Interviewer: integrations/interviewer.md
+    - Junie: integrations/junie.md
     - LangChain: integrations/langchain.md
     - Lemon Zest: integrations/lemon-zest.md
     - Mindcraft: integrations/mindcraft.md

--- a/src/cpp/cli/CMakeLists.txt
+++ b/src/cpp/cli/CMakeLists.txt
@@ -40,6 +40,7 @@ set(COMMON_SOURCES
     agent_config_file.cpp
     opencode_profile.cpp
     pi_profile.cpp
+    junie_profile.cpp
     # Self-describing backend descriptors (plain data; CLI-safe). Lets the CLI
     # read recipe options/flags from descriptors without linking server classes.
     # The matching factories (create()) are server-only and NOT listed here.

--- a/src/cpp/cli/agent_launcher.cpp
+++ b/src/cpp/cli/agent_launcher.cpp
@@ -251,6 +251,36 @@ void configure_pi_agent(const std::string& model,
         "  npm i -g @earendil-works/pi-coding-agent";
 }
 
+void configure_junie_agent(const std::string& api_key,
+                           AgentConfig& config) {
+    const std::string resolved_api_key = api_key.empty() ? kDefaultAgentApiKey : api_key;
+
+#ifdef _WIN32
+    config.binary_name = "junie.exe";
+    config.binary_alternatives = {"junie.cmd", "junie"};
+#else
+    config.binary_name = "junie";
+    config.binary_alternatives = {};
+#endif
+    config.fallback_paths = {
+        "~/.local/bin/junie",
+        "/usr/local/bin/junie"
+    };
+
+    config.env_vars = {
+        {"LEMONADE_API_KEY", resolved_api_key}
+    };
+    // The model is carried by the custom:lemonade profile file written during
+    // config sync, so the launch args just select it.
+    config.extra_args = {
+        "--model", "custom:lemonade"
+    };
+    config.install_instructions =
+        "Install Junie CLI:\n"
+        "  curl -fsSL https://junie.jetbrains.com/install.sh | bash\n"
+        "See https://junie.jetbrains.com/ for details.";
+}
+
 } // namespace
 
 std::string build_agent_server_base_url(const std::string& host, int port) {
@@ -261,7 +291,7 @@ std::string build_agent_server_base_url(const std::string& host, int port) {
 }
 
 bool agent_needs_config_sync(const std::string& agent) {
-    return agent == "opencode" || agent == "pi";
+    return agent == "opencode" || agent == "pi" || agent == "junie";
 }
 
 bool build_agent_config(const std::string& agent,
@@ -294,7 +324,12 @@ bool build_agent_config(const std::string& agent,
         return true;
     }
 
-    error_message = "Unsupported agent: " + agent + ". Supported agents: claude, codex, opencode, pi.";
+    if (agent == "junie") {
+        configure_junie_agent(api_key, config);
+        return true;
+    }
+
+    error_message = "Unsupported agent: " + agent + ". Supported agents: claude, codex, opencode, pi, junie.";
     return false;
 }
 

--- a/src/cpp/cli/junie_profile.cpp
+++ b/src/cpp/cli/junie_profile.cpp
@@ -1,0 +1,126 @@
+#include "lemon_cli/junie_profile.h"
+
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <system_error>
+
+#include <nlohmann/json.hpp>
+
+namespace fs = std::filesystem;
+
+namespace lemon_cli {
+namespace {
+
+// Junie stores its data under ~/.junie by default (%USERPROFILE%\.junie on
+// Windows), or in $JUNIE_HOME if set. Custom model profiles live in the models/
+// subdirectory, one JSON file per model. We always write the "lemonade" profile.
+std::string resolve_junie_models_path() {
+    const char* junie_home = std::getenv("JUNIE_HOME");
+    if (junie_home && junie_home[0] != '\0') {
+        return (fs::path(junie_home) / "models" / "lemonade.json").string();
+    }
+
+#ifdef _WIN32
+    const char* home = std::getenv("USERPROFILE");
+#else
+    const char* home = std::getenv("HOME");
+#endif
+    if (!home || home[0] == '\0') {
+        return "";
+    }
+    return (fs::path(home) / ".junie" / "models" / "lemonade.json").string();
+}
+
+// Atomically write JSON to path, creating parent directories. Mirrors the
+// approach in agent_config_file.cpp / pi_profile.cpp.
+bool write_json_atomic(const std::string& path,
+                       const nlohmann::json& config,
+                       std::string& error_out) {
+    const fs::path output_path(path);
+    std::error_code ec;
+    const fs::path output_dir = output_path.parent_path();
+    if (!output_dir.empty()) {
+        fs::create_directories(output_dir, ec);
+        if (ec) {
+            error_out = "Cannot create directory " + output_dir.string() + ": " + ec.message();
+            return false;
+        }
+    }
+
+    const fs::path tmp_path = output_path.string() + ".tmp";
+    {
+        std::ofstream out(tmp_path);
+        if (!out.is_open()) {
+            error_out = "Cannot open " + tmp_path.string() + " for writing";
+            return false;
+        }
+
+        out << config.dump(2) << "\n";
+        out.flush();
+        if (!out.good()) {
+            out.close();
+            std::error_code remove_ec;
+            fs::remove(tmp_path, remove_ec);
+            error_out = "Write failed for " + tmp_path.string();
+            return false;
+        }
+
+        out.close();
+        if (!out) {
+            std::error_code remove_ec;
+            fs::remove(tmp_path, remove_ec);
+            error_out = "Write failed for " + tmp_path.string();
+            return false;
+        }
+    }
+
+    fs::rename(tmp_path, output_path, ec);
+    if (ec) {
+        // Cross-device or filesystem edge cases can make rename fail.
+        ec.clear();
+        fs::copy_file(tmp_path, output_path, fs::copy_options::overwrite_existing, ec);
+        if (!ec) {
+            std::error_code remove_tmp_ec;
+            fs::remove(tmp_path, remove_tmp_ec);
+        }
+    }
+
+    if (ec) {
+        std::error_code remove_ec;
+        fs::remove(tmp_path, remove_ec);
+        error_out = "Cannot move temp config into place: " + ec.message();
+        return false;
+    }
+
+    return true;
+}
+
+} // namespace
+
+bool sync_junie_model_file(const std::string& base_url,
+                           const std::string& api_key,
+                           const std::string& model_id,
+                           std::string& error_out) {
+    const std::string models_path = resolve_junie_models_path();
+    if (models_path.empty()) {
+        error_out = "Could not resolve junie models path";
+        return false;
+    }
+
+    // The "lemonade" custom model profile is fully owned by Lemonade, so it is
+    // rewritten wholesale on every launch (like the opencode/pi "Lemonade"
+    // provider block). The file name is what `--model custom:lemonade` resolves,
+    // while the `id` field carries the actual Lemonade model name.
+    nlohmann::json profile = nlohmann::json::object();
+    profile["id"] = model_id;
+    profile["baseUrl"] = base_url;
+    profile["apiType"] = "OpenAICompletion";
+    if (!api_key.empty()) {
+        profile["apiKey"] = api_key;
+    }
+
+    return write_json_atomic(models_path, profile, error_out);
+}
+
+} // namespace lemon_cli

--- a/src/cpp/cli/main.cpp
+++ b/src/cpp/cli/main.cpp
@@ -12,6 +12,7 @@
 #include <lemon_cli/agent_launcher.h>
 #include <lemon_cli/opencode_profile.h>
 #include <lemon_cli/pi_profile.h>
+#include <lemon_cli/junie_profile.h>
 #include <lemon/utils/process_manager.h>
 #include <lemon/utils/path_utils.h>
 #include <lemon/utils/network_beacon.h>
@@ -66,7 +67,8 @@ static const std::vector<std::string> SUPPORTED_AGENTS = {
     "claude",
     "codex",
     "opencode",
-    "pi"
+    "pi",
+    "junie"
 };
 
 static bool prompt_agent_selection(std::string& agent_out) {
@@ -664,6 +666,21 @@ static std::vector<lemon_cli::AgentModelEntry> fetch_llm_models_for_sync(
 
 static void sync_agent_config_for_launch(lemonade::LemonadeClient& client,
                                          const CliConfig& config) {
+    // Junie does not use a single config file with a providers map like
+    // opencode/pi. Instead it reads a standalone custom model profile from
+    // ~/.junie/models/lemonade.json, so it gets its own sync path.
+    if (config.agent == "junie") {
+        const std::string config_api_key = config.api_key.empty() ? "lemonade" : config.api_key;
+        const std::string base_url =
+            lemon_tray::build_agent_server_base_url(config.host, config.port) + "/v1/chat/completions";
+        std::string error_message;
+        if (!lemon_cli::sync_junie_model_file(base_url, config_api_key, config.model, error_message)) {
+            std::cerr << "Warning: Failed to sync junie config: " << error_message << std::endl;
+            std::cerr << "Continuing with launch anyway..." << std::endl;
+        }
+        return;
+    }
+
     constexpr int default_context_window = 40960;
     std::vector<lemon_cli::AgentModelEntry> models =
         fetch_llm_models_for_sync(client, default_context_window);

--- a/src/cpp/include/lemon_cli/junie_profile.h
+++ b/src/cpp/include/lemon_cli/junie_profile.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <string>
+
+namespace lemon_cli {
+
+// Junie reads custom model profiles from standalone JSON files under
+// ~/.junie/models/<id>.json (or $JUNIE_HOME/models/<id>.json when JUNIE_HOME is
+// set). Unlike opencode/pi, there is no single config file with a providers map:
+// each file *is* one model profile. Write ~/.junie/models/lemonade.json so that
+// `junie --model custom:lemonade` points Junie at the local Lemonade server.
+bool sync_junie_model_file(const std::string& base_url,
+                           const std::string& api_key,
+                           const std::string& model_id,
+                           std::string& error_out);
+
+} // namespace lemon_cli

--- a/test/server_cli2.py
+++ b/test/server_cli2.py
@@ -1950,6 +1950,72 @@ sys.exit(0)
 
             self.assertEqual(cfg.get("$schema"), "https://opencode.ai/config.json")
 
+    def test_122_launch_junie_with_fake_binary(self):
+        """Launch should execute fake junie binary with --model custom:lemonade."""
+        if IS_WINDOWS:
+            self.skipTest(WINDOWS_LAUNCH_STUB_SKIP_REASON)
+
+        with tempfile.TemporaryDirectory(prefix="lemonade-launch-stub-") as temp_dir:
+            capture_path = os.path.join(temp_dir, "junie_capture.json")
+            self._write_fake_agent(temp_dir, "junie", capture_path)
+            env = self._build_stubbed_agent_env(temp_dir)
+
+            result = run_cli_command(
+                ["launch", "junie", "--model", ENDPOINT_TEST_MODEL],
+                timeout=TIMEOUT_DEFAULT,
+                env=env,
+            )
+
+            self.assertEqual(result.returncode, 0)
+            self.assertTrue(
+                os.path.exists(capture_path),
+                "Fake junie binary was not executed",
+            )
+
+            with open(capture_path, "r", encoding="utf-8") as f:
+                payload = json.load(f)
+
+            argv = payload["argv"]
+            self.assertIn("--model", argv)
+            model_idx = argv.index("--model") + 1
+            self.assertEqual(argv[model_idx], "custom:lemonade")
+
+    def test_123_launch_junie_creates_model_profile(self):
+        """Launch junie should create ~/.junie/models/lemonade.json for the local server."""
+        if IS_WINDOWS:
+            self.skipTest(WINDOWS_LAUNCH_STUB_SKIP_REASON)
+
+        with tempfile.TemporaryDirectory(prefix="lemonade-launch-stub-") as temp_dir:
+            capture_path = os.path.join(temp_dir, "junie_capture_cfg.json")
+            self._write_fake_agent(temp_dir, "junie", capture_path)
+            env = self._build_stubbed_agent_env(temp_dir)
+
+            result = run_cli_command(
+                ["launch", "junie", "--model", ENDPOINT_TEST_MODEL],
+                timeout=TIMEOUT_DEFAULT,
+                env=env,
+            )
+
+            self.assertEqual(result.returncode, 0)
+
+            profile_path = os.path.join(temp_dir, ".junie", "models", "lemonade.json")
+            self.assertTrue(
+                os.path.exists(profile_path),
+                f"lemonade.json not created at {profile_path}",
+            )
+
+            with open(profile_path, "r", encoding="utf-8") as f:
+                profile = json.load(f)
+
+            self.assertEqual(profile["id"], ENDPOINT_TEST_MODEL)
+            self.assertEqual(profile["apiType"], "OpenAICompletion")
+            self.assertTrue(profile["baseUrl"].endswith("/v1/chat/completions"))
+            # Mirrors lemonade api key in use; LEMONADE_API_KEY env wins.
+            self.assertEqual(
+                profile.get("apiKey"),
+                os.environ.get("LEMONADE_API_KEY", "lemonade"),
+            )
+
     # =============================================================================
     # Unload Tests
     # =============================================================================


### PR DESCRIPTION
## Add Junie (JetBrains) as a supported launch agent

This proposes wiring JetBrains' **Junie** CLI (`junie`) into `lemonade launch`, so Lemonade
users can run Junie against their local Lemonade server the same way they already run
`claude`, `codex`, `opencode`, and `pi`. Canonical Junie site/docs: <https://junie.jetbrains.com/>.

Opened at the request of, and approved by, **@AlexanderPrendota** — thank you! This is an
official contribution from JetBrains, offered as a proposal; please review and adjust to match
your conventions.

### How it works

Junie points at a custom OpenAI-compatible endpoint through a **standalone custom model
profile** (`~/.junie/models/<id>.json`), rather than an env var. So this mirrors the file-sync
agents (`opencode`/`pi`): on `lemonade launch junie`, Lemonade writes
`~/.junie/models/lemonade.json` pointing at the local server's
`/v1/chat/completions` endpoint (honoring `JUNIE_HOME`), then starts
`junie --model custom:lemonade`.

### What the PR changes

- **`src/cpp/cli/junie_profile.{h,cpp}`** (new) — `sync_junie_model_file(...)` writes the
  standalone profile atomically (mirroring `pi_profile.cpp`): `{ id, baseUrl, apiType:
  "OpenAICompletion", apiKey? }`, resolving `~/.junie` via `JUNIE_HOME`.
- **`src/cpp/cli/agent_launcher.cpp`** — `configure_junie_agent()` (binary `junie`, install
  hint via the official installer, `env_vars={LEMONADE_API_KEY}`,
  `extra_args={--model, custom:lemonade}`); plus the `junie` branch in `build_agent_config`,
  `agent_needs_config_sync`, and the "Supported agents" error string.
- **`src/cpp/cli/main.cpp`** — `junie` added to `SUPPORTED_AGENTS`; junie config-sync branch in
  `sync_agent_config_for_launch` (base URL = `<server>/v1/chat/completions`).
- **`src/cpp/cli/CMakeLists.txt`** — builds `junie_profile.cpp`.
- **Docs** — new `docs/integrations/junie.md`, `mkdocs.yml` nav entry, and both "Supported
  agents" lines in `docs/guide/cli.md`.
- **`test/server_cli2.py`** — a fake-binary launch test and a profile-creation test, mirroring
  the existing `opencode` launch tests.

### Testing notes

I couldn't run the full CMake build / `server_cli2.py` in my sandbox (no network for the
FetchContent deps and no live server), so I verified the targeted parts locally instead:
compiled `junie_profile.cpp` in isolation and confirmed it writes the expected JSON for both the
`JUNIE_HOME` and `HOME` cases (with and without `apiKey`); `agent_launcher.cpp` passes
`-fsyntax-only`; and `test/server_cli2.py` byte-compiles. Your CI will run the full suite.

### Notes

- This is a **proposal** — happy to adjust naming/paths, the default profile id, or the status
  wiring to match your conventions.
- The profile's `id` should match a model served by the local Lemonade instance; `apiType` is
  `OpenAICompletion` for the OpenAI-compatible endpoint.
