### PR TITLE
Serve example HTML demos over localhost instead of opening from disk

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -42,7 +42,13 @@ python realtime_transcription.py --model Whisper-Small
 
 ### LLM Demos
 
-Open the HTML files directly in your browser.
+Serve the HTML files over localhost, then open them in your browser. Opening them directly from disk (`file://`) is blocked by the server's default `allowed_origins`.
+
+```bash
+cd examples
+python3 -m http.server 8080
+# then open http://localhost:8080/llm-debate.html or http://localhost:8080/multi-model-tester.html
+```
 
 See [debate-arena.md](debate-arena.md) for detailed instructions on the debate demo.
 

--- a/examples/debate-arena.md
+++ b/examples/debate-arena.md
@@ -8,7 +8,7 @@ Debate Arena is a single-file HTML/CSS/JS web app that pits up to 9 LLMs against
 2. Configure the server to support 9 concurrent model instances. Use one of:
    - **Persistent config**: Set `"max_loaded_models": 9` in `config.json`
    - **Runtime API**: `POST` to `/internal/set` with `{"max_loaded_models": 9}`
-3. Download https://github.com/lemonade-sdk/lemonade/blob/main/examples/llm-debate.html and open it in your web browser
+3. Download https://github.com/lemonade-sdk/lemonade/blob/main/examples/llm-debate.html, run `python3 -m http.server 8080` in the folder where you saved it, and open http://localhost:8080/llm-debate.html in your web browser (opening the file directly from disk is blocked by the server's default `allowed_origins`)
 4. You can uncheck some models to save VRAM. Running all 9 requires ~32 GB.
 
 ### How it works


### PR DESCRIPTION
## Spec Driven Development

This PR:
- [x] fixes something (see #3537) and does not need a WG/RFC.
- [ ] is within the scope of WG:
- [ ] has approved RFC #

## Summary

Implement @abn's suggestion on #3537 that HTML example web uis should be launched with python serve.

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Breaking Changes

- [ ] This PR introduces breaking changes.
- [x] This PR does not introduce breaking changes.