### PR TITLE
fix: change deprecated --no-mmap option to --load-mode none for llama.cpp

### DIFF
--- a/docs/api/lemonade.md
+++ b/docs/api/lemonade.md
@@ -409,14 +409,14 @@ curl http://localhost:13305/v1/models/Qwen3-0.6B-GGUF/options
 
 ### Response format
 
-`effective` is the exact request body a [`POST /v1/load`](#post-v1load) for this model uses right now, with every option the recipe accepts resolved through the full priority chain. `defaults` is what a reset model would get. For `llamacpp`, with `--no-mmap` saved and the context size left automatic:
+`effective` is the exact request body a [`POST /v1/load`](#post-v1load) for this model uses right now, with every option the recipe accepts resolved through the full priority chain. `defaults` is what a reset model would get. For `llamacpp`, with `--load-mode none` saved and the context size left automatic:
 
 ```json
 {
   "model_name": "Qwen3-0.6B-GGUF",
   "recipe": "llamacpp",
   "saved": {
-    "llamacpp_args": "--no-mmap"
+    "llamacpp_args": "--load-mode none"
   },
   "effective": {
     "auto_evict": null,
@@ -424,7 +424,7 @@ curl http://localhost:13305/v1/models/Qwen3-0.6B-GGUF/options
     "downsize_idle_timeout": 60,
     "evict_idle_timeout": 300,
     "evict_weight_factor": 1.0,
-    "llamacpp_args": "--no-mmap",
+    "llamacpp_args": "--load-mode none",
     "llamacpp_backend": "vulkan",
     "llamacpp_device": "",
     "merge_args": true,
@@ -1196,7 +1196,7 @@ curl -X POST http://localhost:13305/v1/load \
     "model_name": "Qwen3-0.6B-GGUF",
     "ctx_size": 8192,
     "llamacpp_backend": "rocm",
-    "llamacpp_args": "--flash-attn on --no-mmap"
+    "llamacpp_args": "--flash-attn on --load-mode none"
   }'
 ```
 
@@ -1209,7 +1209,7 @@ curl -X POST http://localhost:13305/v1/load \
     "model_name": "Qwen3-0.6B-GGUF",
     "ctx_size": 8192,
     "llamacpp_backend": "vulkan",
-    "llamacpp_args": "--no-context-shift --no-mmap",
+    "llamacpp_args": "--no-context-shift --load-mode none",
     "save_options": true
   }'
 ```
@@ -1539,11 +1539,11 @@ curl http://localhost:13305/v1/health
         "-m", "~/.cache/huggingface/hub/models--nomic-ai--nomic-embed-text-v1-GGUF/.../nomic-embed-text-v1.Q4_K_S.gguf",
         "--ctx-size", "8192",
         "--port", "8002",
-        "--no-mmap"
+        "--load-mode none"
       ],
       "recipe_options": {
         "ctx_size": 8192,
-        "llamacpp_args": "--no-mmap",
+        "llamacpp_args": "--load-mode none",
         "llamacpp_backend": "rocm"
       },
       "backend_url": "http://127.0.0.1:8002/v1"

--- a/docs/api/openai.md
+++ b/docs/api/openai.md
@@ -1172,7 +1172,7 @@ Returns a single model object with the same fields as described in the [models l
   "labels": ["reasoning"],
   "recipe_options": {
     "ctx_size": 8192,
-    "llamacpp_args": "--no-mmap",
+    "llamacpp_args": "--load-mode none",
     "llamacpp_backend": "rocm"
   }
 }

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -494,7 +494,7 @@ lemonade load Qwen3-0.6B-GGUF --ctx-size 4096 --save-options
 lemonade load Qwen3-0.6B-GGUF --llamacpp vulkan
 
 # Load a llama.cpp model with custom arguments
-lemonade load Qwen3-0.6B-GGUF --llamacpp-args "--flash-attn on --no-mmap"
+lemonade load Qwen3-0.6B-GGUF --llamacpp-args "--flash-attn on --load-mode none"
 
 # Load a model without merging global args (per-model args replace global entirely)
 lemonade load Qwen3-0.6B-GGUF --no-merge-args --llamacpp-args "--flash-attn on"

--- a/test/cpp/test_custom_args.cpp
+++ b/test/cpp/test_custom_args.cpp
@@ -130,17 +130,17 @@ int main() {
         "--override-kv a=bool:false --override-kv b=bool:false --threads 8");
     failures += !expect_merge(
         "binary negation precedence is preserved",
-        "--no-mmap",
-        "--mmap --override-kv a=bool:false --override-kv b=bool:false",
-        "--no-mmap --override-kv a=bool:false --override-kv b=bool:false");
+        "--no-jinja",
+        "--jinja --override-kv a=bool:false --override-kv b=bool:false",
+        "--no-jinja --override-kv a=bool:false --override-kv b=bool:false");
 
     // Overridable-arg detection must compare complete flag tokens, not
     // substrings, so a flag name appearing only inside a value or file path
     // does not suppress a Lemonade default (regression for llama.cpp arg
-    // handling, e.g. "--load-mode none" and the -lm / --mmap aliases).
+    // handling, e.g. "--load-mode none" and the -lm / --load-mode aliases).
     failures += !expect_has_flag(
-        "real long alias token matches",
-        "--no-mmap", "--no-mmap", true);
+        "real long flag token matches",
+        "--load-mode none", "--load-mode", true);
     failures += !expect_has_flag(
         "real short alias token matches",
         "-lm", "-lm", true);
@@ -149,16 +149,16 @@ int main() {
         "--load-mode=auto", "--load-mode", true);
     failures += !expect_has_flag(
         "equals-value alias matches",
-        "--mmap=auto", "--mmap", true);
+        "-lm=auto", "-lm", true);
     failures += !expect_has_flag(
         "alias inside path does not match",
         "--lora /models/alma-lm-adapter.gguf", "-lm", false);
     failures += !expect_has_flag(
         "long alias inside value does not match",
-        "--override-kv tokenizer.mmap=auto", "--mmap", false);
+        "--override-kv tokenizer.load-mode=auto", "--load-mode", false);
     failures += !expect_has_flag(
         "missing alias does not match",
-        "--threads 8", "--mmap", false);
+        "--threads 8", "--load-mode", false);
 
     std::printf("\n%d failures\n", failures);
     return failures == 0 ? 0 : 1;

--- a/test/cpp/test_hrx_contract.cpp
+++ b/test/cpp/test_hrx_contract.cpp
@@ -47,11 +47,11 @@ void check_launch_contract() {
         "--jinja",
         "--metrics",
         "--threads", "7",
-        "--no-mmap",
+        "--load-mode", "none",
         "--parallel", "1",
     };
     const auto argv = hrx::build_server_argv(
-        "/models/qualified.gguf", 32768, 14123, "--threads 7 --no-mmap");
+        "/models/qualified.gguf", 32768, 14123, "--threads 7 --load-mode none");
     check("HRX builds the complete managed argv with a benign custom tail",
           argv == expected_argv);
 

--- a/test/cpp/test_recipe_arg_resolution.cpp
+++ b/test/cpp/test_recipe_arg_resolution.cpp
@@ -52,14 +52,14 @@ int main() {
     const std::string backend = "-b 2048 -ub 1024 -np 1";
     const std::string architecture = "--temp 0.8 --top-k 40";
     const std::string model_defaults = "--flash-attn on";
-    const std::string model = "--no-mmap --threads 8";
+    const std::string model = "--load-mode none --threads 8";
 
     failures += !expect_args(
         "no request inherits backend and model scope",
         resolve_scoped_custom_args(
             {backend, architecture, model_defaults, model,
              CustomArgsRequestState::Omitted, "", true}),
-        "-b 2048 -ub 1024 -np 1 --temp 0.8 --top-k 40 --no-mmap --threads 8");
+        "-b 2048 -ub 1024 -np 1 --temp 0.8 --top-k 40 --load-mode none --threads 8");
 
     failures += !expect_args(
         "request replaces model scope and keeps backend",
@@ -111,11 +111,11 @@ int main() {
         "-b 2048 --threads 4");
 
     failures += !expect_args(
-        "request negation overrides backend opposite",
+        "request load-mode overrides backend load-mode",
         resolve_scoped_custom_args(
-            {"--mmap -b 2048", "", "", "",
-             CustomArgsRequestState::Value, "--no-mmap", true}),
-        "-b 2048 --no-mmap");
+            {"--load-mode mmap -b 2048", "", "", "",
+             CustomArgsRequestState::Value, "--load-mode none", true}),
+        "-b 2048 --load-mode none");
 
     failures += !expect_args(
         "repeatable request flags survive wholesale model replacement",

--- a/test/server_endpoints.py
+++ b/test/server_endpoints.py
@@ -1593,7 +1593,7 @@ class EndpointTests(ServerTestBase):
             timeout=TIMEOUT_DEFAULT,
         )
         self._reset_options()
-        self._set_global_llamacpp_args("--no-mmap --threads 1")
+        self._set_global_llamacpp_args("--load-mode none --threads 1")
 
         response = requests.post(
             self._options_url(),
@@ -1620,7 +1620,7 @@ class EndpointTests(ServerTestBase):
         self.assertIsNotNone(loaded)
         loaded_args = loaded.get("recipe_options", {}).get("llamacpp_args", "")
         self.assertIn("--threads 2", loaded_args)
-        self.assertIn("--no-mmap", loaded_args)
+        self.assertIn("--load-mode none", loaded_args)
         self.assertNotIn("--threads-batch 1", loaded_args)
         self.assertNotIn("--threads 1 ", loaded_args + " ")
 
@@ -1681,11 +1681,11 @@ class EndpointTests(ServerTestBase):
         )
         merged = requests.post(
             self._options_url(),
-            json={"llamacpp_args": "--no-mmap"},
+            json={"llamacpp_args": "--load-mode none"},
             timeout=TIMEOUT_DEFAULT,
         ).json()
         self.assertEqual(merged["saved"].get("ctx_size"), 4096)
-        self.assertEqual(merged["saved"].get("llamacpp_args"), "--no-mmap")
+        self.assertEqual(merged["saved"].get("llamacpp_args"), "--load-mode none")
 
         # Clearing one key leaves the other alone
         partial = requests.post(
@@ -1847,7 +1847,7 @@ class EndpointTests(ServerTestBase):
                 self._reset_options()
                 requests.post(
                     self._options_url(),
-                    json={"ctx_size": ctx_size, "llamacpp_args": "--no-mmap"},
+                    json={"ctx_size": ctx_size, "llamacpp_args": "--load-mode none"},
                     timeout=TIMEOUT_DEFAULT,
                 )
                 effective = requests.get(


### PR DESCRIPTION
## Spec Driven Development

This PR:
- [X] fixes issue #3558 and does not need a WG/RFC.
- [ ] is within the scope of WG: <!-- working group name -->
- [ ] has approved RFC #<!--discussion number -->

## Summary

llama.cpp deprecated the `--mmap` / `--no-mmap` / `--mlock` / `--direct-io` options in favor of `--load-mode`. As far as I can tell it's not referenced anywhere in the core code, but it's still present in tests and documentation.

## Scope

- [X] This PR addresses one clear issue or change.
- [X] I reviewed the full diff myself before submitting.
- [X] I removed unrelated local changes.
- [X] I kept refactoring separate unless it is required for this change.

## Testing

- [X] The code change has been locally tested.

<!-- Describe what you tested, commands run, and results -->
_Testing details:_
Ran CPP ci test.

## Documentation

- [ ] Documentation is not affected by this change.
- [X] Documentation is affected and has been updated.

## Breaking Changes

- [ ] This PR introduces breaking changes.
- [X] This PR does not introduce breaking changes.

<!-- If breaking changes, describe them and migration path -->