### PR TITLE
feat(models): add Ornith 1.5 9B and 35B A3B to the catalogue

### DIFF
--- a/src/cpp/resources/server_models.json
+++ b/src/cpp/resources/server_models.json
@@ -1761,6 +1761,32 @@
         ],
         "size": 14.4
     },
+    "Ornith-1.5-9B-GGUF": {
+        "checkpoint": "ornith-ai/Ornith-1.5-9B-GGUF:Q4_K_M",
+        "mmproj": "mmproj-Ornith-1.5-9B-BF16.gguf",
+        "recipe": "llamacpp",
+        "labels": [
+            "chat",
+            "coding",
+            "reasoning",
+            "tool-calling",
+            "vision"
+        ],
+        "size": 6.7
+    },
+    "Ornith-1.5-35B-A3B-GGUF": {
+        "checkpoint": "ornith-ai/Ornith-1.5-35B-A3B-GGUF:Q4_K_M",
+        "mmproj": "mmproj-Ornith-1.5-35B-BF16.gguf",
+        "recipe": "llamacpp",
+        "labels": [
+            "chat",
+            "coding",
+            "reasoning",
+            "tool-calling",
+            "vision"
+        ],
+        "size": 22.6
+    },
     "Whisper-Tiny": {
         "checkpoints": {
             "main": "ggerganov/whisper.cpp:ggml-tiny.bin",


### PR DESCRIPTION
Closes #3114.

Adds the two Ornith variants that have a vendor GGUF build, appended to the end of the llamacpp block in `server_models.json`:

| Name | Checkpoint | Size (GB) | Params |
|---|---|---|---|
| `Ornith-1.5-9B-GGUF` | `ornith-ai/Ornith-1.5-9B-GGUF:Q4_K_M` | 6.7 | 9.65B |
| `Ornith-1.5-35B-A3B-GGUF` | `ornith-ai/Ornith-1.5-35B-A3B-GGUF:Q4_K_M` | 22.6 | 35.95B |

Both are multimodal and ship a BF16 projector, so both carry `vision` alongside `chat`, `coding`, `reasoning` and `tool-calling`. Sizes come from `tools/model_sizes.py --update`, not by hand.

### Why 1.5 when the issue asked for 1.0

#3114 was filed in August against Ornith 1.0. 1.5 is the current release, and 1.0's GGUF still embeds the chat template that raises `System message must be at the beginning`, which is #2674. Shipping 1.0 in the catalogue would hand users that bug by default. The 1.5 GGUF ships a rewritten template without the guard; details and testing are in a comment on #2674.

### Why only these two

- **31B dense** has no vendor GGUF build, only safetensors.
- **397B MoE** has a GGUF but is out of range for the hardware this catalogue targets.
- **FP8, NVFP4 and MLX** repos exist for several sizes but are for other backends.

### Testing

Registered both through `lemonade pull` and exercised on a RYZEN AI MAX+ 395 (gfx1151), Lemonade 11.9.0, llama.cpp build 10621:

- `/v1/responses` plain, single function tool, and a full Codex-shaped request with mixed tool types
- tool calls round-trip and arrive as `function_call` output items
- thinking lands in a separate `reasoning` item, with no `<think>` leakage into message text
- `/v1/chat/completions` with an inline `image_url` resolves through the projector and answers correctly

Both entries are marked `suggested` so they show up in Lemonade clients.
