### PR TITLE
ci: pin every self-hosted runs-on list to an architecture label

### DIFF
--- a/.github/runners.json
+++ b/.github/runners.json
@@ -14,6 +14,7 @@
     "sjlab-stx-halo-11",
     "sjlab-stx-halo-12",
     "sjlab-stx-halo-13",
-    "sjlab-stx-halo-17"
+    "sjlab-stx-halo-17",
+    "sjlab-dgx-spark-01"
   ]
 }

--- a/.github/workflows/benchmark-regression.yml
+++ b/.github/workflows/benchmark-regression.yml
@@ -94,14 +94,14 @@ jobs:
   # Uses curl + GitHub API only (no gh CLI, no sudo, no cmake).
   # =========================================================================
   # Bench — one job per fork.
-  # Runner: [self-hosted, stx-halo, Linux, lemon-prod]
+  # Runner: [self-hosted, stx-halo, Linux, X64, lemon-prod]
   # max-parallel: 1 is load-bearing: benches must run one at a time on the
   # shared box or the perf numbers are meaningless.
   # =========================================================================
   bench:
     name: Bench ${{ matrix.fork_id }}
     needs: [setup]
-    runs-on: [self-hosted, stx-halo, Linux, lemon-prod]
+    runs-on: [self-hosted, stx-halo, Linux, X64, lemon-prod]
     timeout-minutes: 180
     strategy:
       fail-fast: false

--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -1016,82 +1016,82 @@ jobs:
             script: server_llm.py
             extra_args: "--wrapped-server llamacpp"
             backends: "vulkan rocm"
-            runner: [Windows, vulkan, rocm, lemon-prod]
+            runner: [Windows, X64, vulkan, rocm, lemon-prod]
           - name: omni
             script: server_omni.py
             extra_args: "--wrapped-server llamacpp"
             backends: "vulkan"
-            runner: [Windows, vulkan, stx-halo, lemon-prod]
+            runner: [Windows, X64, vulkan, stx-halo, lemon-prod]
           - name: ryzenai
             script: server_llm.py
             extra_args: "--wrapped-server ryzenai"
             backends: "cpu hybrid npu"
-            runner: [Windows, xdna2, lemon-prod]
+            runner: [Windows, X64, xdna2, lemon-prod]
           - name: flm
             script: server_llm.py
             extra_args: "--wrapped-server flm"
             backends: "npu"
-            runner: [Windows, xdna2, lemon-prod]
+            runner: [Windows, X64, xdna2, lemon-prod]
           - name: whisper
             script: server_whisper.py
             extra_args: "--wrapped-server whispercpp"
             backends: "cpu npu rocm"
-            runner: [Windows, stx-halo, lemon-prod]
+            runner: [Windows, X64, stx-halo, lemon-prod]
           - name: flm-whisper
             script: server_whisper.py
             extra_args: "--wrapped-server flm"
             backends: "npu"
-            runner: [Windows, xdna2, lemon-prod]
+            runner: [Windows, X64, xdna2, lemon-prod]
           - name: moonshine
             script: server_moonshine.py
             extra_args: "--wrapped-server moonshine"
             backends: "cpu"
-            runner: [self-hosted, Windows, lemon-prod]
+            runner: [self-hosted, Windows, X64, lemon-prod]
           - name: classify-onnxruntime
             script: server_classify.py
             extra_args: "--wrapped-server onnxruntime"
             backends: "cpu"
-            runner: [self-hosted, Windows, lemon-prod]
+            runner: [self-hosted, Windows, X64, lemon-prod]
           - name: router-onnxruntime
             script: server_router.py
             extra_args: "--wrapped-server onnxruntime"
             backends: "cpu"
-            runner: [self-hosted, Windows, lemon-prod]
+            runner: [self-hosted, Windows, X64, lemon-prod]
           - name: stable-diffusion
             script: server_sd.py
             extra_args: ""
             backends: "cpu rocm vulkan"
-            runner: [Windows, rocm, vulkan, lemon-prod]
+            runner: [Windows, X64, rocm, vulkan, lemon-prod]
           - name: audio-gen-thinksound
             script: server_audio_generation.py
             extra_args: "--wrapped-server thinksound"
             backends: "vulkan rocm"
-            runner: [Windows, rocm, vulkan, lemon-prod]
+            runner: [Windows, X64, rocm, vulkan, lemon-prod]
           - name: audio-gen-acestep
             script: server_audio_generation.py
             extra_args: "--wrapped-server acestep"
             backends: "vulkan rocm"
-            runner: [Windows, rocm, vulkan, lemon-prod]
+            runner: [Windows, X64, rocm, vulkan, lemon-prod]
           - name: audio-gen-openmoss
             script: server_audio_generation.py
             extra_args: "--wrapped-server openmoss"
             backends: "vulkan rocm"
-            runner: [Windows, rocm, vulkan, lemon-prod]
+            runner: [Windows, X64, rocm, vulkan, lemon-prod]
           - name: text-to-speech
             script: server_tts.py
             extra_args: ""
             backends: ""
-            runner: [self-hosted, Windows, lemon-prod]
+            runner: [self-hosted, Windows, X64, lemon-prod]
           - name: 3d-trellis
             script: server_3d.py
             extra_args: "--wrapped-server trellis"
             backends: "vulkan rocm"
-            runner: [Windows, rocm, vulkan, lemon-prod]
+            runner: [Windows, X64, rocm, vulkan, lemon-prod]
           - name: tts-openmoss
             script: server_tts_openmoss.py
             extra_args: "--wrapped-server openmoss"
             backends: "vulkan rocm"
-            runner: [Windows, rocm, vulkan, lemon-prod]
+            runner: [Windows, X64, rocm, vulkan, lemon-prod]
     env:
       LEMONADE_CI_MODE: "True"
       HF_TOKEN: ${{ secrets.HUGGINGFACE_ACCESS_TOKEN }}
@@ -1289,72 +1289,72 @@ jobs:
             script: server_llm.py
             extra_args: "--wrapped-server llamacpp"
             backends: "vulkan rocm"
-            runner: [Linux, vulkan, rocm, lemon-prod]
+            runner: [Linux, X64, vulkan, rocm, lemon-prod]
           - name: llamacpp-hrx
             script: server_llm.py
             extra_args: "--wrapped-server llamacpp-hrx"
             backends: "hrx"
-            runner: [Linux, rocm, stx-halo, lemon-prod]
+            runner: [Linux, X64, rocm, stx-halo, lemon-prod]
           - name: omni
             script: server_omni.py
             extra_args: "--wrapped-server llamacpp"
             backends: "vulkan"
-            runner: [Linux, vulkan, stx-halo, lemon-prod]
+            runner: [Linux, X64, vulkan, stx-halo, lemon-prod]
           - name: stable-diffusion
             script: server_sd.py
             extra_args: ""
             backends: "cpu rocm vulkan"
-            runner: [Linux, vulkan, rocm, lemon-prod]
+            runner: [Linux, X64, vulkan, rocm, lemon-prod]
           - name: thenoise
             script: server_thenoise.py
             extra_args: "--wrapped-server thenoise"
             backends: "rocm"
-            runner: [Linux, rocm, stx-halo, lemon-prod]
+            runner: [Linux, X64, rocm, stx-halo, lemon-prod]
           - name: audio-gen-thinksound
             script: server_audio_generation.py
             extra_args: "--wrapped-server thinksound"
             backends: "vulkan rocm"
-            runner: [Linux, vulkan, rocm, lemon-prod]
+            runner: [Linux, X64, vulkan, rocm, lemon-prod]
           - name: audio-gen-acestep
             script: server_audio_generation.py
             extra_args: "--wrapped-server acestep"
             backends: "vulkan rocm"
-            runner: [Linux, vulkan, rocm, lemon-prod]
+            runner: [Linux, X64, vulkan, rocm, lemon-prod]
           - name: audio-gen-openmoss
             script: server_audio_generation.py
             extra_args: "--wrapped-server openmoss"
             backends: "vulkan rocm"
-            runner: [Linux, vulkan, rocm, lemon-prod]
+            runner: [Linux, X64, vulkan, rocm, lemon-prod]
           - name: whisper
             script: server_whisper.py
             extra_args: "--wrapped-server whispercpp"
             backends: "cpu vulkan rocm"
-            runner: [Linux, rocm, xdna2, lemon-prod]
+            runner: [Linux, X64, rocm, xdna2, lemon-prod]
           - name: moonshine
             script: server_moonshine.py
             extra_args: "--wrapped-server moonshine"
             backends: "cpu"
-            runner: [self-hosted, Linux, lemon-prod]
+            runner: [self-hosted, Linux, X64, lemon-prod]
           - name: flm
             script: server_llm.py
             extra_args: "--wrapped-server flm"
             backends: "npu"
-            runner: [Linux, xdna2, lemon-prod]
+            runner: [Linux, X64, xdna2, lemon-prod]
           - name: text-to-speech
             script: server_tts.py
             extra_args: ""
             backends: ""
-            runner: [self-hosted, Linux, lemon-prod]
+            runner: [self-hosted, Linux, X64, lemon-prod]
           - name: 3d-trellis
             script: server_3d.py
             extra_args: "--wrapped-server trellis"
             backends: "vulkan rocm"
-            runner: [Linux, vulkan, rocm, lemon-prod]
+            runner: [Linux, X64, vulkan, rocm, lemon-prod]
           - name: tts-openmoss
             script: server_tts_openmoss.py
             extra_args: "--wrapped-server openmoss"
             backends: "vulkan rocm"
-            runner: [Linux, vulkan, rocm, lemon-prod]
+            runner: [Linux, X64, vulkan, rocm, lemon-prod]
     env:
       LEMONADE_CI_MODE: "True"
       HF_TOKEN: ${{ secrets.HUGGINGFACE_ACCESS_TOKEN }}

--- a/.github/workflows/repo-manager.yml
+++ b/.github/workflows/repo-manager.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   repo-manager:
-    runs-on: [self-hosted, linux, repo-manager]
+    runs-on: [self-hosted, linux, X64, repo-manager]
     timeout-minutes: 30
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validate_llamacpp.yml
+++ b/.github/workflows/validate_llamacpp.yml
@@ -446,26 +446,26 @@ jobs:
           - backend: vulkan
             runner: >-
               ${{ fromJSON(needs.build.outputs.lite == 'true'
-              && '["self-hosted","Windows","stx-halo","vulkan","lemon-prod"]'
-              || '["self-hosted","Windows","128gb","vulkan","lemon-prod"]') }}
+              && '["self-hosted","Windows","X64","stx-halo","vulkan","lemon-prod"]'
+              || '["self-hosted","Windows","X64","128gb","vulkan","lemon-prod"]') }}
           - backend: rocm
             channel: stable
             runner: >-
               ${{ fromJSON(needs.build.outputs.lite == 'true'
-              && '["self-hosted","Windows","stx-halo","rocm","lemon-prod"]'
-              || '["self-hosted","Windows","128gb","rocm","lemon-prod"]') }}
+              && '["self-hosted","Windows","X64","stx-halo","rocm","lemon-prod"]'
+              || '["self-hosted","Windows","X64","128gb","rocm","lemon-prod"]') }}
           - backend: rocm
             channel: nightly
             runner: >-
               ${{ fromJSON(needs.build.outputs.lite == 'true'
-              && '["self-hosted","Windows","stx-halo","rocm","lemon-prod"]'
-              || '["self-hosted","Windows","128gb","rocm","lemon-prod"]') }}
+              && '["self-hosted","Windows","X64","stx-halo","rocm","lemon-prod"]'
+              || '["self-hosted","Windows","X64","128gb","rocm","lemon-prod"]') }}
           # CUDA validation is prepared but intentionally disabled until an
           # NVIDIA self-hosted runner is available. To enable it, uncomment this
           # matrix entry.
           #
           # - backend: cuda
-          #   runner: [self-hosted, Windows, 128gb, cuda]
+          #   runner: [self-hosted, Windows, X64, 128gb, cuda]
     steps:
       - name: Capture Vulkan runner configuration
         if: matrix.backend == 'vulkan'

--- a/.github/workflows/validate_sdcpp.yml
+++ b/.github/workflows/validate_sdcpp.yml
@@ -211,11 +211,11 @@ jobs:
           # validation stays disabled until a matching runner exists.
           legs='[
             {"label":"cpu","backend":"cpu","channel":"",
-             "runner":["self-hosted","Windows","stx-halo","vulkan","lemon-prod"]},
+             "runner":["self-hosted","Windows","X64","stx-halo","vulkan","lemon-prod"]},
             {"label":"vulkan","backend":"vulkan","channel":"",
-             "runner":["self-hosted","Windows","stx-halo","vulkan","lemon-prod"]},
+             "runner":["self-hosted","Windows","X64","stx-halo","vulkan","lemon-prod"]},
             {"label":"rocm-stable","backend":"rocm","channel":"stable",
-             "runner":["self-hosted","Windows","stx-halo","rocm","lemon-prod"]}
+             "runner":["self-hosted","Windows","X64","stx-halo","rocm","lemon-prod"]}
           ]'
 
           # cpp_server_build_test_release.yml already exercises sd-cpp on CPU

--- a/.github/workflows/validate_vllm.yml
+++ b/.github/workflows/validate_vllm.yml
@@ -114,7 +114,7 @@ jobs:
     name: Validate vllm (rocm)
     needs: [get-latest-releases, build]
     if: always() && needs.build.result == 'success'
-    runs-on: [self-hosted, stx-halo, Linux, lemon-prod]
+    runs-on: [self-hosted, stx-halo, Linux, X64, lemon-prod]
     steps:
       - uses: actions/checkout@v5
         with:

--- a/docs/dev/adding-a-backend.md
+++ b/docs/dev/adding-a-backend.md
@@ -129,7 +129,7 @@ Add the test to CI in both matrices of `.github/workflows/cpp_server_build_test_
   script: server_<modality>.py
   extra_args: "--wrapped-server <recipe>"
   backends: "vulkan rocm"
-  runner: [Linux, vulkan, rocm, lemon-prod]
+  runner: [Linux, X64, vulkan, rocm, lemon-prod]
 ```
 
 If your backend uses ROCm via TheRock, add its recipe to `_THEROCK_RECIPES` in `test/utils/server_base.py`. Otherwise a cold runner folds the one-time TheRock download into the first request's timeout instead of `TIMEOUT_ROCM_INSTALL`, and the ROCm job flakes.

--- a/docs/dev/self-hosted-runners.md
+++ b/docs/dev/self-hosted-runners.md
@@ -21,7 +21,7 @@ You can read about all this here: [GitHub: About self-hosted runners](https://do
 
 ## Runner Labels
 
-Workflows target self-hosted runners by the labels the runner carries. We use two kinds of labels:
+Workflows target self-hosted runners by the labels the runner carries. We use three kinds of labels, plus the architecture label GitHub applies automatically:
 
 ### Pool membership label
 
@@ -42,9 +42,13 @@ These describe *what a runner can do*. A workflow should request only the capabi
 | `cuda` | Runner can execute CUDA GPU workloads | TBD |
 | `xdna2` | Runner has a Ryzen AI 300/400 series NPU | `ryzenai` backend, `flm` (FastFlowLM) backend |
 
-A job that exercises more than one backend should request all the labels it needs (e.g., `[Windows, vulkan, rocm, lemon-prod]` for a test that runs both Vulkan and ROCm cases). GitHub Actions requires the runner to carry *every* label in the `runs-on` list.
+A job that exercises more than one backend should request all the labels it needs (e.g., `[Windows, X64, vulkan, rocm, lemon-prod]` for a test that runs both Vulkan and ROCm cases). GitHub Actions requires the runner to carry *every* label in the `runs-on` list.
 
 CPU-only jobs should target GitHub-hosted runners when possible.
+
+### Architecture label
+
+GitHub registers every self-hosted runner with an architecture label (`X64`, `ARM64`, or `ARM`) alongside its OS label (`Linux`, `Windows`, `macOS`). **Every self-hosted `runs-on` list must include one of these architecture labels.** The pool contains both x86_64 and ARM64 machines (e.g. the DGX Spark is `[self-hosted, Linux, ARM64, cuda, lemon-prod]`), so a job that only asks for `[self-hosted, Linux, lemon-prod]` can be scheduled onto either and fail with a binary or package built for the other architecture. Capability labels such as `vulkan` or `rocm` do not imply an architecture, so the label is required even when a capability label narrows the pool today. Write `X64` for the AMD Ryzen AI and Strix Halo rigs and `ARM64` for ARM machines; this applies to Windows lists too, so that an ARM64 Windows runner can be added without re-auditing every workflow.
 
 ### Hardware labels
 
@@ -66,6 +70,9 @@ Capability and hardware labels must be present on each runner for the workflow t
 |----------|-----------------|
 | Ryzen AI 300-series laptop (NPU + Vulkan iGPU + ROCm iGPU) | `lemon-prod`, `xdna2`, `vulkan`, `rocm` |
 | Strix Halo | `lemon-prod`, `xdna2`, `rocm`, `stx-halo` |
+| DGX Spark (ARM64 + CUDA) | `lemon-prod`, `cuda` |
+
+GitHub adds the OS and architecture labels (`Linux`/`Windows`, `X64`/`ARM64`) itself when the runner registers; do not add them by hand.
 
 ## New Runner Setup
 
@@ -164,7 +171,8 @@ Here are some general guidelines to observe when creating or modifying workflows
 - Place a 🌩️ emoji in the name of all of your self-host workflows, so that PR reviewers can see at a glance which workflows are using self-hosted resources.
     - Example: `name: Test Lemonade on NPU and Hybrid with OGA environment 🌩️`
 - Avoid triggering your workflow before anyone has had a chance to review it against these guidelines. To avoid triggers, do not include `on: pull request:` in your workflow until after a reviewer has signed off.
-- **Always include `lemon-prod`** in every *production* self-hosted `runs-on` list (see [Pool membership label](#pool-membership-label)). For example, `runs-on: [Windows, xdna2, lemon-prod]` for NPU work, `runs-on: [Linux, vulkan, rocm, lemon-prod]` for a job that exercises both GPU backends. CPU-only self-hosted jobs use `[self-hosted, Windows, lemon-prod]` / `[self-hosted, Linux, lemon-prod]`, but prefer GitHub-hosted runners (`windows-latest`, `ubuntu-latest`) for CPU-only work when possible. Special-purpose runners with their own dedicated labels (e.g. `[self-hosted, linux, repo-manager]`) are the exception and should not include `lemon-prod`.
+- **Always include `lemon-prod`** in every *production* self-hosted `runs-on` list (see [Pool membership label](#pool-membership-label)). For example, `runs-on: [Windows, X64, xdna2, lemon-prod]` for NPU work, `runs-on: [Linux, X64, vulkan, rocm, lemon-prod]` for a job that exercises both GPU backends. CPU-only self-hosted jobs use `[self-hosted, Windows, X64, lemon-prod]` / `[self-hosted, Linux, X64, lemon-prod]`, but prefer GitHub-hosted runners (`windows-latest`, `ubuntu-latest`) for CPU-only work when possible. Special-purpose runners with their own dedicated labels (e.g. `[self-hosted, linux, X64, repo-manager]`) are the exception and should not include `lemon-prod`.
+- **Always include an architecture label** (`X64` or `ARM64`) in every self-hosted `runs-on` list, Windows included (see [Architecture label](#architecture-label)). Without it a job can land on a machine of the wrong architecture.
 - Be very considerate about installing software on to the runners:
     - Installing software into the CWD (e.g., a path of `.\`) is always ok, because that will end up in `C:\actions-runner\_work\REPO`, which is always wiped between tests.
     - Installing software into `AppData`, `Program Files`, etc. is not advisable because that software will persist across tests. See the [setup](#new-runner-setup) section to see which software is already expected on the system.

--- a/docs/dev/self-hosted-runners.md
+++ b/docs/dev/self-hosted-runners.md
@@ -48,7 +48,7 @@ CPU-only jobs should target GitHub-hosted runners when possible.
 
 ### Architecture label
 
-GitHub registers every self-hosted runner with an architecture label (`X64`, `ARM64`, or `ARM`) alongside its OS label (`Linux`, `Windows`, `macOS`). **Every self-hosted `runs-on` list must include one of these architecture labels.** The pool contains both x86_64 and ARM64 machines (e.g. the DGX Spark is `[self-hosted, Linux, ARM64, cuda, lemon-prod]`), so a job that only asks for `[self-hosted, Linux, lemon-prod]` can be scheduled onto either and fail with a binary or package built for the other architecture. Capability labels such as `vulkan` or `rocm` do not imply an architecture, so the label is required even when a capability label narrows the pool today. Write `X64` for the AMD Ryzen AI and Strix Halo rigs and `ARM64` for ARM machines; this applies to Windows lists too, so that an ARM64 Windows runner can be added without re-auditing every workflow.
+GitHub registers every self-hosted runner with an architecture label (`X64`, `ARM64`, or `ARM`) alongside its OS label (`Linux`, `Windows`, `macOS`). **Every self-hosted `runs-on` list must include one of these architecture labels.** The pool contains both x86_64 and ARM64 machines (e.g. the DGX Spark is `[self-hosted, Linux, ARM64, cuda, lemon-prod]`), so a job that only asks for `[self-hosted, Linux, lemon-prod]` can be scheduled onto either and fail with a binary or package built for the other architecture.
 
 ### Hardware labels
 
@@ -71,8 +71,6 @@ Capability and hardware labels must be present on each runner for the workflow t
 | Ryzen AI 300-series laptop (NPU + Vulkan iGPU + ROCm iGPU) | `lemon-prod`, `xdna2`, `vulkan`, `rocm` |
 | Strix Halo | `lemon-prod`, `xdna2`, `rocm`, `stx-halo` |
 | DGX Spark (ARM64 + CUDA) | `lemon-prod`, `cuda` |
-
-GitHub adds the OS and architecture labels (`Linux`/`Windows`, `X64`/`ARM64`) itself when the runner registers; do not add them by hand.
 
 ## New Runner Setup
 


### PR DESCRIPTION
## Spec Driven Development

This PR:
- [x] fixes something and does not need a WG/RFC.
- [ ] is within the scope of WG:
- [ ] has approved RFC #

## Summary

Add support for ARM64 self-hosted runners in lemonade repo by tagging all X64 jobs with the `X64` label. Otherwise, jobs could land on either X64 or ARM64 runners, regardless of their architecture requirement.

This PR also adds our new DGX Spark runner to our "heartbeat" CI job that ensures runners are still working every week.

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Documentation

- [ ] Documentation is not affected by this change.
- [x] Documentation is affected and has been updated.

## Breaking Changes

- [ ] This PR introduces breaking changes.
- [x] This PR does not introduce breaking changes.